### PR TITLE
Classify SSH deployment DNS failures

### DIFF
--- a/app/api/ssh_keys.py
+++ b/app/api/ssh_keys.py
@@ -2025,6 +2025,14 @@ async def deploy_ssh_key_with_copy_id(
                 helpful_hint = (
                     "Check if SSH server is running and firewall allows connections"
                 )
+            elif (
+                "Could not resolve hostname" in error_msg
+                or "Name or service not known" in error_msg
+                or "Temporary failure in name resolution" in error_msg
+                or "nodename nor servname provided" in error_msg
+            ):
+                error_summary = f"Cannot resolve SSH hostname {host}"
+                helpful_hint = "Verify the host name or DNS configuration"
             elif "Permission denied" in error_msg:
                 error_summary = (
                     f"Authentication failed for {username}@{host} - incorrect password"
@@ -2213,6 +2221,14 @@ async def test_ssh_key_connection(
                         f"Cannot connect to {host}:{port} - SSH service not accessible"
                     )
                     helpful_hint = "Verify SSH server is running and port is correct"
+                elif (
+                    "Could not resolve hostname" in error_msg
+                    or "Name or service not known" in error_msg
+                    or "Temporary failure in name resolution" in error_msg
+                    or "nodename nor servname provided" in error_msg
+                ):
+                    error_summary = f"Cannot resolve SSH hostname {host}"
+                    helpful_hint = "Verify the host name or DNS configuration"
                 elif "Permission denied" in error_msg:
                     if "publickey" in error_msg:
                         error_summary = f"SSH key not authorized on {host}"

--- a/app/api/ssh_keys.py
+++ b/app/api/ssh_keys.py
@@ -2044,14 +2044,9 @@ async def deploy_ssh_key_with_copy_id(
                 helpful_hint = (
                     "Check if SSH server is running and firewall allows connections"
                 )
-            elif (
-                "Could not resolve hostname" in error_msg
-                or "Name or service not known" in error_msg
-                or "Temporary failure in name resolution" in error_msg
-                or "nodename nor servname provided" in error_msg
-            ):
-                error_summary = f"Cannot resolve SSH hostname {host}"
-                helpful_hint = "Verify the host name or DNS configuration"
+            elif _is_ssh_dns_resolution_error(error_msg):
+                error_summary = f"Host did not resolve: {host}"
+                helpful_hint = "Check the saved host value, DNS records/resolvers, provider sub-account existence, and container/runtime DNS."
             elif "Permission denied" in error_msg:
                 error_summary = (
                     f"Authentication failed for {username}@{host} - incorrect password"
@@ -2243,14 +2238,6 @@ async def test_ssh_key_connection(
                         f"Cannot connect to {host}:{port} - SSH service not accessible"
                     )
                     helpful_hint = "Verify SSH server is running and port is correct"
-                elif (
-                    "Could not resolve hostname" in error_msg
-                    or "Name or service not known" in error_msg
-                    or "Temporary failure in name resolution" in error_msg
-                    or "nodename nor servname provided" in error_msg
-                ):
-                    error_summary = f"Cannot resolve SSH hostname {host}"
-                    helpful_hint = "Verify the host name or DNS configuration"
                 elif "Permission denied" in error_msg:
                     if "publickey" in error_msg:
                         error_summary = f"SSH key not authorized on {host}"

--- a/tests/unit/test_ssh_key_deployment.py
+++ b/tests/unit/test_ssh_key_deployment.py
@@ -291,6 +291,54 @@ class TestSSHKeyDeployment:
             "Position 4 should be -s flag when defaulting to True"
         )
 
+    @pytest.mark.asyncio
+    async def test_deploy_ssh_key_classifies_dns_resolution_failures(self):
+        """Deployment DNS failures should direct users to host/DNS/runtime checks."""
+        mock_key = MagicMock(spec=SSHKey)
+        mock_key.id = 1
+        mock_key.public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAItest test@test"
+
+        from app.config import settings
+
+        encryption_key = settings.secret_key.encode()[:32]
+        cipher = Fernet(base64.urlsafe_b64encode(encryption_key))
+        fake_private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----\n"
+        mock_key.private_key = cipher.encrypt(fake_private_key.encode()).decode()
+
+        dns_failure = (
+            b"ssh: Could not resolve hostname u331525-sub1.your-storagebox.de: "
+            b"Name or service not known\n"
+        )
+
+        async def mock_subprocess(*cmd, **kwargs):
+            mock_process = AsyncMock()
+            mock_process.communicate = AsyncMock(return_value=(b"", dns_failure))
+            mock_process.returncode = 255
+            return mock_process
+
+        with patch(
+            "app.api.ssh_keys.asyncio.create_subprocess_exec",
+            side_effect=mock_subprocess,
+        ):
+            result = await deploy_ssh_key_with_copy_id(
+                mock_key,
+                "u331525-sub1.your-storagebox.de",
+                "u331525-sub1",
+                "test_password",
+                23,
+            )
+
+        assert result["success"] is False
+        assert (
+            "Host did not resolve: u331525-sub1.your-storagebox.de" in result["error"]
+        )
+        assert "saved host value" in result["error"]
+        assert "DNS" in result["error"]
+        assert "provider sub-account" in result["error"]
+        assert "container/runtime DNS" in result["error"]
+        assert dns_failure.decode().strip() in result["error"]
+        assert "Check SSH server logs" not in result["error"]
+
 
 @pytest.mark.unit
 class TestSSHKeyConnectionTest:
@@ -390,49 +438,3 @@ class TestSSHKeyConnectionTest:
         assert "PreferredAuthentications=publickey" in captured_cmd
         assert "PasswordAuthentication=no" in captured_cmd
         assert "NumberOfPasswordPrompts=0" in captured_cmd
-
-    @pytest.mark.asyncio
-    async def test_connection_test_reports_dns_resolution_failures(self):
-        """DNS failures should tell users to fix the hostname, not SSH server logs."""
-        mock_key = MagicMock(spec=SSHKey)
-        mock_key.id = 1
-        mock_key.public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAItest test@test"
-
-        from app.config import settings
-
-        encryption_key = settings.secret_key.encode()[:32]
-        cipher = Fernet(base64.urlsafe_b64encode(encryption_key))
-        fake_private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----\n"
-        mock_key.private_key = cipher.encrypt(fake_private_key.encode()).decode()
-
-        dns_failure = (
-            b"ssh: Could not resolve hostname u331525-sub1.your-storagebox.de: "
-            b"Name or service not known\n"
-        )
-
-        async def mock_subprocess(*cmd, **kwargs):
-            class MockProcess:
-                returncode = 255
-
-                async def communicate(self):
-                    return b"", dns_failure
-
-            return MockProcess()
-
-        with patch(
-            "app.api.ssh_keys.asyncio.create_subprocess_exec",
-            side_effect=mock_subprocess,
-        ):
-            result = await run_ssh_key_connection_test(
-                mock_key,
-                "u331525-sub1.your-storagebox.de",
-                "u331525-sub1",
-                23,
-            )
-
-        assert result["success"] is False
-        assert (
-            "Cannot resolve SSH hostname u331525-sub1.your-storagebox.de"
-            in result["error"]
-        )
-        assert "Verify the host name or DNS configuration" in result["error"]

--- a/tests/unit/test_ssh_key_deployment.py
+++ b/tests/unit/test_ssh_key_deployment.py
@@ -342,3 +342,49 @@ class TestSSHKeyConnectionTest:
         assert "PreferredAuthentications=publickey" in captured_cmd
         assert "PasswordAuthentication=no" in captured_cmd
         assert "NumberOfPasswordPrompts=0" in captured_cmd
+
+    @pytest.mark.asyncio
+    async def test_connection_test_reports_dns_resolution_failures(self):
+        """DNS failures should tell users to fix the hostname, not SSH server logs."""
+        mock_key = MagicMock(spec=SSHKey)
+        mock_key.id = 1
+        mock_key.public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAItest test@test"
+
+        from app.config import settings
+
+        encryption_key = settings.secret_key.encode()[:32]
+        cipher = Fernet(base64.urlsafe_b64encode(encryption_key))
+        fake_private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----\n"
+        mock_key.private_key = cipher.encrypt(fake_private_key.encode()).decode()
+
+        dns_failure = (
+            b"ssh: Could not resolve hostname u331525-sub1.your-storagebox.de: "
+            b"Name or service not known\n"
+        )
+
+        async def mock_subprocess(*cmd, **kwargs):
+            class MockProcess:
+                returncode = 255
+
+                async def communicate(self):
+                    return b"", dns_failure
+
+            return MockProcess()
+
+        with patch(
+            "app.api.ssh_keys.asyncio.create_subprocess_exec",
+            side_effect=mock_subprocess,
+        ):
+            result = await run_ssh_key_connection_test(
+                mock_key,
+                "u331525-sub1.your-storagebox.de",
+                "u331525-sub1",
+                23,
+            )
+
+        assert result["success"] is False
+        assert (
+            "Cannot resolve SSH hostname u331525-sub1.your-storagebox.de"
+            in result["error"]
+        )
+        assert "Verify the host name or DNS configuration" in result["error"]


### PR DESCRIPTION
## Description
Extends the merged SSH DNS resolver classifier to the `ssh-copy-id` deployment path. SSH connection tests already received the broader DNS handling in #484; this PR now covers the remaining deployment failure path so hostname/DNS errors do not fall back to generic server-log guidance.

## Related Issue
Related to #457
Linear: BOR-20
Follow-up to #484

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass

Commands run:
- `.venv/bin/pytest tests/unit/test_ssh_key_deployment.py::TestSSHKeyDeployment::test_deploy_ssh_key_classifies_dns_resolution_failures -q` (red before fix, green after fix)
- `.venv/bin/pytest tests/unit/test_ssh_key_deployment.py tests/unit/test_api_ssh_keys.py -q`
- `.venv/bin/ruff check app tests`
- `.venv/bin/ruff format --check app tests`
- `git diff --check`

Earlier in the landing gate before the review-driven scope adjustment, `.venv/bin/pytest tests/unit -v` also passed with existing warnings. The final pushed delta is covered by the focused SSH test suite above; full PR CI will rerun on this commit.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

Code comments and documentation were not changed because the new behavior reuses the existing self-describing DNS classifier. Existing warnings are from the current Pydantic/FastAPI/test mock setup.

## Screenshots (if applicable)
Not applicable; backend-only SSH error classification change.

## Additional Context
Reviewer feedback noted similar connection-test DNS work had already landed. I verified #484 on current `origin/main`, preserved that connection-test behavior, and narrowed this PR to the missed deployment path.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.