### PR TITLE
Add database source discovery to backup plans

### DIFF
--- a/app/api/source_discovery.py
+++ b/app/api/source_discovery.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from app.core.security import get_current_user, require_any_role
+from app.database.models import User
+from app.services.source_discovery import SourceDiscoveryResult, scan_database_sources
+
+router = APIRouter(tags=["source-discovery"])
+
+
+@router.get("/databases", response_model=SourceDiscoveryResult)
+async def scan_databases(
+    current_user: User = Depends(get_current_user),
+) -> SourceDiscoveryResult:
+    require_any_role(current_user, "admin", "operator")
+    return scan_database_sources()

--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,7 @@ from app.api import (
     browse,
     notifications,
     scripts,
+    source_discovery,
     packages,
     activity,
     scripts_library,
@@ -212,6 +213,11 @@ app.include_router(
 app.include_router(
     scripts_library.router, prefix="/api", tags=["Script Library"]
 )  # New script management
+app.include_router(
+    source_discovery.router,
+    prefix="/api/source-discovery",
+    tags=["Source Discovery"],
+)
 app.include_router(packages.router, prefix="/api/packages", tags=["Packages"])
 app.include_router(notifications.router)
 app.include_router(activity.router)

--- a/app/services/source_discovery.py
+++ b/app/services/source_discovery.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+import psutil
+from pydantic import BaseModel, Field
+
+
+Confidence = Literal["high", "medium", "low"]
+
+
+class SourceTypeDiscovery(BaseModel):
+    id: str
+    label: str
+    description: str
+    enabled: bool = True
+    planned: bool = False
+
+
+class ScriptTemplate(BaseModel):
+    name: str
+    description: str
+    content: str
+    timeout: int = 120
+    run_on: str = "always"
+
+
+class DatabaseSourceCandidate(BaseModel):
+    id: str
+    engine: str
+    engine_label: str
+    name: str
+    status: str
+    source_directories: list[str]
+    service_name: str
+    discovery_source: str
+    confidence: Confidence
+    notes: list[str] = Field(default_factory=list)
+    pre_backup_script: ScriptTemplate
+    post_backup_script: ScriptTemplate
+
+
+class SourceDiscoveryResult(BaseModel):
+    scanned_at: str
+    source_types: list[SourceTypeDiscovery]
+    databases: list[DatabaseSourceCandidate]
+    templates: list[DatabaseSourceCandidate]
+
+
+@dataclass(frozen=True)
+class DatabaseDefinition:
+    engine: str
+    label: str
+    process_names: tuple[str, ...]
+    service_name: str
+    path_args: tuple[str, ...]
+    default_paths: tuple[str, ...]
+
+
+DATABASE_DEFINITIONS: tuple[DatabaseDefinition, ...] = (
+    DatabaseDefinition(
+        engine="postgresql",
+        label="PostgreSQL",
+        process_names=("postgres", "postmaster"),
+        service_name="postgresql",
+        path_args=("-D", "--data-directory"),
+        default_paths=(
+            "/var/lib/postgresql",
+            "/var/lib/pgsql",
+            "/var/lib/postgres",
+        ),
+    ),
+    DatabaseDefinition(
+        engine="mysql",
+        label="MySQL / MariaDB",
+        process_names=("mysqld", "mariadbd"),
+        service_name="mysql",
+        path_args=("--datadir",),
+        default_paths=("/var/lib/mysql",),
+    ),
+    DatabaseDefinition(
+        engine="mongodb",
+        label="MongoDB",
+        process_names=("mongod",),
+        service_name="mongod",
+        path_args=("--dbpath",),
+        default_paths=("/var/lib/mongodb", "/data/db"),
+    ),
+    DatabaseDefinition(
+        engine="redis",
+        label="Redis",
+        process_names=("redis-server",),
+        service_name="redis-server",
+        path_args=("--dir",),
+        default_paths=("/var/lib/redis",),
+    ),
+)
+
+
+def _source_types() -> list[SourceTypeDiscovery]:
+    return [
+        SourceTypeDiscovery(
+            id="paths",
+            label="Paths",
+            description="Pick local or remote files and directories manually.",
+        ),
+        SourceTypeDiscovery(
+            id="database",
+            label="Databases",
+            description="Scan for supported local database stores.",
+        ),
+        SourceTypeDiscovery(
+            id="container",
+            label="Containers",
+            description="Docker container scanning is planned for a later workflow.",
+            enabled=False,
+            planned=True,
+        ),
+    ]
+
+
+def _script_content(action: Literal["stop", "start"], service_name: str) -> str:
+    title = "Stop" if action == "stop" else "Start"
+    return f"""#!/bin/sh
+set -eu
+
+SERVICE_NAME="${{DB_SERVICE_NAME:-{service_name}}}"
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl {action} "$SERVICE_NAME"
+elif command -v service >/dev/null 2>&1; then
+  service "$SERVICE_NAME" {action}
+else
+  echo "No service manager found. {title} $SERVICE_NAME manually or edit this script." >&2
+  exit 1
+fi
+"""
+
+
+def _scripts_for(
+    definition: DatabaseDefinition,
+) -> tuple[ScriptTemplate, ScriptTemplate]:
+    pre = ScriptTemplate(
+        name=f"Stop {definition.label} before backup",
+        description=(
+            f"Stop {definition.label} before the Borg snapshot for a "
+            "filesystem-consistent backup."
+        ),
+        content=_script_content("stop", definition.service_name),
+        timeout=120,
+        run_on="always",
+    )
+    post = ScriptTemplate(
+        name=f"Start {definition.label} after backup",
+        description=f"Start {definition.label} after the Borg snapshot completes.",
+        content=_script_content("start", definition.service_name),
+        timeout=120,
+        run_on="always",
+    )
+    return pre, post
+
+
+def _normalize_process(process: Any) -> dict[str, Any]:
+    if isinstance(process, dict):
+        return process
+    return getattr(process, "info", {}) or {}
+
+
+def _iter_processes() -> list[dict[str, Any]]:
+    processes: list[dict[str, Any]] = []
+    for process in psutil.process_iter(["name", "cmdline"]):
+        try:
+            processes.append(_normalize_process(process))
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue
+    return processes
+
+
+def _process_name(process: dict[str, Any]) -> str:
+    name = str(process.get("name") or "").strip()
+    if name:
+        return Path(name).name.lower()
+    cmdline = process.get("cmdline") or []
+    if cmdline:
+        return Path(str(cmdline[0])).name.lower()
+    return ""
+
+
+def _process_matches(process: dict[str, Any], definition: DatabaseDefinition) -> bool:
+    process_name = _process_name(process)
+    if process_name in definition.process_names:
+        return True
+
+    cmdline = [Path(str(part)).name.lower() for part in process.get("cmdline") or []]
+    return any(name in cmdline for name in definition.process_names)
+
+
+def _extract_path_from_cmdline(
+    cmdline: list[str], definition: DatabaseDefinition
+) -> str | None:
+    for index, part in enumerate(cmdline):
+        for arg_name in definition.path_args:
+            if part == arg_name and index + 1 < len(cmdline):
+                return cmdline[index + 1]
+            prefix = f"{arg_name}="
+            if part.startswith(prefix):
+                return part.removeprefix(prefix)
+    return None
+
+
+def _first_existing_path(
+    paths: Iterable[str], path_exists: Callable[[str], bool]
+) -> str | None:
+    for path in paths:
+        if path_exists(path):
+            return path
+    return None
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "source"
+
+
+def _candidate(
+    definition: DatabaseDefinition,
+    *,
+    status: str,
+    source_path: str,
+    discovery_source: str,
+    confidence: Confidence,
+) -> DatabaseSourceCandidate:
+    pre, post = _scripts_for(definition)
+    source_directories = [source_path]
+    return DatabaseSourceCandidate(
+        id=f"{definition.engine}-{discovery_source}-{_slug(source_path)}",
+        engine=definition.engine,
+        engine_label=definition.label,
+        name=f"{definition.label} {status.replace('_', ' ')}",
+        status=status,
+        source_directories=source_directories,
+        service_name=definition.service_name,
+        discovery_source=discovery_source,
+        confidence=confidence,
+        notes=[
+            (
+                f"Back up {definition.label} as a filesystem source by stopping "
+                "the service before Borg runs and starting it afterwards."
+            ),
+            "Review the data path and scripts before saving the plan.",
+        ],
+        pre_backup_script=pre,
+        post_backup_script=post,
+    )
+
+
+def _template(definition: DatabaseDefinition) -> DatabaseSourceCandidate:
+    return _candidate(
+        definition,
+        status="template",
+        source_path=definition.default_paths[0],
+        discovery_source="template",
+        confidence="low",
+    )
+
+
+def scan_database_sources(
+    *,
+    processes: Iterable[dict[str, Any]] | None = None,
+    path_exists: Callable[[str], bool] | None = None,
+) -> SourceDiscoveryResult:
+    process_list = list(processes) if processes is not None else _iter_processes()
+    exists = path_exists or (lambda path: Path(path).exists())
+    databases: list[DatabaseSourceCandidate] = []
+    seen_ids: set[str] = set()
+
+    for definition in DATABASE_DEFINITIONS:
+        matching_processes = [
+            process for process in process_list if _process_matches(process, definition)
+        ]
+        for process in matching_processes:
+            cmdline = [str(part) for part in process.get("cmdline") or []]
+            source_path = _extract_path_from_cmdline(cmdline, definition)
+            confidence: Confidence = "high"
+            if not source_path:
+                source_path = _first_existing_path(definition.default_paths, exists)
+                confidence = "medium" if source_path else "low"
+            if not source_path:
+                source_path = definition.default_paths[0]
+
+            candidate = _candidate(
+                definition,
+                status="running",
+                source_path=source_path,
+                discovery_source="process",
+                confidence=confidence,
+            )
+            if candidate.id not in seen_ids:
+                databases.append(candidate)
+                seen_ids.add(candidate.id)
+
+        if matching_processes:
+            continue
+
+        existing_path = _first_existing_path(definition.default_paths, exists)
+        if existing_path:
+            candidate = _candidate(
+                definition,
+                status="path_found",
+                source_path=existing_path,
+                discovery_source="path",
+                confidence="medium",
+            )
+            if candidate.id not in seen_ids:
+                databases.append(candidate)
+                seen_ids.add(candidate.id)
+
+    return SourceDiscoveryResult(
+        scanned_at=datetime.now(timezone.utc).isoformat(),
+        source_types=_source_types(),
+        databases=databases,
+        templates=[_template(definition) for definition in DATABASE_DEFINITIONS],
+    )

--- a/docs/engineering/plans/2026-05-16-automatic-database-scanning.md
+++ b/docs/engineering/plans/2026-05-16-automatic-database-scanning.md
@@ -1,0 +1,23 @@
+# Automatic Database Scanning And Setup Plan
+
+## Plan
+
+1. Add backend source discovery primitives:
+   - Service model for source types, database candidates, and generated script templates.
+   - Local scanner based on running processes and common data paths.
+   - Authenticated API endpoint for admin/operator users.
+2. Add focused backend tests:
+   - Process-based detection extracts source paths and service names.
+   - API returns source type metadata, detected databases, and supported templates.
+3. Add frontend API types and UI:
+   - Source discovery panel in backup-plan source setup.
+   - Database discovery dialog with detected databases and template fallback.
+   - Editable pre/post scripts and apply action that creates scripts and updates plan state.
+4. Add focused frontend tests:
+   - Scan entry point renders alongside existing path setup.
+   - Applying a database creates scripts and updates source directories/script IDs.
+5. Validate:
+   - Targeted backend and frontend tests.
+   - Required backend checks.
+   - Required frontend locale, typecheck, lint, and build checks.
+   - Runtime walkthrough of the backup-plan source setup path.

--- a/docs/engineering/specs/2026-05-16-automatic-database-scanning.md
+++ b/docs/engineering/specs/2026-05-16-automatic-database-scanning.md
@@ -1,0 +1,33 @@
+# Automatic Database Scanning And Setup
+
+## Problem
+
+Backup-plan source setup is path-first. That works for files, but database users need help finding supported database stores and adding the pre/post plan hooks that keep a filesystem backup consistent.
+
+## Scope
+
+- Add a local database discovery endpoint that returns supported database candidates, their source paths, confidence, and editable stop/start hook templates.
+- Add a source discovery panel to backup-plan source setup with databases available now and containers shown as a future source type.
+- Add a guided responsive dialog that scans databases, lets the user review detected candidates or supported templates, edit generated scripts, and apply the result to the current backup plan.
+- Applying a candidate adds the source path and creates pre/post plan scripts through the existing script library API.
+
+## Supported Engines
+
+- PostgreSQL
+- MySQL / MariaDB
+- MongoDB
+- Redis
+
+## Non-Goals
+
+- Remote SSH database scanning.
+- Docker container scanning implementation.
+- Database credential collection or logical dump execution.
+- Automatic editing of existing scripts.
+
+## UX Notes
+
+- Existing path-based local and remote source setup remains the primary baseline.
+- Discovery is an additive assistant below the source location controls.
+- The dialog uses the existing responsive dialog pattern, so it becomes a bottom sheet on mobile.
+- Containers are visible as a disabled planned option to make the source model extensible without implying support.

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -744,6 +744,43 @@
         "runRepositoryScriptsHelper": "Verwendet die konfigurierten Pre/Post-Backup-Skripte jedes Repositorys während seiner eigenen Kopie.",
         "loading": "Skripte werden geladen..."
       },
+      "sourceDiscovery": {
+        "title": "Quellenerkennung",
+        "description": "Strukturierte Quellen scannen und Backup-Plan-Skripte generieren, ohne die manuelle Pfadeinrichtung zu ersetzen.",
+        "databases": {
+          "title": "Datenbanken",
+          "description": "Unterstützte Datenbankspeicher auf diesem Server finden.",
+          "action": "Datenbanken scannen"
+        },
+        "containers": {
+          "title": "Container",
+          "description": "Das Scannen von Docker-Containern wird später denselben Quellen-Workflow verwenden.",
+          "badge": "Geplant",
+          "action": "Später verfügbar"
+        },
+        "scriptName": {
+          "pre": "pre-backup",
+          "post": "post-backup"
+        },
+        "applyFailed": "Datenbankquelle konnte nicht angewendet werden",
+        "dialog": {
+          "title": "Datenbankerkennung",
+          "description": "Lokale Datenbankspeicher scannen und bearbeitbare Plan-Skripte für konsistente Dateisystem-Backups generieren.",
+          "rescan": "Erneut scannen",
+          "scanFailed": "Datenbankscan fehlgeschlagen. Erneut versuchen oder manuelle Pfade verwenden.",
+          "noDetected": "Es wurden keine laufenden unterstützten Datenbanken erkannt. Starte mit einer unterstützten Vorlage und prüfe den Pfad vor dem Speichern.",
+          "template": "Vorlage",
+          "detected": "Erkannt",
+          "strategy": "Borg sichert die Datenbankdateien, während generierte Plan-Skripte den Dienst stoppen und starten.",
+          "sourcePath": "Datenbank-Quellpfad",
+          "preScript": "Pre-Backup-Skript",
+          "postScript": "Post-Backup-Skript",
+          "reviewWarning": "Das Stoppen einer Datenbank pausiert Schreibvorgänge während der Plan läuft. Prüfe Pfade, Dienstnamen und Wartungsfenster, bevor du einen Zeitplan aktivierst.",
+          "selectDatabase": "Wähle eine Datenbank aus, um die generierten Skripte zu prüfen.",
+          "applying": "Wird angewendet...",
+          "apply": "Datenbankquelle verwenden"
+        }
+      },
       "schedule": {
         "title": "Zeitplan",
         "description": "Lege fest, wann dieser Plan automatisch ausgeführt wird. Deaktivieren, um ihn nur auf Abruf zu starten.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -744,6 +744,43 @@
         "runRepositoryScriptsHelper": "Use each repository's configured pre/post backup scripts during its own copy.",
         "loading": "Loading scripts..."
       },
+      "sourceDiscovery": {
+        "title": "Source discovery",
+        "description": "Scan structured sources and generate backup-plan scripts without replacing manual path setup.",
+        "databases": {
+          "title": "Databases",
+          "description": "Find supported database stores on this server.",
+          "action": "Scan databases"
+        },
+        "containers": {
+          "title": "Containers",
+          "description": "Docker container scanning will use this same source workflow later.",
+          "badge": "Planned",
+          "action": "Coming later"
+        },
+        "scriptName": {
+          "pre": "pre-backup",
+          "post": "post-backup"
+        },
+        "applyFailed": "Failed to apply database source",
+        "dialog": {
+          "title": "Database discovery",
+          "description": "Scan local database stores and generate editable plan scripts for consistent filesystem backups.",
+          "rescan": "Rescan",
+          "scanFailed": "Database scan failed. Try again or use manual paths.",
+          "noDetected": "No running supported databases were detected. Start from a supported template and verify the path before saving.",
+          "template": "Template",
+          "detected": "Detected",
+          "strategy": "Borg will back up the database files while generated plan scripts stop and start the service.",
+          "sourcePath": "Database source path",
+          "preScript": "Pre-backup script",
+          "postScript": "Post-backup script",
+          "reviewWarning": "Stopping a database pauses writes while the plan runs. Review paths, service names, and maintenance windows before enabling a schedule.",
+          "selectDatabase": "Select a database to review generated scripts.",
+          "applying": "Applying...",
+          "apply": "Use database source"
+        }
+      },
       "schedule": {
         "title": "Schedule",
         "description": "Choose when this plan should run automatically. Disable to run only on demand.",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -744,6 +744,43 @@
         "runRepositoryScriptsHelper": "Usa los scripts pre/post copia configurados en cada repositorio durante su propia copia.",
         "loading": "Cargando scripts..."
       },
+      "sourceDiscovery": {
+        "title": "Descubrimiento de origen",
+        "description": "Escanea orígenes estructurados y genera scripts del plan sin reemplazar la configuración manual de rutas.",
+        "databases": {
+          "title": "Bases de datos",
+          "description": "Encuentra almacenes de bases de datos compatibles en este servidor.",
+          "action": "Escanear bases de datos"
+        },
+        "containers": {
+          "title": "Contenedores",
+          "description": "El escaneo de contenedores Docker usará este mismo flujo de origen más adelante.",
+          "badge": "Planificado",
+          "action": "Más adelante"
+        },
+        "scriptName": {
+          "pre": "pre-copia",
+          "post": "post-copia"
+        },
+        "applyFailed": "No se pudo aplicar el origen de base de datos",
+        "dialog": {
+          "title": "Descubrimiento de bases de datos",
+          "description": "Escanea almacenes locales de bases de datos y genera scripts editables para copias de sistema de archivos consistentes.",
+          "rescan": "Reescanear",
+          "scanFailed": "El escaneo de bases de datos falló. Inténtalo de nuevo o usa rutas manuales.",
+          "noDetected": "No se detectaron bases de datos compatibles en ejecución. Empieza con una plantilla compatible y verifica la ruta antes de guardar.",
+          "template": "Plantilla",
+          "detected": "Detectado",
+          "strategy": "Borg copiará los archivos de la base de datos mientras los scripts generados detienen e inician el servicio.",
+          "sourcePath": "Ruta de origen de la base de datos",
+          "preScript": "Script previo a la copia",
+          "postScript": "Script posterior a la copia",
+          "reviewWarning": "Detener una base de datos pausa escrituras mientras el plan se ejecuta. Revisa rutas, nombres de servicio y ventanas de mantenimiento antes de habilitar una programación.",
+          "selectDatabase": "Selecciona una base de datos para revisar los scripts generados.",
+          "applying": "Aplicando...",
+          "apply": "Usar origen de base de datos"
+        }
+      },
       "schedule": {
         "title": "Programación",
         "description": "Elige cuándo se debe ejecutar este plan automáticamente. Desactívalo para ejecutarlo solo bajo demanda.",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -744,6 +744,43 @@
         "runRepositoryScriptsHelper": "Usa gli script pre/post backup configurati in ogni repository durante la sua copia.",
         "loading": "Caricamento script..."
       },
+      "sourceDiscovery": {
+        "title": "Rilevamento sorgenti",
+        "description": "Scansiona sorgenti strutturate e genera script del piano senza sostituire la configurazione manuale dei percorsi.",
+        "databases": {
+          "title": "Database",
+          "description": "Trova archivi database supportati su questo server.",
+          "action": "Scansiona database"
+        },
+        "containers": {
+          "title": "Container",
+          "description": "La scansione dei container Docker userà più avanti questo stesso flusso sorgente.",
+          "badge": "Pianificato",
+          "action": "Disponibile più avanti"
+        },
+        "scriptName": {
+          "pre": "pre-backup",
+          "post": "post-backup"
+        },
+        "applyFailed": "Impossibile applicare la sorgente database",
+        "dialog": {
+          "title": "Rilevamento database",
+          "description": "Scansiona archivi database locali e genera script modificabili per backup coerenti del filesystem.",
+          "rescan": "Scansiona di nuovo",
+          "scanFailed": "Scansione database non riuscita. Riprova o usa percorsi manuali.",
+          "noDetected": "Nessun database supportato in esecuzione rilevato. Parti da un modello supportato e verifica il percorso prima di salvare.",
+          "template": "Modello",
+          "detected": "Rilevato",
+          "strategy": "Borg copierà i file del database mentre gli script generati arrestano e avviano il servizio.",
+          "sourcePath": "Percorso sorgente database",
+          "preScript": "Script pre-backup",
+          "postScript": "Script post-backup",
+          "reviewWarning": "Arrestare un database sospende le scritture mentre il piano viene eseguito. Verifica percorsi, nomi servizio e finestre di manutenzione prima di abilitare una pianificazione.",
+          "selectDatabase": "Seleziona un database per rivedere gli script generati.",
+          "applying": "Applicazione...",
+          "apply": "Usa sorgente database"
+        }
+      },
       "schedule": {
         "title": "Pianificazione",
         "description": "Scegli quando questo piano deve essere eseguito automaticamente. Disattiva per avviarlo solo su richiesta.",

--- a/frontend/src/pages/BackupPlans.tsx
+++ b/frontend/src/pages/BackupPlans.tsx
@@ -50,6 +50,7 @@ import type {
   SSHConnection,
   WizardState,
 } from './backup-plans/types'
+import type { DatabaseDiscoverySelection } from './backup-plans/sourceDiscovery'
 
 const stepDefinitions = [
   { key: 'source', labelKey: 'backupPlans.wizard.steps.sources', icon: <ListChecks size={14} /> },
@@ -479,6 +480,51 @@ export default function BackupPlans() {
     ]
   }
 
+  const createDiscoveryScript = async (
+    selection: DatabaseDiscoverySelection,
+    hook: 'pre' | 'post',
+    uniqueSuffix: number
+  ) => {
+    const script = hook === 'pre' ? selection.preBackupScript : selection.postBackupScript
+    const planName = wizardState.name.trim() || t('backupPlans.wizard.createTitle')
+    const hookLabel =
+      hook === 'pre'
+        ? t('backupPlans.wizard.sourceDiscovery.scriptName.pre', {
+            defaultValue: 'pre-backup',
+          })
+        : t('backupPlans.wizard.sourceDiscovery.scriptName.post', {
+            defaultValue: 'post-backup',
+          })
+    const response = await scriptsAPI.create({
+      name: `${planName} - ${selection.database.engine_label} ${hookLabel} ${uniqueSuffix}`,
+      description: script.description,
+      content: script.content,
+      timeout: script.timeout,
+      run_on: script.run_on,
+      category: 'custom',
+    })
+
+    return Number(response.data.id)
+  }
+
+  const applyDatabaseDiscovery = async (selection: DatabaseDiscoverySelection) => {
+    const uniqueSuffix = Date.now()
+    const preBackupScriptId = await createDiscoveryScript(selection, 'pre', uniqueSuffix)
+    const postBackupScriptId = await createDiscoveryScript(selection, 'post', uniqueSuffix)
+
+    setWizardState((prev) => ({
+      ...prev,
+      sourceType: 'local',
+      sourceSshConnectionId: '',
+      sourceDirectories: appendUniquePaths(prev.sourceDirectories, selection.sourceDirectories),
+      preBackupScriptId,
+      postBackupScriptId,
+      preBackupScriptParameters: {},
+      postBackupScriptParameters: {},
+    }))
+    await queryClient.invalidateQueries({ queryKey: ['scripts'] })
+  }
+
   const requireRemoteSourceConnection = () => {
     if (wizardState.sourceType !== 'remote' || selectedSourceConnection) return true
     toast.error(t('backupPlans.toasts.selectSourceConnection'))
@@ -614,6 +660,7 @@ export default function BackupPlans() {
       createBasicRepository={createBasicRepository}
       openSourceExplorer={openSourceExplorer}
       openExcludeExplorer={openExcludeExplorer}
+      onApplyDatabaseDiscovery={applyDatabaseDiscovery}
       setBasicRepositoryOpen={setBasicRepositoryOpen}
       setRepositoryWizardOpen={setRepositoryWizardOpen}
       setShowBasicRepositoryPathExplorer={setShowBasicRepositoryPathExplorer}

--- a/frontend/src/pages/backup-plans/BackupPlanWizardStep.tsx
+++ b/frontend/src/pages/backup-plans/BackupPlanWizardStep.tsx
@@ -29,6 +29,7 @@ export function BackupPlanWizardStep({
   createBasicRepository,
   openSourceExplorer,
   openExcludeExplorer,
+  onApplyDatabaseDiscovery,
   setBasicRepositoryOpen,
   setRepositoryWizardOpen,
   setShowBasicRepositoryPathExplorer,
@@ -44,6 +45,7 @@ export function BackupPlanWizardStep({
         updateState={updateState}
         openSourceExplorer={openSourceExplorer}
         openExcludeExplorer={openExcludeExplorer}
+        onApplyDatabaseDiscovery={onApplyDatabaseDiscovery}
         t={t}
       />
     )

--- a/frontend/src/pages/backup-plans/DatabaseDiscoveryDialog.tsx
+++ b/frontend/src/pages/backup-plans/DatabaseDiscoveryDialog.tsx
@@ -1,0 +1,386 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardActionArea,
+  CardContent,
+  Chip,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  LinearProgress,
+  Stack,
+  TextField,
+  Typography,
+  alpha,
+} from '@mui/material'
+import { Database, RefreshCw } from 'lucide-react'
+import type { TFunction } from 'i18next'
+
+import ResponsiveDialog from '../../components/ResponsiveDialog'
+import {
+  sourceDiscoveryAPI,
+  type SourceDiscoveryDatabase,
+  type SourceDiscoveryResponse,
+} from '../../services/api'
+import type { DatabaseDiscoverySelection } from './sourceDiscovery'
+
+interface DatabaseDiscoveryDialogProps {
+  open: boolean
+  onClose: () => void
+  onApply: (selection: DatabaseDiscoverySelection) => Promise<void> | void
+  t: TFunction
+}
+
+function confidenceColor(confidence: SourceDiscoveryDatabase['confidence']) {
+  if (confidence === 'high') return 'success'
+  if (confidence === 'medium') return 'warning'
+  return 'default'
+}
+
+function candidateGroupLabel(candidate: SourceDiscoveryDatabase, t: TFunction) {
+  if (candidate.discovery_source === 'template') {
+    return t('backupPlans.wizard.sourceDiscovery.dialog.template', {
+      defaultValue: 'Template',
+    })
+  }
+  return t('backupPlans.wizard.sourceDiscovery.dialog.detected', {
+    defaultValue: 'Detected',
+  })
+}
+
+export function DatabaseDiscoveryDialog({
+  open,
+  onClose,
+  onApply,
+  t,
+}: DatabaseDiscoveryDialogProps) {
+  const [data, setData] = useState<SourceDiscoveryResponse | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [sourcePath, setSourcePath] = useState('')
+  const [preScriptContent, setPreScriptContent] = useState('')
+  const [postScriptContent, setPostScriptContent] = useState('')
+  const [applying, setApplying] = useState(false)
+
+  const candidates = useMemo(() => {
+    if (!data) return []
+    return [...data.databases, ...data.templates]
+  }, [data])
+
+  const selected = candidates.find((candidate) => candidate.id === selectedId) || null
+
+  const loadDatabases = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await sourceDiscoveryAPI.scanDatabases()
+      setData(response.data)
+      const firstCandidate = response.data.databases[0] || response.data.templates[0] || null
+      if (firstCandidate) {
+        setSelectedId(firstCandidate.id)
+        setSourcePath(firstCandidate.source_directories[0] || '')
+        setPreScriptContent(firstCandidate.pre_backup_script.content)
+        setPostScriptContent(firstCandidate.post_backup_script.content)
+      }
+    } catch {
+      setError(
+        t('backupPlans.wizard.sourceDiscovery.dialog.scanFailed', {
+          defaultValue: 'Database scan failed. Try again or use manual paths.',
+        })
+      )
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!open) {
+      setData(null)
+      setSelectedId(null)
+      setSourcePath('')
+      setPreScriptContent('')
+      setPostScriptContent('')
+      setError(null)
+      setApplying(false)
+      return
+    }
+
+    void loadDatabases()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  const selectCandidate = (candidate: SourceDiscoveryDatabase) => {
+    setSelectedId(candidate.id)
+    setSourcePath(candidate.source_directories[0] || '')
+    setPreScriptContent(candidate.pre_backup_script.content)
+    setPostScriptContent(candidate.post_backup_script.content)
+    setError(null)
+  }
+
+  const sourceDirectories = sourcePath.trim() ? [sourcePath.trim()] : []
+  const canApply =
+    Boolean(selected) &&
+    sourceDirectories.length > 0 &&
+    preScriptContent.trim().length > 0 &&
+    postScriptContent.trim().length > 0 &&
+    !applying
+
+  const applySelection = async () => {
+    if (!selected || !canApply) return
+    setApplying(true)
+    setError(null)
+    try {
+      await onApply({
+        database: selected,
+        sourceDirectories,
+        preBackupScript: {
+          ...selected.pre_backup_script,
+          content: preScriptContent,
+        },
+        postBackupScript: {
+          ...selected.post_backup_script,
+          content: postScriptContent,
+        },
+      })
+      onClose()
+    } catch {
+      setError(
+        t('backupPlans.wizard.sourceDiscovery.applyFailed', {
+          defaultValue: 'Failed to apply database source',
+        })
+      )
+    } finally {
+      setApplying(false)
+    }
+  }
+
+  return (
+    <ResponsiveDialog
+      open={open}
+      onClose={onClose}
+      maxWidth="lg"
+      fullWidth
+      footer={
+        <DialogActions sx={{ px: 3, py: 2 }}>
+          <Button onClick={onClose} disabled={applying}>
+            {t('common.buttons.cancel', { defaultValue: 'Cancel' })}
+          </Button>
+          <Button variant="contained" onClick={applySelection} disabled={!canApply}>
+            {applying
+              ? t('backupPlans.wizard.sourceDiscovery.dialog.applying', {
+                  defaultValue: 'Applying...',
+                })
+              : t('backupPlans.wizard.sourceDiscovery.dialog.apply', {
+                  defaultValue: 'Use database source',
+                })}
+          </Button>
+        </DialogActions>
+      }
+    >
+      <DialogTitle sx={{ pb: 1 }}>
+        <Stack direction="row" alignItems="center" justifyContent="space-between" gap={2}>
+          <Box>
+            <Typography variant="h6" fontWeight={700}>
+              {t('backupPlans.wizard.sourceDiscovery.dialog.title', {
+                defaultValue: 'Database discovery',
+              })}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {t('backupPlans.wizard.sourceDiscovery.dialog.description', {
+                defaultValue:
+                  'Scan local database stores and generate editable plan scripts for consistent filesystem backups.',
+              })}
+            </Typography>
+          </Box>
+          <Button
+            startIcon={<RefreshCw size={16} />}
+            onClick={loadDatabases}
+            disabled={loading || applying}
+          >
+            {t('backupPlans.wizard.sourceDiscovery.dialog.rescan', {
+              defaultValue: 'Rescan',
+            })}
+          </Button>
+        </Stack>
+      </DialogTitle>
+      <DialogContent sx={{ pt: 2 }}>
+        <Stack spacing={2}>
+          {loading && <LinearProgress />}
+          {error && <Alert severity="error">{error}</Alert>}
+          {data && data.databases.length === 0 && (
+            <Alert severity="info">
+              {t('backupPlans.wizard.sourceDiscovery.dialog.noDetected', {
+                defaultValue:
+                  'No running supported databases were detected. Start from a supported template and verify the path before saving.',
+              })}
+            </Alert>
+          )}
+
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr', md: 'minmax(260px, 0.85fr) 1.4fr' },
+              gap: 2,
+              minHeight: { md: 500 },
+            }}
+          >
+            <Stack spacing={1.5}>
+              {candidates.map((candidate) => {
+                const selectedCandidate = candidate.id === selectedId
+                return (
+                  <Card
+                    key={candidate.id}
+                    variant="outlined"
+                    sx={{
+                      borderColor: selectedCandidate ? 'primary.main' : 'divider',
+                      bgcolor: selectedCandidate
+                        ? (theme) => alpha(theme.palette.primary.main, 0.08)
+                        : 'background.paper',
+                    }}
+                  >
+                    <CardActionArea onClick={() => selectCandidate(candidate)}>
+                      <CardContent>
+                        <Stack direction="row" spacing={1.5} alignItems="flex-start">
+                          <Box
+                            sx={{
+                              display: 'grid',
+                              placeItems: 'center',
+                              width: 38,
+                              height: 38,
+                              borderRadius: 2,
+                              bgcolor: selectedCandidate ? 'primary.main' : 'action.hover',
+                              color: selectedCandidate ? 'primary.contrastText' : 'text.secondary',
+                              flexShrink: 0,
+                            }}
+                          >
+                            <Database size={20} />
+                          </Box>
+                          <Box sx={{ minWidth: 0, flex: 1 }}>
+                            <Typography variant="subtitle2" fontWeight={700}>
+                              {candidate.name}
+                            </Typography>
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                              sx={{
+                                display: 'block',
+                                overflowWrap: 'anywhere',
+                              }}
+                            >
+                              {candidate.source_directories[0]}
+                            </Typography>
+                            <Stack direction="row" spacing={0.75} sx={{ mt: 1, flexWrap: 'wrap' }}>
+                              <Chip
+                                size="small"
+                                label={candidateGroupLabel(candidate, t)}
+                                variant="outlined"
+                              />
+                              <Chip
+                                size="small"
+                                label={candidate.confidence}
+                                color={confidenceColor(candidate.confidence)}
+                                variant="outlined"
+                              />
+                            </Stack>
+                          </Box>
+                        </Stack>
+                      </CardContent>
+                    </CardActionArea>
+                  </Card>
+                )
+              })}
+            </Stack>
+
+            <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 2, p: 2 }}>
+              {selected ? (
+                <Stack spacing={2}>
+                  <Box>
+                    <Typography variant="subtitle1" fontWeight={700}>
+                      {selected.engine_label}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {t('backupPlans.wizard.sourceDiscovery.dialog.strategy', {
+                        defaultValue:
+                          'Borg will back up the database files while generated plan scripts stop and start the service.',
+                      })}
+                    </Typography>
+                  </Box>
+
+                  <TextField
+                    label={t('backupPlans.wizard.sourceDiscovery.dialog.sourcePath', {
+                      defaultValue: 'Database source path',
+                    })}
+                    value={sourcePath}
+                    onChange={(event) => setSourcePath(event.target.value)}
+                    fullWidth
+                    required
+                  />
+
+                  <Divider />
+
+                  <TextField
+                    label={t('backupPlans.wizard.sourceDiscovery.dialog.preScript', {
+                      defaultValue: 'Pre-backup script',
+                    })}
+                    value={preScriptContent}
+                    onChange={(event) => setPreScriptContent(event.target.value)}
+                    multiline
+                    minRows={7}
+                    fullWidth
+                    required
+                    InputProps={{
+                      sx: { fontFamily: 'monospace', fontSize: '0.875rem' },
+                    }}
+                  />
+
+                  <TextField
+                    label={t('backupPlans.wizard.sourceDiscovery.dialog.postScript', {
+                      defaultValue: 'Post-backup script',
+                    })}
+                    value={postScriptContent}
+                    onChange={(event) => setPostScriptContent(event.target.value)}
+                    multiline
+                    minRows={7}
+                    fullWidth
+                    required
+                    InputProps={{
+                      sx: { fontFamily: 'monospace', fontSize: '0.875rem' },
+                    }}
+                  />
+
+                  <Alert severity="warning">
+                    {t('backupPlans.wizard.sourceDiscovery.dialog.reviewWarning', {
+                      defaultValue:
+                        'Stopping a database pauses writes while the plan runs. Review paths, service names, and maintenance windows before enabling a schedule.',
+                    })}
+                  </Alert>
+                </Stack>
+              ) : (
+                <Box
+                  sx={{
+                    minHeight: 240,
+                    display: 'grid',
+                    placeItems: 'center',
+                    textAlign: 'center',
+                    color: 'text.secondary',
+                  }}
+                >
+                  <Typography variant="body2">
+                    {t('backupPlans.wizard.sourceDiscovery.dialog.selectDatabase', {
+                      defaultValue: 'Select a database to review generated scripts.',
+                    })}
+                  </Typography>
+                </Box>
+              )}
+            </Box>
+          </Box>
+        </Stack>
+      </DialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/frontend/src/pages/backup-plans/__tests__/SourceStep.test.tsx
+++ b/frontend/src/pages/backup-plans/__tests__/SourceStep.test.tsx
@@ -1,0 +1,187 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { ThemeProvider, createTheme } from '@mui/material/styles'
+import { describe, expect, it, vi } from 'vitest'
+import type { TFunction } from 'i18next'
+
+import { sourceDiscoveryAPI } from '../../../services/api'
+import { SourceStep } from '../wizard-step/SourceStep'
+import type { WizardState } from '../types'
+
+vi.mock('../../../components/SourceDirectoriesInput', () => ({
+  default: () => <div data-testid="source-directories-input">Path source input</div>,
+}))
+
+vi.mock('../../../components/ExcludePatternInput', () => ({
+  default: () => <div data-testid="exclude-pattern-input">Exclude input</div>,
+}))
+
+vi.mock('../../../components/ResponsiveDialog', () => ({
+  default: ({
+    open,
+    children,
+    footer,
+  }: {
+    open: boolean
+    children: React.ReactNode
+    footer?: React.ReactNode
+  }) =>
+    open ? (
+      <div role="dialog">
+        {children}
+        {footer}
+      </div>
+    ) : null,
+}))
+
+const theme = createTheme()
+
+const t = ((key: string, options?: { defaultValue?: string }) => {
+  const translations: Record<string, string> = {
+    'backupPlans.wizard.fields.planName': 'Plan name',
+    'backupPlans.wizard.fields.description': 'Description',
+    'backupPlans.wizard.sourceDiscovery.title': 'Source discovery',
+    'backupPlans.wizard.sourceDiscovery.description':
+      'Scan supported structured sources and generate plan scripts.',
+    'backupPlans.wizard.sourceDiscovery.databases.title': 'Databases',
+    'backupPlans.wizard.sourceDiscovery.databases.description':
+      'Find database stores on this Borg UI server.',
+    'backupPlans.wizard.sourceDiscovery.databases.action': 'Scan databases',
+    'backupPlans.wizard.sourceDiscovery.containers.title': 'Containers',
+    'backupPlans.wizard.sourceDiscovery.containers.description':
+      'Docker container scanning will be available later.',
+    'backupPlans.wizard.sourceDiscovery.containers.badge': 'Planned',
+    'backupPlans.wizard.sourceDiscovery.applied': 'Database source added',
+    'backupPlans.wizard.sourceDiscovery.applyFailed': 'Failed to apply database source',
+  }
+  return translations[key] ?? options?.defaultValue ?? key
+}) as TFunction
+
+const defaultWizardState: WizardState = {
+  name: 'Nightly databases',
+  description: '',
+  enabled: true,
+  sourceType: 'local',
+  sourceSshConnectionId: '',
+  sourceDirectories: [],
+  excludePatterns: [],
+  repositoryIds: [],
+  compression: 'lz4',
+  archiveNameTemplate: '{plan_name}-{repo_name}-{now}',
+  customFlags: '',
+  uploadRatelimitMb: '',
+  repositoryRunMode: 'series',
+  maxParallelRepositories: 1,
+  failureBehavior: 'continue',
+  scheduleEnabled: false,
+  cronExpression: '0 21 * * *',
+  timezone: 'UTC',
+  preBackupScriptId: null,
+  postBackupScriptId: null,
+  preBackupScriptParameters: {},
+  postBackupScriptParameters: {},
+  runRepositoryScripts: true,
+  runPruneAfter: false,
+  runCompactAfter: false,
+  runCheckAfter: false,
+  checkMaxDuration: 3600,
+  pruneKeepHourly: 0,
+  pruneKeepDaily: 7,
+  pruneKeepWeekly: 4,
+  pruneKeepMonthly: 6,
+  pruneKeepQuarterly: 0,
+  pruneKeepYearly: 1,
+}
+
+function renderSourceStep(overrides: Partial<React.ComponentProps<typeof SourceStep>> = {}) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <SourceStep
+        wizardState={defaultWizardState}
+        sshConnections={[]}
+        updateState={vi.fn()}
+        openSourceExplorer={vi.fn()}
+        openExcludeExplorer={vi.fn()}
+        onApplyDatabaseDiscovery={vi.fn()}
+        t={t}
+        {...overrides}
+      />
+    </ThemeProvider>
+  )
+}
+
+describe('SourceStep', () => {
+  it('keeps path setup available while offering database and planned container discovery', () => {
+    renderSourceStep()
+
+    expect(screen.getByTestId('source-directories-input')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /scan databases/i })).toBeInTheDocument()
+    expect(screen.getByText('Containers')).toBeInTheDocument()
+    expect(screen.getByText('Planned')).toBeInTheDocument()
+  })
+
+  it('applies a detected database source with editable generated scripts', async () => {
+    const onApplyDatabaseDiscovery = vi.fn().mockResolvedValue(undefined)
+    vi.spyOn(sourceDiscoveryAPI, 'scanDatabases').mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {},
+      data: {
+        scanned_at: '2026-05-16T11:00:00Z',
+        source_types: [],
+        templates: [],
+        databases: [
+          {
+            id: 'postgresql-process-var-lib-postgresql-16-main',
+            engine: 'postgresql',
+            engine_label: 'PostgreSQL',
+            name: 'PostgreSQL cluster',
+            status: 'running',
+            source_directories: ['/var/lib/postgresql/16/main'],
+            service_name: 'postgresql',
+            discovery_source: 'process',
+            confidence: 'high',
+            notes: ['Stop PostgreSQL before the Borg snapshot and start it afterwards.'],
+            pre_backup_script: {
+              name: 'Stop PostgreSQL before backup',
+              description: 'Stop PostgreSQL for a filesystem-consistent backup.',
+              content: '#!/bin/sh\nsystemctl stop postgresql\n',
+              timeout: 120,
+              run_on: 'always',
+            },
+            post_backup_script: {
+              name: 'Start PostgreSQL after backup',
+              description: 'Start PostgreSQL after the Borg snapshot.',
+              content: '#!/bin/sh\nsystemctl start postgresql\n',
+              timeout: 120,
+              run_on: 'always',
+            },
+          },
+        ],
+      },
+    } as unknown as Awaited<ReturnType<typeof sourceDiscoveryAPI.scanDatabases>>)
+
+    renderSourceStep({ onApplyDatabaseDiscovery })
+
+    fireEvent.click(screen.getByRole('button', { name: /scan databases/i }))
+    fireEvent.click(await screen.findByText('PostgreSQL cluster'))
+    fireEvent.change(screen.getByLabelText(/pre-backup script/i), {
+      target: { value: '#!/bin/sh\nservice postgresql stop' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /use database source/i }))
+
+    await waitFor(() => {
+      expect(onApplyDatabaseDiscovery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceDirectories: ['/var/lib/postgresql/16/main'],
+          preBackupScript: expect.objectContaining({
+            content: expect.stringContaining('service postgresql stop'),
+          }),
+          postBackupScript: expect.objectContaining({
+            content: expect.stringContaining('systemctl start postgresql'),
+          }),
+        })
+      )
+    })
+  })
+})

