### PR TITLE
Classify SSH DNS resolution failures

### DIFF
--- a/app/api/ssh_keys.py
+++ b/app/api/ssh_keys.py
@@ -29,6 +29,25 @@ router = APIRouter(tags=["ssh-keys"], dependencies=[Depends(authorize_request)])
 
 
 # Helper functions
+SSH_DNS_RESOLUTION_ERROR_MARKERS = (
+    "could not resolve hostname",
+    "name or service not known",
+    "nodename nor servname provided",
+    "temporary failure in name resolution",
+    "no address associated with hostname",
+    "name does not resolve",
+    "non-recoverable failure in name resolution",
+    "getaddrinfo",
+)
+
+
+def _is_ssh_dns_resolution_error(error_msg: str) -> bool:
+    normalized_error = error_msg.lower()
+    return any(
+        marker in normalized_error for marker in SSH_DNS_RESOLUTION_ERROR_MARKERS
+    )
+
+
 def format_bytes(bytes_size: int) -> str:
     """Format bytes to human readable string (e.g., '1.23 GB')"""
     for unit in ["B", "KB", "MB", "GB", "TB", "PB"]:
@@ -2208,6 +2227,9 @@ async def test_ssh_key_connection(
                         f"SSH connection works but remote shell is restricted"
                     )
                     helpful_hint = "Server uses restricted shell (e.g., Hetzner Storage Box). Connection is valid for borg/rsync/sftp operations."
+                elif _is_ssh_dns_resolution_error(error_msg):
+                    error_summary = f"Host did not resolve: {host}"
+                    helpful_hint = "Check the saved host value, DNS records/resolvers, provider sub-account existence, and container/runtime DNS."
                 elif "Connection refused" in error_msg:
                     error_summary = (
                         f"Cannot connect to {host}:{port} - SSH service not accessible"

--- a/tests/unit/test_api_ssh_keys.py
+++ b/tests/unit/test_api_ssh_keys.py
@@ -137,6 +137,77 @@ class TestSSHKeysEndpoints:
 
         assert response.status_code == 401
 
+    def test_connection_test_dns_failure_stores_diagnostic_details(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """DNS failures should be returned and stored with the original stderr details."""
+        from app.core.security import encrypt_secret
+
+        fake_private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----\n"
+        ssh_key = SSHKey(
+            name="DNS failure key",
+            public_key="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAItest test@test",
+            private_key=encrypt_secret(fake_private_key),
+            is_active=True,
+        )
+        test_db.add(ssh_key)
+        test_db.commit()
+        test_db.refresh(ssh_key)
+
+        dns_stderr = (
+            b"ssh: Could not resolve hostname missing.example: "
+            b"Name or service not known\r\n"
+        )
+
+        async def mock_subprocess(*cmd, **kwargs):
+            mock_process = AsyncMock()
+            mock_process.communicate = AsyncMock(return_value=(b"", dns_stderr))
+            mock_process.returncode = 255
+            return mock_process
+
+        with patch(
+            "app.api.ssh_keys.asyncio.create_subprocess_exec",
+            side_effect=mock_subprocess,
+        ):
+            response = test_client.post(
+                f"/api/ssh-keys/{ssh_key.id}/test-connection",
+                json={"host": "missing.example", "username": "backup", "port": 22},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        error_message = data["connection"]["error_message"]
+
+        assert data["success"] is False
+        assert data["connection"]["status"] == "failed"
+        assert "Host did not resolve: missing.example" in error_message
+        assert "saved host value" in error_message
+        assert dns_stderr.decode().strip() in error_message
+
+        stored_connection = (
+            test_db.query(SSHConnection)
+            .filter(
+                SSHConnection.ssh_key_id == ssh_key.id,
+                SSHConnection.host == "missing.example",
+                SSHConnection.username == "backup",
+                SSHConnection.port == 22,
+            )
+            .one()
+        )
+        assert stored_connection.error_message == error_message
+
+        list_response = test_client.get(
+            "/api/ssh-keys/connections", headers=admin_headers
+        )
+        assert list_response.status_code == 200
+        listed_connection = next(
+            connection
+            for connection in list_response.json()["connections"]
+            if connection["id"] == stored_connection.id
+        )
+        assert listed_connection["error_message"] == error_message
+
 
 @pytest.mark.unit
 class TestRunDfCommand:

--- a/tests/unit/test_ssh_key_deployment.py
+++ b/tests/unit/test_ssh_key_deployment.py
@@ -297,6 +297,56 @@ class TestSSHKeyConnectionTest:
     """Test SSH key-based connection checks."""
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            b"ssh: Could not resolve hostname missing.example: Name or service not known\r\n",
+            b"ssh: Could not resolve hostname missing.example: nodename nor servname provided, or not known\r\n",
+            b"ssh: Could not resolve hostname missing.example: Temporary failure in name resolution\r\n",
+            b"ssh: Could not resolve hostname missing.example: No address associated with hostname\r\n",
+            b"ssh: Could not resolve hostname missing.example: getaddrinfo: Name does not resolve\r\n",
+        ],
+    )
+    async def test_connection_test_classifies_dns_resolution_failures(self, stderr):
+        """DNS failures should direct users to host/DNS/runtime checks, not SSH server logs."""
+        mock_key = MagicMock(spec=SSHKey)
+        mock_key.id = 1
+        mock_key.public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAItest test@test"
+
+        from app.config import settings
+
+        encryption_key = settings.secret_key.encode()[:32]
+        cipher = Fernet(base64.urlsafe_b64encode(encryption_key))
+        fake_private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----\n"
+        mock_key.private_key = cipher.encrypt(fake_private_key.encode()).decode()
+
+        async def mock_subprocess(*cmd, **kwargs):
+            mock_process = AsyncMock()
+            mock_process.communicate = AsyncMock(return_value=(b"", stderr))
+            mock_process.returncode = 255
+            return mock_process
+
+        with patch(
+            "app.api.ssh_keys.asyncio.create_subprocess_exec",
+            side_effect=mock_subprocess,
+        ):
+            result = await run_ssh_key_connection_test(
+                mock_key,
+                "missing.example",
+                "backup",
+                22,
+            )
+
+        assert result["success"] is False
+        assert "Host did not resolve" in result["error"]
+        assert "saved host value" in result["error"]
+        assert "DNS" in result["error"]
+        assert "provider sub-account" in result["error"]
+        assert "container/runtime DNS" in result["error"]
+        assert stderr.decode().strip() in result["error"]
+        assert "Check SSH server configuration and logs" not in result["error"]
+
+    @pytest.mark.asyncio
     async def test_connection_test_forces_single_noninteractive_public_key(self):
         """Connection tests should not fall back to other identities or password prompts."""
         mock_key = MagicMock(spec=SSHKey)
@@ -325,18 +375,16 @@ class TestSSHKeyConnectionTest:
             "app.api.ssh_keys.asyncio.create_subprocess_exec",
             side_effect=mock_subprocess,
         ):
