### PR TITLE
Fix Hetzner SFTP child folder browsing

### DIFF
--- a/app/api/filesystem.py
+++ b/app/api/filesystem.py
@@ -334,50 +334,95 @@ async def browse_ssh_filesystem(
 
         os.chmod(temp_key_file, 0o600)
 
+        def run_sftp_listing(cd_path: Optional[str]):
+            sftp_batch_file = None
+            try:
+                # Create SFTP batch file with commands
+                with tempfile.NamedTemporaryFile(
+                    mode="w", delete=False, suffix=".sftp"
+                ) as batch_f:
+                    if cd_path:
+                        batch_f.write(f'cd "{cd_path}"\n')
+                    batch_f.write("ls -la\n")
+                    sftp_batch_file = batch_f.name
+
+                logger.info("Browsing SSH path via SFTP", host=host, path=path)
+
+                sftp_cmd = [
+                    "sftp",
+                    "-b",
+                    sftp_batch_file,
+                    "-i",
+                    temp_key_file,
+                    "-P",
+                    str(port),
+                    "-o",
+                    "StrictHostKeyChecking=no",
+                    "-o",
+                    "UserKnownHostsFile=/dev/null",
+                    "-o",
+                    "ConnectTimeout=10",
+                    f"{username}@{host}",
+                ]
+
+                return subprocess.run(
+                    sftp_cmd, capture_output=True, text=True, timeout=30
+                )
+            finally:
+                # Clean up SFTP batch file
+                if sftp_batch_file and os.path.exists(sftp_batch_file):
+                    try:
+                        os.unlink(sftp_batch_file)
+                    except Exception:
+                        pass
+
+        def has_sftp_listing_entries(stdout: str) -> bool:
+            for line in stdout.strip().split("\n"):
+                if (
+                    not line
+                    or line.startswith("sftp>")
+                    or line.startswith("total")
+                    or "Connecting to" in line
+                ):
+                    continue
+                return True
+            return False
+
+        def sftp_listing_failed(result) -> bool:
+            if result.returncode != 0:
+                return True
+
+            stderr = (result.stderr or "").lower()
+            failure_markers = (
+                "remote readdir",
+                "permission denied",
+                "no such file",
+                "not found",
+                "couldn't",
+                "cannot",
+                "failure",
+            )
+            return any(marker in stderr for marker in failure_markers) and not (
+                result.stdout and has_sftp_listing_entries(result.stdout)
+            )
+
         # Use SFTP for browsing (compatible with restricted shells like Hetzner Storage Box)
         # SFTP batch commands: ls -la shows detailed listing
-        sftp_batch_file = None
-        try:
-            # Create SFTP batch file with commands
-            with tempfile.NamedTemporaryFile(
-                mode="w", delete=False, suffix=".sftp"
-            ) as batch_f:
-                if path != "/":
-                    batch_f.write(f'cd "{path}"\n')
-                batch_f.write("ls -la\n")
-                sftp_batch_file = batch_f.name
+        result = run_sftp_listing(None if path == "/" else path)
 
-            logger.info("Browsing SSH path via SFTP", host=host, path=path)
+        if path.startswith("/") and path != "/" and sftp_listing_failed(result):
+            relative_path = path.lstrip("/")
+            if relative_path:
+                logger.info(
+                    "Retrying SFTP path relative to login directory",
+                    host=host,
+                    path=path,
+                    relative_path=relative_path,
+                    stderr=result.stderr[:500] if result.stderr else None,
+                )
+                result = run_sftp_listing(relative_path)
 
-            sftp_cmd = [
-                "sftp",
-                "-b",
-                sftp_batch_file,
-                "-i",
-                temp_key_file,
-                "-P",
-                str(port),
-                "-o",
-                "StrictHostKeyChecking=no",
-                "-o",
-                "UserKnownHostsFile=/dev/null",
-                "-o",
-                "ConnectTimeout=10",
-                f"{username}@{host}",
-            ]
-
-            result = subprocess.run(
-                sftp_cmd, capture_output=True, text=True, timeout=30
-            )
-        finally:
-            # Clean up SFTP batch file
-            if sftp_batch_file and os.path.exists(sftp_batch_file):
-                try:
-                    os.unlink(sftp_batch_file)
-                except Exception:
-                    pass
-
-        if result.returncode != 0:
+        if sftp_listing_failed(result):
             error_msg = (
                 result.stderr.strip()
                 if result.stderr

--- a/tests/unit/test_api_filesystem.py
+++ b/tests/unit/test_api_filesystem.py
@@ -374,6 +374,83 @@ class TestFilesystemBrowseSSH:
         assert response.items[0].path == "/backups/repo"
 
     @pytest.mark.asyncio
+    async def test_browse_ssh_filesystem_retries_nested_sftp_path_relative_to_login_dir(
+        self,
+        monkeypatch,
+    ):
+        secret_key = "a" * 32
+        monkeypatch.setattr(
+            filesystem.settings, "secret_key", secret_key, raising=False
+        )
+        monkeypatch.setattr(
+            filesystem.settings.__class__, "get_local_mount_points", lambda self: []
+        )
+        ssh_key = SSHKey(
+            id=42,
+            name="ssh-key",
+            public_key="ssh-rsa AAA",
+            private_key=_encrypt_private_key(secret_key, "PRIVATE KEY"),
+        )
+
+        class QueryStub:
+            def filter(self, *args, **kwargs):
+                return self
+
+            def first(self):
+                return ssh_key
+
+        class SessionStub:
+            def query(self, *args, **kwargs):
+                return QueryStub()
+
+        batch_commands = []
+
+        def run_side_effect(cmd, *args, **kwargs):
+            if cmd[0] == "sftp":
+                batch_path = Path(cmd[cmd.index("-b") + 1])
+                commands = batch_path.read_text()
+                batch_commands.append(commands)
+
+                if commands == 'cd "/backups/repo"\nls -la\n':
+                    return SimpleNamespace(
+                        returncode=0,
+                        stdout='sftp> cd "/backups/repo"\nsftp> ls -la\n',
+                        stderr='remote readdir("/backups/repo"): Permission denied\n',
+                    )
+
+                if commands == 'cd "backups/repo"\nls -la\n':
+                    return SimpleNamespace(
+                        returncode=0,
+                        stdout=("drwxr-xr-x    ? user user 3 Aug 17 2023 snapshots\n"),
+                        stderr="",
+                    )
+
+                raise AssertionError(f"unexpected SFTP batch commands: {commands!r}")
+
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(filesystem.subprocess, "run", run_side_effect)
+        monkeypatch.setattr(
+            filesystem, "is_borg_repository_ssh", lambda *args, **kwargs: False
+        )
+
+        response = await filesystem.browse_ssh_filesystem(
+            path="/backups/repo",
+            ssh_key_id=ssh_key.id,
+            host="example.com",
+            username="borg",
+            port=22,
+            db=SessionStub(),
+        )
+
+        assert batch_commands == [
+            'cd "/backups/repo"\nls -la\n',
+            'cd "backups/repo"\nls -la\n',
+        ]
+        assert [item.name for item in response.items] == ["snapshots"]
+        assert response.items[0].path == "/backups/repo/snapshots"
+
+    @pytest.mark.asyncio
     async def test_browse_ssh_filesystem_missing_key_returns_404(self, test_db):
         with pytest.raises(filesystem.HTTPException) as exc:
             await filesystem.browse_ssh_filesystem(

--- a/tests/unit/test_api_filesystem.py
+++ b/tests/unit/test_api_filesystem.py
@@ -297,6 +297,83 @@ class TestFilesystemBrowseSSH:
         assert [item.name for item in response.items] == ["backups"]
 
     @pytest.mark.asyncio
+    async def test_browse_ssh_filesystem_retries_non_root_sftp_path_relative_to_login_dir(
+        self,
+        monkeypatch,
+    ):
+        secret_key = "a" * 32
+        monkeypatch.setattr(
+            filesystem.settings, "secret_key", secret_key, raising=False
+        )
+        monkeypatch.setattr(
+            filesystem.settings.__class__, "get_local_mount_points", lambda self: []
+        )
+        ssh_key = SSHKey(
+            id=42,
+            name="ssh-key",
+            public_key="ssh-rsa AAA",
+            private_key=_encrypt_private_key(secret_key, "PRIVATE KEY"),
+        )
+
+        class QueryStub:
+            def filter(self, *args, **kwargs):
+                return self
+
+            def first(self):
+                return ssh_key
+
+        class SessionStub:
+            def query(self, *args, **kwargs):
+                return QueryStub()
+
+        batch_commands = []
+
+        def run_side_effect(cmd, *args, **kwargs):
+            if cmd[0] == "sftp":
+                batch_path = Path(cmd[cmd.index("-b") + 1])
+                commands = batch_path.read_text()
+                batch_commands.append(commands)
+
+                if commands == 'cd "/backups"\nls -la\n':
+                    return SimpleNamespace(
+                        returncode=0,
+                        stdout='sftp> cd "/backups"\nsftp> ls -la\n',
+                        stderr='remote readdir("/backups"): Permission denied\n',
+                    )
+
+                if commands == 'cd "backups"\nls -la\n':
+                    return SimpleNamespace(
+                        returncode=0,
+                        stdout=("drwxr-xr-x    ? user user 3 Aug 17 2023 repo\n"),
+                        stderr="",
+                    )
+
+                raise AssertionError(f"unexpected SFTP batch commands: {commands!r}")
+
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(filesystem.subprocess, "run", run_side_effect)
+        monkeypatch.setattr(
+            filesystem, "is_borg_repository_ssh", lambda *args, **kwargs: False
+        )
+
+        response = await filesystem.browse_ssh_filesystem(
+            path="/backups",
+            ssh_key_id=ssh_key.id,
+            host="example.com",
+            username="borg",
+            port=22,
+            db=SessionStub(),
+        )
+
+        assert batch_commands == [
+            'cd "/backups"\nls -la\n',
+            'cd "backups"\nls -la\n',
+        ]
+        assert [item.name for item in response.items] == ["repo"]
+        assert response.items[0].path == "/backups/repo"
+
+    @pytest.mark.asyncio
     async def test_browse_ssh_filesystem_missing_key_returns_404(self, test_db):
         with pytest.raises(filesystem.HTTPException) as exc:
             await filesystem.browse_ssh_filesystem(


### PR DESCRIPTION
## Description
Fixes the newer Hetzner Storage Box SFTP browse case where the root folder can be listed, but selecting a first-level child such as `backups` fails. The filesystem browser now keeps the existing absolute SFTP attempt first, then retries leading-slash paths relative to the SFTP login directory when the absolute listing reports a failure.

This is intentionally scoped to the newer Storage Box child-folder report. The original #406 title and earlier comments describe archive list/count behavior on first repository load, which is a separate issue path. The test coverage also verifies a subsequent nested listing such as `/backups/repo`, so the fallback applies beyond the first child folder.

## Related Issue
Fixes #488
Related to #406

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass; full suite was not run for this scoped backend fix

Validation run:
- `pytest tests/unit/test_api_filesystem.py::TestFilesystemBrowseSSH::test_browse_ssh_filesystem_retries_nested_sftp_path_relative_to_login_dir -q`
- `ruff check app tests`
- `ruff format --check app tests`
- `pytest tests/unit/test_api_filesystem.py::TestFilesystemBrowseSSH -q`
- Earlier branch validation also ran `pytest tests/unit/test_api_filesystem.py::TestFilesystemBrowseSSH::test_browse_ssh_filesystem_retries_non_root_sftp_path_relative_to_login_dir`
- Earlier branch validation also ran `DEV_PORT=8083 docker compose -p borg-ui-dev -f docker-compose.dev.yml up -d --build --force-recreate app`; `/docs` returned HTTP 200; `docker compose ... down`

## Checklist
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines; no `CONTRIBUTING.md` file is present in this checkout
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation; not needed for this backend bug fix
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes for the touched SSH filesystem scope

## Screenshots (if applicable)
Not applicable; this is backend SFTP path handling.

## Additional Context
A direct run of `pytest tests/unit/test_api_filesystem.py::TestFilesystemBrowseSSH` now passed locally without a temporary Borg shim, completing 7 SSH filesystem tests in 64.77s. The run emitted existing deprecation/resource warnings from the test harness but no failures.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