--- a/frontend/src/pages/backup-plans/sourceDiscovery.ts
+++ b/frontend/src/pages/backup-plans/sourceDiscovery.ts
@@ -1,0 +1,8 @@
+import type { SourceDiscoveryDatabase, SourceDiscoveryScriptTemplate } from '../../services/api'
+
+export interface DatabaseDiscoverySelection {
+  database: SourceDiscoveryDatabase
+  sourceDirectories: string[]
+  preBackupScript: SourceDiscoveryScriptTemplate
+  postBackupScript: SourceDiscoveryScriptTemplate
+}

--- a/frontend/src/pages/backup-plans/wizard-step/SourceStep.tsx
+++ b/frontend/src/pages/backup-plans/wizard-step/SourceStep.tsx
@@ -1,7 +1,11 @@
-import { Stack, TextField } from '@mui/material'
+import { useState } from 'react'
+import { Box, Button, Card, CardContent, Chip, Stack, TextField, Typography } from '@mui/material'
+import { Database, Package } from 'lucide-react'
 
 import ExcludePatternInput from '../../../components/ExcludePatternInput'
 import { WizardStepDataSource } from '../../../components/wizard'
+import { DatabaseDiscoveryDialog } from '../DatabaseDiscoveryDialog'
+import type { DatabaseDiscoverySelection } from '../sourceDiscovery'
 import type { BackupPlanWizardStepProps } from './types'
 
 type SourceStepProps = Pick<
