### PR TITLE
Document Synology SSH path prefixes

### DIFF
--- a/docs/ssh-keys.md
+++ b/docs/ssh-keys.md
@@ -93,6 +93,33 @@ For Hetzner Storage Box-style paths, keep the provider-specific path syntax:
 ssh://u123456@u123456.your-storagebox.de:23/./backup-repo
 ```
 
+## Synology and NAS Path Prefixes
+
+Some NAS devices expose different paths over SFTP and SSH. Synology DSM is a
+common example:
+
+```text
+SFTP path shown while browsing: /playbackup/borguitest
+Path Borg needs over SSH:       /volume1/playbackup/borguitest
+```
+
+In this setup, configure the remote machine like this:
+
+```text
+Default path: /playbackup
+SSH path prefix: /volume1
+```
+
+Then select or enter repository paths using the SFTP-visible path, such as
+`/playbackup/borguitest`. Borg UI keeps SFTP browsing in that namespace and
+prepends the SSH path prefix only when it builds SSH/Borg commands.
+
+If repository initialization fails with an error like `The parent path of the
+repo directory [...] does not exist`, compare the path shown by SFTP browsing
+with the full path needed by Borg over SSH. Put only the missing leading
+segment, such as `/volume1`, in SSH path prefix. Do not include that prefix
+again in the repository path, or the generated SSH path may be wrong.
+
 ## Import an Existing Key
 
 If you import from the host filesystem, mount the key read-only into the container first:


### PR DESCRIPTION
## Description
Adds a concrete Synology/DSM Remote Machines documentation section that explains how to configure `SSH path prefix` when SFTP browsing shows a share path but Borg needs the `/volumeN` path over SSH.

## Related Issue
Fixes #230

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally with `cd docs && npm run build`
- [ ] I have added tests that prove my fix is effective or that my feature works; not applicable for this docs-only change
- [ ] All existing tests pass; not run because this change only updates VitePress documentation

## Checklist
- [x] I have read the contributing guidelines in `docs/contributing.md`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas; not applicable for this docs-only change
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings in the docs build
- [ ] New and existing unit tests pass locally with my changes; not run because no backend or frontend runtime code changed

## Screenshots (if applicable)
Not applicable; documentation-only change.

## Additional Context
The backend already supports `ssh_path_prefix` for remote machine connections. This PR documents the Synology case from #230 so users know to keep repository paths in the SFTP-visible namespace and configure only the missing `/volumeN` prefix separately.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
