### PR TITLE
Fix backend unit test collection on Python 3.9

### DIFF
--- a/app/api/dashboard.py
+++ b/app/api/dashboard.py
@@ -162,9 +162,10 @@ def build_restore_check_health(
     thresholds = thresholds or DashboardHealthThresholds()
     # "Configured" requires both a cron expression AND the user-facing toggle
     # being on. Pausing via the toggle should not penalize dashboard health.
-    configured = bool(repo.restore_check_cron_expression) and bool(
-        getattr(repo, "restore_check_schedule_enabled", True)
-    )
+    schedule_enabled = getattr(repo, "restore_check_schedule_enabled", None)
+    if schedule_enabled is None:
+        schedule_enabled = True
+    configured = bool(repo.restore_check_cron_expression) and bool(schedule_enabled)
     latest_status = latest_restore_check.status if latest_restore_check else None
     latest_error = latest_restore_check.error_message if latest_restore_check else None
     last_success = repo.last_restore_check

--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import os
 import json

--- a/app/services/restore_check_canary.py
+++ b/app/services/restore_check_canary.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 import json
 from pathlib import Path


### PR DESCRIPTION
## Description
- Restores backend unit-test collection on Python 3.9 by postponing annotation evaluation in `restore_check_canary.py` and `backup_service.py`.
- Preserves dashboard restore-check schedule default semantics for unsaved `Repository` instances so dashboard helper behavior matches the model default.


## Related Issue
Linear: BOR-7 - https://linear.app/nullcodeai/issue/BOR-7/fix-backend-unit-tests


## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring


## Testing
- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works; this fix uses the existing failing backend unit tests as regression coverage.
- [x] All existing tests pass

Validation run locally:
- `python3 -m pytest tests/unit/test_restore_check_canary.py -v`
- `python3 -m pytest tests/unit/test_backup_service.py -v`
- `python3 -m pytest tests/unit/test_api_dashboard.py::TestDashboardHelpers::test_full_repository_health_warns_when_restore_check_configured_never_ran tests/unit/test_api_dashboard.py::TestDashboardHelpers::test_observe_repository_health_includes_restore_check_signal -v`
- `python3 -m pytest tests/unit -v`
- `uvx --from ruff==0.14.0 ruff check app tests`
- `uvx --from ruff==0.14.0 ruff format --check app tests`
- `git diff --check`


## Checklist
- [ ] `CONTRIBUTING.md` is not present in this checkout, so the template guideline link could not be read.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No additional code comments were needed for this focused compatibility fix
- [x] No documentation changes were needed for this backend test fix
- [x] My changes generate no new warnings in the exercised backend unit suite
- [x] New and existing unit tests pass locally with my changes


## Screenshots (if applicable)
Not applicable; backend-only test/runtime compatibility fix.


## Additional Context
- Local `ruff` is not installed on `PATH`, so validation used `uvx --from ruff==0.14.0` as the same-version fallback.
- Full local backend unit suite passed with 1536 passed, 8 skipped, and 52 existing warnings on Python 3.9.6.


---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