-            with patch("app.api.ssh_keys.asyncio.wait_for") as mock_wait:
-                mock_wait.return_value = (b"", permission_denied)
-
-                result = await run_ssh_key_connection_test(
-                    mock_key,
-                    "synology.local",
-                    "backup",
-                    22,
-                )
+            result = await run_ssh_key_connection_test(
+                mock_key,
+                "synology.local",
+                "backup",
+                22,
+            )
 
         assert result["success"] is False
         assert "SSH key not authorized" in result["error"]
+        assert "Host did not resolve" not in result["error"]
         assert "BatchMode=yes" in captured_cmd
         assert "IdentitiesOnly=yes" in captured_cmd
         assert "PreferredAuthentications=publickey" in captured_cmd


### PR DESCRIPTION
## Description
Classifies OpenSSH DNS/name-resolution failures during SSH connection tests so users see host/DNS/runtime guidance instead of the generic SSH server configuration message.

The parser now recognizes `Could not resolve hostname`, `Name or service not known`, and common resolver variants while preserving the original stderr in the connection error details used for diagnostics.

## Related Issue
Linear: https://linear.app/nullcodeai/issue/BOR-21/classify-ssh-dns-resolution-failures-with-actionable-guidance

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `pytest tests/unit/test_ssh_key_deployment.py::TestSSHKeyConnectionTest -q`
- `pytest tests/unit/test_ssh_key_deployment.py tests/unit/test_api_ssh_keys.py -q`
- `ruff check app tests`
- `ruff format --check app tests`
- `git diff --check`

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Code comments are not needed; the new classifier is self-describing
- [x] Documentation changes are not required for this backend parser fix
- [x] Existing warnings are from the current Pydantic/FastAPI/test mock setup, not this parser change
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; this is a backend SSH connection-test parser/API behavior change.

## Additional Context
The change does not alter SSH command construction, key deployment, host normalization, or BOR-14 host validation scope. Connection status continues to store the full error text with `Details:` for diagnostics.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
