### PR TITLE
Update Italian translations

### DIFF
--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -4005,7 +4005,7 @@
     "instanceIdLabel": "ID istanza",
     "activeLicenseIdLabel": "Licenza attiva",
     "licenseKeyLabel": "Chiave di licenza",
-    "licenseKeyPlaceholder": "BORG-XXXX-XXXX-XXXX",
+    "licenseKeyPlaceholder": "BORG-0000-0000-0000",
     "activateLicenseButton": "Attiva licenza",
     "replaceLicenseButton": "Sostituisci licenza",
     "refreshLicenseButton": "Aggiorna stato",
@@ -4054,20 +4054,20 @@
     "defaultMessage": "Questa funzionalità richiede il piano {{plan}}.",
     "requiresPlan": "Richiede il piano {{plan}}",
     "buyLink": "Passa a borgui.com",
-    "learnMore": "See what's included →"
+    "learnMore": "Scopri cosa include →"
   },
   "announcements": {
-    "highlights": "What's new",
-    "viewDetails": "View details",
-    "remindLater": "Remind me later",
-    "gotIt": "Got it",
+    "highlights": "Novità",
+    "viewDetails": "Visualizza dettagli",
+    "remindLater": "Ricordamelo più tardi",
+    "gotIt": "Fatto",
     "types": {
-      "update_available": "Update available",
-      "release_highlight": "Release highlight",
-      "security_notice": "Security notice",
-      "maintenance_notice": "Maintenance notice",
-      "migration_notice": "Migration notice",
-      "custom_announcement": "Announcement"
+      "update_available": "Aggiornamento disponibile",
+      "release_highlight": "Novità del rilascio",
+      "security_notice": "Avviso di sicurezza",
+      "maintenance_notice": "Avviso di manutenzione",
+      "migration_notice": "Avviso di migrazione",
+      "custom_announcement": "Annuncio"
     }
   }
 }


### PR DESCRIPTION
## Description
Updates the Italian locale strings for licensing upgrade prompts and announcements. Reproduces the intended content from PR 456 on current main with valid JSON formatting.

## Related Issue
Linear: BOR-5

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Test addition/improvement
- [ ] Refactoring

## Testing
- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run from frontend/:
- npm run check:locales
- npm run typecheck
- npm run lint
- npm run format:check
- npm run build

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; locale text update only.

## Additional Context
PR 456 is blocked because its Frontend / Code Quality check failed on Prettier formatting for frontend/src/locales/it.json. This PR applies the same intended translations on top of current main and verifies formatting locally.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.