### PR TITLE
Add backup source discovery flow

### DIFF
--- a/app/api/source_discovery.py
+++ b/app/api/source_discovery.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+from typing import Literal
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from app.core.security import get_current_user
+from app.database.models import User
+
+router = APIRouter()
+
+DatabaseStatus = Literal["detected", "template"]
+DetectionConfidence = Literal["high", "medium", "template"]
+
+
+class SourceTypeResponse(BaseModel):
+    id: str
+    label: str
+    description: str
+    enabled: bool
+    unavailable_reason: str | None = None
+
+
+class DatabaseTargetResponse(BaseModel):
+    id: str
+    engine: str
+    engine_label: str
+    display_name: str
+    status: DatabaseStatus
+    confidence: DetectionConfidence
+    service_name: str
+    source_directories: list[str]
+    warnings: list[str]
+    pre_backup_script: str
+    post_backup_script: str
+    script_name_base: str
+    documentation_url: str
+
+
+class DatabaseDiscoveryResponse(BaseModel):
+    source_types: list[SourceTypeResponse]
+    databases: list[DatabaseTargetResponse]
+    templates: list[DatabaseTargetResponse]
+
+
+DATABASE_DEFINITIONS = [
+    {
+        "engine": "postgresql",
+        "engine_label": "PostgreSQL",
+        "service_name": "postgresql",
+        "data_directories": ["/var/lib/postgresql", "/var/lib/pgsql"],
+        "sockets": ["/var/run/postgresql/.s.PGSQL.5432", "/tmp/.s.PGSQL.5432"],
+        "ports": [5432],
+        "documentation_url": "https://www.postgresql.org/docs/17/app-pgdump.html",
+    },
+    {
+        "engine": "mysql",
+        "engine_label": "MySQL / MariaDB",
+        "service_name": "mysql",
+        "data_directories": ["/var/lib/mysql"],
+        "sockets": ["/var/run/mysqld/mysqld.sock", "/tmp/mysql.sock"],
+        "ports": [3306],
+        "documentation_url": "https://dev.mysql.com/doc/refman/8.4/en/using-mysqldump.html",
+    },
+    {
+        "engine": "mongodb",
+        "engine_label": "MongoDB",
+        "service_name": "mongod",
+        "data_directories": ["/var/lib/mongodb", "/var/lib/mongo"],
+        "sockets": ["/tmp/mongodb-27017.sock"],
+        "ports": [27017],
+        "documentation_url": "https://www.mongodb.com/docs/database-tools/mongodump/index.html",
+    },
+    {
+        "engine": "redis",
+        "engine_label": "Redis",
+        "service_name": "redis-server",
+        "data_directories": ["/var/lib/redis"],
+        "sockets": ["/var/run/redis/redis-server.sock", "/tmp/redis.sock"],
+        "ports": [6379],
+        "documentation_url": "https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/",
+    },
+]
+
+
+def _path_exists(path: str) -> bool:
+    return Path(path).exists()
+
+
+def _is_port_open(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.settimeout(0.08)
+        return probe.connect_ex(("127.0.0.1", port)) == 0
+
+
+def _source_types() -> list[SourceTypeResponse]:
+    return [
+        SourceTypeResponse(
+            id="paths",
+            label="Files and folders",
+            description="Choose files or folders from the Borg UI server or a remote client.",
+            enabled=True,
+        ),
+        SourceTypeResponse(
+            id="database",
+            label="Database",
+            description="Scan supported local databases and prepare backup scripts.",
+            enabled=True,
+        ),
+        SourceTypeResponse(
+            id="container",
+            label="Docker containers",
+            description="Container scanning will use this same source chooser next.",
+            enabled=False,
+            unavailable_reason="Container scanning is planned for a later release.",
+        ),
+    ]
+
+
+def _service_script(service_name: str, action: Literal["start", "stop"]) -> str:
+    action_label = "Stop" if action == "stop" else "Start"
+    return f"""#!/usr/bin/env bash
+set -euo pipefail
+
+# {action_label} the database service around the Borg backup.
+# Override SERVICE_NAME if your distribution uses a different unit name.
+SERVICE_NAME="${{SERVICE_NAME:-{service_name}}}"
+
+if command -v systemctl >/dev/null 2>&1; then
+  sudo -n systemctl {action} "$SERVICE_NAME"
+elif command -v service >/dev/null 2>&1; then
+  sudo -n service "$SERVICE_NAME" {action}
+else
+  echo "No supported service manager found. Edit this script for your host." >&2
+  exit 1
+fi
+"""
+
+
+def _build_target(
+    definition: dict[str, object],
+    *,
+    status: DatabaseStatus,
+    confidence: DetectionConfidence,
+    source_directories: list[str],
+) -> DatabaseTargetResponse:
+    engine = str(definition["engine"])
+    engine_label = str(definition["engine_label"])
+    service_name = str(definition["service_name"])
+    return DatabaseTargetResponse(
+        id=f"{engine}-{status}",
+        engine=engine,
+        engine_label=engine_label,
+        display_name=(
+            f"{engine_label} on this server"
+            if status == "detected"
+            else f"{engine_label} template"
+        ),
+        status=status,
+        confidence=confidence,
+        service_name=service_name,
+        source_directories=source_directories,
+        warnings=[
+            "Review generated scripts before enabling the plan.",
+            "Stopping services may require passwordless sudo for the Borg UI runtime user.",
+        ],
+        pre_backup_script=_service_script(service_name, "stop"),
+        post_backup_script=_service_script(service_name, "start"),
+        script_name_base=f"{engine_label} stop-start backup",
+        documentation_url=str(definition["documentation_url"]),
+    )
+
+
+def _detect_target(definition: dict[str, object]) -> DatabaseTargetResponse | None:
+    data_directories = [str(path) for path in definition["data_directories"]]
+    sockets = [str(path) for path in definition["sockets"]]
+    ports = [int(port) for port in definition["ports"]]
+
+    existing_directories = [path for path in data_directories if _path_exists(path)]
+    socket_found = any(_path_exists(path) for path in sockets)
+    port_found = any(_is_port_open(port) for port in ports)
+
+    if not existing_directories and not socket_found and not port_found:
+        return None
+
+    confidence: DetectionConfidence = "high" if socket_found or port_found else "medium"
+    return _build_target(
+        definition,
+        status="detected",
+        confidence=confidence,
+        source_directories=existing_directories or [data_directories[0]],
+    )
+
+
+def _template_target(definition: dict[str, object]) -> DatabaseTargetResponse:
+    data_directories = [str(path) for path in definition["data_directories"]]
+    return _build_target(
+        definition,
+        status="template",
+        confidence="template",
+        source_directories=[data_directories[0]],
+    )
+
+
+@router.get("/databases", response_model=DatabaseDiscoveryResponse)
+async def scan_databases(
+    current_user: User = Depends(get_current_user),
+) -> DatabaseDiscoveryResponse:
+    _ = current_user
+    detected = [
+        target
+        for definition in DATABASE_DEFINITIONS
+        if (target := _detect_target(definition)) is not None
+    ]
+
+    return DatabaseDiscoveryResponse(
+        source_types=_source_types(),
+        databases=detected,
+        templates=[_template_target(definition) for definition in DATABASE_DEFINITIONS],
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,7 @@ from app.api import (
     browse,
     notifications,
     scripts,
+    source_discovery,
     packages,
     activity,
     scripts_library,
@@ -212,6 +213,11 @@ app.include_router(
 app.include_router(
     scripts_library.router, prefix="/api", tags=["Script Library"]
 )  # New script management
+app.include_router(
+    source_discovery.router,
+    prefix="/api/source-discovery",
+    tags=["Source Discovery"],
+)
 app.include_router(packages.router, prefix="/api/packages", tags=["Packages"])
 app.include_router(notifications.router)
 app.include_router(activity.router)

--- a/docs/engineering/plans/2026-05-16-source-selection-discovery.md
+++ b/docs/engineering/plans/2026-05-16-source-selection-discovery.md
@@ -1,0 +1,114 @@
+# Source Selection Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a guided backup-plan source-selection flow with database discovery and explicit generated-script handling.
+
+**Architecture:** Add a small backend source-discovery endpoint that returns detected local databases plus templates and script drafts. Add a focused frontend source-selection dialog that applies its output to the existing backup-plan wizard state without changing the backup-plan persistence model.
+
+**Tech Stack:** FastAPI, Pydantic, SQLAlchemy auth dependency, React, TypeScript, MUI, React Query, Vitest.
+
+---
+
+## Files
+
+- Create: `app/api/source_discovery.py`
+- Modify: `app/main.py`
+- Create: `tests/unit/test_source_discovery.py`
+- Modify: `frontend/src/services/api.ts`
+- Modify: `frontend/src/pages/backup-plans/types.ts`
+- Modify: `frontend/src/pages/backup-plans/wizard-step/types.ts`
+- Modify: `frontend/src/pages/backup-plans/BackupPlanWizardStep.tsx`
+- Modify: `frontend/src/pages/backup-plans/wizard-step/SourceStep.tsx`
+- Create: `frontend/src/pages/backup-plans/source-discovery/types.ts`
+- Create: `frontend/src/pages/backup-plans/source-discovery/SourceSelectionDialog.tsx`
+- Create: `frontend/src/pages/backup-plans/__tests__/SourceStep.test.tsx`
+- Modify: `frontend/src/locales/en.json`
+- Modify: `frontend/src/locales/es.json`
+- Modify: `frontend/src/locales/it.json`
+
+## Task 1: Backend Source Discovery Contract
+
+- [ ] Step 1: Add failing API tests in `tests/unit/test_source_discovery.py`.
+  - Assert `GET /api/source-discovery/databases` requires auth.
+  - Assert the response includes source type entries for `paths`, `database`, and disabled `container`.
+  - Patch scanner helpers so PostgreSQL is detected and assert script drafts plus source directories are returned.
+  - Assert templates include PostgreSQL, MySQL, MongoDB, and Redis when no database is detected.
+
+- [ ] Step 2: Run the focused test and confirm it fails because the route does not exist.
+  - Command: `pytest tests/unit/test_source_discovery.py -q`
+  - Expected: 404 or import failure for the missing endpoint.
+
+- [ ] Step 3: Implement `app/api/source_discovery.py`.
+  - Define Pydantic models for source types and database targets.
+  - Implement conservative helpers for common data-directory existence, socket existence, and local port checks.
+  - Return generated stop/start pre/post script drafts with editable service names.
+
+- [ ] Step 4: Register the router in `app/main.py`.
+  - Prefix: `/api/source-discovery`
+  - Tags: `Source Discovery`
+
+- [ ] Step 5: Run the focused backend test and keep it green.
+  - Command: `pytest tests/unit/test_source_discovery.py -q`
+
+## Task 2: Frontend Source Selection Dialog
+
+- [ ] Step 1: Add failing UI tests in `frontend/src/pages/backup-plans/__tests__/SourceStep.test.tsx`.
+  - Render `SourceStep` with minimal wizard state and mocked `sourceDiscoveryAPI.scanDatabases`.
+  - Assert initial source directories are not exposed as the first control path until the user opens the chooser.
+  - Assert "Choose source" opens the source-selection dialog.
+  - Assert choosing database scan displays returned detected/template database choices.
+  - Assert applying a database with "create scripts" calls `scriptsAPI.create` with user-editable names and updates source directories plus plan script IDs.
+  - Assert files/folders path keeps the existing local/remote path controls available.
+
+- [ ] Step 2: Run the focused frontend test and confirm it fails on missing UI.
+  - Command: `cd frontend && npm test -- --run src/pages/backup-plans/__tests__/SourceStep.test.tsx`
+
+- [ ] Step 3: Add frontend source-discovery types and API helper.
+  - Add `sourceDiscoveryAPI.scanDatabases()` to `frontend/src/services/api.ts`.
+  - Keep response types in `frontend/src/pages/backup-plans/source-discovery/types.ts`.
+
+- [ ] Step 4: Create `SourceSelectionDialog.tsx`.
+  - Use `ResponsiveDialog`.
+  - Render source type choices with lucide icons.
+  - Render database scan results/templates and generated script preview.
+  - Render script mode controls: create new scripts, use existing scripts, skip for now.
+  - Disable apply when required script names or existing script IDs are missing.
+
+- [ ] Step 5: Rework `SourceStep.tsx`.
+  - Keep plan name and description.
+  - Replace initial inline source controls with a compact source summary plus "Choose source".
+  - Render `WizardStepDataSource` and `ExcludePatternInput` only after path/manual selection or after a database selection has populated paths.
+  - On database apply, update `sourceType`, `sourceDirectories`, `preBackupScriptId`, `postBackupScriptId`, and script parameters.
+
+- [ ] Step 6: Pass scripts into `SourceStep`.
+  - Extend `BackupPlanWizardStepProps` and `BackupPlanWizardStep.tsx` so `SourceStep` receives `scripts` and `loadingScripts`.
+
+- [ ] Step 7: Add locale keys to English, Spanish, and Italian locale files.
+  - Keep translations aligned so `npm run check:locales` passes.
+
+- [ ] Step 8: Run focused frontend tests.
+  - Command: `cd frontend && npm test -- --run src/pages/backup-plans/__tests__/SourceStep.test.tsx src/components/wizard/__tests__/WizardStepDataSource.test.tsx`
+
+## Task 3: Validation and Handoff
+
+- [ ] Step 1: Run backend validation.
+  - `ruff check app tests`
+  - `ruff format --check app tests`
+  - `pytest tests/unit/test_source_discovery.py -q`
+
+- [ ] Step 2: Run frontend validation.
+  - `cd frontend && npm run check:locales`
+  - `cd frontend && npm run typecheck`
+  - `cd frontend && npm run lint`
+  - `cd frontend && npm run build`
+  - Focused Vitest command from Task 2.
+
+- [ ] Step 3: Run app walkthrough.
+  - Launch with `./scripts/dev.sh`.
+  - Visit `/backup-plans`.
+  - Open create backup plan.
+  - Open source chooser.
+  - Choose database scan, choose detected database or template, create/reuse scripts, verify source summary and scripts are populated.
+
+- [ ] Step 4: Commit, push, create PR, attach PR, apply `symphony` label, run PR feedback sweep, and move Linear to Human Review only after checks are green.

--- a/docs/engineering/specs/2026-05-16-source-selection-discovery.md
+++ b/docs/engineering/specs/2026-05-16-source-selection-discovery.md
@@ -1,0 +1,127 @@
+# Source Selection Discovery Spec
+
+## Goal
+
+Rework backup-plan source setup into a guided source-selection flow that supports normal file paths today, database discovery now, and future container discovery without making users start from raw path fields.
+
+## Context
+
+The current backup-plan source step asks for the plan name, description, local or remote source, source directories, and excludes inline. There is no source-type chooser, no database scan entry point, and no explicit script creation decision.
+
+Reviewer feedback requires the rework attempt to do three things differently:
+
+- Move source selection into its own modal or mobile bottom sheet.
+- Treat databases as one source type among paths, files/folders, and future Docker/container scan.
+- When generated scripts are needed, tell users scripts will be created and let them create named scripts or reuse existing scripts.
+
+Practical database backup research supports database-specific flows instead of a generic "copy files" assumption:
+
+- PostgreSQL documents `pg_dump` as creating consistent logical backups while the database is in use.
+- MySQL documents `mysqldump` and `--single-transaction` for logical backups.
+- MongoDB documents `mongodump` for database dumps.
+- Redis documents RDB snapshots and notes that RDB files are copy-friendly while Redis is running.
+
+Sources:
+
+- https://www.postgresql.org/docs/17/app-pgdump.html
+- https://dev.mysql.com/doc/refman/8.4/en/using-mysqldump.html
+- https://www.mongodb.com/docs/database-tools/mongodump/index.html
+- https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/
+
+## Product Behavior
+
+The source step keeps plan name and description visible, then shows a compact source summary and a primary "Choose source" action. The raw path and exclude controls remain available only after a path-like source is selected.
+
+The source chooser is a `ResponsiveDialog`, so it is a centered modal on desktop and a bottom sheet on mobile. It has three stages:
+
+1. Choose source type:
+   - Files and folders, enabled, preserves existing local/remote path behavior.
+   - Database, enabled, opens scan results and templates.
+   - Docker containers, visible but disabled as "coming next".
+   - Manual paths, enabled, jumps to existing path entry.
+2. Configure database source:
+   - Load detected databases from the backend scan endpoint.
+   - Show template choices for supported database engines even when nothing is detected.
+   - Selecting a database sets suggested source directories and displays the generated pre/post script drafts.
+3. Choose script handling:
+   - Create new plan scripts with editable names.
+   - Reuse existing scripts from the loaded script library.
+   - Skip script assignment for now, leaving script draft visible for manual copying.
+
+For database sources, applying the selection updates the backup-plan state:
+
+- `sourceType` stays `local` for this initial implementation.
+- `sourceDirectories` are populated from the selected database target.
+- `preBackupScriptId` and `postBackupScriptId` are populated when scripts are created or reused.
+- Existing path-based behavior remains compatible with the payload that backup plans already submit.
+
+## Backend Contract
+
+Add `GET /api/source-discovery/databases`.
+
+Response shape:
+
+```json
+{
+  "source_types": [
+    {
+      "id": "paths",
+      "label": "Files and folders",
+      "description": "Choose files or folders from the Borg UI server or a remote client.",
+      "enabled": true
+    }
+  ],
+  "databases": [
+    {
+      "id": "postgresql-local",
+      "engine": "postgresql",
+      "engine_label": "PostgreSQL",
+      "display_name": "PostgreSQL on this server",
+      "status": "detected",
+      "confidence": "high",
+      "service_name": "postgresql",
+      "source_directories": ["/var/lib/postgresql"],
+      "warnings": ["Scripts may require sudo privileges to stop and start services."],
+      "pre_backup_script": "...",
+      "post_backup_script": "...",
+      "script_name_base": "PostgreSQL stop-start backup",
+      "documentation_url": "https://www.postgresql.org/docs/17/app-pgdump.html"
+    }
+  ],
+  "templates": []
+}
+```
+
+Detection stays conservative:
+
+- Inspect common data directories and UNIX socket paths.
+- Check common local ports with a short timeout.
+- Do not require root access.
+- Return templates for PostgreSQL, MySQL/MariaDB, MongoDB, and Redis so users can proceed when scan cannot confirm services from the Borg UI process environment.
+
+Generated scripts are drafts. They use `systemctl` or `service` where available and include clear environment-variable overrides for service name. They are editable before creation.
+
+## UI Design Notes
+
+The implementation follows existing Borg UI patterns:
+
+- MUI surfaces, subdued outlines, and `ResponsiveDialog` for desktop/mobile behavior.
+- Lucide icons for source types and actions.
+- No heavy left accent borders.
+- Cards are used only for repeated choices, not nested inside another card.
+- The source step remains dense and operational rather than a marketing-style hero.
+
+## Error Handling
+
+- If the scan endpoint fails, the chooser shows an alert and keeps database templates available once backend data can be fetched again.
+- If script creation fails, keep the dialog open and surface the error toast. Do not apply a partially configured database source silently.
+- If the user chooses "reuse existing scripts" without selecting required scripts, the apply action is disabled.
+
+## Acceptance Criteria
+
+- Source setup opens a dedicated source-selection modal on desktop and bottom-sheet-like flow on mobile.
+- Source choices include files/folders, database scan, Docker/container scan placeholder, and manual path entry.
+- Database scan shows detected databases and supported templates.
+- Database selection can populate source directories and generated script drafts.
+- Script handling explicitly supports creating named scripts, reusing existing scripts, or skipping assignment.
+- Existing path-based local/remote source setup and backup-plan payload compatibility are preserved.

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -675,6 +675,44 @@
         "schedule": "Zeitplan",
         "review": "Überprüfung"
       },
+      "sourceSelection": {
+        "summaryTitle": "Backup source",
+        "summaryEmpty": "Choose files, folders, databases, or other source types.",
+        "summaryConfigured": "{{count}} source path selected",
+        "chooseSource": "Choose source",
+        "changeSource": "Change source",
+        "dialogTitle": "Choose backup source",
+        "comingSoon": "Coming soon",
+        "apply": "Apply source",
+        "scanning": "Scanning local databases...",
+        "scanFailed": "Database scan failed. Try again or use manual paths.",
+        "detected": "Detected",
+        "template": "Template",
+        "scriptsWillBeCreated": "This database source can create plan scripts that stop the service before backup and start it afterwards. Review and edit them before applying.",
+        "scriptModeCreate": "Create new scripts",
+        "scriptModeReuse": "Use existing scripts",
+        "scriptModeSkip": "Skip script assignment",
+        "preScriptName": "Pre-backup script name",
+        "postScriptName": "Post-backup script name",
+        "preScriptContent": "Pre-backup script content",
+        "postScriptContent": "Post-backup script content",
+        "reusePreScript": "Existing pre-backup script",
+        "reusePostScript": "Existing post-backup script",
+        "generatedScriptDescription": "Generated source-discovery script for {{database}}.",
+        "scriptCreateFailed": "Failed to create generated scripts. Review the names and try again.",
+        "sourceTypes": {
+          "paths": "Files and folders",
+          "database": "Database",
+          "manual": "Manual paths",
+          "container": "Docker containers"
+        },
+        "sourceTypeDescriptions": {
+          "paths": "Choose files or folders from the Borg UI server or a remote client.",
+          "database": "Scan supported databases and prepare backup scripts.",
+          "manual": "Enter paths directly using the existing source controls.",
+          "container": "Container scanning will use this chooser next."
+        }
+      },
       "fields": {
         "planName": "Planname",
         "description": "Beschreibung",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -675,6 +675,44 @@
         "schedule": "Schedule",
         "review": "Review"
       },
+      "sourceSelection": {
+        "summaryTitle": "Backup source",
+        "summaryEmpty": "Choose files, folders, databases, or other source types.",
+        "summaryConfigured": "{{count}} source path selected",
+        "chooseSource": "Choose source",
+        "changeSource": "Change source",
+        "dialogTitle": "Choose backup source",
+        "comingSoon": "Coming soon",
+        "apply": "Apply source",
+        "scanning": "Scanning local databases...",
+        "scanFailed": "Database scan failed. Try again or use manual paths.",
+        "detected": "Detected",
+        "template": "Template",
+        "scriptsWillBeCreated": "This database source can create plan scripts that stop the service before backup and start it afterwards. Review and edit them before applying.",
+        "scriptModeCreate": "Create new scripts",
+        "scriptModeReuse": "Use existing scripts",
+        "scriptModeSkip": "Skip script assignment",
+        "preScriptName": "Pre-backup script name",
+        "postScriptName": "Post-backup script name",
+        "preScriptContent": "Pre-backup script content",
+        "postScriptContent": "Post-backup script content",
+        "reusePreScript": "Existing pre-backup script",
+        "reusePostScript": "Existing post-backup script",
+        "generatedScriptDescription": "Generated source-discovery script for {{database}}.",
+        "scriptCreateFailed": "Failed to create generated scripts. Review the names and try again.",
+        "sourceTypes": {
+          "paths": "Files and folders",
+          "database": "Database",
+          "manual": "Manual paths",
+          "container": "Docker containers"
+        },
+        "sourceTypeDescriptions": {
+          "paths": "Choose files or folders from the Borg UI server or a remote client.",
+          "database": "Scan supported databases and prepare backup scripts.",
+          "manual": "Enter paths directly using the existing source controls.",
+          "container": "Container scanning will use this chooser next."
+        }
+      },
       "fields": {
         "planName": "Plan name",
         "description": "Description",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -675,6 +675,44 @@
         "schedule": "Programación",
         "review": "Revisión"
       },
+      "sourceSelection": {
+        "summaryTitle": "Backup source",
+        "summaryEmpty": "Choose files, folders, databases, or other source types.",
+        "summaryConfigured": "{{count}} source path selected",
+        "chooseSource": "Choose source",
+        "changeSource": "Change source",
+        "dialogTitle": "Choose backup source",
+        "comingSoon": "Coming soon",
+        "apply": "Apply source",
+        "scanning": "Scanning local databases...",
+        "scanFailed": "Database scan failed. Try again or use manual paths.",
+        "detected": "Detected",
+        "template": "Template",
+        "scriptsWillBeCreated": "This database source can create plan scripts that stop the service before backup and start it afterwards. Review and edit them before applying.",
+        "scriptModeCreate": "Create new scripts",
+        "scriptModeReuse": "Use existing scripts",
+        "scriptModeSkip": "Skip script assignment",
+        "preScriptName": "Pre-backup script name",
+        "postScriptName": "Post-backup script name",
+        "preScriptContent": "Pre-backup script content",
+        "postScriptContent": "Post-backup script content",
+        "reusePreScript": "Existing pre-backup script",
+        "reusePostScript": "Existing post-backup script",
+        "generatedScriptDescription": "Generated source-discovery script for {{database}}.",
+        "scriptCreateFailed": "Failed to create generated scripts. Review the names and try again.",
+        "sourceTypes": {
+          "paths": "Files and folders",
+          "database": "Database",
+          "manual": "Manual paths",
+          "container": "Docker containers"
+        },
+        "sourceTypeDescriptions": {
+          "paths": "Choose files or folders from the Borg UI server or a remote client.",
+          "database": "Scan supported databases and prepare backup scripts.",
+          "manual": "Enter paths directly using the existing source controls.",
+          "container": "Container scanning will use this chooser next."
+        }
+      },
       "fields": {
         "planName": "Nombre del plan",
         "description": "Descripción",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -675,6 +675,44 @@
         "schedule": "Pianificazione",
         "review": "Revisione"
       },
+      "sourceSelection": {
+        "summaryTitle": "Backup source",
+        "summaryEmpty": "Choose files, folders, databases, or other source types.",
+        "summaryConfigured": "{{count}} source path selected",
+        "chooseSource": "Choose source",
+        "changeSource": "Change source",
+        "dialogTitle": "Choose backup source",
+        "comingSoon": "Coming soon",
+        "apply": "Apply source",
+        "scanning": "Scanning local databases...",
+        "scanFailed": "Database scan failed. Try again or use manual paths.",
+        "detected": "Detected",
+        "template": "Template",
+        "scriptsWillBeCreated": "This database source can create plan scripts that stop the service before backup and start it afterwards. Review and edit them before applying.",
+        "scriptModeCreate": "Create new scripts",
+        "scriptModeReuse": "Use existing scripts",
+        "scriptModeSkip": "Skip script assignment",
+        "preScriptName": "Pre-backup script name",
+        "postScriptName": "Post-backup script name",
+        "preScriptContent": "Pre-backup script content",
+        "postScriptContent": "Post-backup script content",
+        "reusePreScript": "Existing pre-backup script",
+        "reusePostScript": "Existing post-backup script",
+        "generatedScriptDescription": "Generated source-discovery script for {{database}}.",
+        "scriptCreateFailed": "Failed to create generated scripts. Review the names and try again.",
+        "sourceTypes": {
+          "paths": "Files and folders",
+          "database": "Database",
+          "manual": "Manual paths",
+          "container": "Docker containers"
+        },
+        "sourceTypeDescriptions": {
+          "paths": "Choose files or folders from the Borg UI server or a remote client.",
+          "database": "Scan supported databases and prepare backup scripts.",
+          "manual": "Enter paths directly using the existing source controls.",
+          "container": "Container scanning will use this chooser next."
+        }
+      },
       "fields": {
         "planName": "Nome piano",
         "description": "Descrizione",

--- a/frontend/src/pages/backup-plans/BackupPlanWizardStep.tsx
+++ b/frontend/src/pages/backup-plans/BackupPlanWizardStep.tsx
@@ -41,6 +41,8 @@ export function BackupPlanWizardStep({
       <SourceStep
         wizardState={wizardState}
         sshConnections={sshConnections}
+        scripts={scripts}
+        loadingScripts={loadingScripts}
         updateState={updateState}
         openSourceExplorer={openSourceExplorer}
         openExcludeExplorer={openExcludeExplorer}

--- a/frontend/src/pages/backup-plans/__tests__/SourceStep.test.tsx
+++ b/frontend/src/pages/backup-plans/__tests__/SourceStep.test.tsx
@@ -1,0 +1,194 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ThemeProvider, createTheme } from '@mui/material/styles'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { TFunction } from 'i18next'
+
+import { SourceStep } from '../wizard-step/SourceStep'
+import { createInitialState } from '../state'
+
+const apiMocks = vi.hoisted(() => ({
+  scanDatabases: vi.fn(),
+  createScript: vi.fn(),
+}))
+
+vi.mock('../../../components/SourceDirectoriesInput', () => ({
+  default: () => <div data-testid="source-directories-input">Source directories input</div>,
+}))
+
+vi.mock('../../../services/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../services/api')>()
+  return {
+    ...actual,
+    sourceDiscoveryAPI: {
+      scanDatabases: apiMocks.scanDatabases,
+    },
+    scriptsAPI: {
+      ...actual.scriptsAPI,
+      create: apiMocks.createScript,
+    },
+  }
+})
+
+const theme = createTheme()
+
+const t = ((key: string, options?: { defaultValue?: string }) => {
+  const translations: Record<string, string> = {
+    'backupPlans.wizard.fields.planName': 'Plan name',
+    'backupPlans.wizard.fields.description': 'Description',
+    'backupPlans.wizard.sourceSelection.summaryTitle': 'Backup source',
+    'backupPlans.wizard.sourceSelection.chooseSource': 'Choose source',
+    'backupPlans.wizard.sourceSelection.changeSource': 'Change source',
+    'backupPlans.wizard.sourceSelection.dialogTitle': 'Choose backup source',
+    'backupPlans.wizard.sourceSelection.sourceTypes.paths': 'Files and folders',
+    'backupPlans.wizard.sourceSelection.sourceTypes.database': 'Database',
+    'backupPlans.wizard.sourceSelection.sourceTypes.container': 'Docker containers',
+    'backupPlans.wizard.sourceSelection.apply': 'Apply source',
+    'backupPlans.wizard.sourceSelection.scriptModeCreate': 'Create new scripts',
+  }
+  return translations[key] ?? options?.defaultValue ?? key
+}) as TFunction
+
+const discoveryResponse = {
+  data: {
+    source_types: [
+      {
+        id: 'paths',
+        label: 'Files and folders',
+        description: 'Choose files or folders.',
+        enabled: true,
+      },
+      {
+        id: 'database',
+        label: 'Database',
+        description: 'Scan supported databases.',
+        enabled: true,
+      },
+      {
+        id: 'container',
+        label: 'Docker containers',
+        description: 'Coming next.',
+        enabled: false,
+        unavailable_reason: 'Container scanning is planned.',
+      },
+    ],
+    databases: [
+      {
+        id: 'postgresql-detected',
+        engine: 'postgresql',
+        engine_label: 'PostgreSQL',
+        display_name: 'PostgreSQL on this server',
+        status: 'detected',
+        confidence: 'high',
+        service_name: 'postgresql',
+        source_directories: ['/var/lib/postgresql'],
+        warnings: ['Review generated scripts before enabling the plan.'],
+        pre_backup_script: '#!/usr/bin/env bash\nsystemctl stop postgresql\n',
+        post_backup_script: '#!/usr/bin/env bash\nsystemctl start postgresql\n',
+        script_name_base: 'PostgreSQL stop-start backup',
+        documentation_url: 'https://www.postgresql.org/docs/17/app-pgdump.html',
+      },
+    ],
+    templates: [],
+  },
+}
+
+function renderSourceStep(overrides: Partial<React.ComponentProps<typeof SourceStep>> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const props: React.ComponentProps<typeof SourceStep> = {
+    wizardState: createInitialState(),
+    sshConnections: [],
+    scripts: [{ id: 8, name: 'Existing database stop script' }],
+    loadingScripts: false,
+    updateState: vi.fn(),
+    openSourceExplorer: vi.fn(),
+    openExcludeExplorer: vi.fn(),
+    t,
+    ...overrides,
+  }
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={theme}>
+        <SourceStep {...props} />
+      </ThemeProvider>
+    </QueryClientProvider>
+  )
+
+  return props
+}
+
+describe('SourceStep source selection', () => {
+  beforeEach(() => {
+    apiMocks.scanDatabases.mockReset()
+    apiMocks.createScript.mockReset()
+    apiMocks.scanDatabases.mockResolvedValue(discoveryResponse)
+    apiMocks.createScript
+      .mockResolvedValueOnce({ data: { id: 31, name: 'PostgreSQL stop-start backup pre' } })
+      .mockResolvedValueOnce({ data: { id: 32, name: 'PostgreSQL stop-start backup post' } })
+  })
+
+  it('starts from a source chooser instead of exposing path controls inline', () => {
+    renderSourceStep()
+
+    expect(screen.getByRole('button', { name: /choose source/i })).toBeInTheDocument()
+    expect(screen.queryByTestId('source-directories-input')).not.toBeInTheDocument()
+  })
+
+  it('creates named scripts and applies a scanned database source', async () => {
+    const user = userEvent.setup()
+    const updateState = vi.fn()
+    renderSourceStep({ updateState })
+
+    await user.click(screen.getByRole('button', { name: /choose source/i }))
+    await user.click(await screen.findByRole('button', { name: /database/i }))
+
+    expect(await screen.findByText('PostgreSQL on this server')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('PostgreSQL stop-start backup pre')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('PostgreSQL stop-start backup post')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /apply source/i }))
+
+    await waitFor(() => {
+      expect(apiMocks.createScript).toHaveBeenCalledTimes(2)
+    })
+    expect(apiMocks.createScript).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        name: 'PostgreSQL stop-start backup pre',
+        content: expect.stringContaining('systemctl stop postgresql'),
+      })
+    )
+    expect(apiMocks.createScript).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        name: 'PostgreSQL stop-start backup post',
+        content: expect.stringContaining('systemctl start postgresql'),
+      })
+    )
+    await waitFor(() => {
+      expect(updateState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceType: 'local',
+          sourceSshConnectionId: '',
+          sourceDirectories: ['/var/lib/postgresql'],
+          preBackupScriptId: 31,
+          postBackupScriptId: 32,
+        })
+      )
+    })
+  }, 30000)
+
+  it('keeps the existing file and folder source path flow available', async () => {
+    const user = userEvent.setup()
+    renderSourceStep()
+
+    await user.click(screen.getByRole('button', { name: /choose source/i }))
+    await user.click(await screen.findByRole('button', { name: /files and folders/i }))
+
+    expect(await screen.findByTestId('source-directories-input')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/backup-plans/source-discovery/SourceSelectionDialog.tsx
+++ b/frontend/src/pages/backup-plans/source-discovery/SourceSelectionDialog.tsx
@@ -1,0 +1,463 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import type { TFunction } from 'i18next'
+import {
+  Alert,
+  Box,
+  Button,
+  ButtonBase,
+  Chip,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Radio,
+  RadioGroup,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+  alpha,
+} from '@mui/material'
+import { Container, Database, FileInput, FolderOpen } from 'lucide-react'
+
+import ResponsiveDialog from '../../../components/ResponsiveDialog'
+import { scriptsAPI, sourceDiscoveryAPI } from '../../../services/api'
+import type { ScriptOption } from '../types'
+import type {
+  AppliedDatabaseSource,
+  DatabaseDiscoveryResponse,
+  DatabaseDiscoveryTarget,
+} from './types'
+
+type SourceType = 'paths' | 'database' | 'manual' | 'container'
+type ScriptMode = 'create' | 'reuse' | 'skip'
+
+interface SourceSelectionDialogProps {
+  open: boolean
+  scripts: ScriptOption[]
+  loadingScripts: boolean
+  onClose: () => void
+  onUsePaths: () => void
+  onApplyDatabase: (source: AppliedDatabaseSource) => void
+  t: TFunction
+}
+
+const sourceTypeIcons = {
+  paths: FolderOpen,
+  database: Database,
+  manual: FileInput,
+  container: Container,
+}
+
+function sourceTypeLabel(type: SourceType, t: TFunction) {
+  return t(`backupPlans.wizard.sourceSelection.sourceTypes.${type}`)
+}
+
+function sourceTypeDescription(type: SourceType, t: TFunction) {
+  return t(`backupPlans.wizard.sourceSelection.sourceTypeDescriptions.${type}`)
+}
+
+function SourceTypeButton({
+  type,
+  disabled = false,
+  onClick,
+  t,
+}: {
+  type: SourceType
+  disabled?: boolean
+  onClick: () => void
+  t: TFunction
+}) {
+  const Icon = sourceTypeIcons[type]
+
+  return (
+    <ButtonBase
+      aria-label={sourceTypeLabel(type, t)}
+      disabled={disabled}
+      onClick={onClick}
+      sx={{
+        display: 'flex',
+        alignItems: 'stretch',
+        justifyContent: 'flex-start',
+        gap: 2,
+        width: '100%',
+        p: 2,
+        border: 1,
+        borderColor: 'divider',
+        borderRadius: 1,
+        textAlign: 'left',
+        opacity: disabled ? 0.55 : 1,
+        bgcolor: 'background.paper',
+        transition: 'border-color 150ms ease, background-color 150ms ease',
+        '&:hover': disabled
+          ? {}
+          : {
+              borderColor: 'primary.main',
+              bgcolor: (theme) => alpha(theme.palette.primary.main, 0.04),
+            },
+      }}
+    >
+      <Box
+        sx={{
+          width: 40,
+          height: 40,
+          borderRadius: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          bgcolor: 'action.hover',
+          color: disabled ? 'text.disabled' : 'primary.main',
+          flexShrink: 0,
+        }}
+      >
+        <Icon size={20} />
+      </Box>
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+          <Typography variant="subtitle2" fontWeight={700}>
+            {sourceTypeLabel(type, t)}
+          </Typography>
+          {disabled && (
+            <Chip size="small" label={t('backupPlans.wizard.sourceSelection.comingSoon')} />
+          )}
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {sourceTypeDescription(type, t)}
+        </Typography>
+      </Box>
+    </ButtonBase>
+  )
+}
+
+function targetLabel(target: DatabaseDiscoveryTarget) {
+  return target.status === 'detected' ? target.display_name : `${target.engine_label} template`
+}
+
+export function SourceSelectionDialog({
+  open,
+  scripts,
+  loadingScripts,
+  onClose,
+  onUsePaths,
+  onApplyDatabase,
+  t,
+}: SourceSelectionDialogProps) {
+  const queryClient = useQueryClient()
+  const [activeType, setActiveType] = useState<SourceType | null>(null)
+  const [selectedTargetId, setSelectedTargetId] = useState('')
+  const [scriptMode, setScriptMode] = useState<ScriptMode>('create')
+  const [preScriptName, setPreScriptName] = useState('')
+  const [postScriptName, setPostScriptName] = useState('')
+  const [preScriptContent, setPreScriptContent] = useState('')
+  const [postScriptContent, setPostScriptContent] = useState('')
+  const [reusePreScriptId, setReusePreScriptId] = useState<number | ''>('')
+  const [reusePostScriptId, setReusePostScriptId] = useState<number | ''>('')
+  const [scriptError, setScriptError] = useState('')
+  const [creatingScripts, setCreatingScripts] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      setActiveType(null)
+      setSelectedTargetId('')
+      setScriptMode('create')
+      setScriptError('')
+    }
+  }, [open])
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['source-discovery', 'databases'],
+    queryFn: async () => {
+      const response = await sourceDiscoveryAPI.scanDatabases()
+      return response.data as DatabaseDiscoveryResponse
+    },
+    enabled: open && activeType === 'database',
+  })
+
+  const databaseTargets = useMemo(
+    () => [...(data?.databases || []), ...(data?.templates || [])],
+    [data]
+  )
+  const selectedTarget =
+    databaseTargets.find((target) => target.id === selectedTargetId) || databaseTargets[0]
+
+  useEffect(() => {
+    if (!selectedTarget && selectedTargetId) {
+      setSelectedTargetId('')
+    } else if (selectedTarget && !selectedTargetId) {
+      setSelectedTargetId(selectedTarget.id)
+    }
+  }, [selectedTarget, selectedTargetId])
+
+  useEffect(() => {
+    if (!selectedTarget) return
+    setPreScriptName(`${selectedTarget.script_name_base} pre`)
+    setPostScriptName(`${selectedTarget.script_name_base} post`)
+    setPreScriptContent(selectedTarget.pre_backup_script)
+    setPostScriptContent(selectedTarget.post_backup_script)
+    setScriptError('')
+  }, [selectedTarget])
+
+  const applyDisabled =
+    creatingScripts ||
+    !selectedTarget ||
+    (scriptMode === 'create' && (!preScriptName.trim() || !postScriptName.trim())) ||
+    (scriptMode === 'reuse' && (!reusePreScriptId || !reusePostScriptId))
+
+  const handleApplyDatabase = async () => {
+    if (!selectedTarget || applyDisabled) return
+    setScriptError('')
+
+    let preBackupScriptId: number | null = null
+    let postBackupScriptId: number | null = null
+
+    try {
+      if (scriptMode === 'create') {
+        setCreatingScripts(true)
+        const [preResponse, postResponse] = await Promise.all([
+          scriptsAPI.create({
+            name: preScriptName.trim(),
+            description: t('backupPlans.wizard.sourceSelection.generatedScriptDescription', {
+              database: selectedTarget.display_name,
+            }),
+            content: preScriptContent,
+            timeout: 300,
+            run_on: 'always',
+            category: 'custom',
+          }),
+          scriptsAPI.create({
+            name: postScriptName.trim(),
+            description: t('backupPlans.wizard.sourceSelection.generatedScriptDescription', {
+              database: selectedTarget.display_name,
+            }),
+            content: postScriptContent,
+            timeout: 300,
+            run_on: 'always',
+            category: 'custom',
+          }),
+        ])
+        preBackupScriptId = Number(preResponse.data.id)
+        postBackupScriptId = Number(postResponse.data.id)
+        queryClient.invalidateQueries({ queryKey: ['scripts'] })
+      } else if (scriptMode === 'reuse') {
+        preBackupScriptId = Number(reusePreScriptId)
+        postBackupScriptId = Number(reusePostScriptId)
+      }
+
+      onApplyDatabase({
+        sourceType: 'local',
+        sourceSshConnectionId: '',
+        sourceDirectories: selectedTarget.source_directories,
+        preBackupScriptId,
+        postBackupScriptId,
+        preBackupScriptParameters: {},
+        postBackupScriptParameters: {},
+      })
+    } catch {
+      setScriptError(t('backupPlans.wizard.sourceSelection.scriptCreateFailed'))
+    } finally {
+      setCreatingScripts(false)
+    }
+  }
+
+  const footer = (
+    <DialogActions>
+      {activeType === 'database' && (
+        <Button onClick={() => setActiveType(null)} disabled={creatingScripts}>
+          {t('common.buttons.back')}
+        </Button>
+      )}
+      <Button onClick={onClose} disabled={creatingScripts}>
+        {t('common.buttons.cancel')}
+      </Button>
+      {activeType === 'database' && (
+        <Button variant="contained" onClick={handleApplyDatabase} disabled={applyDisabled}>
+          {t('backupPlans.wizard.sourceSelection.apply')}
+        </Button>
+      )}
+    </DialogActions>
+  )
+
+  return (
+    <ResponsiveDialog open={open} onClose={onClose} maxWidth="md" fullWidth footer={footer}>
+      <DialogTitle sx={{ fontWeight: 700 }}>
+        {t('backupPlans.wizard.sourceSelection.dialogTitle')}
+      </DialogTitle>
+      <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, pb: 2 }}>
+        {!activeType && (
+          <Stack spacing={1.5}>
+            <SourceTypeButton type="paths" onClick={onUsePaths} t={t} />
+            <SourceTypeButton type="database" onClick={() => setActiveType('database')} t={t} />
+            <SourceTypeButton type="manual" onClick={onUsePaths} t={t} />
+            <SourceTypeButton type="container" onClick={() => {}} disabled t={t} />
+          </Stack>
+        )}
+
+        {activeType === 'database' && (
+          <Stack spacing={2}>
+            {isLoading && (
+              <Alert severity="info">{t('backupPlans.wizard.sourceSelection.scanning')}</Alert>
+            )}
+            {isError && (
+              <Alert severity="error">{t('backupPlans.wizard.sourceSelection.scanFailed')}</Alert>
+            )}
+
+            {databaseTargets.length > 0 && (
+              <Stack spacing={1}>
+                {databaseTargets.map((target) => (
+                  <ButtonBase
+                    key={target.id}
+                    onClick={() => setSelectedTargetId(target.id)}
+                    sx={{
+                      p: 1.5,
+                      border: 1,
+                      borderColor: selectedTarget?.id === target.id ? 'primary.main' : 'divider',
+                      borderRadius: 1,
+                      textAlign: 'left',
+                      display: 'block',
+                      bgcolor:
+                        selectedTarget?.id === target.id
+                          ? (theme) => alpha(theme.palette.primary.main, 0.08)
+                          : 'background.paper',
+                    }}
+                  >
+                    <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+                      <Typography variant="subtitle2" fontWeight={700}>
+                        {targetLabel(target)}
+                      </Typography>
+                      <Chip
+                        size="small"
+                        label={
+                          target.status === 'detected'
+                            ? t('backupPlans.wizard.sourceSelection.detected')
+                            : t('backupPlans.wizard.sourceSelection.template')
+                        }
+                        color={target.status === 'detected' ? 'success' : 'default'}
+                      />
+                    </Box>
+                    <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                      {target.source_directories.join(', ')}
+                    </Typography>
+                  </ButtonBase>
+                ))}
+              </Stack>
+            )}
+
+            {selectedTarget && (
+              <Stack spacing={2}>
+                <Alert severity="info">
+                  {t('backupPlans.wizard.sourceSelection.scriptsWillBeCreated')}
+                </Alert>
+                {selectedTarget.warnings.map((warning) => (
+                  <Alert key={warning} severity="warning">
+                    {warning}
+                  </Alert>
+                ))}
+
+                <RadioGroup
+                  value={scriptMode}
+                  onChange={(event) => setScriptMode(event.target.value as ScriptMode)}
+                >
+                  <FormControlLabel
+                    value="create"
+                    control={<Radio />}
+                    label={t('backupPlans.wizard.sourceSelection.scriptModeCreate')}
+                  />
+                  <FormControlLabel
+                    value="reuse"
+                    control={<Radio />}
+                    label={t('backupPlans.wizard.sourceSelection.scriptModeReuse')}
+                  />
+                  <FormControlLabel
+                    value="skip"
+                    control={<Radio />}
+                    label={t('backupPlans.wizard.sourceSelection.scriptModeSkip')}
+                  />
+                </RadioGroup>
+
+                {scriptMode === 'create' && (
+                  <Stack spacing={2}>
+                    <TextField
+                      label={t('backupPlans.wizard.sourceSelection.preScriptName')}
+                      value={preScriptName}
+                      onChange={(event) => setPreScriptName(event.target.value)}
+                      fullWidth
+                    />
+                    <TextField
+                      label={t('backupPlans.wizard.sourceSelection.preScriptContent')}
+                      value={preScriptContent}
+                      onChange={(event) => setPreScriptContent(event.target.value)}
+                      multiline
+                      minRows={4}
+                      fullWidth
+                    />
+                    <TextField
+                      label={t('backupPlans.wizard.sourceSelection.postScriptName')}
+                      value={postScriptName}
+                      onChange={(event) => setPostScriptName(event.target.value)}
+                      fullWidth
+                    />
+                    <TextField
+                      label={t('backupPlans.wizard.sourceSelection.postScriptContent')}
+                      value={postScriptContent}
+                      onChange={(event) => setPostScriptContent(event.target.value)}
+                      multiline
+                      minRows={4}
+                      fullWidth
+                    />
+                  </Stack>
+                )}
+
+                {scriptMode === 'reuse' && (
+                  <Stack spacing={2}>
+                    <FormControl fullWidth disabled={loadingScripts}>
+                      <InputLabel>
+                        {t('backupPlans.wizard.sourceSelection.reusePreScript')}
+                      </InputLabel>
+                      <Select
+                        value={reusePreScriptId}
+                        label={t('backupPlans.wizard.sourceSelection.reusePreScript')}
+                        onChange={(event) =>
+                          setReusePreScriptId(event.target.value ? Number(event.target.value) : '')
+                        }
+                      >
+                        {scripts.map((script) => (
+                          <MenuItem key={script.id} value={script.id}>
+                            {script.name}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                    <FormControl fullWidth disabled={loadingScripts}>
+                      <InputLabel>
+                        {t('backupPlans.wizard.sourceSelection.reusePostScript')}
+                      </InputLabel>
+                      <Select
+                        value={reusePostScriptId}
+                        label={t('backupPlans.wizard.sourceSelection.reusePostScript')}
+                        onChange={(event) =>
+                          setReusePostScriptId(event.target.value ? Number(event.target.value) : '')
+                        }
+                      >
+                        {scripts.map((script) => (
+                          <MenuItem key={script.id} value={script.id}>
+                            {script.name}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </Stack>
+                )}
+
+                {scriptError && <Alert severity="error">{scriptError}</Alert>}
+              </Stack>
+            )}
+          </Stack>
+        )}
+      </DialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/frontend/src/pages/backup-plans/source-discovery/types.ts
+++ b/frontend/src/pages/backup-plans/source-discovery/types.ts
@@ -1,0 +1,39 @@
+export interface SourceDiscoveryType {
+  id: 'paths' | 'database' | 'container' | string
+  label: string
+  description: string
+  enabled: boolean
+  unavailable_reason?: string | null
+}
+
+export interface DatabaseDiscoveryTarget {
+  id: string
+  engine: string
+  engine_label: string
+  display_name: string
+  status: 'detected' | 'template'
+  confidence: 'high' | 'medium' | 'template'
+  service_name: string
+  source_directories: string[]
+  warnings: string[]
+  pre_backup_script: string
+  post_backup_script: string
+  script_name_base: string
+  documentation_url: string
+}
+
+export interface DatabaseDiscoveryResponse {
+  source_types: SourceDiscoveryType[]
+  databases: DatabaseDiscoveryTarget[]
+  templates: DatabaseDiscoveryTarget[]
+}
+
+export interface AppliedDatabaseSource {
+  sourceType: 'local'
+  sourceSshConnectionId: ''
+  sourceDirectories: string[]
+  preBackupScriptId: number | null
+  postBackupScriptId: number | null
+  preBackupScriptParameters: Record<string, string>
+  postBackupScriptParameters: Record<string, string>
+}

--- a/frontend/src/pages/backup-plans/wizard-step/SourceStep.tsx
+++ b/frontend/src/pages/backup-plans/wizard-step/SourceStep.tsx
@@ -1,13 +1,19 @@
-import { Stack, TextField } from '@mui/material'
+import { useState } from 'react'
+import { Box, Button, Stack, TextField, Typography } from '@mui/material'
+import { Database, FolderOpen } from 'lucide-react'
 
 import ExcludePatternInput from '../../../components/ExcludePatternInput'
 import { WizardStepDataSource } from '../../../components/wizard'
+import { SourceSelectionDialog } from '../source-discovery/SourceSelectionDialog'
+import type { AppliedDatabaseSource } from '../source-discovery/types'
 import type { BackupPlanWizardStepProps } from './types'
 
 type SourceStepProps = Pick<
   BackupPlanWizardStepProps,
   | 'wizardState'
   | 'sshConnections'
+  | 'scripts'
+  | 'loadingScripts'
   | 'updateState'
   | 'openSourceExplorer'
   | 'openExcludeExplorer'
@@ -17,11 +23,36 @@ type SourceStepProps = Pick<
 export function SourceStep({
   wizardState,
   sshConnections,
+  scripts,
+  loadingScripts,
   updateState,
   openSourceExplorer,
   openExcludeExplorer,
   t,
 }: SourceStepProps) {
+  const [sourceDialogOpen, setSourceDialogOpen] = useState(false)
+  const [showPathControls, setShowPathControls] = useState(
+    () => wizardState.sourceDirectories.length > 0
+  )
+
+  const hasConfiguredSource = wizardState.sourceDirectories.length > 0
+  const sourceSummary = hasConfiguredSource
+    ? t('backupPlans.wizard.sourceSelection.summaryConfigured', {
+        count: wizardState.sourceDirectories.length,
+      })
+    : t('backupPlans.wizard.sourceSelection.summaryEmpty')
+
+  const handleUsePaths = () => {
+    setShowPathControls(true)
+    setSourceDialogOpen(false)
+  }
+
+  const handleApplyDatabase = (source: AppliedDatabaseSource) => {
+    updateState(source)
+    setShowPathControls(true)
+    setSourceDialogOpen(false)
+  }
+
   return (
     <Stack spacing={3}>
       <TextField
@@ -39,32 +70,94 @@ export function SourceStep({
         rows={2}
         fullWidth
       />
-      <WizardStepDataSource
-        repositoryLocation="local"
-        repoSshConnectionId=""
-        repositoryMode="full"
-        data={{
-          dataSource: wizardState.sourceType,
-          sourceSshConnectionId: wizardState.sourceSshConnectionId,
-          sourceDirs: wizardState.sourceDirectories,
+
+      <Box
+        sx={{
+          border: 1,
+          borderColor: 'divider',
+          borderRadius: 1,
+          p: 2,
+          display: 'flex',
+          alignItems: { xs: 'stretch', sm: 'center' },
+          justifyContent: 'space-between',
+          flexDirection: { xs: 'column', sm: 'row' },
+          gap: 2,
         }}
-        sshConnections={sshConnections}
-        onChange={(updates) => {
-          updateState({
-            ...(updates.dataSource ? { sourceType: updates.dataSource } : {}),
-            ...(updates.sourceSshConnectionId !== undefined
-              ? { sourceSshConnectionId: updates.sourceSshConnectionId }
-              : {}),
-            ...(updates.sourceDirs !== undefined ? { sourceDirectories: updates.sourceDirs } : {}),
-          })
-        }}
-        onBrowseSource={openSourceExplorer}
-        onBrowseRemoteSource={openSourceExplorer}
-      />
-      <ExcludePatternInput
-        patterns={wizardState.excludePatterns}
-        onChange={(excludePatterns) => updateState({ excludePatterns })}
-        onBrowseClick={openExcludeExplorer}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, minWidth: 0 }}>
+          <Box
+            sx={{
+              width: 40,
+              height: 40,
+              borderRadius: 1,
+              bgcolor: 'action.hover',
+              color: 'primary.main',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+            }}
+          >
+            {hasConfiguredSource ? <Database size={20} /> : <FolderOpen size={20} />}
+          </Box>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography variant="subtitle2" fontWeight={700}>
+              {t('backupPlans.wizard.sourceSelection.summaryTitle')}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {sourceSummary}
+            </Typography>
+          </Box>
+        </Box>
+        <Button variant="outlined" onClick={() => setSourceDialogOpen(true)}>
+          {hasConfiguredSource
+            ? t('backupPlans.wizard.sourceSelection.changeSource')
+            : t('backupPlans.wizard.sourceSelection.chooseSource')}
+        </Button>
+      </Box>
+
+      {(showPathControls || hasConfiguredSource) && (
+        <>
+          <WizardStepDataSource
+            repositoryLocation="local"
+            repoSshConnectionId=""
+            repositoryMode="full"
+            data={{
+              dataSource: wizardState.sourceType,
+              sourceSshConnectionId: wizardState.sourceSshConnectionId,
+              sourceDirs: wizardState.sourceDirectories,
+            }}
+            sshConnections={sshConnections}
+            onChange={(updates) => {
+              updateState({
+                ...(updates.dataSource ? { sourceType: updates.dataSource } : {}),
+                ...(updates.sourceSshConnectionId !== undefined
+                  ? { sourceSshConnectionId: updates.sourceSshConnectionId }
+                  : {}),
+                ...(updates.sourceDirs !== undefined
+                  ? { sourceDirectories: updates.sourceDirs }
+                  : {}),
+              })
+            }}
+            onBrowseSource={openSourceExplorer}
+            onBrowseRemoteSource={openSourceExplorer}
+          />
+          <ExcludePatternInput
+            patterns={wizardState.excludePatterns}
+            onChange={(excludePatterns) => updateState({ excludePatterns })}
+            onBrowseClick={openExcludeExplorer}
+          />
+        </>
+      )}
+
+      <SourceSelectionDialog
+        open={sourceDialogOpen}
+        scripts={scripts}
+        loadingScripts={loadingScripts}
+        onClose={() => setSourceDialogOpen(false)}
+        onUsePaths={handleUsePaths}
+        onApplyDatabase={handleApplyDatabase}
+        t={t}
       />
     </Stack>
   )

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -731,6 +731,10 @@ export const scriptsAPI = {
   delete: (scriptId: number) => api.delete(`/scripts/${scriptId}`),
 }
 
+export const sourceDiscoveryAPI = {
+  scanDatabases: () => api.get('/source-discovery/databases'),
+}
+
 export const mountsAPI = {
   // Mount a Borg repository or archive
   mountBorgArchive: (data: {

--- a/tests/unit/test_source_discovery.py
+++ b/tests/unit/test_source_discovery.py
@@ -1,0 +1,55 @@
+def test_database_discovery_requires_auth(test_client):
+    response = test_client.get("/api/source-discovery/databases")
+
+    assert response.status_code in {401, 403}
+
+
+def test_database_discovery_returns_source_types_and_templates(
+    test_client, admin_headers
+):
+    response = test_client.get("/api/source-discovery/databases", headers=admin_headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    source_types = {item["id"]: item for item in payload["source_types"]}
+    assert source_types["paths"]["enabled"] is True
+    assert source_types["database"]["enabled"] is True
+    assert source_types["container"]["enabled"] is False
+
+    template_engines = {item["engine"] for item in payload["templates"]}
+    assert {"postgresql", "mysql", "mongodb", "redis"}.issubset(template_engines)
+
+    for target in payload["templates"]:
+        assert target["source_directories"]
+        assert target["pre_backup_script"].startswith("#!/usr/bin/env bash")
+        assert target["post_backup_script"].startswith("#!/usr/bin/env bash")
+        assert target["script_name_base"]
+
+
+def test_database_discovery_reports_detected_postgresql(
+    test_client, admin_headers, monkeypatch
+):
+    from app.api import source_discovery
+
+    monkeypatch.setattr(
+        source_discovery,
+        "_path_exists",
+        lambda path: path == "/var/lib/postgresql",
+    )
+    monkeypatch.setattr(source_discovery, "_is_port_open", lambda port: False)
+
+    response = test_client.get("/api/source-discovery/databases", headers=admin_headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert len(payload["databases"]) == 1
+    target = payload["databases"][0]
+    assert target["engine"] == "postgresql"
+    assert target["status"] == "detected"
+    assert target["confidence"] == "medium"
+    assert target["service_name"] == "postgresql"
+    assert target["source_directories"] == ["/var/lib/postgresql"]
+    assert 'systemctl stop "$SERVICE_NAME"' in target["pre_backup_script"]
+    assert 'systemctl start "$SERVICE_NAME"' in target["post_backup_script"]


### PR DESCRIPTION
## Description
Adds a guided backup source chooser for backup-plan creation. The source step now opens a responsive dialog/bottom sheet where users can choose files and folders, manual path entry, database scanning, or see Docker/container scanning as a planned source type.

The database path adds an authenticated `/api/source-discovery/databases` endpoint for PostgreSQL, MySQL/MariaDB, MongoDB, and Redis. It returns conservative local detections, reusable templates, source directories, warnings, documentation links, and editable stop/start pre/post script drafts. The UI lets users create named generated scripts, reuse existing scripts, or skip script assignment before applying the discovered source.

The PR also adds durable spec/plan docs and focused backend/frontend tests for the new flow while preserving the existing path-based backup source setup.

## Related Issue
Linear: https://linear.app/nullcodeai/issue/BOR-17/automatic-database-scanning-and-setup

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing targeted tests pass

Validation run:
- `pytest tests/unit/test_source_discovery.py -q`
- `ruff check app tests`
- `ruff format --check app tests`
- `cd frontend && npm test -- --run src/pages/backup-plans/__tests__/SourceStep.test.tsx src/components/wizard/__tests__/WizardStepDataSource.test.tsx`
- `cd frontend && npm run format:check`
- `cd frontend && npm run check:locales`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

Runtime walkthrough:
- Launched with `./scripts/dev.sh`.
- Confirmed backend docs and frontend `/backup-plans` served locally.
- Authenticated `GET /api/source-discovery/databases` returned enabled path/database source types, disabled container source type, four database templates, and stop/start script drafts.
- Confirmed Vite served the changed source-step and source-selection dialog modules.

## Checklist
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines (file is not present in this repository copy)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not captured in this environment. Runtime validation used the live dev stack plus focused React tests because no Playwright package or browser binary was available locally.

## Additional Context
`ui-ux-pro-max` is referenced by the ticket/repo instructions, but that skill is not available in the current skill list or local skill paths. The implementation follows the existing MUI/ResponsiveDialog design system instead.

The production build still reports the repository's existing Vite warnings for the mixed static/dynamic `webauthn.ts` import and large bundle chunk.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