@@ -11,6 +15,7 @@ type SourceStepProps = Pick<
   | 'updateState'
   | 'openSourceExplorer'
   | 'openExcludeExplorer'
+  | 'onApplyDatabaseDiscovery'
   | 't'
 >
 
@@ -20,8 +25,11 @@ export function SourceStep({
   updateState,
   openSourceExplorer,
   openExcludeExplorer,
+  onApplyDatabaseDiscovery,
   t,
 }: SourceStepProps) {
+  const [databaseDiscoveryOpen, setDatabaseDiscoveryOpen] = useState(false)
+
   return (
     <Stack spacing={3}>
       <TextField
@@ -61,10 +69,134 @@ export function SourceStep({
         onBrowseSource={openSourceExplorer}
         onBrowseRemoteSource={openSourceExplorer}
       />
+      <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 2, p: 2 }}>
+        <Stack spacing={2}>
+          <Box>
+            <Typography variant="subtitle2" fontWeight={700}>
+              {t('backupPlans.wizard.sourceDiscovery.title', {
+                defaultValue: 'Source discovery',
+              })}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {t('backupPlans.wizard.sourceDiscovery.description', {
+                defaultValue:
+                  'Scan structured sources and generate backup-plan scripts without replacing manual path setup.',
+              })}
+            </Typography>
+          </Box>
+
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+              gap: 2,
+            }}
+          >
+            <Card variant="outlined" sx={{ bgcolor: 'background.default' }}>
+              <CardContent>
+                <Stack spacing={1.5}>
+                  <Stack direction="row" spacing={1.5} alignItems="center">
+                    <Box
+                      sx={{
+                        display: 'grid',
+                        placeItems: 'center',
+                        width: 38,
+                        height: 38,
+                        borderRadius: 2,
+                        bgcolor: 'primary.main',
+                        color: 'primary.contrastText',
+                        flexShrink: 0,
+                      }}
+                    >
+                      <Database size={20} />
+                    </Box>
+                    <Box sx={{ minWidth: 0 }}>
+                      <Typography variant="subtitle2" fontWeight={700}>
+                        {t('backupPlans.wizard.sourceDiscovery.databases.title', {
+                          defaultValue: 'Databases',
+                        })}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {t('backupPlans.wizard.sourceDiscovery.databases.description', {
+                          defaultValue: 'Find supported database stores on this server.',
+                        })}
+                      </Typography>
+                    </Box>
+                  </Stack>
+                  <Button
+                    variant="outlined"
+                    onClick={() => setDatabaseDiscoveryOpen(true)}
+                    fullWidth
+                  >
+                    {t('backupPlans.wizard.sourceDiscovery.databases.action', {
+                      defaultValue: 'Scan databases',
+                    })}
+                  </Button>
+                </Stack>
+              </CardContent>
+            </Card>
+
+            <Card variant="outlined" sx={{ bgcolor: 'background.default', opacity: 0.72 }}>
+              <CardContent>
+                <Stack spacing={1.5}>
+                  <Stack direction="row" spacing={1.5} alignItems="center">
+                    <Box
+                      sx={{
+                        display: 'grid',
+                        placeItems: 'center',
+                        width: 38,
+                        height: 38,
+                        borderRadius: 2,
+                        bgcolor: 'action.hover',
+                        color: 'text.secondary',
+                        flexShrink: 0,
+                      }}
+                    >
+                      <Package size={20} />
+                    </Box>
+                    <Box sx={{ minWidth: 0, flex: 1 }}>
+                      <Stack direction="row" spacing={1} alignItems="center">
+                        <Typography variant="subtitle2" fontWeight={700}>
+                          {t('backupPlans.wizard.sourceDiscovery.containers.title', {
+                            defaultValue: 'Containers',
+                          })}
+                        </Typography>
+                        <Chip
+                          size="small"
+                          label={t('backupPlans.wizard.sourceDiscovery.containers.badge', {
+                            defaultValue: 'Planned',
+                          })}
+                        />
+                      </Stack>
+                      <Typography variant="caption" color="text.secondary">
+                        {t('backupPlans.wizard.sourceDiscovery.containers.description', {
+                          defaultValue:
+                            'Docker container scanning will use this same source workflow later.',
+                        })}
+                      </Typography>
+                    </Box>
+                  </Stack>
+                  <Button variant="outlined" disabled fullWidth>
+                    {t('backupPlans.wizard.sourceDiscovery.containers.action', {
+                      defaultValue: 'Coming later',
+                    })}
+                  </Button>
+                </Stack>
+              </CardContent>
+            </Card>
+          </Box>
+        </Stack>
+      </Box>
       <ExcludePatternInput
         patterns={wizardState.excludePatterns}
         onChange={(excludePatterns) => updateState({ excludePatterns })}
         onBrowseClick={openExcludeExplorer}
