### PR TITLE
Remove Restore Checks summary cards

### DIFF
--- a/frontend/src/components/ScheduledRestoreChecksSection.tsx
+++ b/frontend/src/components/ScheduledRestoreChecksSection.tsx
@@ -5,8 +5,6 @@ import {
   Alert,
   Box,
   Button,
-  Card,
-  CardContent,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -24,7 +22,7 @@ import {
   CircularProgress,
   Tooltip,
 } from '@mui/material'
-import { Eye, FolderOpen, LifeBuoy, ShieldCheck, TestTubeDiagonal, Vault } from 'lucide-react'
+import { Eye, FolderOpen, LifeBuoy } from 'lucide-react'
 import { toast } from 'react-hot-toast'
 import { repositoriesAPI } from '../services/api'
 import { BorgApiClient } from '../services/borgApi'
@@ -190,8 +188,6 @@ const ScheduledRestoreChecksSection = forwardRef<ScheduledRestoreChecksSectionRe
     enabled: repositories.length > 0 && !loadingRepositories,
   })
 
-  const restoreSchedules = useMemo(() => scheduledChecks || [], [scheduledChecks])
-
   const {
     data: archiveListData,
     isFetching: loadingArchiveList,
@@ -244,35 +240,6 @@ const ScheduledRestoreChecksSection = forwardRef<ScheduledRestoreChecksSectionRe
   })
 
   const restoreJobs = restoreJobsData || []
-
-  const statCards = useMemo(
-    () => [
-      {
-        label: t('integrity.stats.restoreSchedules'),
-        value: restoreSchedules.length,
-        icon: <LifeBuoy size={18} />,
-      },
-      {
-        label: t('integrity.stats.canaryProtected'),
-        value: restoreSchedules.filter((schedule) => schedule.restore_check_mode === 'canary')
-          .length,
-        icon: <ShieldCheck size={18} />,
-      },
-      {
-        label: t('integrity.stats.probeProtected'),
-        value: restoreSchedules.filter((schedule) => schedule.restore_check_mode === 'probe_paths')
-          .length,
-        icon: <TestTubeDiagonal size={18} />,
-      },
-      {
-        label: t('integrity.stats.fullDrills'),
-        value: restoreSchedules.filter((schedule) => schedule.restore_check_mode === 'full_archive')
-          .length,
-        icon: <Vault size={18} />,
-      },
-    ],
-    [restoreSchedules, t]
-  )
 
   const historyColumns: Column<RestoreCheckJobRow>[] = [
     {
@@ -598,32 +565,6 @@ const ScheduledRestoreChecksSection = forwardRef<ScheduledRestoreChecksSectionRe
         <Alert severity="info">{t('scheduledRestoreChecks.needRepository')}</Alert>
       ) : (
         <Stack spacing={3}>
-          <Box
-            sx={{
-              display: 'grid',
-              gridTemplateColumns: { xs: '1fr', md: 'repeat(4, minmax(0, 1fr))' },
-              gap: 2,
-            }}
-          >
-            {statCards.map((card) => (
-              <Card key={card.label} variant="outlined" sx={{ borderRadius: 2 }}>
-                <CardContent>
-                  <Stack direction="row" spacing={1.25} alignItems="center">
-                    <Box sx={{ color: 'success.main' }}>{card.icon}</Box>
-                    <Box>
-                      <Typography variant="h5" fontWeight={700}>
-                        {card.value}
-                      </Typography>
-                      <Typography variant="body2" color="text.secondary">
-                        {card.label}
-                      </Typography>
-                    </Box>
-                  </Stack>
-                </CardContent>
-              </Card>
-            ))}
-          </Box>
-
           {isLoading || loadingRepositories ? (
             <Stack spacing={2}>
               {[0, 1, 2].map((i) => (

--- a/frontend/src/components/__tests__/ScheduledRestoreChecksSection.test.tsx
+++ b/frontend/src/components/__tests__/ScheduledRestoreChecksSection.test.tsx
@@ -207,6 +207,37 @@ describe('ScheduledRestoreChecksSection', () => {
     expect(screen.getByLabelText('Probe Paths')).toHaveValue('etc\nsrv/app/config.yml')
   })
 
+  it('omits restore-check summary cards while preserving scheduled checks', async () => {
+    vi.mocked(repositoriesAPI.getRestoreCheckSchedule).mockResolvedValue({
+      data: {
+        repository_id: 1,
+        repository_name: 'Repo One',
+        repository_path: '/repo-one',
+        restore_check_cron_expression: '0 4 * * 0',
+        restore_check_timezone: 'UTC',
+        restore_check_paths: [],
+        restore_check_full_archive: false,
+        restore_check_canary_enabled: true,
+        restore_check_mode: 'canary',
+        last_restore_check: null,
+        last_scheduled_restore_check: null,
+        next_scheduled_restore_check: '2026-01-03T00:00:00Z',
+        notify_on_restore_check_success: false,
+        notify_on_restore_check_failure: true,
+        enabled: true,
+        restore_check_schedule_enabled: true,
+      },
+    } as AxiosResponse)
+
+    renderWithProviders(<ScheduledRestoreChecksSection />)
+
+    expect(await screen.findByText('Repo One')).toBeInTheDocument()
+    expect(screen.queryByText('Restore schedules')).not.toBeInTheDocument()
+    expect(screen.queryByText('Canary-protected')).not.toBeInTheDocument()
+    expect(screen.queryByText('Probe-path schedules')).not.toBeInTheDocument()
+    expect(screen.queryByText('Full-archive drills')).not.toBeInTheDocument()
+  })
+
   it('supports observe-only repositories while disabling canary mode', async () => {
     const user = userEvent.setup()
     vi.mocked(repositoriesAPI.getRepositories).mockResolvedValue({


### PR DESCRIPTION
## Description
- Removes the four summary cards from Schedule > Restore Checks: Restore schedules, Canary-protected, Probe-path schedules, and Full-archive drills.
- Keeps scheduled restore-check cards, empty states, history, dialogs, and actions unchanged.
- Adds a regression test proving the summary labels are absent while a scheduled restore-check row remains visible.

## Related Issue
Fixes BOR-6
Linear: https://linear.app/nullcodeai/issue/BOR-6/remove-the-chips-in-restore-checks-tab-in-schedule-tab

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Validation run:
- `npm test -- ScheduledRestoreChecksSection.test.tsx -t "omits restore-check summary cards while preserving scheduled checks"`
- `npm test -- ScheduledRestoreChecksSection.test.tsx`
- `npm run check:locales`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `./scripts/dev.sh` runtime route/module proof for Schedule > Restore Checks

## Checklist
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines (file is not present in this repository copy)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (no complex code added)
- [x] My changes do not require documentation updates
- [x] My changes generate no new warnings; local build emitted existing Vite/Node/chunk warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not attached. The change removes a summary-card row; runtime validation used the local dev server route and Vite-served component module, with component tests covering the visible Restore Checks state.

## Additional Context
This is a fresh Rework attempt from `origin/main`. The prior PR for BOR-6 was closed before this branch was created.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
