### PR TITLE
Fix multi-repository plan content label

### DIFF
--- a/docs/plan-content.json
+++ b/docs/plan-content.json
@@ -224,7 +224,7 @@
       "availability": "included"
     },
     {
-      "id": "multi_repo_orchestration",
+      "id": "backup_plan_multi_repository",
       "plan": "pro",
       "label": "Multi-repository backup",
       "label_localized": {

--- a/frontend/src/components/__tests__/PlanInfoDrawer.test.tsx
+++ b/frontend/src/components/__tests__/PlanInfoDrawer.test.tsx
@@ -33,6 +33,13 @@ const { usePlanContentMock } = vi.hoisted(() => ({
         availability: 'included',
       },
       {
+        id: 'backup_plan_multi_repository',
+        plan: 'pro',
+        label: 'Multi-repository backup',
+        description: 'Back up to multiple destinations from one config.',
+        availability: 'included',
+      },
+      {
         id: 'backup_reports',
         plan: 'pro',
         label: 'Backup reports',
@@ -107,6 +114,7 @@ vi.mock('../../hooks/useAuth', () => ({
 
 const featureMap = {
   borg_v2: 'pro',
+  backup_plan_multi_repository: 'pro',
   multi_user: 'community',
   extra_users: 'pro',
 } as const
@@ -204,6 +212,8 @@ describe('PlanInfoDrawer', () => {
     expect(screen.getByText('Borg v2 beta testing')).toBeInTheDocument()
     expect(screen.getByText('Up to 10 users')).toBeInTheDocument()
     expect(screen.getByText('Deployment on 3 servers')).toBeInTheDocument()
+    expect(screen.getByText('Multi-repository backup')).toBeInTheDocument()
+    expect(screen.queryByText('backup_plan_multi_repository')).not.toBeInTheDocument()
 
     await user.click(screen.getByText('Enterprise'))
 

--- a/frontend/src/data/plan-content.json
+++ b/frontend/src/data/plan-content.json
@@ -224,7 +224,7 @@
       "availability": "included"
     },
     {
-      "id": "multi_repo_orchestration",
+      "id": "backup_plan_multi_repository",
       "plan": "pro",
       "label": "Multi-repository backup",
       "label_localized": {


### PR DESCRIPTION
## Description
Aligns the multi-repository backup plan-content manifest entry with the backend feature key `backup_plan_multi_repository`. This prevents the plan drawer from falling back to the raw internal key and keeps the user-facing `Multi-repository backup` text in the bundled frontend fallback and production updates feed source.

## Related Issue
Linear: https://linear.app/nullcodeai/issue/BOR-16/fix-backup-plan-multi-repository-string-lying-in-plan

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass

Commands run:
- `npm run test -- PlanInfoDrawer --run`
- `npm run check:locales`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run preview -- --host 127.0.0.1 --port 4187`, then fetched the built `plan-content` asset and confirmed `backup_plan_multi_repository` resolves to `Multi-repository backup` while `multi_repo_orchestration` is absent.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable. This is a manifest key/content fix covered by the drawer regression test and built asset runtime check.

## Additional Context
Wrangler deployment was attempted from `updates-worker` after installing that package's dependencies. `npm run deploy:updates` passed the worker typecheck step, but deployment could not complete because Wrangler requires `CLOUDFLARE_API_TOKEN` in non-interactive mode. Retrying with a TTY started a fresh OAuth login flow instead of using an existing local session, so production deployment is blocked on Cloudflare auth in this environment.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