+      />
+      <DatabaseDiscoveryDialog
+        open={databaseDiscoveryOpen}
+        onClose={() => setDatabaseDiscoveryOpen(false)}
+        onApply={(selection: DatabaseDiscoverySelection) => onApplyDatabaseDiscovery(selection)}
+        t={t}
       />
     </Stack>
   )

--- a/frontend/src/pages/backup-plans/wizard-step/types.ts
+++ b/frontend/src/pages/backup-plans/wizard-step/types.ts
@@ -4,6 +4,7 @@ import type { TFunction } from 'i18next'
 import type { PruneSettings } from '../../../components/PruneSettingsInput'
 import type { Repository } from '../../../types'
 import type { BasicRepositoryState, ScriptOption, SSHConnection, WizardState } from '../types'
+import type { DatabaseDiscoverySelection } from '../sourceDiscovery'
 
 export interface BackupPlanWizardStepProps {
   activeStep: number
@@ -28,6 +29,7 @@ export interface BackupPlanWizardStepProps {
   createBasicRepository: () => void
   openSourceExplorer: () => void
   openExcludeExplorer: () => void
+  onApplyDatabaseDiscovery: (selection: DatabaseDiscoverySelection) => Promise<void> | void
   setBasicRepositoryOpen: Dispatch<SetStateAction<boolean>>
   setRepositoryWizardOpen: Dispatch<SetStateAction<boolean>>
   setShowBasicRepositoryPathExplorer: Dispatch<SetStateAction<boolean>>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -233,6 +233,44 @@ export interface OidcLinkStartResponse {
 // Generic type for object data
 type ApiData = Record<string, unknown>
 
+export interface SourceDiscoveryScriptTemplate {
+  name: string
+  description: string
+  content: string
+  timeout: number
+  run_on: string
+}
+
+export interface SourceDiscoverySourceType {
+  id: string
+  label: string
+  description: string
+  enabled: boolean
+  planned: boolean
+}
+
+export interface SourceDiscoveryDatabase {
+  id: string
+  engine: string
+  engine_label: string
+  name: string
+  status: string
+  source_directories: string[]
+  service_name: string
+  discovery_source: string
+  confidence: 'high' | 'medium' | 'low'
+  notes: string[]
+  pre_backup_script: SourceDiscoveryScriptTemplate
+  post_backup_script: SourceDiscoveryScriptTemplate
+}
+
+export interface SourceDiscoveryResponse {
+  scanned_at: string
+  source_types: SourceDiscoverySourceType[]
+  databases: SourceDiscoveryDatabase[]
+  templates: SourceDiscoveryDatabase[]
+}
+
 export const authAPI = {
   getAuthConfig: () => api.get<AuthConfigResponse>('/auth/config'),
   getOidcLoginUrl: (returnTo?: string) => {
@@ -729,6 +767,10 @@ export const scriptsAPI = {
 
   // Delete a script
   delete: (scriptId: number) => api.delete(`/scripts/${scriptId}`),
+}
+
+export const sourceDiscoveryAPI = {
+  scanDatabases: () => api.get<SourceDiscoveryResponse>('/source-discovery/databases'),
 }
 
 export const mountsAPI = {

--- a/tests/unit/test_source_discovery.py
+++ b/tests/unit/test_source_discovery.py
@@ -1,0 +1,72 @@
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.services.source_discovery import scan_database_sources
+
+
+@pytest.mark.unit
+def test_scan_database_sources_detects_postgres_process_data_dir():
+    result = scan_database_sources(
+        processes=[
+            {
+                "name": "postgres",
+                "cmdline": ["postgres", "-D", "/var/lib/postgresql/16/main"],
+            }
+        ],
+        path_exists=lambda _path: False,
+    )
+
+    postgres = next(item for item in result.databases if item.engine == "postgresql")
+
+    assert postgres.status == "running"
+    assert postgres.source_directories == ["/var/lib/postgresql/16/main"]
+    assert postgres.service_name == "postgresql"
+    assert postgres.confidence == "high"
+    assert "DB_SERVICE_NAME:-postgresql" in postgres.pre_backup_script.content
+    assert "systemctl stop" in postgres.pre_backup_script.content
+    assert "systemctl start" in postgres.post_backup_script.content
+
+
+@pytest.mark.unit
+def test_scan_database_sources_exposes_container_source_as_planned():
+    result = scan_database_sources(processes=[], path_exists=lambda _path: False)
+
+    source_types = {source_type.id: source_type for source_type in result.source_types}
+
+    assert source_types["database"].enabled is True
+    assert source_types["container"].enabled is False
+    assert source_types["container"].planned is True
+    assert {template.engine for template in result.templates} >= {
+        "postgresql",
+        "mysql",
+        "mongodb",
+        "redis",
+    }
+
+
+@pytest.mark.unit
+def test_source_discovery_api_returns_database_scan(
+    test_client: TestClient, admin_headers
+):
+    with patch("app.api.source_discovery.scan_database_sources") as scan:
+        scan.return_value = scan_database_sources(
+            processes=[
+                {
+                    "name": "mongod",
+                    "cmdline": ["mongod", "--dbpath", "/srv/mongodb"],
+                }
+            ],
+            path_exists=lambda _path: False,
+        )
+
+        response = test_client.get(
+            "/api/source-discovery/databases", headers=admin_headers
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["databases"][0]["engine"] == "mongodb"
+    assert data["databases"][0]["source_directories"] == ["/srv/mongodb"]
+    assert data["source_types"][1]["id"] == "database"


### PR DESCRIPTION
## Description
Adds guided database source discovery to the backup-plan source step. The backend now exposes an authenticated source-discovery API for PostgreSQL, MySQL/MariaDB, MongoDB, and Redis using process and common-path detection, with editable stop/start hook templates. The frontend adds a responsive discovery dialog that can apply a detected database or supported template by creating pre/post script-library entries and populating the plan source paths.

The source model also exposes a disabled planned container option so the workflow can extend to Docker/container scanning later without implying support in this PR.

## Related Issue
Linear: https://linear.app/nullcodeai/issue/BOR-17/automatic-database-scanning-and-setup

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Validation run:
- `ruff check app tests`
- `ruff format --check app tests`
- `pytest tests/unit/test_source_discovery.py -q`
- `cd frontend && npm run format:check`
- `cd frontend && npm run check:locales`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm test -- --run src/pages/backup-plans/__tests__/SourceStep.test.tsx src/components/wizard/__tests__/WizardStepDataSource.test.tsx`
- `cd frontend && npm run build`

Runtime walkthrough:
- Launched Borg UI with `./scripts/dev.sh`.
- Confirmed `/backup-plans` served from Vite.
- Authenticated as the local default admin and confirmed `GET /api/source-discovery/databases` returned database source types plus four supported templates.
- Confirmed the served source step includes the `Scan databases` entry point and `DatabaseDiscoveryDialog`.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not captured in this headless session. Runtime validation covered the source setup route and source-discovery API response.

## Additional Context
Vite build emitted existing dynamic-import and chunk-size warnings; no new warning class was introduced by this change.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
