### PR TITLE
#173: Support using Unix Sockets with External Redis Instances

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -65,8 +65,8 @@ class Settings(BaseSettings):
 
     # Redis/Archive cache settings
     # Option 1: External Redis URL (takes precedence if set)
-    # Format: redis://[password@]hostname:port/db or rediss:// for TLS
-    # Example: redis://192.168.1.100:6379/0 or redis://:password@remote-host:6379/0
+    # Format: redis://[password@]hostname:port/db, rediss:// for TLS, or unix:// for Unix sockets
+    # Example: redis://192.168.1.100:6379/0 or redis://:password@remote-host:6379/0 or unix:///run/redis-socket/redis.sock?db=0
     redis_url: Optional[str] = None
 
     # Option 2: Local Redis (used if redis_url not set)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -418,6 +418,9 @@ services:
       # Or with password
       # - REDIS_URL=redis://:password@192.168.1.100:6379/0
 
+      # Or with Unix socket (when Redis and Borg UI are on same system)
+      # - REDIS_URL=unix:///run/redis-socket/redis.sock?db=0&password=password
+
       # Cache settings
       - CACHE_TTL_SECONDS=7200    # 2 hours
       - CACHE_MAX_SIZE_MB=2048    # 2GB

--- a/frontend/src/components/CacheManagementTab.tsx
+++ b/frontend/src/components/CacheManagementTab.tsx
@@ -384,11 +384,12 @@ const CacheManagementTab: React.FC = () => {
                   value={redisUrl}
                   onChange={(e) => setRedisUrl(e.target.value)}
                   placeholder="redis://192.168.1.100:6379/0"
-                  helperText="Format: redis://[password@]host:port/db or rediss:// for TLS"
+                  helperText="Format: redis://[password@]host:port/db, rediss:// for TLS, or unix:// for Unix sockets"
                   error={
                     redisUrl.trim() !== '' &&
                     !redisUrl.startsWith('redis://') &&
-                    !redisUrl.startsWith('rediss://')
+                    !redisUrl.startsWith('rediss://') &&
+                    !redisUrl.startsWith('unix://')
                   }
                 />
                 <Button


### PR DESCRIPTION
## Description
This pull request adds support for using Unix sockets to connect to an external Redis instance and updates the relevant documentation.


## Related Issue
<!-- Link to the issue this PR addresses -->
Fixes #173 


## Type of Change
<!-- Mark the relevant option with an 'x' -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring


## Testing
I have verified that when connecting to a Redis instance using a Unix socket, the connection works and the user interface no longer displays an error message (see screenshot below).

- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass


## Checklist
<!-- Mark completed items with an 'x' -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->
<img width="1459" height="546" alt="image" src="https://github.com/user-attachments/assets/0e549987-a4a7-42d3-892e-4737f738fbd9" />

## Additional Context
<!-- Add any other context about the PR here -->
N/A

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
