### PR TITLE
feat: Change header used for authorization to allow for use of Borg UI behind reverse proxies with HTTP Basic Auth.

### DIFF
--- a/Borg_UI_API.postman_collection.json
+++ b/Borg_UI_API.postman_collection.json
@@ -6,11 +6,21 @@
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"auth": {
-		"type": "bearer",
-		"bearer": [
+		"type": "apikey",
+		"apikey": [
 			{
-				"key": "token",
-				"value": "{{access_token}}",
+				"key": "key",
+				"value": "X-Borg-Authorization",
+				"type": "string"
+			},
+			{
+				"key": "value",
+				"value": "Bearer {{access_token}}",
+				"type": "string"
+			},
+			{
+				"key": "in",
+				"value": "header",
 				"type": "string"
 			}
 		]

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -128,8 +128,8 @@ async def stream_events(
             # Token from query parameter
             token_str = token
         else:
-            # Try to get from X-Borg-Authorization header
-            auth_header = request.headers.get("X-Borg-Authorization")
+            # Try to get from X-Borg-Authorization header, falling back to Authorization
+            auth_header = request.headers.get("X-Borg-Authorization") or request.headers.get("Authorization")
             if auth_header and auth_header.startswith("Bearer "):
                 token_str = auth_header.split(" ")[1]
 

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -128,8 +128,8 @@ async def stream_events(
             # Token from query parameter
             token_str = token
         else:
-            # Try to get from Authorization header
-            auth_header = request.headers.get("Authorization")
+            # Try to get from X-Borg-Authorization header
+            auth_header = request.headers.get("X-Borg-Authorization")
             if auth_header and auth_header.startswith("Bearer "):
                 token_str = auth_header.split(" ")[1]
 

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -79,7 +79,8 @@ async def get_current_user(
         headers={"WWW-Authenticate": "Bearer"},
     )
 
-    auth_header = request.headers.get("Authorization")
+    # Prefer X-Borg-Authorization so reverse proxies can still use Authorization.
+    auth_header = request.headers.get("X-Borg-Authorization") or request.headers.get("Authorization")
     if not auth_header or not auth_header.startswith("Bearer "):
         raise credentials_exception
 
@@ -197,7 +198,7 @@ async def get_current_download_user(
     if settings.disable_authentication:
         return await get_current_user_proxy(request, db)
 
-    auth_header = request.headers.get("Authorization")
+    auth_header = request.headers.get("X-Borg-Authorization") or request.headers.get("Authorization")
     token: Optional[str] = None
 
     if auth_header and auth_header.startswith("Bearer "):

--- a/docs/script-parameters.md
+++ b/docs/script-parameters.md
@@ -271,6 +271,8 @@ else
 fi
 ```
 
+> **Note:** The `X-Borg-Authorization` header is recommended for API requests because it avoids conflicts with reverse proxies that use HTTP Basic Auth. The legacy `Authorization` header is still accepted for backward compatibility, but `X-Borg-Authorization` takes precedence when both are present.
+
 ### File Sync to S3
 
 ```bash

--- a/docs/script-parameters.md
+++ b/docs/script-parameters.md
@@ -259,7 +259,7 @@ TIMEOUT="${TIMEOUT:-10}"
 
 response=$(curl -s -w "%{http_code}" -o /dev/null \
   --max-time "$TIMEOUT" \
-  -H "Authorization: Bearer $API_TOKEN" \
+  -H "X-Borg-Authorization: Bearer $API_TOKEN" \
   "$API_URL/health")
 
 if [ "$response" = "200" ]; then

--- a/frontend/src/components/BackupJobsTable.tsx
+++ b/frontend/src/components/BackupJobsTable.tsx
@@ -215,7 +215,7 @@ export const BackupJobsTable = <T extends Job = Job>({
       const response = await fetch(`${BASE_PATH}/api/activity/${jobType}/${cancelJob.id}/cancel`, {
         method: 'POST',
         headers: {
-          Authorization: `Bearer ${localStorage.getItem('access_token') || ''}`,
+          'X-Borg-Authorization': `Bearer ${localStorage.getItem('access_token') || ''}`,
         },
       })
 
@@ -289,7 +289,7 @@ export const BackupJobsTable = <T extends Job = Job>({
       const response = await fetch(`${BASE_PATH}/api/activity/${jobType}/${jobToDelete.id}`, {
         method: 'DELETE',
         headers: {
-          Authorization: `Bearer ${localStorage.getItem('access_token') || ''}`,
+          'X-Borg-Authorization': `Bearer ${localStorage.getItem('access_token') || ''}`,
         },
       })
 

--- a/frontend/src/components/LogViewerDialog.tsx
+++ b/frontend/src/components/LogViewerDialog.tsx
@@ -49,7 +49,7 @@ export default function LogViewerDialog<T extends JobWithLogs>({
       try {
         const res = await fetch(`${BASE_PATH}/api/activity/recent?job_type=${jobType}&limit=100`, {
           headers: {
-            Authorization: `Bearer ${localStorage.getItem('access_token') || ''}`,
+            'X-Borg-Authorization': `Bearer ${localStorage.getItem('access_token') || ''}`,
           },
         })
         if (!res.ok) return
@@ -73,7 +73,7 @@ export default function LogViewerDialog<T extends JobWithLogs>({
         `${BASE_PATH}/api/activity/${jobType}/${jobId}/logs?offset=${offset}&limit=500`,
         {
           headers: {
-            Authorization: `Bearer ${localStorage.getItem('access_token') || ''}`,
+            'X-Borg-Authorization': `Bearer ${localStorage.getItem('access_token') || ''}`,
           },
         }
       )

--- a/frontend/src/components/__tests__/BackupJobsTable.actions.test.tsx
+++ b/frontend/src/components/__tests__/BackupJobsTable.actions.test.tsx
@@ -225,7 +225,7 @@ describe('BackupJobsTable action internals', () => {
       expect(global.fetch).toHaveBeenCalledWith('/api/activity/restore/20/cancel', {
         method: 'POST',
         headers: {
-          Authorization: 'Bearer token-123',
+          'X-Borg-Authorization': 'Bearer token-123',
         },
       })
     })
@@ -335,7 +335,7 @@ describe('BackupJobsTable action internals', () => {
       expect(global.fetch).toHaveBeenCalledWith('/api/activity/backup/40', {
         method: 'DELETE',
         headers: {
-          Authorization: 'Bearer token-123',
+          'X-Borg-Authorization': 'Bearer token-123',
         },
       })
     })

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -33,13 +33,13 @@ describe('API Request Interceptor', () => {
     })
   })
 
-  it('attaches Authorization header when token exists', async () => {
+  it('attaches X-Borg-Authorization header when token exists', async () => {
     const mock = new MockAdapter(api)
     localStorageMock['access_token'] = 'test-token-123'
 
     mock.onGet('/test').reply((config) => {
       // Verify the Authorization header was added
-      expect(config.headers?.Authorization).toBe('Bearer test-token-123')
+      expect(config.headers?.['X-Borg-Authorization']).toBe('Bearer test-token-123')
       return [200, { success: true }]
     })
 
@@ -47,13 +47,13 @@ describe('API Request Interceptor', () => {
     mock.restore()
   })
 
-  it('does not add Authorization header when no token exists', async () => {
+  it('does not add X-Borg-Authorization header when no token exists', async () => {
     const mock = new MockAdapter(api)
     // No token in localStorage
 
     mock.onGet('/test').reply((config) => {
       // Authorization header should not be present
-      expect(config.headers?.Authorization).toBeUndefined()
+      expect(config.headers?.['X-Borg-Authorization']).toBeUndefined()
       return [200, { success: true }]
     })
 
@@ -61,13 +61,13 @@ describe('API Request Interceptor', () => {
     mock.restore()
   })
 
-  it('preserves other headers while adding Authorization', async () => {
+  it('preserves other headers while adding X-Borg-Authorization', async () => {
     const mock = new MockAdapter(api)
     localStorageMock['access_token'] = 'test-token'
 
     mock.onGet('/test').reply((config) => {
       // Check both headers are present
-      expect(config.headers?.Authorization).toBe('Bearer test-token')
+      expect(config.headers?.['X-Borg-Authorization']).toBe('Bearer test-token')
       expect(config.headers?.['Content-Type']).toBe('application/json')
       return [200, { success: true }]
     })

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -21,7 +21,7 @@ const api = axios.create({
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem('access_token')
   if (token) {
-    config.headers.Authorization = `Bearer ${token}`
+    config.headers['X-Borg-Authorization'] = `Bearer ${token}`
   }
   return config
 })

--- a/tests/fixtures/api.py
+++ b/tests/fixtures/api.py
@@ -148,13 +148,13 @@ def admin_token(admin_user):
 @pytest.fixture
 def auth_headers(auth_token):
     """Create authorization headers with test user token"""
-    return {"Authorization": f"Bearer {auth_token}"}
+    return {"X-Borg-Authorization": f"Bearer {auth_token}"}
 
 
 @pytest.fixture
 def admin_headers(admin_token):
     """Create authorization headers with admin token"""
-    return {"Authorization": f"Bearer {admin_token}"}
+    return {"X-Borg-Authorization": f"Bearer {admin_token}"}
 
 
 @pytest.fixture
@@ -179,4 +179,4 @@ def operator_token(operator_user):
 
 @pytest.fixture
 def operator_headers(operator_token):
-    return {"Authorization": f"Bearer {operator_token}"}
+    return {"X-Borg-Authorization": f"Bearer {operator_token}"}

--- a/tests/integration/test_archive_contents.py
+++ b/tests/integration/test_archive_contents.py
@@ -85,7 +85,7 @@ class ArchiveContentsTester:
     def get_existing_repositories(self) -> list:
         """Get list of existing repositories"""
         try:
-            headers = {"Authorization": f"Bearer {self.auth_token}"}
+            headers = {"X-Borg-Authorization": f"Bearer {self.auth_token}"}
             response = self.session.get(
                 f"{self.base_url}/api/repositories/",
                 headers=headers,
@@ -103,7 +103,7 @@ class ArchiveContentsTester:
     def delete_repository(self, repo_id: int) -> bool:
         """Delete a repository by ID"""
         try:
-            headers = {"Authorization": f"Bearer {self.auth_token}"}
+            headers = {"X-Borg-Authorization": f"Bearer {self.auth_token}"}
             response = self.session.delete(
                 f"{self.base_url}/api/repositories/{repo_id}",
                 headers=headers,
@@ -203,7 +203,7 @@ class ArchiveContentsTester:
         Returns set of immediate children at the given path
         """
         try:
-            headers = {"Authorization": f"Bearer {self.auth_token}"}
+            headers = {"X-Borg-Authorization": f"Bearer {self.auth_token}"}
             params = {"path": path}
 
             response = self.session.get(
@@ -229,7 +229,7 @@ class ArchiveContentsTester:
         """Add a repository to Borg UI, returns repository ID"""
         try:
             headers = {
-                "Authorization": f"Bearer {self.auth_token}",
+                "X-Borg-Authorization": f"Bearer {self.auth_token}",
                 "Content-Type": "application/json"
             }
 

--- a/tests/integration/test_archive_directory_browsing.py
+++ b/tests/integration/test_archive_directory_browsing.py
@@ -134,7 +134,7 @@ class ArchiveBrowsingTester:
         Returns set of directory names
         """
         try:
-            headers = {"Authorization": f"Bearer {self.auth_token}"}
+            headers = {"X-Borg-Authorization": f"Bearer {self.auth_token}"}
             params = {"path": path}
 
             response = self.session.get(
@@ -219,7 +219,7 @@ class ArchiveBrowsingTester:
         Test that response size is reasonable (not fetching all files)
         """
         try:
-            headers = {"Authorization": f"Bearer {self.auth_token}"}
+            headers = {"X-Borg-Authorization": f"Bearer {self.auth_token}"}
             params = {"path": path}
 
             response = self.session.get(
@@ -313,7 +313,7 @@ class ArchiveBrowsingTester:
         """Add repository to Borg UI and return repo ID"""
         try:
             headers = {
-                "Authorization": f"Bearer {self.auth_token}",
+                "X-Borg-Authorization": f"Bearer {self.auth_token}",
                 "Content-Type": "application/json"
             }
 
@@ -351,7 +351,7 @@ class ArchiveBrowsingTester:
     def delete_repository_from_ui(self, repo_id: int):
         """Delete repository from UI"""
         try:
-            headers = {"Authorization": f"Bearer {self.auth_token}"}
+            headers = {"X-Borg-Authorization": f"Bearer {self.auth_token}"}
             self.session.delete(
                 f"{self.base_url}/api/repositories/{repo_id}",
                 headers=headers,

--- a/tests/integration/test_log_management_api.py
+++ b/tests/integration/test_log_management_api.py
@@ -126,7 +126,7 @@ class TestGetSystemSettings:
 
         response = client.get(
             "/api/settings/system",
-            headers={"Authorization": f"Bearer {admin_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {admin_token}"}
         )
 
         assert response.status_code == 200
@@ -153,7 +153,7 @@ class TestGetSystemSettings:
         """Should create default settings if none exist"""
         response = client.get(
             "/api/settings/system",
-            headers={"Authorization": f"Bearer {admin_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {admin_token}"}
         )
 
         assert response.status_code == 200
@@ -179,7 +179,7 @@ class TestUpdateSystemSettings:
         response = client.put(
             "/api/settings/system",
             json={"log_save_policy": "all_jobs"},
-            headers={"Authorization": f"Bearer {admin_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {admin_token}"}
         )
 
         assert response.status_code == 200
@@ -195,7 +195,7 @@ class TestUpdateSystemSettings:
         response = client.put(
             "/api/settings/system",
             json={"log_max_total_size_mb": 1000},
-            headers={"Authorization": f"Bearer {admin_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {admin_token}"}
         )
 
         assert response.status_code == 200
@@ -209,7 +209,7 @@ class TestUpdateSystemSettings:
         response = client.put(
             "/api/settings/system",
             json={"log_cleanup_on_startup": False},
-            headers={"Authorization": f"Bearer {admin_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {admin_token}"}
         )
 
         assert response.status_code == 200
@@ -223,7 +223,7 @@ class TestUpdateSystemSettings:
         response = client.put(
             "/api/settings/system",
             json={"log_save_policy": "invalid_policy"},
-            headers={"Authorization": f"Bearer {admin_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {admin_token}"}
         )
 
         assert response.status_code == 400
@@ -234,7 +234,7 @@ class TestUpdateSystemSettings:
         response = client.put(
             "/api/settings/system",
             json={"log_max_total_size_mb": 5},  # Below minimum of 10
-            headers={"Authorization": f"Bearer {admin_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {admin_token}"}
         )
 
         assert response.status_code == 400
@@ -245,7 +245,7 @@ class TestUpdateSystemSettings:
         response = client.put(
             "/api/settings/system",
             json={"log_save_policy": "all_jobs"},
-            headers={"Authorization": f"Bearer {user_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {user_token}"}
         )
 
         assert response.status_code == 403
@@ -270,7 +270,7 @@ class TestUpdateSystemSettings:
         response = client.put(
             "/api/settings/system",
             json={"log_max_total_size_mb": 500},  # Below current usage
-            headers={"Authorization": f"Bearer {admin_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {admin_token}"}
         )
 
         assert response.status_code == 200
@@ -294,7 +294,7 @@ class TestGetLogStorageStats:
 
         response = client.get(
             "/api/settings/system/logs/storage",
-            headers={"Authorization": f"Bearer {admin_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {admin_token}"}
         )
 
         assert response.status_code == 200
@@ -324,7 +324,7 @@ class TestGetLogStorageStats:
         """Should allow regular users to view log storage stats"""
         response = client.get(
             "/api/settings/system/logs/storage",
-            headers={"Authorization": f"Bearer {user_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {user_token}"}
         )
 
         assert response.status_code == 200
@@ -371,7 +371,7 @@ class TestManualLogCleanup:
 
         response = client.post(
             "/api/settings/system/logs/cleanup",
-            headers={"Authorization": f"Bearer {admin_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {admin_token}"}
         )
 
         assert response.status_code == 200
@@ -390,7 +390,7 @@ class TestManualLogCleanup:
         """Should require admin access"""
         response = client.post(
             "/api/settings/system/logs/cleanup",
-            headers={"Authorization": f"Bearer {user_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {user_token}"}
         )
 
         assert response.status_code == 403
@@ -429,7 +429,7 @@ class TestManualLogCleanup:
 
         response = client.post(
             "/api/settings/system/logs/cleanup",
-            headers={"Authorization": f"Bearer {admin_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {admin_token}"}
         )
 
         assert response.status_code == 200
@@ -448,7 +448,7 @@ class TestLogManagementEndToEnd:
         # Step 1: Get initial settings
         response = client.get(
             "/api/settings/system",
-            headers={"Authorization": f"Bearer {admin_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {admin_token}"}
         )
         assert response.status_code == 200
         initial_settings = response.json()["settings"]
@@ -462,14 +462,14 @@ class TestLogManagementEndToEnd:
                 "log_max_total_size_mb": 250,
                 "log_cleanup_on_startup": False
             },
-            headers={"Authorization": f"Bearer {admin_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {admin_token}"}
         )
         assert response.status_code == 200
 
         # Step 3: Verify settings were updated
         response = client.get(
             "/api/settings/system",
-            headers={"Authorization": f"Bearer {admin_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {admin_token}"}
         )
         assert response.status_code == 200
         updated_settings = response.json()["settings"]
@@ -482,7 +482,7 @@ class TestLogManagementEndToEnd:
         # Step 4: Get log storage stats
         response = client.get(
             "/api/settings/system/logs/storage",
-            headers={"Authorization": f"Bearer {admin_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {admin_token}"}
         )
         assert response.status_code == 200
         storage_stats = response.json()["storage"]

--- a/tests/integration/test_multiple_source_dirs.py
+++ b/tests/integration/test_multiple_source_dirs.py
@@ -114,7 +114,7 @@ class MultipleSourceDirTester:
         """
         try:
             headers = {
-                "Authorization": f"Bearer {self.auth_token}",
+                "X-Borg-Authorization": f"Bearer {self.auth_token}",
                 "Content-Type": "application/json"
             }
 
@@ -162,7 +162,7 @@ class MultipleSourceDirTester:
     def verify_repository_config(self, repo_id):
         """Verify repository has both source directories stored"""
         try:
-            headers = {"Authorization": f"Bearer {self.auth_token}"}
+            headers = {"X-Borg-Authorization": f"Bearer {self.auth_token}"}
 
             response = self.session.get(
                 f"{self.base_url}/api/repositories/",
@@ -210,7 +210,7 @@ class MultipleSourceDirTester:
         """
         try:
             headers = {
-                "Authorization": f"Bearer {self.auth_token}",
+                "X-Borg-Authorization": f"Bearer {self.auth_token}",
                 "Content-Type": "application/json"
             }
 
@@ -239,7 +239,7 @@ class MultipleSourceDirTester:
         """Wait for backup to complete"""
         import time
 
-        headers = {"Authorization": f"Bearer {self.auth_token}"}
+        headers = {"X-Borg-Authorization": f"Bearer {self.auth_token}"}
         start_time = time.time()
 
         while time.time() - start_time < timeout:

--- a/tests/manual/test_app.py
+++ b/tests/manual/test_app.py
@@ -107,7 +107,7 @@ class BorgWebUITester:
                     self.log_test("Authentication Login", True, "Successfully logged in and got token")
                     
                     # Test getting user info with token
-                    headers = {"Authorization": f"Bearer {self.auth_token}"}
+                    headers = {"X-Borg-Authorization": f"Bearer {self.auth_token}"}
                     user_response = self.session.get(f"{self.base_url}/api/auth/me", headers=headers, timeout=5)
                     
                     if user_response.status_code == 200:
@@ -138,7 +138,7 @@ class BorgWebUITester:
             self.log_test("Protected Endpoints", False, "No auth token available")
             return False
         
-        headers = {"Authorization": f"Bearer {self.auth_token}"}
+        headers = {"X-Borg-Authorization": f"Bearer {self.auth_token}"}
         protected_routes = [
             "/api/dashboard/status",
             "/api/dashboard/metrics",
@@ -167,7 +167,7 @@ class BorgWebUITester:
             self.log_test("Config Endpoints", False, "No auth token available")
             return False
 
-        headers = {"Authorization": f"Bearer {self.auth_token}", "Content-Type": "application/json"}
+        headers = {"X-Borg-Authorization": f"Bearer {self.auth_token}", "Content-Type": "application/json"}
 
         try:
             # Test settings/profile endpoint
@@ -189,7 +189,7 @@ class BorgWebUITester:
             self.log_test("System Info", False, "No auth token available")
             return False
 
-        headers = {"Authorization": f"Bearer {self.auth_token}"}
+        headers = {"X-Borg-Authorization": f"Bearer {self.auth_token}"}
 
         try:
             # Test system info
@@ -228,7 +228,7 @@ class BorgWebUITester:
             self.log_test("Repository Operations", False, "No auth token available")
             return False
         
-        headers = {"Authorization": f"Bearer {self.auth_token}", "Content-Type": "application/json"}
+        headers = {"X-Borg-Authorization": f"Bearer {self.auth_token}", "Content-Type": "application/json"}
         
         try:
             # Test listing repositories

--- a/tests/unit/test_api_auth.py
+++ b/tests/unit/test_api_auth.py
@@ -447,7 +447,7 @@ class TestProtectedEndpoints:
         """Test getting current user with invalid token"""
         response = test_client.get(
             "/api/auth/me",
-            headers={"Authorization": "Bearer invalid_token"}
+            headers={"X-Borg-Authorization": "Bearer invalid_token"}
         )
 
         assert response.status_code == 401
@@ -474,7 +474,7 @@ class TestProtectedEndpoints:
         """Test accessing protected endpoint with malformed token"""
         response = test_client.get(
             "/api/auth/me",
-            headers={"Authorization": "Bearer malformed_token"}
+            headers={"X-Borg-Authorization": "Bearer malformed_token"}
         )
 
         assert response.status_code == 401
@@ -486,7 +486,7 @@ class TestProtectedEndpoints:
         """Should return 401 for invalid JWT token"""
         response = test_client.get(
             "/api/repositories/",
-            headers={"Authorization": "Bearer invalid_token_here"}
+            headers={"X-Borg-Authorization": "Bearer invalid_token_here"}
         )
 
         assert response.status_code == 401
@@ -501,7 +501,7 @@ class TestProtectedEndpoints:
 
         response = test_client.get(
             "/api/auth/me",
-            headers={"Authorization": f"Bearer {expired_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {expired_token}"}
         )
 
         assert response.status_code == 401
@@ -510,7 +510,7 @@ class TestProtectedEndpoints:
         """Test accessing protected endpoint without Bearer prefix"""
         response = test_client.get(
             "/api/auth/me",
-            headers={"Authorization": auth_token}  # Missing "Bearer" prefix
+            headers={"X-Borg-Authorization": auth_token}  # Missing "Bearer" prefix
         )
 
         assert response.status_code == 401
@@ -540,7 +540,7 @@ class TestTokenValidation:
 
         response = test_client.get(
             "/api/repositories/",
-            headers={"Authorization": f"Bearer {expired_token}"}
+            headers={"X-Borg-Authorization": f"Bearer {expired_token}"}
         )
 
         assert response.status_code == 401
@@ -549,7 +549,7 @@ class TestTokenValidation:
         """Should return 401 for malformed token"""
         response = test_client.get(
             "/api/repositories/",
-            headers={"Authorization": "Bearer not.a.valid.jwt"}
+            headers={"X-Borg-Authorization": "Bearer not.a.valid.jwt"}
         )
 
         assert response.status_code == 401
@@ -561,7 +561,7 @@ class TestTokenValidation:
         """
         response = test_client.get(
             "/api/repositories/",
-            headers={"Authorization": "InvalidPrefix token_here"}
+            headers={"X-Borg-Authorization": "InvalidPrefix token_here"}
         )
 
         assert response.status_code == 401

--- a/tests/unit/test_api_auth.py
+++ b/tests/unit/test_api_auth.py
@@ -844,3 +844,53 @@ class TestProxyAuthentication:
 
         # Last login should be updated
         assert second_login > first_login
+
+
+@pytest.mark.unit
+class TestDualHeaderFallback:
+    """Test that both X-Borg-Authorization and legacy Authorization headers are accepted"""
+
+    def test_legacy_authorization_header_still_works(
+        self,
+        test_client: TestClient,
+        admin_token
+    ):
+        """Legacy Authorization header should still be accepted for backward compatibility"""
+        response = test_client.get(
+            "/api/repositories/",
+            headers={"Authorization": f"Bearer {admin_token}"}
+        )
+
+        assert response.status_code in [200, 204]
+
+    def test_x_borg_authorization_takes_precedence(
+        self,
+        test_client: TestClient,
+        admin_token
+    ):
+        """X-Borg-Authorization should take precedence over Authorization"""
+        response = test_client.get(
+            "/api/repositories/",
+            headers={
+                "X-Borg-Authorization": f"Bearer {admin_token}",
+                "Authorization": "Bearer invalid_token_here",
+            }
+        )
+
+        assert response.status_code in [200, 204]
+
+    def test_invalid_x_borg_does_not_fall_back_to_valid_authorization(
+        self,
+        test_client: TestClient,
+        admin_token
+    ):
+        """When X-Borg-Authorization is present but invalid, it should NOT fall back to Authorization"""
+        response = test_client.get(
+            "/api/repositories/",
+            headers={
+                "X-Borg-Authorization": "Bearer invalid_token_here",
+                "Authorization": f"Bearer {admin_token}",
+            }
+        )
+
+        assert response.status_code == 401


### PR DESCRIPTION
## Description
This pull request changes the HTTP header used for authorization from `Authorization` to `X-Borg-Authorization`. This resolves the issue with using Borg UI behind a reverse proxy with HTTP Basic Auth as described in issue #361.


## Related Issue
<!-- Link to the issue this PR addresses -->
Fixes #361


## Type of Change
<!-- Mark the relevant option with an 'x' -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring


## Testing
<!-- Describe the tests you ran to verify your changes -->

- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Output from running tests:
<img width="1897" height="287" alt="Screenshot 2026-03-23 121100" src="https://github.com/user-attachments/assets/7bf8fab3-86b9-411e-a2cd-cbbe2a63e4dc" />

## Checklist
<!-- Mark completed items with an 'x' -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


## Additional Context
I marked these changes as breaking because although anyone using the web UI will not notice any difference in how the application functions, users that that interact with the application through scripting as shown [here in the documentation](https://karanhudia.github.io/borg-ui/script-parameters.html#api-health-check) will need to update their scripts to use the `X-Borg-Authorization` header.