### PR TITLE
fix: Fix use of Authorization header instead of X-Borg-Authorization for auth token.

### DIFF
--- a/frontend/src/pages/DashboardV3.tsx
+++ b/frontend/src/pages/DashboardV3.tsx
@@ -987,7 +987,7 @@ export default function DashboardV3() {
     queryKey: ['dashboard-v3'],
     queryFn: async () => {
       const res = await fetch(`${BASE_PATH}/api/dashboard/overview`, {
-        headers: { Authorization: `Bearer ${localStorage.getItem('access_token')}` },
+        headers: { 'X-Borg-Authorization': `Bearer ${localStorage.getItem('access_token')}` },
       })
       if (!res.ok) throw new Error('Failed')
       return res.json()

--- a/frontend/src/pages/__tests__/DashboardV3.test.tsx
+++ b/frontend/src/pages/__tests__/DashboardV3.test.tsx
@@ -174,12 +174,12 @@ describe('DashboardV3', () => {
       expect(fetchMock).toHaveBeenCalledWith(
         '/api/dashboard/overview',
         expect.objectContaining({
-          headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
+          headers: expect.objectContaining({ 'X-Borg-Authorization': 'Bearer test-token' }),
         })
       )
     })
 
-    it('sends the stored access token in the Authorization header', async () => {
+    it('sends the stored access token in the X-Borg-Authorization header', async () => {
       vi.stubGlobal('localStorage', {
         getItem: (key: string) => (key === 'access_token' ? 'my-secret-token' : null),
       })
@@ -190,7 +190,7 @@ describe('DashboardV3', () => {
       renderDashboard()
       await waitFor(() => screen.getAllByText('my-server'))
       const [, options] = fetchMock.mock.calls[0]
-      expect(options.headers.Authorization).toBe('Bearer my-secret-token')
+      expect(options.headers['X-Borg-Authorization']).toBe('Bearer my-secret-token')
     })
 
     it('fetches exactly once on initial render', async () => {

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -38,7 +38,7 @@ describe('API Request Interceptor', () => {
     localStorageMock['access_token'] = 'test-token-123'
 
     mock.onGet('/test').reply((config) => {
-      // Verify the Authorization header was added
+      // Verify the X-Borg-Authorization header was added
       expect(config.headers?.['X-Borg-Authorization']).toBe('Bearer test-token-123')
       return [200, { success: true }]
     })
@@ -52,7 +52,7 @@ describe('API Request Interceptor', () => {
     // No token in localStorage
 
     mock.onGet('/test').reply((config) => {
-      // Authorization header should not be present
+      // X-Borg-Authorization header should not be present
       expect(config.headers?.['X-Borg-Authorization']).toBeUndefined()
       return [200, { success: true }]
     })

--- a/frontend/src/services/borgApi/client.test.ts
+++ b/frontend/src/services/borgApi/client.test.ts
@@ -1,9 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import MockAdapter from 'axios-mock-adapter'
 
 describe('BorgApiClient', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
+  })
+
+  it('attaches X-Borg-Authorization when access_token is in localStorage', async () => {
+    localStorage.setItem('access_token', 'borg-jwt')
+    const clientModule = await import('./client')
+    const mock = new MockAdapter(clientModule.httpClient)
+    mock.onGet('/repositories/1/info').reply((config) => {
+      expect(config.headers?.['X-Borg-Authorization']).toBe('Bearer borg-jwt')
+      return [200, {}]
+    })
+    const { BorgApiClient } = clientModule
+    const client = new BorgApiClient({ id: 1, borg_version: 1, path: '/p' } as never)
+    await client.getInfo()
+    mock.restore()
   })
 
   it('downloads files in the same tab', async () => {

--- a/frontend/src/services/borgApi/client.ts
+++ b/frontend/src/services/borgApi/client.ts
@@ -26,7 +26,7 @@ export const httpClient = axios.create({
 // Mirror the auth interceptor so this client also attaches tokens
 httpClient.interceptors.request.use((config) => {
   const token = localStorage.getItem('access_token')
-  if (token) config.headers.Authorization = `Bearer ${token}`
+  if (token) config.headers['X-Borg-Authorization'] = `Bearer ${token}`
   return config
 })
 

--- a/frontend/src/utils/__tests__/analytics.test.ts
+++ b/frontend/src/utils/__tests__/analytics.test.ts
@@ -72,7 +72,9 @@ describe('analytics (umami)', () => {
     })
 
     it('loads analytics preference from API when token exists', async () => {
-      Storage.prototype.getItem = vi.fn().mockReturnValue('test-token')
+      const getItemSpy = vi.spyOn(localStorage, 'getItem').mockImplementation((key) =>
+        key === 'access_token' ? 'test-token' : null
+      )
       global.fetch = vi
         .fn()
         .mockResolvedValueOnce({
@@ -86,9 +88,17 @@ describe('analytics (umami)', () => {
           }),
         } as Response)
 
-      await loadUserPreference()
+      try {
+        await loadUserPreference()
 
-      expect(arePreferencesLoaded()).toBe(true)
+        expect(arePreferencesLoaded()).toBe(true)
+        const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+        expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2)
+        const prefsCall = fetchMock.mock.calls[1]
+        expect(prefsCall[1]?.headers?.['X-Borg-Authorization']).toBe('Bearer test-token')
+      } finally {
+        getItemSpy.mockRestore()
+      }
     })
 
     it('defaults to opt-out when API fails', async () => {

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -108,7 +108,7 @@ export const loadUserPreference = async (): Promise<void> => {
 
     const headers: Record<string, string> = {}
     if (token) {
-      headers.Authorization = `Bearer ${token}`
+      headers['X-Borg-Authorization'] = `Bearer ${token}`
     }
 
     const response = await fetch(`${BASE_PATH}/api/settings/preferences`, { headers })

--- a/tests/manual/test_app.py
+++ b/tests/manual/test_app.py
@@ -155,7 +155,7 @@ class BorgWebUITester:
                     )
 
                     # Test getting user info with token
-                    headers = {"Authorization": f"Bearer {self.auth_token}"}
+                    headers = {"X-Borg-Authorization": f"Bearer {self.auth_token}"}
                     user_response = self.session.get(
                         f"{self.base_url}/api/auth/me", headers=headers, timeout=5
                     )
@@ -208,7 +208,7 @@ class BorgWebUITester:
             self.log_test("Protected Endpoints", False, "No auth token available")
             return False
 
-        headers = {"Authorization": f"Bearer {self.auth_token}"}
+        headers = {"X-Borg-Authorization": f"Bearer {self.auth_token}"}
         protected_routes = [
             "/api/dashboard/status",
             "/api/dashboard/metrics",
@@ -248,7 +248,7 @@ class BorgWebUITester:
             return False
 
         headers = {
-            "Authorization": f"Bearer {self.auth_token}",
+            "X-Borg-Authorization": f"Bearer {self.auth_token}",
             "Content-Type": "application/json",
         }
 
@@ -284,7 +284,7 @@ class BorgWebUITester:
             self.log_test("System Info", False, "No auth token available")
             return False
 
-        headers = {"Authorization": f"Bearer {self.auth_token}"}
+        headers = {"X-Borg-Authorization": f"Bearer {self.auth_token}"}
 
         try:
             # Test system info
@@ -337,7 +337,7 @@ class BorgWebUITester:
             return False
 
         headers = {
-            "Authorization": f"Bearer {self.auth_token}",
+            "X-Borg-Authorization": f"Bearer {self.auth_token}",
             "Content-Type": "application/json",
         }
 

--- a/tests/smoke/live_helpers.py
+++ b/tests/smoke/live_helpers.py
@@ -53,7 +53,7 @@ class SmokeClient:
         headers = {}
         auth_token = token or self.token
         if auth_token:
-            headers["Authorization"] = f"Bearer {auth_token}"
+            headers["X-Borg-Authorization"] = f"Bearer {auth_token}"
         if json_body:
             headers["Content-Type"] = "application/json"
         return headers

--- a/tests/smoke/test_borg2_backup_contract_smoke.py
+++ b/tests/smoke/test_borg2_backup_contract_smoke.py
@@ -27,7 +27,7 @@ def _start_borg2_backup(
         response = requests.post(
             f"{base_url.rstrip('/')}/api/v2/backup/run",
             headers={
-                "Authorization": f"Bearer {token}",
+                "X-Borg-Authorization": f"Bearer {token}",
                 "Content-Type": "application/json",
             },
             json={"repository_id": repository_id},


### PR DESCRIPTION
## Description
This pull request is a follow-up to #364 to fix the use of `Authorization` in several instances where `X-Borg-Authorization` should be used instead.


## Type of Change
<!-- Mark the relevant option with an 'x' -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring


## Testing
<!-- Describe the tests you ran to verify your changes -->

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass


## Checklist
<!-- Mark completed items with an 'x' -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes