### PR TITLE
Allow multiple backup source locations

### DIFF
--- a/app/api/backup_plans.py
+++ b/app/api/backup_plans.py
@@ -22,6 +22,7 @@ from app.database.models import (
     ScheduledJobRepository,
     Script,
     ScriptExecution,
+    SSHConnection,
     User,
 )
 from app.services.backup_plan_policy import (
@@ -36,6 +37,13 @@ from app.utils.schedule_time import (
     InvalidScheduleTimezone,
     calculate_next_cron_run,
     normalize_schedule_timezone,
+)
+from app.utils.source_locations import (
+    SourceLocationPayload,
+    flatten_source_directories,
+    normalize_source_locations,
+    source_locations_from_record,
+    summarize_legacy_source_fields,
 )
 
 logger = structlog.get_logger()
@@ -59,7 +67,8 @@ class BackupPlanPayload(BaseModel):
     enabled: bool = True
     source_type: str = "local"
     source_ssh_connection_id: Optional[int] = None
-    source_directories: list[str]
+    source_directories: list[str] = Field(default_factory=list)
+    source_locations: Optional[list[SourceLocationPayload]] = None
     exclude_patterns: Optional[list[str]] = None
     archive_name_template: str = "{plan_name}-{now}"
     compression: str = "lz4"
@@ -218,13 +227,19 @@ def _payload_from_repository(
         else "{plan_name}-{repo_name}-{now}"
     )
 
+    source_locations = source_locations_from_record(repository)
+    source_type, source_ssh_connection_id, source_directories = (
+        summarize_legacy_source_fields(source_locations)
+    )
+
     return BackupPlanPayload(
         name=name,
         description=f'Created from repository "{repository.name}".',
         enabled=True,
-        source_type="remote" if repository.source_ssh_connection_id else "local",
-        source_ssh_connection_id=repository.source_ssh_connection_id,
-        source_directories=_decode_json_list(repository.source_directories),
+        source_type=source_type,
+        source_ssh_connection_id=source_ssh_connection_id,
+        source_directories=source_directories,
+        source_locations=[SourceLocationPayload(**item) for item in source_locations],
         exclude_patterns=_decode_json_list(repository.exclude_patterns),
         archive_name_template=archive_name_template,
         compression=repository.compression or "lz4",
@@ -295,14 +310,19 @@ def _serialize_repository_link(link: BackupPlanRepository) -> dict[str, Any]:
 
 def _serialize_plan(plan: BackupPlan, *, detail: bool = False) -> dict[str, Any]:
     enabled_links = [link for link in plan.repositories if link.enabled]
+    source_locations = source_locations_from_record(plan)
+    source_type, source_ssh_connection_id, source_directories = (
+        summarize_legacy_source_fields(source_locations)
+    )
     payload: dict[str, Any] = {
         "id": plan.id,
         "name": plan.name,
         "description": plan.description,
         "enabled": bool(plan.enabled),
-        "source_type": plan.source_type,
-        "source_ssh_connection_id": plan.source_ssh_connection_id,
-        "source_directories": _decode_json_list(plan.source_directories),
+        "source_type": source_type,
+        "source_ssh_connection_id": source_ssh_connection_id,
+        "source_directories": source_directories,
+        "source_locations": source_locations,
         "exclude_patterns": _decode_json_list(plan.exclude_patterns),
         "archive_name_template": plan.archive_name_template,
         "compression": plan.compression,
@@ -526,21 +546,54 @@ def _validate_payload(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={"key": "backend.errors.backupPlans.nameRequired"},
         )
-    if payload.source_type not in {"local", "remote"}:
+    source_locations = normalize_source_locations(
+        payload.source_locations,
+        source_type=payload.source_type,
+        source_ssh_connection_id=payload.source_ssh_connection_id,
+        source_directories=payload.source_directories,
+    )
+    if payload.source_locations is None and payload.source_type not in {
+        "local",
+        "remote",
+    }:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={"key": "backend.errors.backupPlans.invalidSourceType"},
         )
-    if payload.source_type == "remote" and not payload.source_ssh_connection_id:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={"key": "backend.errors.backupPlans.sourceConnectionRequired"},
-        )
-    if not payload.source_directories:
+    if not source_locations or not flatten_source_directories(source_locations):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={"key": "backend.errors.backupPlans.sourceRequired"},
         )
+    for location in source_locations:
+        if location["source_type"] not in {"local", "remote"}:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={"key": "backend.errors.backupPlans.invalidSourceType"},
+            )
+        if not location["source_directories"]:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={"key": "backend.errors.backupPlans.sourceRequired"},
+            )
+        if location["source_type"] == "remote":
+            connection_id = location["source_ssh_connection_id"]
+            if not connection_id:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail={
+                        "key": "backend.errors.backupPlans.sourceConnectionRequired"
+                    },
+                )
+            if (
+                not db.query(SSHConnection.id)
+                .filter(SSHConnection.id == connection_id)
+                .first()
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail={"key": "backend.errors.ssh.sshConnectionNotFound"},
+                )
     if not payload.repositories:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -682,18 +735,29 @@ def _clear_legacy_source_settings(
         if repository.id not in clear_ids:
             continue
         repository.source_directories = None
+        repository.source_locations = None
         repository.exclude_patterns = None
         repository.source_ssh_connection_id = None
         repository.updated_at = datetime.utcnow()
 
 
 def _apply_payload(plan: BackupPlan, payload: BackupPlanPayload) -> None:
+    source_locations = normalize_source_locations(
+        payload.source_locations,
+        source_type=payload.source_type,
+        source_ssh_connection_id=payload.source_ssh_connection_id,
+        source_directories=payload.source_directories,
+    )
+    source_type, source_ssh_connection_id, source_directories = (
+        summarize_legacy_source_fields(source_locations)
+    )
     plan.name = payload.name.strip()
     plan.description = payload.description.strip() if payload.description else None
     plan.enabled = payload.enabled
-    plan.source_type = payload.source_type
-    plan.source_ssh_connection_id = payload.source_ssh_connection_id
-    plan.source_directories = json.dumps(payload.source_directories)
+    plan.source_type = source_type
+    plan.source_ssh_connection_id = source_ssh_connection_id
+    plan.source_directories = json.dumps(source_directories)
+    plan.source_locations = json.dumps(source_locations)
     plan.exclude_patterns = json.dumps(payload.exclude_patterns or [])
     plan.archive_name_template = (
         payload.archive_name_template.strip() or "{plan_name}-{now}"
@@ -934,6 +998,7 @@ async def create_backup_plan_from_repository(
     source_settings_moved = False
     if payload.move_source_settings:
         repository.source_directories = None
+        repository.source_locations = None
         repository.exclude_patterns = None
         repository.source_ssh_connection_id = None
         repository.updated_at = datetime.utcnow()

--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -52,6 +52,12 @@ from app.utils.schedule_time import (
 )
 from app.utils.archive_job_metadata import enrich_archives_with_backup_metadata
 from app.utils.ssh_paths import apply_ssh_command_prefix
+from app.utils.source_locations import (
+    SourceLocationPayload,
+    normalize_source_locations,
+    source_locations_from_record,
+    summarize_legacy_source_fields,
+)
 from app.utils.borg_env import (
     get_standard_ssh_opts as shared_get_standard_ssh_opts,
     setup_borg_env as shared_setup_borg_env,
@@ -681,6 +687,7 @@ class RepositoryCreate(BaseModel):
     compression: str = "lz4"  # lz4, zstd, zlib, none
     passphrase: Optional[str] = None
     source_directories: Optional[List[str]] = None  # List of directories to backup
+    source_locations: Optional[List[SourceLocationPayload]] = None
     exclude_patterns: Optional[List[str]] = (
         None  # List of exclude patterns (e.g., ["*.log", "*.tmp"])
     )
@@ -721,6 +728,7 @@ class RepositoryImport(BaseModel):
     passphrase: Optional[str] = None  # Required if repository is encrypted
     compression: str = "lz4"  # Default compression for future backups
     source_directories: Optional[List[str]] = None  # List of directories to backup
+    source_locations: Optional[List[SourceLocationPayload]] = None
     exclude_patterns: Optional[List[str]] = None  # List of exclude patterns
     connection_id: Optional[int] = None  # SSH connection ID for repository location
     remote_path: Optional[str] = None  # Path to borg on remote server
@@ -757,6 +765,7 @@ class RepositoryUpdate(BaseModel):
     path: Optional[str] = None
     compression: Optional[str] = None
     source_directories: Optional[List[str]] = None
+    source_locations: Optional[List[SourceLocationPayload]] = None
     exclude_patterns: Optional[List[str]] = None
     connection_id: Optional[int] = None  # SSH connection ID for repository location
     remote_path: Optional[str] = None
@@ -794,6 +803,38 @@ class RepositoryInfo(BaseModel):
     is_active: bool
     created_at: str
     updated_at: Optional[str]
+
+
+def _normalized_payload_source_locations(
+    repo_data: Union[RepositoryCreate, RepositoryImport, RepositoryUpdate],
+) -> list[dict[str, Any]]:
+    return normalize_source_locations(
+        repo_data.source_locations,
+        source_type="remote" if repo_data.source_connection_id else "local",
+        source_ssh_connection_id=repo_data.source_connection_id,
+        source_directories=repo_data.source_directories,
+    )
+
+
+def _validate_source_locations(
+    db: Session, source_locations: list[dict[str, Any]]
+) -> None:
+    for location in source_locations:
+        if location["source_type"] not in {"local", "remote"}:
+            raise HTTPException(
+                status_code=400,
+                detail={"key": "backend.errors.backupPlans.invalidSourceType"},
+            )
+        if location["source_type"] == "remote":
+            connection_id = location["source_ssh_connection_id"]
+            if not connection_id:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "key": "backend.errors.backupPlans.sourceConnectionRequired"
+                    },
+                )
+            get_connection_details(connection_id, db)
 
 
 def _uses_borg2_payload(data: Union[RepositoryCreate, RepositoryImport]) -> bool:
@@ -839,6 +880,10 @@ async def get_repositories(
         # Check for running maintenance jobs for each repository
         repo_list = []
         for repo in repositories:
+            source_locations = source_locations_from_record(repo)
+            source_type, source_ssh_connection_id, source_directories = (
+                summarize_legacy_source_fields(source_locations)
+            )
             # Check if this repository has running check, compact, or prune jobs
             has_check = (
                 db.query(CheckJob)
@@ -871,9 +916,9 @@ async def get_repositories(
                     "path": repo.path,
                     "encryption": repo.encryption,
                     "compression": repo.compression,
-                    "source_directories": _decode_json_list_field(
-                        repo.source_directories
-                    ),
+                    "source_directories": source_directories,
+                    "source_type": source_type,
+                    "source_locations": source_locations,
                     "exclude_patterns": _decode_json_list_field(repo.exclude_patterns),
                     "repository_type": repo.repository_type,
                     "host": repo.host,
@@ -908,7 +953,7 @@ async def get_repositories(
                     "schedule_timezone": schedule_summary["schedule_timezone"],
                     "next_run": schedule_summary["next_run"],
                     "has_keyfile": repo.has_keyfile or False,
-                    "source_ssh_connection_id": repo.source_ssh_connection_id,
+                    "source_ssh_connection_id": source_ssh_connection_id,
                     "borg_version": repo.borg_version or 1,
                 }
             )
@@ -1155,10 +1200,11 @@ async def create_repository(
                 detail={"key": "backend.errors.repo.failedToInitializeRepository"},
             )
 
-        # Serialize source directories as JSON
-        source_directories_json = None
-        if repo_data.source_directories:
-            source_directories_json = json.dumps(repo_data.source_directories)
+        source_locations = _normalized_payload_source_locations(repo_data)
+        _validate_source_locations(db, source_locations)
+        _source_type, source_ssh_connection_id, source_directories = (
+            summarize_legacy_source_fields(source_locations)
+        )
 
         # Serialize exclude patterns as JSON
         exclude_patterns_json = None
@@ -1172,7 +1218,10 @@ async def create_repository(
             encryption=repo_data.encryption,
             compression=repo_data.compression,
             passphrase=repo_data.passphrase,  # Store passphrase for backups
-            source_directories=source_directories_json,
+            source_directories=json.dumps(source_directories)
+            if source_directories
+            else None,
+            source_locations=json.dumps(source_locations) if source_locations else None,
             exclude_patterns=exclude_patterns_json,
             connection_id=repo_data.connection_id,
             remote_path=repo_data.remote_path,
@@ -1186,7 +1235,7 @@ async def create_repository(
             mode=repo_data.mode,
             bypass_lock=repo_data.bypass_lock,
             custom_flags=repo_data.custom_flags,
-            source_ssh_connection_id=repo_data.source_connection_id,
+            source_ssh_connection_id=source_ssh_connection_id,
         )
 
         db.add(repository)
@@ -1442,10 +1491,11 @@ async def import_repository(
         repo_info = verify_result.get("info", {})
         encryption_mode = repo_info.get("encryption", {}).get("mode", "unknown")
 
-        # Serialize source directories as JSON
-        source_directories_json = None
-        if repo_data.source_directories:
-            source_directories_json = json.dumps(repo_data.source_directories)
+        source_locations = _normalized_payload_source_locations(repo_data)
+        _validate_source_locations(db, source_locations)
+        _source_type, source_ssh_connection_id, source_directories = (
+            summarize_legacy_source_fields(source_locations)
+        )
 
         # Serialize exclude patterns as JSON
         exclude_patterns_json = None
@@ -1460,7 +1510,10 @@ async def import_repository(
             encryption=encryption_mode,
             compression=repo_data.compression,
             passphrase=repo_data.passphrase,
-            source_directories=source_directories_json,
+            source_directories=json.dumps(source_directories)
+            if source_directories
+            else None,
+            source_locations=json.dumps(source_locations) if source_locations else None,
             exclude_patterns=exclude_patterns_json,
             connection_id=repo_data.connection_id,
             remote_path=repo_data.remote_path,
@@ -1475,7 +1528,7 @@ async def import_repository(
             mode=repo_data.mode,
             bypass_lock=repo_data.bypass_lock,
             custom_flags=repo_data.custom_flags,
-            source_ssh_connection_id=repo_data.source_connection_id,
+            source_ssh_connection_id=source_ssh_connection_id,
         )
 
         db.add(repository)
@@ -1701,6 +1754,10 @@ async def get_repository(
 
         # Get repository statistics
         stats = await get_repository_stats(repository, db, bypass_lock=use_bypass_lock)
+        source_locations = source_locations_from_record(repository)
+        source_type, source_ssh_connection_id, source_directories = (
+            summarize_legacy_source_fields(source_locations)
+        )
 
         return {
             "success": True,
@@ -1716,7 +1773,10 @@ async def get_repository(
                 "created_at": format_datetime(repository.created_at),
                 "updated_at": format_datetime(repository.updated_at),
                 "has_keyfile": repository.has_keyfile or False,
-                "source_ssh_connection_id": repository.source_ssh_connection_id,
+                "source_type": source_type,
+                "source_directories": source_directories,
+                "source_locations": source_locations,
+                "source_ssh_connection_id": source_ssh_connection_id,
                 "stats": stats,
             },
         }
@@ -1946,12 +2006,27 @@ async def update_repository(
         if repo_data.compression is not None:
             repository.compression = repo_data.compression
 
-        if repo_data.source_directories is not None:
-            repository.source_directories = (
-                json.dumps(repo_data.source_directories)
-                if repo_data.source_directories
-                else None
+        source_payload_fields = repo_data.model_dump(exclude_unset=True)
+        if any(
+            field in source_payload_fields
+            for field in (
+                "source_locations",
+                "source_directories",
+                "source_connection_id",
             )
+        ):
+            source_locations = _normalized_payload_source_locations(repo_data)
+            _validate_source_locations(db, source_locations)
+            _source_type, source_ssh_connection_id, source_directories = (
+                summarize_legacy_source_fields(source_locations)
+            )
+            repository.source_directories = (
+                json.dumps(source_directories) if source_directories else None
+            )
+            repository.source_locations = (
+                json.dumps(source_locations) if source_locations else None
+            )
+            repository.source_ssh_connection_id = source_ssh_connection_id
 
         if repo_data.exclude_patterns is not None:
             repository.exclude_patterns = (
@@ -2007,14 +2082,6 @@ async def update_repository(
 
         if repo_data.custom_flags is not None:
             repository.custom_flags = repo_data.custom_flags
-
-        # Update source_connection_id - allow null to clear the field
-        # The frontend always sends this field explicitly (either with value or null)
-        # If not provided in the request body at all, Pydantic sets it to None (default)
-        # Since we can't distinguish "not provided" from "provided as null" with current setup,
-        # and the frontend wizard always sends this field, we check if it's in the request
-        if "source_connection_id" in repo_data.model_dump(exclude_unset=True):
-            repository.source_ssh_connection_id = repo_data.source_connection_id
 
         repository.updated_at = datetime.utcnow()
         db.commit()

--- a/app/api/ssh_keys.py
+++ b/app/api/ssh_keys.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 import asyncio
 import tempfile
+import json
 
 from app.database.database import get_db
 from app.database.models import (
@@ -14,6 +15,7 @@ from app.database.models import (
     SSHKey,
     SSHConnection,
     Repository,
+    BackupPlan,
     BackupJob,
     RestoreJob,
     ScheduledJob,
@@ -22,6 +24,10 @@ from app.core.authorization import authorize_request
 from app.core.security import get_current_user, encrypt_secret, decrypt_secret
 from app.config import settings
 from app.utils.datetime_utils import serialize_datetime
+from app.utils.source_locations import (
+    source_locations_from_record,
+    summarize_legacy_source_fields,
+)
 import hashlib
 
 logger = structlog.get_logger()
@@ -29,6 +35,27 @@ router = APIRouter(tags=["ssh-keys"], dependencies=[Depends(authorize_request)])
 
 
 # Helper functions
+def _remove_source_locations_for_connection(records, connection_id: int) -> None:
+    for record in records:
+        source_locations = [
+            location
+            for location in source_locations_from_record(record)
+            if location["source_ssh_connection_id"] != connection_id
+        ]
+        source_type, source_ssh_connection_id, source_directories = (
+            summarize_legacy_source_fields(source_locations)
+        )
+        if hasattr(record, "source_type"):
+            record.source_type = source_type
+        record.source_ssh_connection_id = source_ssh_connection_id
+        record.source_directories = (
+            json.dumps(source_directories) if source_directories else None
+        )
+        record.source_locations = (
+            json.dumps(source_locations) if source_locations else None
+        )
+
+
 def format_bytes(bytes_size: int) -> str:
     """Format bytes to human readable string (e.g., '1.23 GB')"""
     for unit in ["B", "KB", "MB", "GB", "TB", "PB"]:
@@ -1571,8 +1598,22 @@ async def delete_ssh_connection(
         host = connection.host
 
         # Null out FK references so child records are preserved after deletion
+        _remove_source_locations_for_connection(
+            db.query(Repository).filter(Repository.source_locations.isnot(None)).all(),
+            connection_id,
+        )
+        _remove_source_locations_for_connection(
+            db.query(BackupPlan).filter(BackupPlan.source_locations.isnot(None)).all(),
+            connection_id,
+        )
         db.query(Repository).filter(Repository.connection_id == connection_id).update(
             {"connection_id": None}, synchronize_session=False
+        )
+        db.query(BackupPlan).filter(
+            BackupPlan.source_ssh_connection_id == connection_id
+        ).update(
+            {"source_type": "local", "source_ssh_connection_id": None},
+            synchronize_session=False,
         )
         db.query(Repository).filter(
             Repository.source_ssh_connection_id == connection_id

--- a/app/api/v2/repositories.py
+++ b/app/api/v2/repositories.py
@@ -25,6 +25,11 @@ from app.services.v2.repository_service import repository_v2_service
 from app.utils.fs import calculate_path_size_bytes
 from app.utils.borg_env import repository_borg_env
 from app.utils.archive_job_metadata import enrich_archives_with_backup_metadata
+from app.utils.source_locations import (
+    SourceLocationPayload,
+    normalize_source_locations,
+    summarize_legacy_source_fields,
+)
 
 logger = structlog.get_logger()
 router = APIRouter(tags=["Repositories v2"], dependencies=[require_feature("borg_v2")])
@@ -42,6 +47,7 @@ class RepositoryV2Create(BaseModel):
     connection_id: Optional[int] = None
     remote_path: Optional[str] = None
     source_directories: Optional[list[str]] = None
+    source_locations: Optional[list[SourceLocationPayload]] = None
     exclude_patterns: Optional[list[str]] = None
     mode: str = "full"
     bypass_lock: bool = False
@@ -64,6 +70,7 @@ class RepositoryV2Import(BaseModel):
     connection_id: Optional[int] = None
     remote_path: Optional[str] = None
     source_directories: Optional[list[str]] = None
+    source_locations: Optional[list[SourceLocationPayload]] = None
     exclude_patterns: Optional[list[str]] = None
     mode: str = "full"
     bypass_lock: bool = False
@@ -119,6 +126,46 @@ def _borg_keyfile_name(repo_path: str) -> str:
         else repo_path.lstrip("/")
     )
     return re.sub(r"[^a-zA-Z0-9]", "_", path)
+
+
+def _normalized_payload_source_locations(
+    data: RepositoryV2Create | RepositoryV2Import,
+) -> list[dict]:
+    return normalize_source_locations(
+        data.source_locations,
+        source_type="remote" if data.source_connection_id else "local",
+        source_ssh_connection_id=data.source_connection_id,
+        source_directories=data.source_directories,
+    )
+
+
+def _validate_source_locations(db: Session, source_locations: list[dict]) -> None:
+    for location in source_locations:
+        if location["source_type"] not in {"local", "remote"}:
+            raise HTTPException(
+                status_code=400,
+                detail={"key": "backend.errors.backupPlans.invalidSourceType"},
+            )
+        if location["source_type"] == "remote":
+            connection_id = location["source_ssh_connection_id"]
+            if not connection_id:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "key": "backend.errors.backupPlans.sourceConnectionRequired"
+                    },
+                )
+            from app.database.models import SSHConnection
+
+            if (
+                not db.query(SSHConnection.id)
+                .filter(SSHConnection.id == connection_id)
+                .first()
+            ):
+                raise HTTPException(
+                    status_code=404,
+                    detail={"key": "backend.errors.repo.sshConnectionNotFound"},
+                )
 
 
 async def _rcreate(
@@ -240,9 +287,12 @@ async def create_repository(
             },
         )
 
-    source_dirs_json = (
-        json.dumps(data.source_directories) if data.source_directories else None
+    source_locations = _normalized_payload_source_locations(data)
+    _validate_source_locations(db, source_locations)
+    _source_type, source_ssh_connection_id, source_directories = (
+        summarize_legacy_source_fields(source_locations)
     )
+    source_dirs_json = json.dumps(source_directories) if source_directories else None
     exclude_patterns_json = (
         json.dumps(data.exclude_patterns) if data.exclude_patterns else None
     )
@@ -254,6 +304,7 @@ async def create_repository(
         compression=data.compression,
         passphrase=data.passphrase,
         source_directories=source_dirs_json,
+        source_locations=json.dumps(source_locations) if source_locations else None,
         exclude_patterns=exclude_patterns_json,
         connection_id=data.connection_id,
         remote_path=data.remote_path,
@@ -266,7 +317,7 @@ async def create_repository(
         post_hook_timeout=data.post_hook_timeout,
         continue_on_hook_failure=data.continue_on_hook_failure,
         skip_on_hook_failure=data.skip_on_hook_failure,
-        source_ssh_connection_id=data.source_connection_id,
+        source_ssh_connection_id=source_ssh_connection_id,
         borg_version=2,
         repository_type="ssh" if data.connection_id else "local",
     )
@@ -359,9 +410,12 @@ async def import_repository(
             },
         )
 
-    source_dirs_json = (
-        json.dumps(data.source_directories) if data.source_directories else None
+    source_locations = _normalized_payload_source_locations(data)
+    _validate_source_locations(db, source_locations)
+    _source_type, source_ssh_connection_id, source_directories = (
+        summarize_legacy_source_fields(source_locations)
     )
+    source_dirs_json = json.dumps(source_directories) if source_directories else None
     exclude_patterns_json = (
         json.dumps(data.exclude_patterns) if data.exclude_patterns else None
     )
@@ -373,6 +427,7 @@ async def import_repository(
         compression=data.compression,
         passphrase=data.passphrase,
         source_directories=source_dirs_json,
+        source_locations=json.dumps(source_locations) if source_locations else None,
         exclude_patterns=exclude_patterns_json,
         connection_id=data.connection_id,
         remote_path=data.remote_path,
@@ -385,7 +440,7 @@ async def import_repository(
         post_hook_timeout=data.post_hook_timeout,
         continue_on_hook_failure=data.continue_on_hook_failure,
         skip_on_hook_failure=data.skip_on_hook_failure,
-        source_ssh_connection_id=data.source_connection_id,
+        source_ssh_connection_id=source_ssh_connection_id,
         has_keyfile=bool(keyfile_path),
         borg_version=2,
         repository_type="ssh" if data.connection_id else "local",

--- a/app/database/migrations/104_add_backup_plans.py
+++ b/app/database/migrations/104_add_backup_plans.py
@@ -39,6 +39,7 @@ def upgrade(db):
                     source_type VARCHAR NOT NULL DEFAULT 'local',
                     source_ssh_connection_id INTEGER REFERENCES ssh_connections(id),
                     source_directories TEXT NOT NULL,
+                    source_locations TEXT,
                     exclude_patterns TEXT,
                     archive_name_template VARCHAR NOT NULL DEFAULT '{plan_name}-{now}',
                     compression VARCHAR NOT NULL DEFAULT 'lz4',
@@ -75,6 +76,14 @@ def upgrade(db):
         )
         db.execute(text("CREATE INDEX ix_backup_plans_id ON backup_plans (id)"))
         db.execute(text("CREATE INDEX ix_backup_plans_name ON backup_plans (name)"))
+
+    if _table_exists(db, "backup_plans"):
+        _add_column_if_missing(
+            db,
+            "backup_plans",
+            "source_locations",
+            "source_locations TEXT",
+        )
 
     if not _table_exists(db, "backup_plan_repositories"):
         db.execute(

--- a/app/database/migrations/107_add_source_locations.py
+++ b/app/database/migrations/107_add_source_locations.py
@@ -1,0 +1,46 @@
+"""Add multi-source location JSON fields."""
+
+from sqlalchemy import text
+
+
+def _table_exists(db, table_name: str) -> bool:
+    result = db.execute(
+        text(
+            """
+            SELECT name FROM sqlite_master
+            WHERE type='table' AND name=:table_name
+            """
+        ),
+        {"table_name": table_name},
+    )
+    return result.fetchone() is not None
+
+
+def _columns(db, table_name: str) -> set[str]:
+    result = db.execute(text(f"PRAGMA table_info({table_name})"))
+    return {row[1] for row in result.fetchall()}
+
+
+def _add_column_if_missing(db, table_name: str, column_name: str, ddl: str) -> None:
+    if _table_exists(db, table_name) and column_name not in _columns(db, table_name):
+        db.execute(text(f"ALTER TABLE {table_name} ADD COLUMN {ddl}"))
+
+
+def upgrade(db):
+    _add_column_if_missing(
+        db,
+        "repositories",
+        "source_locations",
+        "source_locations TEXT",
+    )
+    _add_column_if_missing(
+        db,
+        "backup_plans",
+        "source_locations",
+        "source_locations TEXT",
+    )
+    db.commit()
+
+
+def downgrade(db):
+    db.commit()

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -128,6 +128,9 @@ class Repository(Base):
     source_directories = Column(
         Text, nullable=True
     )  # JSON array of directories to backup
+    source_locations = Column(
+        Text, nullable=True
+    )  # JSON array of source location objects to backup
     exclude_patterns = Column(
         Text, nullable=True
     )  # JSON array of exclude patterns (e.g., ["*.log", "*.tmp"])
@@ -585,6 +588,7 @@ class BackupPlan(Base):
         Integer, ForeignKey("ssh_connections.id"), nullable=True
     )
     source_directories = Column(Text, nullable=False)
+    source_locations = Column(Text, nullable=True)
     exclude_patterns = Column(Text, nullable=True)
 
     archive_name_template = Column(String, default="{plan_name}-{now}", nullable=False)

--- a/app/services/backup_plan_execution_service.py
+++ b/app/services/backup_plan_execution_service.py
@@ -38,6 +38,10 @@ from app.services.template_service import get_system_variables
 from app.utils.archive_names import build_archive_name
 from app.utils.script_params import SYSTEM_VARIABLE_PREFIX
 from app.utils.schedule_time import calculate_next_cron_run, to_utc_naive
+from app.utils.source_locations import (
+    source_locations_from_record,
+    summarize_legacy_source_fields,
+)
 
 logger = structlog.get_logger()
 
@@ -61,6 +65,7 @@ class PlanRunContext:
     source_type: str
     source_ssh_connection_id: Optional[int]
     source_directories: list[str]
+    source_locations: list[dict[str, Any]]
     exclude_patterns: list[str]
     archive_name_template: str
     compression: str
@@ -443,12 +448,17 @@ class BackupPlanExecutionService:
                 raise ValueError("Backup plan has no enabled repositories")
 
             now = datetime.now()
+            source_locations = source_locations_from_record(plan)
+            source_type, source_ssh_connection_id, source_directories = (
+                summarize_legacy_source_fields(source_locations)
+            )
             context = PlanRunContext(
                 plan_id=plan.id,
                 plan_name=plan.name,
-                source_type=plan.source_type,
-                source_ssh_connection_id=plan.source_ssh_connection_id,
-                source_directories=_json_list(plan.source_directories),
+                source_type=source_type,
+                source_ssh_connection_id=source_ssh_connection_id,
+                source_directories=source_directories,
+                source_locations=source_locations,
                 exclude_patterns=_json_list(plan.exclude_patterns),
                 archive_name_template=plan.archive_name_template,
                 compression=plan.compression,
@@ -614,7 +624,7 @@ class BackupPlanExecutionService:
                 raise FileNotFoundError(f"Script file not found: {script.file_path}")
 
             source_connection = None
-            if context.source_type == "remote" and context.source_ssh_connection_id:
+            if context.source_ssh_connection_id:
                 source_connection = (
                     db.query(SSHConnection)
                     .filter(SSHConnection.id == context.source_ssh_connection_id)
@@ -643,6 +653,7 @@ class BackupPlanExecutionService:
                     "BORG_UI_SOURCE_DIRECTORIES": json.dumps(
                         context.source_directories
                     ),
+                    "BORG_UI_SOURCE_LOCATIONS": json.dumps(context.source_locations),
                 }
             )
             if source_connection:
@@ -768,11 +779,7 @@ class BackupPlanExecutionService:
                 backup_plan_id=context.plan_id,
                 backup_plan_run_id=run_id,
                 status="pending",
-                source_ssh_connection_id=(
-                    context.source_ssh_connection_id
-                    if context.source_type == "remote"
-                    else None
-                ),
+                source_ssh_connection_id=(context.source_ssh_connection_id),
                 created_at=datetime.utcnow(),
             )
             db.add(backup_job)
@@ -801,11 +808,8 @@ class BackupPlanExecutionService:
                 archive_name=archive_name,
                 skip_hooks=not context.run_repository_scripts,
                 source_directories=context.source_directories,
-                source_ssh_connection_id=(
-                    context.source_ssh_connection_id
-                    if context.source_type == "remote"
-                    else None
-                ),
+                source_ssh_connection_id=(context.source_ssh_connection_id),
+                source_locations=context.source_locations,
                 exclude_patterns_override=context.exclude_patterns,
                 compression_override=repository_context.compression,
                 custom_flags_override=repository_context.custom_flags,

--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -24,6 +24,12 @@ from app.services.restore_check_canary import (
     to_restore_canary_archive_source_path,
 )
 from app.utils.ssh_paths import resolve_sshfs_source_path
+from app.utils.source_locations import (
+    flatten_source_directories,
+    normalize_source_locations,
+    source_locations_from_record,
+    summarize_legacy_source_fields,
+)
 from app.utils.borg_env import (
     build_repository_borg_env,
     cleanup_temp_key_file,
@@ -1256,6 +1262,90 @@ class BackupService:
 
         return backup_paths, backup_cwd
 
+    def _resolve_source_locations_for_backup(
+        self,
+        repo_record: Repository,
+        *,
+        source_locations: list[dict] | None,
+        source_directories: list[str] | None,
+        source_ssh_connection_id: int | None,
+    ) -> list[dict]:
+        if source_locations is not None:
+            return normalize_source_locations(
+                source_locations,
+                source_type="remote" if source_ssh_connection_id else "local",
+                source_ssh_connection_id=source_ssh_connection_id,
+                source_directories=source_directories,
+            )
+        if source_directories is not None:
+            return normalize_source_locations(
+                None,
+                source_type="remote" if source_ssh_connection_id else "local",
+                source_ssh_connection_id=source_ssh_connection_id,
+                source_directories=source_directories,
+            )
+        if source_ssh_connection_id is not None:
+            return normalize_source_locations(
+                None,
+                source_type="remote",
+                source_ssh_connection_id=source_ssh_connection_id,
+                source_directories=repo_record.source_directories,
+            )
+        return source_locations_from_record(repo_record)
+
+    def _build_source_paths_from_locations(
+        self,
+        db: Session,
+        source_locations: list[dict],
+        repository: str,
+    ) -> tuple[list[str], int | None]:
+        from app.database.models import SSHConnection
+
+        source_paths: list[str] = []
+        for location in source_locations:
+            source_dirs = location.get("source_directories") or []
+            if location.get("source_type") == "remote":
+                connection_id = location.get("source_ssh_connection_id")
+                connection = (
+                    db.query(SSHConnection)
+                    .filter(SSHConnection.id == connection_id)
+                    .first()
+                )
+                if not connection:
+                    error_msg = (
+                        f"SSH connection {connection_id} not found for remote source"
+                    )
+                    logger.error(error_msg, repository=repository)
+                    raise ValueError(error_msg)
+
+                source_paths.extend(
+                    f"ssh://{connection.username}@{connection.host}:{connection.port}"
+                    f"{resolve_sshfs_source_path(path, connection.default_path)}"
+                    for path in source_dirs
+                )
+                logger.info(
+                    "Using remote source location (pull-based backup)",
+                    repository=repository,
+                    connection_id=connection.id,
+                    connection_host=connection.host,
+                    source_directories=source_dirs,
+                )
+            else:
+                source_paths.extend(source_dirs)
+                logger.info(
+                    "Using local source location",
+                    repository=repository,
+                    source_directories=source_dirs,
+                )
+
+        source_type, source_ssh_connection_id, _source_directories = (
+            summarize_legacy_source_fields(source_locations)
+        )
+        single_source_ssh_connection_id = (
+            source_ssh_connection_id if source_type == "remote" else None
+        )
+        return source_paths, single_source_ssh_connection_id
+
     async def execute_backup(
         self,
         job_id: int,
@@ -1265,6 +1355,7 @@ class BackupService:
         skip_hooks: bool = False,
         source_directories: list[str] = None,
         source_ssh_connection_id: int = None,
+        source_locations: list[dict] = None,
         exclude_patterns_override: list[str] = None,
         compression_override: str = None,
         custom_flags_override: str = None,
@@ -1326,11 +1417,24 @@ class BackupService:
                 if not repo_record:
                     raise Exception(f"Repository not found: {repository}")
 
-                remote_source_paths = (
-                    source_directories
-                    if source_directories is not None
-                    else json.loads(repo_record.source_directories or "[]")
+                remote_source_locations = self._resolve_source_locations_for_backup(
+                    repo_record,
+                    source_locations=source_locations,
+                    source_directories=source_directories,
+                    source_ssh_connection_id=source_ssh_connection_id
+                    or job.source_ssh_connection_id,
                 )
+                if len(remote_source_locations) != 1:
+                    raise ValueError(
+                        "Remote SSH execution supports one source location. "
+                        "Use local execution for mixed source locations."
+                    )
+                remote_location = remote_source_locations[0]
+                if remote_location["source_type"] != "remote":
+                    raise ValueError(
+                        "Remote SSH execution requires a remote source location."
+                    )
+                remote_source_paths = remote_location["source_directories"]
                 remote_exclude_patterns = (
                     exclude_patterns_override
                     if exclude_patterns_override is not None
@@ -1342,11 +1446,9 @@ class BackupService:
                     if custom_flags_override is not None
                     else repo_record.custom_flags
                 )
-                remote_source_connection_id = (
-                    source_ssh_connection_id
-                    if source_directories is not None
-                    else job.source_ssh_connection_id
-                )
+                remote_source_connection_id = remote_location[
+                    "source_ssh_connection_id"
+                ]
 
                 # Execute remote backup
                 await remote_backup_service.execute_remote_backup(
@@ -1430,7 +1532,7 @@ class BackupService:
             exclude_patterns = []  # Default no exclusions
             compression = "lz4"  # Default compression
             router = None
-            using_source_override = source_directories is not None
+            effective_source_ssh_connection_id = None
             try:
                 repo_record = (
                     db.query(Repository).filter(Repository.path == repository).first()
@@ -1460,71 +1562,26 @@ class BackupService:
                             compression=compression,
                         )
 
-                    if using_source_override:
-                        source_dirs = source_directories or []
-                    elif repo_record.source_directories:
-                        try:
-                            source_dirs = json.loads(repo_record.source_directories)
-                        except json.JSONDecodeError as e:
-                            error_msg = (
-                                f"Could not parse source_directories JSON: {str(e)}"
-                            )
-                            logger.error(error_msg, repository=repository)
-                            raise ValueError(error_msg)
-                    else:
-                        error_msg = "No source directories configured for this repository. Please add source directories in repository settings."
-                        logger.error(error_msg, repository=repository)
-                        raise ValueError(error_msg)
-
-                    if not source_dirs or not isinstance(source_dirs, list):
+                    backup_source_locations = self._resolve_source_locations_for_backup(
+                        repo_record,
+                        source_locations=source_locations,
+                        source_directories=source_directories,
+                        source_ssh_connection_id=source_ssh_connection_id,
+                    )
+                    if not backup_source_locations or not flatten_source_directories(
+                        backup_source_locations
+                    ):
                         error_msg = "No source directories configured for this backup."
                         logger.error(error_msg, repository=repository)
                         raise ValueError(error_msg)
 
-                    effective_source_ssh_connection_id = (
-                        source_ssh_connection_id
-                        if using_source_override
-                        else repo_record.source_ssh_connection_id
+                    source_paths, effective_source_ssh_connection_id = (
+                        self._build_source_paths_from_locations(
+                            db,
+                            backup_source_locations,
+                            repository,
+                        )
                     )
-
-                    # Check if this is a remote source (pull-based backup)
-                    if effective_source_ssh_connection_id:
-                        from app.database.models import SSHConnection
-
-                        connection = (
-                            db.query(SSHConnection)
-                            .filter(
-                                SSHConnection.id == effective_source_ssh_connection_id
-                            )
-                            .first()
-                        )
-
-                        if connection:
-                            # Convert source paths from the SFTP/browsing view into
-                            # executable SSH paths for SSHFS mounts.
-                            source_paths = [
-                                f"ssh://{connection.username}@{connection.host}:{connection.port}{resolve_sshfs_source_path(path, connection.default_path)}"
-                                for path in source_dirs
-                            ]
-                            logger.info(
-                                "Using remote source directories (pull-based backup)",
-                                repository=repository,
-                                connection_id=connection.id,
-                                connection_host=connection.host,
-                                source_directories=source_paths,
-                            )
-                        else:
-                            error_msg = f"SSH connection {effective_source_ssh_connection_id} not found for remote source"
-                            logger.error(error_msg, repository=repository)
-                            raise ValueError(error_msg)
-                    else:
-                        # Local source paths
-                        source_paths = source_dirs
-                        logger.info(
-                            "Using local source directories",
-                            repository=repository,
-                            source_directories=source_paths,
-                        )
 
                     # Parse exclude patterns from JSON if available, or use caller override.
                     if exclude_patterns_override is not None:

--- a/app/utils/source_locations.py
+++ b/app/utils/source_locations.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class SourceLocationPayload(BaseModel):
+    source_type: str = "local"
+    source_ssh_connection_id: Optional[int] = None
+    source_directories: list[str] = Field(default_factory=list)
+
+
+def decode_json_list(value: Any) -> list[Any]:
+    if value in (None, ""):
+        return []
+    if isinstance(value, list):
+        return value
+    try:
+        decoded = json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return []
+    return decoded if isinstance(decoded, list) else []
+
+
+def payload_to_dict(value: Any) -> dict[str, Any]:
+    if hasattr(value, "model_dump"):
+        return value.model_dump()
+    if hasattr(value, "dict"):
+        return value.dict()
+    return dict(value)
+
+
+def normalize_source_locations(
+    source_locations: Any = None,
+    *,
+    source_type: str = "local",
+    source_ssh_connection_id: Optional[int] = None,
+    source_directories: Any = None,
+) -> list[dict[str, Any]]:
+    if source_locations not in (None, ""):
+        raw_locations = decode_json_list(source_locations)
+    else:
+        legacy_directories = decode_json_list(source_directories)
+        raw_locations = (
+            [
+                {
+                    "source_type": source_type,
+                    "source_ssh_connection_id": source_ssh_connection_id,
+                    "source_directories": legacy_directories,
+                }
+            ]
+            if legacy_directories
+            else []
+        )
+
+    normalized: list[dict[str, Any]] = []
+    for raw in raw_locations:
+        if not (
+            isinstance(raw, dict) or hasattr(raw, "model_dump") or hasattr(raw, "dict")
+        ):
+            continue
+        location = payload_to_dict(raw)
+        location_type = location.get("source_type") or "local"
+        connection_id = location.get("source_ssh_connection_id")
+        if connection_id is None:
+            connection_id = location.get("source_connection_id")
+        directories = [
+            path.strip()
+            for path in decode_json_list(location.get("source_directories"))
+            if isinstance(path, str) and path.strip()
+        ]
+        normalized.append(
+            {
+                "source_type": location_type,
+                "source_ssh_connection_id": (
+                    int(connection_id) if connection_id not in (None, "") else None
+                ),
+                "source_directories": directories,
+            }
+        )
+    return normalized
+
+
+def source_locations_from_legacy(
+    *,
+    source_type: str = "local",
+    source_ssh_connection_id: Optional[int] = None,
+    source_directories: Any = None,
+) -> list[dict[str, Any]]:
+    return normalize_source_locations(
+        None,
+        source_type=source_type,
+        source_ssh_connection_id=source_ssh_connection_id,
+        source_directories=source_directories,
+    )
+
+
+def source_locations_from_record(record: Any) -> list[dict[str, Any]]:
+    return normalize_source_locations(
+        getattr(record, "source_locations", None),
+        source_type=getattr(record, "source_type", None) or "local",
+        source_ssh_connection_id=getattr(record, "source_ssh_connection_id", None),
+        source_directories=getattr(record, "source_directories", None),
+    )
+
+
+def flatten_source_directories(source_locations: list[dict[str, Any]]) -> list[str]:
+    return [
+        path
+        for location in source_locations
+        for path in location.get("source_directories", [])
+    ]
+
+
+def summarize_legacy_source_fields(
+    source_locations: list[dict[str, Any]],
+) -> tuple[str, Optional[int], list[str]]:
+    source_directories = flatten_source_directories(source_locations)
+    if len(source_locations) == 1:
+        location = source_locations[0]
+        return (
+            location["source_type"],
+            location["source_ssh_connection_id"]
+            if location["source_type"] == "remote"
+            else None,
+            source_directories,
+        )
+    return "mixed" if source_locations else "local", None, source_directories

--- a/docs/engineering/plans/2026-05-16-multiple-backup-source-locations.md
+++ b/docs/engineering/plans/2026-05-16-multiple-backup-source-locations.md
@@ -1,0 +1,40 @@
+# Multiple Backup Source Locations
+
+## Goal
+
+Allow repository and backup-plan configurations to define more than one source
+location. A source location owns its source type, optional SSH connection, and
+paths, so users can combine local paths with paths from one or more SSH
+connections in a single backup definition.
+
+## Current Signal
+
+The existing backup-plan payload has one `source_type`, one
+`source_ssh_connection_id`, and one shared `source_directories` list. Repository
+payloads follow the same single-location shape with `source_connection_id`.
+That makes mixed local/remote sources impossible to represent.
+
+## Compatibility Model
+
+- Add nullable `source_locations` JSON columns to `repositories` and
+  `backup_plans`.
+- Keep existing single-source fields for older configs and API clients.
+- Serialize `source_locations` for all records. When the new field is empty,
+  derive one location from the legacy fields.
+- When a new payload includes `source_locations`, validate and store it, then
+  mirror a legacy summary into the existing fields for backward compatibility.
+- Runtime backup execution should prefer `source_locations` when present and
+  fall back to the legacy fields.
+
+## Implementation Steps
+
+1. Add shared source-location normalization helpers and database migration.
+2. Update repository and backup-plan APIs to accept, validate, store, and
+   serialize source locations.
+3. Update backup execution to resolve local and per-connection remote source
+   groups through the existing SSHFS mount flow.
+4. Update frontend types, payload builders, repository wizard, backup-plan
+   wizard, review views, and source browsing state.
+5. Add focused backend and frontend tests for mixed local/remote source
+   locations and legacy compatibility.
+6. Run required backend/frontend validation and a local app walkthrough.

--- a/frontend/src/components/RepositoryWizard.tsx
+++ b/frontend/src/components/RepositoryWizard.tsx
@@ -5,21 +5,29 @@ import { FolderOpen, Database, Shield, Settings, CheckCircle } from 'lucide-reac
 import {
   WizardDialog,
   WizardStepLocation,
-  WizardStepDataSource,
   WizardStepSecurity,
   WizardStepRepositoryAdvanced,
   WizardStepBackupConfig,
   WizardStepReview,
 } from './wizard'
+import SourceLocationsInput from './SourceLocationsInput'
 import FileExplorerDialog from './FileExplorerDialog'
 import { sshKeysAPI, RepositoryData } from '../services/api'
 import { useAnalytics } from '../hooks/useAnalytics'
+import {
+  createSourceLocationState,
+  normalizeSourceLocations,
+  summarizeSourceLocations,
+  type SourceLocationState,
+} from '../utils/backupPlanPayload'
+import type { SourceLocation } from '../types'
 
 interface Repository extends RepositoryData {
   id: number
   passphrase?: string
   source_ssh_connection_id?: number | null
   source_directories?: string[]
+  source_locations?: SourceLocation[]
   exclude_patterns?: string[]
   custom_flags?: string | null
   remote_path?: string
@@ -64,6 +72,7 @@ interface WizardState {
   dataSource: 'local' | 'remote'
   sourceSshConnectionId: number | ''
   sourceDirs: string[]
+  sourceLocations: SourceLocationState[]
   // Security step
   encryption: string
   passphrase: string
@@ -91,6 +100,7 @@ const createInitialState = (): WizardState => ({
   dataSource: 'local',
   sourceSshConnectionId: '',
   sourceDirs: [],
+  sourceLocations: [createSourceLocationState()],
   encryption: 'repokey',
   passphrase: '',
   remotePath: '',
@@ -115,7 +125,7 @@ const RepositoryWizard = ({ open, onClose, mode, repository, onSubmit }: Reposit
   // File explorer states
   const [showPathExplorer, setShowPathExplorer] = useState(false)
   const [showSourceExplorer, setShowSourceExplorer] = useState(false)
-  const [showRemoteSourceExplorer, setShowRemoteSourceExplorer] = useState(false)
+  const [activeSourceLocationIndex, setActiveSourceLocationIndex] = useState(0)
   const [showExcludeExplorer, setShowExcludeExplorer] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const showLegacyBackupSteps =
@@ -123,6 +133,7 @@ const RepositoryWizard = ({ open, onClose, mode, repository, onSubmit }: Reposit
     wizardState.repositoryMode === 'full' &&
     Boolean(
       repository?.source_directories?.length ||
+      repository?.source_locations?.length ||
       repository?.exclude_patterns?.length ||
       repository?.source_ssh_connection_id ||
       repository?.custom_flags ||
@@ -212,6 +223,30 @@ const RepositoryWizard = ({ open, onClose, mode, repository, onSubmit }: Reposit
         : repository.repository_type === 'ssh' || (repository.path || '').startsWith('ssh://') // Legacy fallback
 
     const repoVersion = (repository.borg_version === 2 ? 2 : 1) as 1 | 2
+    const sourceLocations =
+      repository.source_locations && repository.source_locations.length > 0
+        ? repository.source_locations.map((location) =>
+            createSourceLocationState({
+              sourceType: location.source_type,
+              sourceSshConnectionId: location.source_ssh_connection_id || '',
+              sourceDirectories: location.source_directories || [],
+            })
+          )
+        : [
+            createSourceLocationState({
+              sourceType: repository.source_ssh_connection_id ? 'remote' : 'local',
+              sourceSshConnectionId: repository.source_ssh_connection_id || '',
+              sourceDirectories: repository.source_directories || [],
+            }),
+          ]
+    const sourceSummary = summarizeSourceLocations(
+      normalizeSourceLocations({
+        sourceType: repository.source_ssh_connection_id ? 'remote' : 'local',
+        sourceSshConnectionId: repository.source_ssh_connection_id || '',
+        sourceDirectories: repository.source_directories || [],
+        sourceLocations,
+      })
+    )
     setWizardState({
       name: repository.name || '',
       borgVersion: repoVersion,
@@ -220,9 +255,10 @@ const RepositoryWizard = ({ open, onClose, mode, repository, onSubmit }: Reposit
       path: repoPath,
       repoSshConnectionId: repository.connection_id || '',
       bypassLock: repository.bypass_lock || false,
-      dataSource: repository.source_ssh_connection_id ? 'remote' : 'local',
-      sourceSshConnectionId: repository.source_ssh_connection_id || '',
-      sourceDirs: repository.source_directories || [],
+      dataSource: sourceSummary.sourceType === 'remote' ? 'remote' : 'local',
+      sourceSshConnectionId: sourceSummary.sourceSshConnectionId || '',
+      sourceDirs: sourceSummary.sourceDirectories,
+      sourceLocations,
       encryption: repository.encryption || (repoVersion === 2 ? 'repokey-aes-ocb' : 'repokey'),
       passphrase: repository.passphrase || '',
       remotePath: repository.remote_path || '',
@@ -309,67 +345,19 @@ const RepositoryWizard = ({ open, onClose, mode, repository, onSubmit }: Reposit
     handleStateChange({ path: newPath })
   }
 
-  const normalizeSourceDirs = (
-    paths: string[]
-  ): { processedPaths: string[]; detectedSshConnectionId: number | '' } => {
-    const processedPaths: string[] = []
-    let detectedSshConnection: SSHConnection | null = null
-
-    for (const p of paths) {
-      if (p.startsWith('ssh://')) {
-        const matchWithPort = p.match(/^ssh:\/\/([^@]+)@([^:/]+):(\d+)(\/.*)$/)
-        const matchWithoutPort = p.match(/^ssh:\/\/([^@]+)@([^/]+)(\/.*)$/)
-
-        if (matchWithPort) {
-          const [, parsedUsername, parsedHost, parsedPort, remotePath] = matchWithPort
-          if (!detectedSshConnection) {
-            detectedSshConnection =
-              sshConnections.find(
-                (c) =>
-                  c.username === parsedUsername &&
-                  c.host === parsedHost &&
-                  c.port === parseInt(parsedPort)
-              ) || null
-          }
-          processedPaths.push(remotePath || '/')
-        } else if (matchWithoutPort) {
-          const [, parsedUsername, parsedHost, remotePath] = matchWithoutPort
-          if (!detectedSshConnection) {
-            detectedSshConnection =
-              sshConnections.find(
-                (c) => c.username === parsedUsername && c.host === parsedHost && c.port === 22
-              ) || null
-          }
-          processedPaths.push(remotePath || '/')
-        } else {
-          processedPaths.push(p)
-        }
-      } else {
-        processedPaths.push(p)
-      }
-    }
-
-    return {
-      processedPaths,
-      detectedSshConnectionId: detectedSshConnection?.id ?? '',
-    }
-  }
-
-  // Handle source directories change with SSH URL detection
-  const handleSourceDirsChange = (paths: string[]) => {
-    const { processedPaths, detectedSshConnectionId } = normalizeSourceDirs(paths)
-
-    if (detectedSshConnectionId) {
-      handleStateChange({
-        dataSource: 'remote',
-        sourceSshConnectionId: detectedSshConnectionId,
-        sourceDirs: [...wizardState.sourceDirs, ...processedPaths],
-      })
-      return
-    }
-
+  const applySourceLocations = (sourceLocations: SourceLocationState[]) => {
+    const normalized = normalizeSourceLocations({
+      sourceType: wizardState.dataSource,
+      sourceSshConnectionId: wizardState.sourceSshConnectionId,
+      sourceDirectories: wizardState.sourceDirs,
+      sourceLocations,
+    })
+    const summary = summarizeSourceLocations(normalized)
     handleStateChange({
-      sourceDirs: [...wizardState.sourceDirs, ...processedPaths],
+      sourceLocations,
+      dataSource: summary.sourceType === 'remote' ? 'remote' : 'local',
+      sourceSshConnectionId: summary.sourceSshConnectionId || '',
+      sourceDirs: summary.sourceDirectories,
     })
   }
 
@@ -438,7 +426,12 @@ const RepositoryWizard = ({ open, onClose, mode, repository, onSubmit }: Reposit
         return true
 
       case 'source':
-        if (wizardState.dataSource === 'remote' && !wizardState.sourceSshConnectionId) return false
+        if (
+          wizardState.sourceLocations.some(
+            (location) => location.sourceType === 'remote' && !location.sourceSshConnectionId
+          )
+        )
+          return false
         return true
 
       case 'security':
@@ -465,6 +458,13 @@ const RepositoryWizard = ({ open, onClose, mode, repository, onSubmit }: Reposit
   }
 
   const handleSubmit = async () => {
+    const sourceLocations = normalizeSourceLocations({
+      sourceType: wizardState.dataSource,
+      sourceSshConnectionId: wizardState.sourceSshConnectionId,
+      sourceDirectories: wizardState.sourceDirs,
+      sourceLocations: wizardState.sourceLocations,
+    })
+    const sourceSummary = summarizeSourceLocations(sourceLocations)
     const data: RepositoryData = {
       name: wizardState.name,
       borg_version: wizardState.borgVersion,
@@ -473,7 +473,15 @@ const RepositoryWizard = ({ open, onClose, mode, repository, onSubmit }: Reposit
       encryption: wizardState.encryption,
       passphrase: wizardState.passphrase,
       compression: wizardState.compression,
-      source_directories: wizardState.sourceDirs,
+      source_directories: sourceSummary.sourceDirectories,
+      source_locations: sourceLocations.map((location) => ({
+        source_type: location.sourceType,
+        source_ssh_connection_id:
+          location.sourceType === 'remote' && location.sourceSshConnectionId
+            ? Number(location.sourceSshConnectionId)
+            : null,
+        source_directories: location.sourceDirectories,
+      })),
       exclude_patterns: wizardState.excludePatterns,
       custom_flags: wizardState.customFlags,
       remote_path: wizardState.remotePath,
@@ -486,10 +494,7 @@ const RepositoryWizard = ({ open, onClose, mode, repository, onSubmit }: Reposit
       bypass_lock: wizardState.bypassLock,
       // Connection IDs - single source of truth for SSH
       connection_id: wizardState.repoSshConnectionId || null,
-      source_connection_id:
-        wizardState.dataSource === 'remote' && wizardState.sourceSshConnectionId
-          ? wizardState.sourceSshConnectionId
-          : null,
+      source_connection_id: sourceSummary.sourceSshConnectionId,
     }
 
     track(
@@ -562,38 +567,19 @@ const RepositoryWizard = ({ open, onClose, mode, repository, onSubmit }: Reposit
 
       case 'source':
         return (
-          <WizardStepDataSource
+          <SourceLocationsInput
             repositoryLocation={wizardState.repositoryLocation}
             repoSshConnectionId={wizardState.repoSshConnectionId}
-            repositoryMode={wizardState.repositoryMode}
-            data={{
-              dataSource: wizardState.dataSource,
-              sourceSshConnectionId: wizardState.sourceSshConnectionId,
-              sourceDirs: wizardState.sourceDirs,
-            }}
+            sourceLocations={wizardState.sourceLocations}
             sshConnections={sshConnections}
-            onChange={(updates) => {
-              if (updates.sourceDirs) {
-                const { processedPaths, detectedSshConnectionId } = normalizeSourceDirs(
-                  updates.sourceDirs
-                )
-                handleStateChange({
-                  ...updates,
-                  dataSource: detectedSshConnectionId
-                    ? 'remote'
-                    : (updates.dataSource ?? wizardState.dataSource),
-                  sourceSshConnectionId:
-                    detectedSshConnectionId || updates.sourceSshConnectionId || '',
-                  sourceDirs: processedPaths,
-                })
-                return
-              }
-
-              handleStateChange(updates)
+            onChange={(sourceLocations) => {
+              applySourceLocations(sourceLocations)
             }}
-            onBrowseSource={() => setShowSourceExplorer(true)}
-            onBrowseRemoteSource={() => setShowRemoteSourceExplorer(true)}
-            sourceRequired={false}
+            onBrowse={(sourceLocationIndex) => {
+              setActiveSourceLocationIndex(sourceLocationIndex)
+              setShowSourceExplorer(true)
+            }}
+            required={false}
           />
         )
 
@@ -684,6 +670,14 @@ const RepositoryWizard = ({ open, onClose, mode, repository, onSubmit }: Reposit
         return null
     }
   }
+
+  const activeSourceLocation = wizardState.sourceLocations[activeSourceLocationIndex] || null
+  const activeSourceConnection =
+    activeSourceLocation?.sourceType === 'remote' && activeSourceLocation.sourceSshConnectionId
+      ? sshConnections.find(
+          (connection) => connection.id === activeSourceLocation.sourceSshConnectionId
+        )
+      : null
 
   return (
     <>
@@ -784,62 +778,48 @@ const RepositoryWizard = ({ open, onClose, mode, repository, onSubmit }: Reposit
       />
 
       <FileExplorerDialog
+        key={`source-explorer-${activeSourceLocation?.sourceType || 'local'}-${
+          activeSourceLocation?.sourceSshConnectionId || 'local'
+        }`}
         open={showSourceExplorer}
         onClose={() => setShowSourceExplorer(false)}
         onSelect={(paths) => {
-          handleSourceDirsChange(paths)
+          const nextSourceLocations = wizardState.sourceLocations.map((location, index) =>
+            index === activeSourceLocationIndex
+              ? {
+                  ...location,
+                  sourceDirectories: [...location.sourceDirectories, ...paths],
+                }
+              : location
+          )
+          applySourceLocations(nextSourceLocations)
           setShowSourceExplorer(false)
         }}
         title={
-          wizardState.sourceSshConnectionId && wizardState.dataSource === 'local'
-            ? t('repositoryWizard.fileExplorer.selectSourceDirsRemote')
+          activeSourceLocation?.sourceType === 'remote'
+            ? t('repositoryWizard.fileExplorer.selectSourceDirsOrFilesRemote')
             : t('repositoryWizard.fileExplorer.selectSourceDirs')
         }
-        initialPath="/"
+        initialPath={
+          activeSourceLocation?.sourceType === 'remote'
+            ? activeSourceConnection?.default_path || '/'
+            : '/'
+        }
         multiSelect={true}
-        connectionType="local"
-        selectMode="both"
-        showSshMountPoints={
-          wizardState.repositoryLocation !== 'ssh' &&
-          (!!wizardState.sourceSshConnectionId || wizardState.sourceDirs.length === 0)
-        }
-        allowedSshConnectionId={
-          wizardState.dataSource === 'local' ? wizardState.sourceSshConnectionId || null : null
-        }
-      />
-
-      {showRemoteSourceExplorer &&
-        wizardState.sourceSshConnectionId &&
-        (() => {
-          const conn = sshConnections.find((c) => c.id === wizardState.sourceSshConnectionId)
-          const config = conn
+        connectionType={activeSourceLocation?.sourceType === 'remote' ? 'ssh' : 'local'}
+        sshConfig={
+          activeSourceLocation?.sourceType === 'remote' && activeSourceConnection
             ? {
-                ssh_key_id: conn.ssh_key_id,
-                host: conn.host,
-                username: conn.username,
-                port: conn.port,
+                ssh_key_id: activeSourceConnection.ssh_key_id,
+                host: activeSourceConnection.host,
+                username: activeSourceConnection.username,
+                port: activeSourceConnection.port,
               }
             : undefined
-
-          return (
-            <FileExplorerDialog
-              open={true}
-              onClose={() => setShowRemoteSourceExplorer(false)}
-              onSelect={(paths) => {
-                handleStateChange({
-                  sourceDirs: [...wizardState.sourceDirs, ...paths],
-                })
-                setShowRemoteSourceExplorer(false)
-              }}
-              title={t('repositoryWizard.fileExplorer.selectSourceDirsOrFilesRemote')}
-              initialPath="/"
-              multiSelect={true}
-              connectionType="ssh"
-              sshConfig={config}
-              selectMode="both"
-            />
-          )
-        })()}
+        }
+        selectMode="both"
+        showSshMountPoints={false}
+      />
 
       {showExcludeExplorer &&
         (() => {

--- a/frontend/src/components/SourceLocationsInput.tsx
+++ b/frontend/src/components/SourceLocationsInput.tsx
@@ -1,0 +1,223 @@
+import {
+  Alert,
+  Box,
+  Button,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import { HardDrive, Laptop, Plus, Trash2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import type { SourceLocationState } from '../utils/backupPlanPayload'
+import SourceDirectoriesInput from './SourceDirectoriesInput'
+
+interface SSHConnection {
+  id: number
+  host: string
+  username: string
+  port: number
+  ssh_key_id: number
+  default_path?: string
+  mount_point?: string
+  status: string
+}
+
+interface SourceLocationsInputProps {
+  sourceLocations: SourceLocationState[]
+  sshConnections: SSHConnection[]
+  onChange: (sourceLocations: SourceLocationState[]) => void
+  onBrowse: (index: number) => void
+  repositoryLocation?: 'local' | 'ssh'
+  repoSshConnectionId?: number | ''
+  required?: boolean
+}
+
+export default function SourceLocationsInput({
+  sourceLocations,
+  sshConnections,
+  onChange,
+  onBrowse,
+  repositoryLocation = 'local',
+  repoSshConnectionId = '',
+  required = true,
+}: SourceLocationsInputProps) {
+  const { t } = useTranslation()
+  const locations = sourceLocations.length > 0 ? sourceLocations : []
+  const remoteDisabled = repositoryLocation === 'ssh'
+  const availableConnections = sshConnections.filter((connection) => {
+    if (repositoryLocation === 'ssh' && repoSshConnectionId) {
+      return connection.id === repoSshConnectionId
+    }
+    return true
+  })
+
+  const updateLocation = (index: number, updates: Partial<SourceLocationState>) => {
+    onChange(locations.map((location, i) => (i === index ? { ...location, ...updates } : location)))
+  }
+
+  const removeLocation = (index: number) => {
+    onChange(locations.filter((_, i) => i !== index))
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Stack spacing={1}>
+        <Typography variant="subtitle2">{t('sourceLocations.title')}</Typography>
+        <Typography variant="caption" color="text.secondary">
+          {t('sourceLocations.subtitle')}
+        </Typography>
+      </Stack>
+
+      {locations.map((location, index) => {
+        const isRemote = location.sourceType === 'remote'
+        return (
+          <Box
+            key={location.id}
+            sx={{
+              border: 1,
+              borderColor: 'divider',
+              borderRadius: 1,
+              p: 2,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 2,
+              bgcolor: 'background.paper',
+            }}
+          >
+            <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1}>
+              <Stack direction="row" alignItems="center" spacing={1} sx={{ minWidth: 0 }}>
+                {isRemote ? <Laptop size={16} /> : <HardDrive size={16} />}
+                <Typography variant="subtitle2" noWrap>
+                  {t('sourceLocations.sourceLabel', { count: index + 1 })}
+                </Typography>
+              </Stack>
+              {locations.length > 1 && (
+                <Tooltip title={t('sourceLocations.remove')} arrow>
+                  <IconButton
+                    size="small"
+                    onClick={() => removeLocation(index)}
+                    aria-label={t('sourceLocations.remove')}
+                  >
+                    <Trash2 size={16} />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </Stack>
+
+            <ToggleButtonGroup
+              size="small"
+              exclusive
+              value={location.sourceType}
+              onChange={(_, value: 'local' | 'remote' | null) => {
+                if (!value || (value === 'remote' && remoteDisabled)) return
+                updateLocation(index, {
+                  sourceType: value,
+                  sourceSshConnectionId: value === 'remote' ? location.sourceSshConnectionId : '',
+                  sourceDirectories: [],
+                })
+              }}
+              aria-label={t('sourceLocations.type')}
+            >
+              <ToggleButton value="local">
+                <HardDrive size={14} />
+                <Box component="span" sx={{ ml: 0.75 }}>
+                  {t('sourceLocations.local')}
+                </Box>
+              </ToggleButton>
+              <ToggleButton value="remote" disabled={remoteDisabled}>
+                <Laptop size={14} />
+                <Box component="span" sx={{ ml: 0.75 }}>
+                  {t('sourceLocations.remote')}
+                </Box>
+              </ToggleButton>
+            </ToggleButtonGroup>
+
+            {remoteDisabled && (
+              <Alert severity="info">{t('wizard.dataSource.remoteToRemoteBody')}</Alert>
+            )}
+
+            {isRemote && !remoteDisabled && (
+              <>
+                {!Array.isArray(sshConnections) || sshConnections.length === 0 ? (
+                  <Alert severity="warning">{t('wizard.noSshConnections')}</Alert>
+                ) : (
+                  <FormControl fullWidth>
+                    <InputLabel>{t('wizard.dataSource.selectRemoteClient')}</InputLabel>
+                    <Select
+                      value={
+                        location.sourceSshConnectionId === ''
+                          ? ''
+                          : String(location.sourceSshConnectionId)
+                      }
+                      label={t('wizard.dataSource.selectRemoteClient')}
+                      onChange={(event) => {
+                        updateLocation(index, {
+                          sourceSshConnectionId: Number(event.target.value),
+                          sourceDirectories: [],
+                        })
+                      }}
+                    >
+                      {availableConnections.map((connection) => (
+                        <MenuItem key={connection.id} value={String(connection.id)}>
+                          <Stack direction="row" spacing={1} alignItems="center">
+                            <Laptop size={16} />
+                            <Box>
+                              <Typography variant="body2">
+                                {connection.username}@{connection.host}
+                              </Typography>
+                              <Typography variant="caption" color="text.secondary">
+                                Port {connection.port}
+                              </Typography>
+                            </Box>
+                          </Stack>
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                )}
+              </>
+            )}
+
+            {(!isRemote || location.sourceSshConnectionId) && (
+              <SourceDirectoriesInput
+                directories={location.sourceDirectories}
+                onChange={(sourceDirectories) => updateLocation(index, { sourceDirectories })}
+                onBrowseClick={() => onBrowse(index)}
+                required={required}
+              />
+            )}
+          </Box>
+        )
+      })}
+
+      <Button
+        variant="outlined"
+        startIcon={<Plus size={16} />}
+        onClick={() =>
+          onChange([
+            ...locations,
+            {
+              id:
+                globalThis.crypto?.randomUUID?.() ||
+                `source-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+              sourceType: 'local',
+              sourceSshConnectionId: '',
+              sourceDirectories: [],
+            },
+          ])
+        }
+        sx={{ alignSelf: 'flex-start' }}
+      >
+        {t('sourceLocations.add')}
+      </Button>
+    </Box>
+  )
+}

--- a/frontend/src/components/__tests__/RepositoryWizard.test.tsx
+++ b/frontend/src/components/__tests__/RepositoryWizard.test.tsx
@@ -303,7 +303,7 @@ describe('RepositoryWizard', () => {
           null
         )
       })
-    })
+    }, 45000)
   })
 
   describe('import mode', () => {
@@ -397,7 +397,7 @@ describe('RepositoryWizard', () => {
       expect(mockTrackRepository).toHaveBeenCalledWith('upload', {
         name: 'Imported Keyfile Repo',
       })
-    })
+    }, 45000)
 
     it('submits observability-only imports with bypass lock', async () => {
       const user = userEvent.setup()
@@ -434,7 +434,7 @@ describe('RepositoryWizard', () => {
           null
         )
       })
-    })
+    }, 45000)
   })
 
   describe('legacy edit mode', () => {
@@ -474,7 +474,7 @@ describe('RepositoryWizard', () => {
 
       await user.click(screen.getByRole('button', { name: /Next/i }))
       await waitFor(() => {
-        expect(screen.getByText(/Where is the data you want to back up/i)).toBeInTheDocument()
+        expect(screen.getByText(/Source Locations/i)).toBeInTheDocument()
       })
       await user.click(screen.getByRole('button', { name: /Next/i }))
       await waitFor(() => {
@@ -494,7 +494,7 @@ describe('RepositoryWizard', () => {
 
       await user.click(screen.getByRole('button', { name: /Next/i }))
       await waitFor(() => {
-        expect(screen.getByText(/Where is the data you want to back up/i)).toBeInTheDocument()
+        expect(screen.getByText(/Source Locations/i)).toBeInTheDocument()
       })
       await user.click(screen.getByRole('button', { name: /Next/i }))
       await waitFor(() => {
@@ -513,7 +513,7 @@ describe('RepositoryWizard', () => {
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /Save Changes/i })).toBeInTheDocument()
       })
-    })
+    }, 45000)
   })
 
   describe('SSH and loading behavior', () => {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -589,7 +589,8 @@
       "scheduled": "Geplant",
       "manual": "Nur manuell",
       "localSource": "Lokale Quelle",
-      "remoteSource": "Remote-Quelle"
+      "remoteSource": "Remote-Quelle",
+      "mixedSource": "Gemischte Quellen"
     },
     "noMatch": {
       "title": "Keine passenden Backup-Pläne",
@@ -622,6 +623,7 @@
       "sourcePathCount_other": "{{count}} Quellpfade",
       "localSource": "Lokale Quelle",
       "remoteSource": "Remote-Quelle",
+      "mixedSource": "Gemischte Quellen",
       "manualOnly": "Nur manuell",
       "nextRunBadge": "Nächster Lauf {{when}}",
       "scheduledBadge": "Geplant",
@@ -2445,6 +2447,17 @@
     "placeholder": "/home/benutzer/dokumente oder /var/log/app.log",
     "browseTitle": "Verzeichnisse und Dateien durchsuchen",
     "add": "Hinzufügen"
+  },
+  "sourceLocations": {
+    "title": "Quellorte",
+    "subtitle": "Kombiniere lokale und SSH-Quellen in einer Sicherung.",
+    "sourceLabel": "Quelle {{index}}",
+    "remove": "Quelle entfernen",
+    "type": "Quelltyp",
+    "local": "Lokal",
+    "remote": "SSH",
+    "mixed": "Gemischt",
+    "add": "Quelle hinzufügen"
   },
   "excludePatterns": {
     "title": "Ausschlussmuster (Optional)",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -589,7 +589,8 @@
       "scheduled": "Scheduled",
       "manual": "Manual only",
       "localSource": "Local source",
-      "remoteSource": "Remote source"
+      "remoteSource": "Remote source",
+      "mixedSource": "Mixed sources"
     },
     "noMatch": {
       "title": "No matching backup plans",
@@ -622,6 +623,7 @@
       "sourcePathCount_other": "{{count}} source paths",
       "localSource": "Local source",
       "remoteSource": "Remote source",
+      "mixedSource": "Mixed sources",
       "manualOnly": "Manual only",
       "nextRunBadge": "Next {{when}}",
       "scheduledBadge": "Scheduled",
@@ -2445,6 +2447,17 @@
     "placeholder": "/home/user/documents or /var/log/app.log",
     "browseTitle": "Browse directories and files",
     "add": "Add"
+  },
+  "sourceLocations": {
+    "title": "Source Locations",
+    "subtitle": "Combine local and SSH sources in one backup.",
+    "sourceLabel": "Source {{index}}",
+    "remove": "Remove source",
+    "type": "Source type",
+    "local": "Local",
+    "remote": "SSH",
+    "mixed": "Mixed",
+    "add": "Add source"
   },
   "excludePatterns": {
     "title": "Exclude Patterns (Optional)",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -589,7 +589,8 @@
       "scheduled": "Programados",
       "manual": "Solo manual",
       "localSource": "Origen local",
-      "remoteSource": "Origen remoto"
+      "remoteSource": "Origen remoto",
+      "mixedSource": "Origenes mixtos"
     },
     "noMatch": {
       "title": "No hay planes de copia coincidentes",
@@ -622,6 +623,7 @@
       "sourcePathCount_other": "{{count}} rutas de origen",
       "localSource": "Origen local",
       "remoteSource": "Origen remoto",
+      "mixedSource": "Origenes mixtos",
       "manualOnly": "Solo manual",
       "nextRunBadge": "Próxima {{when}}",
       "scheduledBadge": "Programado",
@@ -2445,6 +2447,17 @@
     "placeholder": "/home/usuario/documentos o /var/log/app.log",
     "browseTitle": "Explorar directorios y archivos",
     "add": "Agregar"
+  },
+  "sourceLocations": {
+    "title": "Ubicaciones de origen",
+    "subtitle": "Combina origenes locales y SSH en una copia.",
+    "sourceLabel": "Origen {{index}}",
+    "remove": "Eliminar origen",
+    "type": "Tipo de origen",
+    "local": "Local",
+    "remote": "SSH",
+    "mixed": "Mixto",
+    "add": "Agregar origen"
   },
   "excludePatterns": {
     "title": "Patrones de exclusión (Opcional)",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -589,7 +589,8 @@
       "scheduled": "Pianificati",
       "manual": "Solo manuale",
       "localSource": "Origine locale",
-      "remoteSource": "Origine remota"
+      "remoteSource": "Origine remota",
+      "mixedSource": "Origini miste"
     },
     "noMatch": {
       "title": "Nessun piano di backup corrispondente",
@@ -622,6 +623,7 @@
       "sourcePathCount_other": "{{count}} percorsi sorgente",
       "localSource": "Sorgente locale",
       "remoteSource": "Sorgente remota",
+      "mixedSource": "Origini miste",
       "manualOnly": "Solo manuale",
       "nextRunBadge": "Prossima {{when}}",
       "scheduledBadge": "Pianificato",
@@ -2445,6 +2447,17 @@
     "placeholder": "/home/utente/documenti o /var/log/app.log",
     "browseTitle": "Sfoglia directory e file",
     "add": "Aggiungi"
+  },
+  "sourceLocations": {
+    "title": "Posizioni di origine",
+    "subtitle": "Combina origini locali e SSH in un backup.",
+    "sourceLabel": "Origine {{index}}",
+    "remove": "Rimuovi origine",
+    "type": "Tipo di origine",
+    "local": "Locale",
+    "remote": "SSH",
+    "mixed": "Miste",
+    "add": "Aggiungi origine"
   },
   "excludePatterns": {
     "title": "Pattern di Esclusione (Opzionale)",

--- a/frontend/src/pages/BackupPlans.tsx
+++ b/frontend/src/pages/BackupPlans.tsx
@@ -23,7 +23,12 @@ import {
 import { BorgApiClient } from '../services/borgApi'
 import { usePlan } from '../hooks/usePlan'
 import { translateBackendKey } from '../utils/translateBackendKey'
-import { buildBackupPlanPayload } from '../utils/backupPlanPayload'
+import {
+  buildBackupPlanPayload,
+  normalizeSourceLocations,
+  summarizeSourceLocations,
+  type SourceLocationState,
+} from '../utils/backupPlanPayload'
 import {
   applyRepositorySelectionLimit,
   isRepositorySelectionOverLimit,
@@ -97,6 +102,7 @@ export default function BackupPlans() {
     createInitialBasicRepositoryState()
   )
   const [showSourceExplorer, setShowSourceExplorer] = useState(false)
+  const [activeSourceLocationIndex, setActiveSourceLocationIndex] = useState(0)
   const [showExcludeExplorer, setShowExcludeExplorer] = useState(false)
   const [showBasicRepositoryPathExplorer, setShowBasicRepositoryPathExplorer] = useState(false)
   const [startingPlanId, setStartingPlanId] = useState<number | null>(null)
@@ -199,9 +205,11 @@ export default function BackupPlans() {
     } else if (groupBy === 'source') {
       const local = sorted.filter((p) => p.source_type === 'local')
       const remote = sorted.filter((p) => p.source_type === 'remote')
+      const mixed = sorted.filter((p) => p.source_type === 'mixed')
       if (local.length > 0) groups.push({ name: t('backupPlans.groups.localSource'), plans: local })
       if (remote.length > 0)
         groups.push({ name: t('backupPlans.groups.remoteSource'), plans: remote })
+      if (mixed.length > 0) groups.push({ name: t('backupPlans.groups.mixedSource'), plans: mixed })
     }
 
     return { groups: groups.length > 0 ? groups : [{ name: null as string | null, plans: sorted }] }
@@ -244,17 +252,28 @@ export default function BackupPlans() {
         : null,
     [sshConnections, wizardState.sourceSshConnectionId]
   )
+  const sourceLocationsState = wizardState.sourceLocations || []
+  const activeSourceLocation = sourceLocationsState[activeSourceLocationIndex] || null
+  const activeSourceConnection = useMemo(
+    () =>
+      activeSourceLocation?.sourceType === 'remote' && activeSourceLocation.sourceSshConnectionId
+        ? sshConnections.find(
+            (connection) => connection.id === activeSourceLocation.sourceSshConnectionId
+          ) || null
+        : null,
+    [activeSourceLocation, sshConnections]
+  )
   const sourceExplorerSshConfig = useMemo(
     () =>
-      selectedSourceConnection
+      activeSourceConnection
         ? {
-            ssh_key_id: selectedSourceConnection.ssh_key_id,
-            host: selectedSourceConnection.host,
-            username: selectedSourceConnection.username,
-            port: selectedSourceConnection.port,
+            ssh_key_id: activeSourceConnection.ssh_key_id,
+            host: activeSourceConnection.host,
+            username: activeSourceConnection.username,
+            port: activeSourceConnection.port,
           }
         : undefined,
-    [selectedSourceConnection]
+    [activeSourceConnection]
   )
   const wizardSteps = useMemo(
     () =>
@@ -291,6 +310,7 @@ export default function BackupPlans() {
     setBasicRepositoryState(createInitialBasicRepositoryState())
     setBasicRepositoryOpen(false)
     setShowSourceExplorer(false)
+    setActiveSourceLocationIndex(0)
     setShowExcludeExplorer(false)
     setShowBasicRepositoryPathExplorer(false)
     setActiveStep(0)
@@ -440,6 +460,7 @@ export default function BackupPlans() {
     setBasicRepositoryState(createInitialBasicRepositoryState())
     setBasicRepositoryOpen(false)
     setShowSourceExplorer(false)
+    setActiveSourceLocationIndex(0)
     setShowExcludeExplorer(false)
     setShowBasicRepositoryPathExplorer(false)
     setLegacySourceReviewOpen(false)
@@ -455,6 +476,7 @@ export default function BackupPlans() {
     setBasicRepositoryState(createInitialBasicRepositoryState())
     setBasicRepositoryOpen(false)
     setLegacySourceReviewOpen(false)
+    setActiveSourceLocationIndex(0)
     setActiveStep(0)
     setWizardOpen(true)
   }
@@ -479,14 +501,30 @@ export default function BackupPlans() {
     ]
   }
 
-  const requireRemoteSourceConnection = () => {
-    if (wizardState.sourceType !== 'remote' || selectedSourceConnection) return true
+  const applySourceLocations = (sourceLocations: SourceLocationState[]) => {
+    const normalized = normalizeSourceLocations({
+      ...wizardState,
+      sourceLocations,
+    })
+    const summary = summarizeSourceLocations(normalized)
+    updateState({
+      sourceLocations,
+      sourceType: summary.sourceType === 'remote' ? 'remote' : 'local',
+      sourceSshConnectionId: summary.sourceSshConnectionId || '',
+      sourceDirectories: summary.sourceDirectories,
+    })
+  }
+
+  const requireRemoteSourceConnection = (sourceLocationIndex = 0) => {
+    const location = sourceLocationsState[sourceLocationIndex]
+    if (!location || location.sourceType !== 'remote' || location.sourceSshConnectionId) return true
     toast.error(t('backupPlans.toasts.selectSourceConnection'))
     return false
   }
 
-  const openSourceExplorer = () => {
-    if (!requireRemoteSourceConnection()) return
+  const openSourceExplorer = (sourceLocationIndex: number) => {
+    if (!requireRemoteSourceConnection(sourceLocationIndex)) return
+    setActiveSourceLocationIndex(sourceLocationIndex)
     setShowSourceExplorer(true)
   }
 
@@ -539,10 +577,15 @@ export default function BackupPlans() {
   const canProceed = () => {
     const stepKey = stepDefinitions[activeStep]?.key
     if (stepKey === 'source') {
+      const sourceLocations = normalizeSourceLocations(wizardState)
       return Boolean(
         wizardState.name.trim() &&
-        wizardState.sourceDirectories.length > 0 &&
-        (wizardState.sourceType === 'local' || wizardState.sourceSshConnectionId)
+        sourceLocations.length > 0 &&
+        sourceLocations.every(
+          (location) =>
+            location.sourceDirectories.length > 0 &&
+            (location.sourceType === 'local' || location.sourceSshConnectionId)
+        )
       )
     }
     if (stepKey === 'repositories') {
@@ -733,22 +776,34 @@ export default function BackupPlans() {
       />
 
       <FileExplorerDialog
-        key={`plan-source-explorer-${wizardState.sourceType}-${wizardState.sourceSshConnectionId || 'local'}`}
+        key={`plan-source-explorer-${activeSourceLocation?.sourceType || 'local'}-${
+          activeSourceLocation?.sourceSshConnectionId || 'local'
+        }`}
         open={showSourceExplorer}
         onClose={() => setShowSourceExplorer(false)}
         onSelect={(paths) => {
-          updateState({
-            sourceDirectories: appendUniquePaths(wizardState.sourceDirectories, paths),
-          })
+          const nextSourceLocations = sourceLocationsState.map((location, index) =>
+            index === activeSourceLocationIndex
+              ? {
+                  ...location,
+                  sourceDirectories: appendUniquePaths(location.sourceDirectories, paths),
+                }
+              : location
+          )
+          applySourceLocations(nextSourceLocations)
           setShowSourceExplorer(false)
         }}
         title={t('backupPlans.wizard.fileExplorer.sourceTitle')}
         initialPath={
-          wizardState.sourceType === 'remote' ? selectedSourceConnection?.default_path || '/' : '/'
+          activeSourceLocation?.sourceType === 'remote'
+            ? activeSourceConnection?.default_path || '/'
+            : '/'
         }
         multiSelect
-        connectionType={wizardState.sourceType === 'remote' ? 'ssh' : 'local'}
-        sshConfig={wizardState.sourceType === 'remote' ? sourceExplorerSshConfig : undefined}
+        connectionType={activeSourceLocation?.sourceType === 'remote' ? 'ssh' : 'local'}
+        sshConfig={
+          activeSourceLocation?.sourceType === 'remote' ? sourceExplorerSshConfig : undefined
+        }
         selectMode="both"
         showSshMountPoints={false}
       />

--- a/frontend/src/pages/__tests__/BackupPlans.test.tsx
+++ b/frontend/src/pages/__tests__/BackupPlans.test.tsx
@@ -267,6 +267,74 @@ describe('BackupPlans payload', () => {
     expect(payload.source_ssh_connection_id).toBe(42)
   })
 
+  it('builds mixed source location payloads', () => {
+    const payload = buildBackupPlanPayload({
+      name: 'Mixed Plan',
+      description: '',
+      enabled: true,
+      sourceType: 'local',
+      sourceSshConnectionId: '',
+      sourceDirectories: ['/srv/local', '/srv/remote'],
+      sourceLocations: [
+        {
+          id: 'local-source',
+          sourceType: 'local',
+          sourceSshConnectionId: '',
+          sourceDirectories: ['/srv/local'],
+        },
+        {
+          id: 'remote-source',
+          sourceType: 'remote',
+          sourceSshConnectionId: 42,
+          sourceDirectories: ['/srv/remote'],
+        },
+      ],
+      excludePatterns: [],
+      repositoryIds: [10],
+      compression: 'lz4',
+      archiveNameTemplate: '{plan_name}-{repo_name}-{now}',
+      customFlags: '',
+      uploadRatelimitMb: '',
+      repositoryRunMode: 'series',
+      maxParallelRepositories: 1,
+      failureBehavior: 'continue',
+      scheduleEnabled: false,
+      cronExpression: '0 21 * * *',
+      timezone: 'UTC',
+      preBackupScriptId: null,
+      postBackupScriptId: null,
+      preBackupScriptParameters: {},
+      postBackupScriptParameters: {},
+      runRepositoryScripts: true,
+      runPruneAfter: false,
+      runCompactAfter: false,
+      runCheckAfter: false,
+      checkMaxDuration: 3600,
+      pruneKeepHourly: 0,
+      pruneKeepDaily: 7,
+      pruneKeepWeekly: 4,
+      pruneKeepMonthly: 6,
+      pruneKeepQuarterly: 0,
+      pruneKeepYearly: 1,
+    })
+
+    expect(payload.source_type).toBe('mixed')
+    expect(payload.source_ssh_connection_id).toBeNull()
+    expect(payload.source_directories).toEqual(['/srv/local', '/srv/remote'])
+    expect(payload.source_locations).toEqual([
+      {
+        source_type: 'local',
+        source_ssh_connection_id: null,
+        source_directories: ['/srv/local'],
+      },
+      {
+        source_type: 'remote',
+        source_ssh_connection_id: 42,
+        source_directories: ['/srv/remote'],
+      },
+    ])
+  })
+
   it('includes repository ids whose legacy source settings should be cleared', () => {
     const payload = buildBackupPlanPayload(
       {

--- a/frontend/src/pages/backup-plans/BackupPlansContent.tsx
+++ b/frontend/src/pages/backup-plans/BackupPlansContent.tsx
@@ -327,7 +327,9 @@ export function BackupPlansContent({
                   const sourceTypeLabel =
                     plan.source_type === 'remote'
                       ? t('backupPlans.status.remoteSource')
-                      : t('backupPlans.status.localSource')
+                      : plan.source_type === 'mixed'
+                        ? t('backupPlans.status.mixedSource')
+                        : t('backupPlans.status.localSource')
 
                   return (
                     <Stack key={plan.id} spacing={1.25}>

--- a/frontend/src/pages/backup-plans/state.ts
+++ b/frontend/src/pages/backup-plans/state.ts
@@ -1,6 +1,11 @@
 import { getDefaultRepositoryEncryption } from '../../components/wizard'
 import { getBrowserTimeZone } from '../../utils/dateUtils'
-import type { BackupPlan } from '../../types'
+import type { BackupPlan, SourceLocation } from '../../types'
+import {
+  createSourceLocationState,
+  normalizeSourceLocations,
+  summarizeSourceLocations,
+} from '../../utils/backupPlanPayload'
 import type { BasicRepositoryState, WizardState } from './types'
 
 export const createInitialState = (): WizardState => ({
@@ -10,6 +15,7 @@ export const createInitialState = (): WizardState => ({
   sourceType: 'local',
   sourceSshConnectionId: '',
   sourceDirectories: [],
+  sourceLocations: [createSourceLocationState()],
   excludePatterns: [],
   repositoryIds: [],
   compression: 'lz4',
@@ -57,13 +63,41 @@ export function planToState(plan: BackupPlan): WizardState {
     .filter((link) => link.enabled)
     .sort((a, b) => a.execution_order - b.execution_order)
 
+  const sourceLocations =
+    plan.source_locations && plan.source_locations.length > 0
+      ? plan.source_locations.map((location: SourceLocation) =>
+          createSourceLocationState({
+            sourceType: location.source_type,
+            sourceSshConnectionId: location.source_ssh_connection_id || '',
+            sourceDirectories: location.source_directories || [],
+          })
+        )
+      : [
+          createSourceLocationState({
+            sourceType:
+              plan.source_type === 'remote' || plan.source_ssh_connection_id ? 'remote' : 'local',
+            sourceSshConnectionId: plan.source_ssh_connection_id || '',
+            sourceDirectories: plan.source_directories || [],
+          }),
+        ]
+  const sourceSummary = summarizeSourceLocations(
+    normalizeSourceLocations({
+      sourceType:
+        plan.source_type === 'remote' || plan.source_ssh_connection_id ? 'remote' : 'local',
+      sourceSshConnectionId: plan.source_ssh_connection_id || '',
+      sourceDirectories: plan.source_directories || [],
+      sourceLocations,
+    })
+  )
+
   return {
     name: plan.name,
     description: plan.description || '',
     enabled: plan.enabled,
-    sourceType: plan.source_type === 'remote' || plan.source_ssh_connection_id ? 'remote' : 'local',
-    sourceSshConnectionId: plan.source_ssh_connection_id || '',
-    sourceDirectories: plan.source_directories || [],
+    sourceType: sourceSummary.sourceType === 'remote' ? 'remote' : 'local',
+    sourceSshConnectionId: sourceSummary.sourceSshConnectionId || '',
+    sourceDirectories: sourceSummary.sourceDirectories,
+    sourceLocations,
     excludePatterns: plan.exclude_patterns || [],
     repositoryIds: repositoryLinks.map((link) => link.repository_id),
     compression: plan.compression || 'lz4',

--- a/frontend/src/pages/backup-plans/wizard-step/ReviewStep.tsx
+++ b/frontend/src/pages/backup-plans/wizard-step/ReviewStep.tsx
@@ -39,10 +39,19 @@ export function ReviewStep({
   scripts,
   t,
 }: ReviewStepProps) {
+  const configuredSourceLocations = (wizardState.sourceLocations || []).filter(
+    (location) => location.sourceDirectories.length > 0
+  )
+  const sourceDirectoryCount = configuredSourceLocations.reduce(
+    (count, location) => count + location.sourceDirectories.length,
+    0
+  )
   const sourceLocationLabel =
-    wizardState.sourceType === 'remote'
-      ? t('backupPlans.wizard.review.remoteSource')
-      : t('backupPlans.wizard.review.localSource')
+    configuredSourceLocations.length > 1
+      ? t('sourceLocations.mixed')
+      : wizardState.sourceType === 'remote'
+        ? t('backupPlans.wizard.review.remoteSource')
+        : t('backupPlans.wizard.review.localSource')
   const sourceConnectionLabel = selectedSourceConnection
     ? formatSshConnectionLabel(selectedSourceConnection)
     : wizardState.sourceSshConnectionId
@@ -55,9 +64,11 @@ export function ReviewStep({
   const selectedRepositories = wizardState.repositoryIds
     .map((repositoryId) => repositories.find((repository) => repository.id === repositoryId))
     .filter((repository): repository is Repository => Boolean(repository))
-  const visibleSourceDirectories = wizardState.sourceDirectories.slice(0, 6)
+  const visibleSourceDirectories = configuredSourceLocations
+    .flatMap((location) => location.sourceDirectories)
+    .slice(0, 6)
   const hiddenSourceDirectoryCount = Math.max(
-    wizardState.sourceDirectories.length - visibleSourceDirectories.length,
+    sourceDirectoryCount - visibleSourceDirectories.length,
     0
   )
   const visibleExcludePatterns = wizardState.excludePatterns.slice(0, 4)
@@ -113,7 +124,9 @@ export function ReviewStep({
 
           <ReviewAttrRow label={t('backupPlans.wizard.review.sourceLocation')}>
             <Stack direction="row" spacing={0.5} alignItems="center" sx={{ minWidth: 0 }}>
-              {wizardState.sourceType === 'remote' ? (
+              {configuredSourceLocations.length > 1 ? (
+                <ListChecks size={12} style={{ opacity: 0.6, flexShrink: 0 }} />
+              ) : wizardState.sourceType === 'remote' ? (
                 <Laptop size={12} style={{ opacity: 0.6, flexShrink: 0 }} />
               ) : (
                 <HardDrive size={12} style={{ opacity: 0.6, flexShrink: 0 }} />
@@ -124,7 +137,7 @@ export function ReviewStep({
             </Stack>
           </ReviewAttrRow>
 
-          {wizardState.sourceType === 'remote' && (
+          {configuredSourceLocations.length <= 1 && wizardState.sourceType === 'remote' && (
             <ReviewAttrRow label={t('backupPlans.wizard.review.sourceConnection')}>
               <Typography variant="body2" fontSize="0.75rem" fontWeight={500} noWrap>
                 {sourceConnectionLabel}
@@ -153,7 +166,7 @@ export function ReviewStep({
               </Typography>
               <ReviewCount>
                 {t('backupPlans.wizard.review.pathCount', {
-                  count: wizardState.sourceDirectories.length,
+                  count: sourceDirectoryCount,
                 })}
               </ReviewCount>
             </Box>

--- a/frontend/src/pages/backup-plans/wizard-step/SourceStep.tsx
+++ b/frontend/src/pages/backup-plans/wizard-step/SourceStep.tsx
@@ -1,7 +1,11 @@
 import { Stack, TextField } from '@mui/material'
 
 import ExcludePatternInput from '../../../components/ExcludePatternInput'
-import { WizardStepDataSource } from '../../../components/wizard'
+import SourceLocationsInput from '../../../components/SourceLocationsInput'
+import {
+  normalizeSourceLocations,
+  summarizeSourceLocations,
+} from '../../../utils/backupPlanPayload'
 import type { BackupPlanWizardStepProps } from './types'
 
 type SourceStepProps = Pick<
@@ -39,27 +43,24 @@ export function SourceStep({
         rows={2}
         fullWidth
       />
-      <WizardStepDataSource
+      <SourceLocationsInput
         repositoryLocation="local"
-        repoSshConnectionId=""
-        repositoryMode="full"
-        data={{
-          dataSource: wizardState.sourceType,
-          sourceSshConnectionId: wizardState.sourceSshConnectionId,
-          sourceDirs: wizardState.sourceDirectories,
-        }}
+        sourceLocations={wizardState.sourceLocations || []}
         sshConnections={sshConnections}
-        onChange={(updates) => {
+        onChange={(sourceLocations) => {
+          const normalized = normalizeSourceLocations({
+            ...wizardState,
+            sourceLocations,
+          })
+          const summary = summarizeSourceLocations(normalized)
           updateState({
-            ...(updates.dataSource ? { sourceType: updates.dataSource } : {}),
-            ...(updates.sourceSshConnectionId !== undefined
-              ? { sourceSshConnectionId: updates.sourceSshConnectionId }
-              : {}),
-            ...(updates.sourceDirs !== undefined ? { sourceDirectories: updates.sourceDirs } : {}),
+            sourceLocations,
+            sourceType: summary.sourceType === 'remote' ? 'remote' : 'local',
+            sourceSshConnectionId: summary.sourceSshConnectionId || '',
+            sourceDirectories: summary.sourceDirectories,
           })
         }}
-        onBrowseSource={openSourceExplorer}
-        onBrowseRemoteSource={openSourceExplorer}
+        onBrowse={openSourceExplorer}
       />
       <ExcludePatternInput
         patterns={wizardState.excludePatterns}

--- a/frontend/src/pages/backup-plans/wizard-step/types.ts
+++ b/frontend/src/pages/backup-plans/wizard-step/types.ts
@@ -26,7 +26,7 @@ export interface BackupPlanWizardStepProps {
   handleRepositoryIdsChange: (ids: number[]) => void
   handlePruneSettingsChange: (values: PruneSettings) => void
   createBasicRepository: () => void
-  openSourceExplorer: () => void
+  openSourceExplorer: (sourceLocationIndex: number) => void
   openExcludeExplorer: () => void
   setBasicRepositoryOpen: Dispatch<SetStateAction<boolean>>
   setRepositoryWizardOpen: Dispatch<SetStateAction<boolean>>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -4,7 +4,7 @@ import { BASE_PATH } from '@/utils/basePath'
 import { API_BASE_URL, buildDownloadUrl } from '@/utils/downloadUrl'
 import { attachAccessTokenHeader } from './authHeaders'
 import type { RestoreLayout, RestorePathMetadata } from '@/utils/restorePaths'
-import type { BackupPlan, BackupPlanData } from '../types'
+import type { BackupPlan, BackupPlanData, SourceLocation } from '../types'
 
 export type AuthTransportMode = 'jwt' | 'proxy' | 'insecure-no-auth'
 
@@ -58,6 +58,7 @@ export interface RepositoryData {
   encryption?: string
   compression?: string
   source_directories?: string[]
+  source_locations?: SourceLocation[]
   exclude_patterns?: string[]
   repository_type?: string
   host?: string

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -14,6 +14,8 @@ export interface Repository {
   remote_path?: string
   connection_id?: number | null
   source_directories?: string[]
+  source_type?: SourceLocationType
+  source_locations?: SourceLocation[]
   exclude_patterns?: string[]
   mode?: 'full' | 'observe'
   bypass_lock?: boolean
@@ -31,6 +33,14 @@ export interface Repository {
   has_keyfile?: boolean
   source_ssh_connection_id?: number | null
   [key: string]: unknown
+}
+
+export type SourceLocationType = 'local' | 'remote' | 'mixed'
+
+export interface SourceLocation {
+  source_type: 'local' | 'remote'
+  source_ssh_connection_id?: number | null
+  source_directories: string[]
 }
 
 export interface Archive {
@@ -101,9 +111,10 @@ export interface BackupPlan {
   name: string
   description?: string | null
   enabled: boolean
-  source_type: 'local' | 'remote'
+  source_type: SourceLocationType
   source_ssh_connection_id?: number | null
   source_directories: string[]
+  source_locations?: SourceLocation[]
   exclude_patterns: string[]
   archive_name_template: string
   compression: string
@@ -180,9 +191,10 @@ export interface BackupPlanData {
   name: string
   description?: string | null
   enabled: boolean
-  source_type: 'local' | 'remote'
+  source_type: SourceLocationType
   source_ssh_connection_id?: number | null
   source_directories: string[]
+  source_locations?: SourceLocation[]
   exclude_patterns?: string[]
   archive_name_template: string
   compression: string

--- a/frontend/src/utils/backupPlanPayload.ts
+++ b/frontend/src/utils/backupPlanPayload.ts
@@ -1,4 +1,11 @@
-import type { BackupPlanData } from '../types'
+import type { BackupPlanData, SourceLocationType } from '../types'
+
+export interface SourceLocationState {
+  id: string
+  sourceType: 'local' | 'remote'
+  sourceSshConnectionId: number | ''
+  sourceDirectories: string[]
+}
 
 export interface BackupPlanPayloadState {
   name: string
@@ -7,6 +14,7 @@ export interface BackupPlanPayloadState {
   sourceType: 'local' | 'remote'
   sourceSshConnectionId: number | ''
   sourceDirectories: string[]
+  sourceLocations?: SourceLocationState[]
   excludePatterns: string[]
   repositoryIds: number[]
   compression: string
@@ -42,20 +50,92 @@ function mbToKib(value: string): number | null {
   return Math.round(parsed * 1024)
 }
 
+export function createSourceLocationState(
+  overrides: Partial<SourceLocationState> = {}
+): SourceLocationState {
+  return {
+    id:
+      overrides.id ||
+      globalThis.crypto?.randomUUID?.() ||
+      `source-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    sourceType: overrides.sourceType || 'local',
+    sourceSshConnectionId: overrides.sourceSshConnectionId ?? '',
+    sourceDirectories: overrides.sourceDirectories || [],
+  }
+}
+
+export function normalizeSourceLocations(
+  state: Pick<
+    BackupPlanPayloadState,
+    'sourceType' | 'sourceSshConnectionId' | 'sourceDirectories' | 'sourceLocations'
+  >
+): SourceLocationState[] {
+  const locations =
+    state.sourceLocations && state.sourceLocations.length > 0
+      ? state.sourceLocations
+      : [
+          createSourceLocationState({
+            sourceType: state.sourceType,
+            sourceSshConnectionId: state.sourceSshConnectionId,
+            sourceDirectories: state.sourceDirectories,
+          }),
+        ]
+
+  return locations
+    .map((location) => ({
+      ...location,
+      sourceSshConnectionId: location.sourceType === 'remote' ? location.sourceSshConnectionId : '',
+      sourceDirectories: location.sourceDirectories.filter((path) => path.trim()),
+    }))
+    .filter((location) => location.sourceDirectories.length > 0)
+}
+
+export function summarizeSourceLocations(sourceLocations: SourceLocationState[]): {
+  sourceType: SourceLocationType
+  sourceSshConnectionId: number | null
+  sourceDirectories: string[]
+} {
+  const sourceDirectories = sourceLocations.flatMap((location) => location.sourceDirectories)
+  if (sourceLocations.length === 1) {
+    const [location] = sourceLocations
+    return {
+      sourceType: location.sourceType,
+      sourceSshConnectionId:
+        location.sourceType === 'remote' && location.sourceSshConnectionId
+          ? Number(location.sourceSshConnectionId)
+          : null,
+      sourceDirectories,
+    }
+  }
+  return {
+    sourceType: sourceLocations.length > 0 ? 'mixed' : 'local',
+    sourceSshConnectionId: null,
+    sourceDirectories,
+  }
+}
+
 export function buildBackupPlanPayload(
   state: BackupPlanPayloadState,
   clearLegacySourceRepositoryIds: number[] = []
 ): BackupPlanData {
+  const sourceLocations = normalizeSourceLocations(state)
+  const sourceSummary = summarizeSourceLocations(sourceLocations)
+
   return {
     name: state.name.trim(),
     description: state.description.trim() || null,
     enabled: state.enabled,
-    source_type: state.sourceType,
-    source_ssh_connection_id:
-      state.sourceType === 'remote' && state.sourceSshConnectionId
-        ? Number(state.sourceSshConnectionId)
-        : null,
-    source_directories: state.sourceDirectories,
+    source_type: sourceSummary.sourceType,
+    source_ssh_connection_id: sourceSummary.sourceSshConnectionId,
+    source_directories: sourceSummary.sourceDirectories,
+    source_locations: sourceLocations.map((location) => ({
+      source_type: location.sourceType,
+      source_ssh_connection_id:
+        location.sourceType === 'remote' && location.sourceSshConnectionId
+          ? Number(location.sourceSshConnectionId)
+          : null,
+      source_directories: location.sourceDirectories,
+    })),
     exclude_patterns: state.excludePatterns,
     archive_name_template: state.archiveNameTemplate.trim() || '{plan_name}-{repo_name}-{now}',
     compression: state.compression,

--- a/tests/unit/test_api_backup_plans.py
+++ b/tests/unit/test_api_backup_plans.py
@@ -413,6 +413,81 @@ class TestBackupPlanRoutes:
         assert body["source_type"] == "remote"
         assert body["source_ssh_connection_id"] == source_connection.id
         assert body["source_directories"] == ["/home/tester/project"]
+        assert body["source_locations"] == [
+            {
+                "source_type": "remote",
+                "source_ssh_connection_id": source_connection.id,
+                "source_directories": ["/home/tester/project"],
+            }
+        ]
+
+    def test_create_plan_supports_multiple_source_locations(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        repo = _create_repo(test_db, "Primary", "/repos/primary")
+        source_a = _create_ssh_connection(test_db, host="ssh-a.example")
+        source_b = _create_ssh_connection(test_db, host="ssh-b.example")
+
+        response = test_client.post(
+            "/api/backup-plans/",
+            json=_payload(
+                [repo.id],
+                source_type="mixed",
+                source_ssh_connection_id=None,
+                source_directories=[
+                    "/local/project",
+                    "/home/tester/a",
+                    "/home/tester/b",
+                ],
+                source_locations=[
+                    {
+                        "source_type": "local",
+                        "source_directories": ["/local/project"],
+                    },
+                    {
+                        "source_type": "remote",
+                        "source_ssh_connection_id": source_a.id,
+                        "source_directories": ["/home/tester/a"],
+                    },
+                    {
+                        "source_type": "remote",
+                        "source_ssh_connection_id": source_b.id,
+                        "source_directories": ["/home/tester/b"],
+                    },
+                ],
+            ),
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["source_type"] == "mixed"
+        assert body["source_ssh_connection_id"] is None
+        assert body["source_directories"] == [
+            "/local/project",
+            "/home/tester/a",
+            "/home/tester/b",
+        ]
+        assert body["source_locations"] == [
+            {
+                "source_type": "local",
+                "source_ssh_connection_id": None,
+                "source_directories": ["/local/project"],
+            },
+            {
+                "source_type": "remote",
+                "source_ssh_connection_id": source_a.id,
+                "source_directories": ["/home/tester/a"],
+            },
+            {
+                "source_type": "remote",
+                "source_ssh_connection_id": source_b.id,
+                "source_directories": ["/home/tester/b"],
+            },
+        ]
+
+        plan = test_db.query(BackupPlan).filter_by(id=body["id"]).one()
+        assert json.loads(plan.source_locations) == body["source_locations"]
 
     def test_remote_source_requires_connection(
         self, test_client: TestClient, admin_headers, test_db
@@ -1513,6 +1588,57 @@ class TestBackupPlanRoutes:
         run = test_db.query(BackupPlanRun).filter_by(id=run.id).one()
         assert run.status == "completed"
         assert backup_job.source_ssh_connection_id == source_connection.id
+
+    @pytest.mark.asyncio
+    async def test_execute_plan_run_uses_multiple_source_locations(self, test_db):
+        repo = _create_repo(test_db, "Primary", "/repos/primary")
+        source_connection = _create_ssh_connection(test_db)
+        source_locations = [
+            {
+                "source_type": "local",
+                "source_ssh_connection_id": None,
+                "source_directories": ["/srv/local"],
+            },
+            {
+                "source_type": "remote",
+                "source_ssh_connection_id": source_connection.id,
+                "source_directories": ["/home/tester/project"],
+            },
+        ]
+        _plan, run = _create_execution_plan(
+            test_db,
+            [repo],
+            source_type="mixed",
+            source_ssh_connection_id=None,
+            source_directories=json.dumps(["/srv/local", "/home/tester/project"]),
+            source_locations=json.dumps(source_locations),
+        )
+
+        async def fake_execute_backup(job_id, repository, db, **kwargs):
+            assert repository == repo.path
+            assert kwargs["source_directories"] == [
+                "/srv/local",
+                "/home/tester/project",
+            ]
+            assert kwargs["source_ssh_connection_id"] is None
+            assert kwargs["source_locations"] == source_locations
+            job = db.query(BackupJob).filter_by(id=job_id).one()
+            assert job.source_ssh_connection_id is None
+            job.status = "completed"
+            job.completed_at = datetime.utcnow()
+            db.commit()
+
+        with patch(
+            "app.services.backup_plan_execution_service.backup_service.execute_backup",
+            side_effect=fake_execute_backup,
+        ):
+            await backup_plan_execution_service.execute_run(run.id)
+
+        test_db.expire_all()
+        backup_job = test_db.query(BackupJob).filter_by(backup_plan_run_id=run.id).one()
+        run = test_db.query(BackupPlanRun).filter_by(id=run.id).one()
+        assert run.status == "completed"
+        assert backup_job.source_ssh_connection_id is None
 
     @pytest.mark.asyncio
     async def test_execute_plan_run_wraps_repositories_with_plan_scripts(self, test_db):

--- a/tests/unit/test_api_repositories.py
+++ b/tests/unit/test_api_repositories.py
@@ -444,6 +444,62 @@ class TestRepositoriesCreate:
 
         assert response.status_code == 200
 
+    def test_create_repository_with_multiple_source_locations(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """Test creating repository with mixed local and remote source locations"""
+        connection = SSHConnection(host="server", username="user", port=22)
+        test_db.add(connection)
+        test_db.commit()
+        test_db.refresh(connection)
+
+        with (
+            patch(
+                "app.api.repositories.initialize_borg_repository",
+                new=AsyncMock(return_value={"success": True}),
+            ),
+            patch("app.api.repositories.mqtt_service.sync_state_with_db"),
+        ):
+            response = test_client.post(
+                "/api/repositories/",
+                json={
+                    "name": "Mixed Source Repo",
+                    "path": "/tmp/mixed-source",
+                    "encryption": "none",
+                    "compression": "lz4",
+                    "repository_type": "local",
+                    "source_locations": [
+                        {
+                            "source_type": "local",
+                            "source_directories": ["/srv/local"],
+                        },
+                        {
+                            "source_type": "remote",
+                            "source_ssh_connection_id": connection.id,
+                            "source_directories": ["/srv/remote"],
+                        },
+                    ],
+                },
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        repo = test_db.query(Repository).filter_by(name="Mixed Source Repo").one()
+        assert json.loads(repo.source_directories) == ["/srv/local", "/srv/remote"]
+        assert repo.source_ssh_connection_id is None
+        assert json.loads(repo.source_locations) == [
+            {
+                "source_type": "local",
+                "source_ssh_connection_id": None,
+                "source_directories": ["/srv/local"],
+            },
+            {
+                "source_type": "remote",
+                "source_ssh_connection_id": connection.id,
+                "source_directories": ["/srv/remote"],
+            },
+        ]
+
     def test_create_repository_with_exclude_patterns(
         self, test_client: TestClient, admin_headers
     ):

--- a/tests/unit/test_api_v2_repositories.py
+++ b/tests/unit/test_api_v2_repositories.py
@@ -70,6 +70,19 @@ def _create_v2_repo(
     return repo
 
 
+def _create_source_connection(test_db, *, host="source.example.com"):
+    connection = SSHConnection(
+        host=host,
+        username="backup",
+        port=22,
+        status="connected",
+    )
+    test_db.add(connection)
+    test_db.commit()
+    test_db.refresh(connection)
+    return connection
+
+
 @pytest.mark.unit
 class TestV2RepositoryRoutes:
     def test_encryption_modes_are_feature_gated(
@@ -101,13 +114,14 @@ class TestV2RepositoryRoutes:
         self, test_client: TestClient, admin_headers, test_db
     ):
         _enable_borg_v2(test_db)
+        source_connection = _create_source_connection(test_db)
         payload = {
             "name": "Borg 2 Repo",
             "path": "/tmp/v2-create-repo",
             "encryption": "repokey-aes-ocb",
             "compression": "lz4",
             "source_directories": ["/data/source-a", "/data/source-b"],
-            "source_connection_id": 44,
+            "source_connection_id": source_connection.id,
         }
 
         with patch(
@@ -139,7 +153,7 @@ class TestV2RepositoryRoutes:
         assert repo is not None
         assert repo.borg_version == 2
         assert json.loads(repo.source_directories) == payload["source_directories"]
-        assert repo.source_ssh_connection_id == 44
+        assert repo.source_ssh_connection_id == source_connection.id
         mock_rcreate.assert_awaited_once()
 
     def test_create_repository_rejects_invalid_encryption(
@@ -334,6 +348,9 @@ class TestV2RepositoryRoutes:
         self, test_client: TestClient, admin_headers, test_db
     ):
         _enable_borg_v2(test_db)
+        source_connection = _create_source_connection(
+            test_db, host="import-source.example.com"
+        )
 
         with patch(
             "app.api.v2.repositories._rinfo",
@@ -352,7 +369,7 @@ class TestV2RepositoryRoutes:
                     "path": "/tmp/v2-import-success",
                     "encryption": "none",
                     "source_directories": ["/data/source"],
-                    "source_connection_id": 55,
+                    "source_connection_id": source_connection.id,
                     "custom_flags": "--stats",
                     "pre_backup_script": "echo pre",
                     "post_backup_script": "echo post",
@@ -368,7 +385,7 @@ class TestV2RepositoryRoutes:
             test_db.query(Repository).filter(Repository.name == "Imported Repo").first()
         )
         assert repo is not None
-        assert repo.source_ssh_connection_id == 55
+        assert repo.source_ssh_connection_id == source_connection.id
         assert repo.custom_flags == "--stats"
         assert repo.pre_backup_script == "echo pre"
         assert repo.post_backup_script == "echo post"

--- a/tests/unit/test_backup_service_mocks.py
+++ b/tests/unit/test_backup_service_mocks.py
@@ -2,7 +2,13 @@ import json
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock, Mock
 from app.services.backup_service import BackupService
-from app.database.models import BackupJob, Repository, SystemSettings, RepositoryScript
+from app.database.models import (
+    BackupJob,
+    Repository,
+    RepositoryScript,
+    SSHConnection,
+    SystemSettings,
+)
 
 
 @pytest.fixture
@@ -41,6 +47,46 @@ def _notification_service_mock():
     notifications.send_backup_success = AsyncMock()
     notifications.send_backup_warning = AsyncMock()
     return notifications
+
+
+def test_build_source_paths_from_multiple_locations(
+    backup_service_fixture, mock_db_session
+):
+    connection = SSHConnection(
+        id=7,
+        host="source.example",
+        username="backup",
+        port=2222,
+        default_path="/home/backup",
+    )
+    mock_db_session.query.return_value.filter.return_value.first.return_value = (
+        connection
+    )
+
+    paths, single_connection_id = (
+        backup_service_fixture._build_source_paths_from_locations(
+            mock_db_session,
+            [
+                {
+                    "source_type": "local",
+                    "source_ssh_connection_id": None,
+                    "source_directories": ["/srv/local"],
+                },
+                {
+                    "source_type": "remote",
+                    "source_ssh_connection_id": connection.id,
+                    "source_directories": ["project"],
+                },
+            ],
+            "/backups/repo",
+        )
+    )
+
+    assert paths == [
+        "/srv/local",
+        "ssh://backup@source.example:2222/home/backup/project",
+    ]
+    assert single_connection_id is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
Adds multi-source backup configuration for repositories and backup plans. A source location now carries its own type, optional SSH connection, and paths, so one backup can combine local directories with paths from one or more SSH servers. Existing single-source fields are still mirrored for compatibility.

Backend changes include `source_locations` persistence, API validation/serialization, backup-plan execution context, existing SSHFS-based source resolution, and cleanup when SSH connections are deleted. Frontend changes add reusable multi-source controls in repository and backup-plan flows, source browsing scoped to the selected source, review/list summaries, locale coverage, and updated wizard tests.

## Related Issue
Linear: https://linear.app/nullcodeai/issue/BOR-15/allow-mutliple-source-locations-for-backups

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Validation run:
- `ruff check app tests`
- `ruff format --check app tests`
- `pytest tests/unit/test_api_backup_plans.py tests/unit/test_api_repositories.py tests/unit/test_backup_service_mocks.py -q`
- `pytest tests/unit/test_api_v2_repositories.py -q`
- `cd frontend && npm run check:locales`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `cd frontend && npm test -- --run src/pages/__tests__/BackupPlans.test.tsx`
- `cd frontend && npm test -- --run src/components/__tests__/RepositoryWizard.test.tsx src/pages/__tests__/BackupPlans.test.tsx`
- `./scripts/dev.sh` runtime walkthrough: created and reloaded a repository and backup plan with one local and one SSH source; both returned `source_type: mixed` with two `source_locations`.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
No static screenshots were captured. Runtime validation launched the dev app and verified the mixed-source create/reload flow through the running frontend/backend environment.

## Additional Context
The new `source_locations` field is additive. Legacy `source_type`, `source_ssh_connection_id`, and `source_directories` fields remain populated from a summary of the configured locations so older API clients keep working.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
