### PR TITLE
Allow Linear Merging to bypass review-required PRs

### DIFF
--- a/.codex/skills/land/SKILL.md
+++ b/.codex/skills/land/SKILL.md
@@ -14,6 +14,9 @@ description:
 - Keep CI green and fix failures when they occur.
 - Use a fast path for already-green PRs whose head SHA matches the Human Review
   handoff.
+- Treat Linear `Merging` as the human approval signal for
+  `reviewDecision=REVIEW_REQUIRED` only when the fast-path preflight reports
+  administrator bypass is required.
 - Squash-merge the PR once checks pass.
 - Do not yield to the user until the PR is merged; keep the watcher loop running
   unless the fast path proves the full watcher is unnecessary or landing is
@@ -32,13 +35,14 @@ description:
 2. Read the workpad final handoff notes and find the exact line:
    `Human Review handoff: head=<PR head SHA>; at=<ISO-8601 timestamp>; validation=<commands>`.
 3. Run the fast-path preflight:
-   `python3 .codex/skills/land/land_watch.py --preflight --handoff-note '<handoff note>'`.
+   `python3 .codex/skills/land/land_watch.py --preflight --json --handoff-note '<handoff note>'`.
 4. If the preflight exits `0`, skip full local validation and the full watcher
    loop for this already-green PR. The preflight has confirmed the head SHA is
-   unchanged since Human Review, mergeability is clean, checks are green, and no
-   new human/Codex feedback appeared since Human Review. Squash-merge with the
-   PR title/body after one final `gh pr view --json mergeable,mergeStateStatus`
-   check still reports a clean merge state.
+   unchanged since Human Review, checks are green, and no new human/Codex
+   feedback appeared since Human Review. Squash-merge with the PR title/body
+   after one final `gh pr view --json mergeable,mergeStateStatus,reviewDecision`
+   check still reports either a clean merge state or the exact
+   `BLOCKED + REVIEW_REQUIRED` state that requires administrator bypass.
 5. If the preflight exits `6`, fails, or reports missing/uncertain data, use the
    conservative fallback below.
 6. Conservative fallback: confirm the Borg UI validation gauntlet is green
@@ -85,11 +89,23 @@ handoff_note='Human Review handoff: head=<sha>; at=<timestamp>; validation=<comm
 
 # Fast path for already-green PRs. If this exits 0, skip local validation and
 # the full watcher loop. If it exits 6 or errors, use the conservative fallback.
-if python3 .codex/skills/land/land_watch.py --preflight --handoff-note "$handoff_note"; then
+if preflight_json=$(python3 .codex/skills/land/land_watch.py --preflight --json --handoff-note "$handoff_note"); then
+  requires_admin_bypass=$(
+    printf '%s' "$preflight_json" |
+      python3 -c 'import json,sys; print("true" if json.load(sys.stdin).get("requires_admin_bypass") else "false")'
+  )
   mergeable=$(gh pr view --json mergeable -q .mergeable)
   merge_state=$(gh pr view --json mergeStateStatus -q .mergeStateStatus)
-  if [ "$mergeable" = "MERGEABLE" ] && { [ "$merge_state" = "CLEAN" ] || [ "$merge_state" = "HAS_HOOKS" ]; }; then
-    gh pr merge --squash --subject "$pr_title" --body "$pr_body"
+  review_decision=$(gh pr view --json reviewDecision -q .reviewDecision)
+  merge_args=(--squash --subject "$pr_title" --body "$pr_body")
+  if [ "$requires_admin_bypass" = "true" ]; then
+    if [ "$mergeable" = "MERGEABLE" ] && [ "$merge_state" = "BLOCKED" ] && [ "$review_decision" = "REVIEW_REQUIRED" ]; then
+      merge_args+=(--admin)
+      gh pr merge "${merge_args[@]}"
+      exit 0
+    fi
+  elif [ "$mergeable" = "MERGEABLE" ] && { [ "$merge_state" = "CLEAN" ] || [ "$merge_state" = "HAS_HOOKS" ]; }; then
+    gh pr merge "${merge_args[@]}"
     exit 0
   fi
 fi
@@ -155,7 +171,7 @@ The handoff note must come from the workpad final handoff notes:
 Human Review handoff: head=<PR head SHA>; at=<ISO-8601 timestamp>; validation=<commands>
 ```
 
-The fast path is allowed only when all of these are true:
+The normal fast path is allowed only when all of these are true:
 
 - The current PR head SHA matches the Human Review handoff SHA.
 - Mergeability is `MERGEABLE` and merge state is `CLEAN` or `HAS_HOOKS`.
@@ -165,9 +181,17 @@ The fast path is allowed only when all of these are true:
   Codex review issue comments, or Codex inline comments appeared after the
   Human Review handoff timestamp.
 
+The BOR-34 administrator-bypass fast path is allowed only when the same checks
+and feedback requirements pass, mergeability is `MERGEABLE`, merge state is
+`BLOCKED`, and `reviewDecision` is `REVIEW_REQUIRED`. In that case the preflight
+JSON includes `"requires_admin_bypass": true`; merge with `gh pr merge --admin`.
+If GitHub rejects the admin merge, record the missing merge permission as the
+blocker.
+
 Exit codes:
 
-- 0: Fast path ready; skip full local validation and full watcher mode.
+- 0: Fast path ready; skip full local validation and full watcher mode. Check
+  the JSON `requires_admin_bypass` field before choosing merge arguments.
 - 6: Full validation required; use the conservative fallback.
 
 ## Async Watch Helper
@@ -205,6 +229,8 @@ Exit codes:
 - If all jobs fail with corrupted npm lockfile errors on the merge commit, the
   remediation is to fetch latest `origin/main`, merge, force-push, and rerun CI.
 - If mergeability is `UNKNOWN`, wait and re-check.
+- If `gh pr merge --admin` fails, do not retry normal merge. Record the exact
+  permission or branch-policy error in the workpad as the landing blocker.
 - Do not merge while review comments (human or Codex review) are outstanding.
 - Codex review jobs retry on failure and are non-blocking; use the presence of
   `## Codex Review — <persona>` issue comments (not job status) as the signal

--- a/.codex/skills/land/land_watch.py
+++ b/.codex/skills/land/land_watch.py
@@ -33,12 +33,15 @@ class PrInfo:
     head_sha: str
     mergeable: str | None
     merge_state: str | None
+    review_decision: str | None = None
 
 
 @dataclass
 class FastPathDecision:
     can_fast_path: bool
     reasons: list[str]
+    requires_admin_bypass: bool = False
+    admin_bypass_reason: str | None = None
 
 
 class RateLimitError(RuntimeError):
@@ -80,7 +83,7 @@ async def get_pr_info() -> PrInfo:
         "pr",
         "view",
         "--json",
-        "number,url,headRefOid,mergeable,mergeStateStatus",
+        "number,url,headRefOid,mergeable,mergeStateStatus,reviewDecision",
     )
     parsed = json.loads(data)
     return PrInfo(
@@ -89,6 +92,7 @@ async def get_pr_info() -> PrInfo:
         head_sha=parsed["headRefOid"],
         mergeable=parsed.get("mergeable"),
         merge_state=parsed.get("mergeStateStatus"),
+        review_decision=parsed.get("reviewDecision"),
     )
 
 
@@ -588,6 +592,7 @@ def evaluate_fast_path(
     review_request_at: datetime | None,
 ) -> FastPathDecision:
     reasons: list[str] = []
+    admin_bypass_reason: str | None = None
 
     if not human_review_sha:
         reasons.append("Missing Human Review handoff SHA")
@@ -608,7 +613,12 @@ def evaluate_fast_path(
     if pr.merge_state is None:
         reasons.append("PR merge state is unknown")
     elif pr.merge_state not in FAST_PATH_MERGE_STATES:
-        reasons.append(f"PR merge state is {pr.merge_state}")
+        if requires_review_admin_bypass(pr):
+            admin_bypass_reason = (
+                "GitHub review requirement satisfied by Linear Merging"
+            )
+        else:
+            reasons.append(f"PR merge state is {pr.merge_state}")
 
     if not check_runs:
         reasons.append("GitHub checks are missing")
@@ -632,11 +642,25 @@ def evaluate_fast_path(
             )
         )
 
-    return FastPathDecision(can_fast_path=not reasons, reasons=reasons)
+    can_fast_path = not reasons
+    return FastPathDecision(
+        can_fast_path=can_fast_path,
+        reasons=reasons,
+        requires_admin_bypass=bool(can_fast_path and admin_bypass_reason),
+        admin_bypass_reason=admin_bypass_reason if can_fast_path else None,
+    )
 
 
 def is_merge_conflicting(pr: PrInfo) -> bool:
     return pr.mergeable == "CONFLICTING" or pr.merge_state == "DIRTY"
+
+
+def requires_review_admin_bypass(pr: PrInfo) -> bool:
+    return (
+        pr.mergeable == "MERGEABLE"
+        and pr.merge_state == "BLOCKED"
+        and pr.review_decision == "REVIEW_REQUIRED"
+    )
 
 
 async def fetch_review_context(
@@ -828,6 +852,8 @@ def print_preflight_decision(
                 {
                     "can_fast_path": decision.can_fast_path,
                     "reasons": decision.reasons,
+                    "requires_admin_bypass": decision.requires_admin_bypass,
+                    "admin_bypass_reason": decision.admin_bypass_reason,
                 },
                 indent=2,
             )
@@ -839,6 +865,8 @@ def print_preflight_decision(
             "Fast path ready: PR head unchanged, mergeable, checks green, and "
             "no new feedback since Human Review."
         )
+        if decision.requires_admin_bypass:
+            print(f"Administrator bypass required: {decision.admin_bypass_reason}")
         return
 
     print("Full validation required:")

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -274,11 +274,21 @@ Use this only when completion is blocked by missing required tools or missing au
 5. When the issue is in `Merging`, open and follow `.codex/skills/land/SKILL.md`; do not call `gh pr merge` directly outside that skill.
 6. Start with the fast landing preflight for already-green PRs:
    - Read the latest `Human Review handoff: ...` note from the workpad.
-   - Run `python3 .codex/skills/land/land_watch.py --preflight --handoff-note '<handoff note>'`.
+   - Run `python3 .codex/skills/land/land_watch.py --preflight --json --handoff-note '<handoff note>'`.
    - If the preflight exits `0`, the PR head SHA is unchanged, GitHub checks
-     are green, mergeability is clean, and no new human/Codex feedback was
-     found since Human Review; skip full local validation and the full watcher
-     loop, then merge through the `land` skill flow.
+     are green, and no new human/Codex feedback was found since Human Review;
+     skip full local validation and the full watcher loop, then merge through
+     the `land` skill flow.
+   - If the preflight JSON has `requires_admin_bypass: true`, this means the
+     issue is in `Merging`, GitHub reports `reviewDecision=REVIEW_REQUIRED`,
+     and the remaining branch-policy approval requirement is being satisfied by
+     the Linear state transition. Use `gh pr merge --admin` only after a final
+     check still reports `mergeable=MERGEABLE`,
+     `mergeStateStatus=BLOCKED`, and `reviewDecision=REVIEW_REQUIRED`.
+     If that admin merge fails, record the exact missing permission or
+     branch-policy error in the workpad as the landing blocker.
+   - If `requires_admin_bypass` is false, merge only after the final check still
+     reports `mergeable=MERGEABLE` and `mergeStateStatus=CLEAN` or `HAS_HOOKS`.
    - If the preflight exits `6`, fails, or lacks handoff/check/mergeability
      data, use the conservative fallback in `.codex/skills/land/SKILL.md`.
 7. Always use the conservative fallback, including full local validation and

--- a/docs/engineering/plans/2026-05-18-bor-34-human-review-merge-bypass.md
+++ b/docs/engineering/plans/2026-05-18-bor-34-human-review-merge-bypass.md
@@ -1,0 +1,250 @@
+# BOR-34 Human Review Merge Bypass Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Symphony's land flow treat Linear `Merging` as the human approval signal for GitHub `REVIEW_REQUIRED` branch-policy blockers while preserving other merge blockers.
+
+**Architecture:** Extend the existing `.codex/skills/land/land_watch.py` preflight model with GitHub `reviewDecision` and explicit administrator-bypass metadata. Update the land workflow docs to use `gh pr merge --admin` only when preflight proves the BOR-34 review-policy case.
+
+**Tech Stack:** Python 3, pytest, ruff, GitHub CLI, Linear-driven Borg UI workflow docs.
+
+---
+
+### Task 1: Add the Failing BOR-34 Fast-Path Test
+
+**Files:**
+- Modify: `tests/unit/test_land_watch_fast_path.py`
+
+- [ ] **Step 1: Extend the test PR factory**
+
+  Add a `review_decision` keyword to `pr_info` so tests can describe GitHub's
+  review state:
+
+  ```python
+  def pr_info(
+      *,
+      head_sha="abc1234",
+      mergeable="MERGEABLE",
+      merge_state="CLEAN",
+      review_decision="APPROVED",
+  ):
+      return land_watch.PrInfo(
+          number=22,
+          url="https://github.com/example/repo/pull/22",
+          head_sha=head_sha,
+          mergeable=mergeable,
+          merge_state=merge_state,
+          review_decision=review_decision,
+      )
+  ```
+
+- [ ] **Step 2: Add the BOR-34 regression test**
+
+  Add this test near the other merge-state tests:
+
+  ```python
+  def test_fast_path_allows_review_required_when_admin_bypass_is_required():
+      decision = green_decision(
+          pr=pr_info(merge_state="BLOCKED", review_decision="REVIEW_REQUIRED")
+      )
+
+      assert decision.can_fast_path is True
+      assert decision.requires_admin_bypass is True
+      assert decision.admin_bypass_reason == (
+          "GitHub review requirement satisfied by Linear Merging"
+      )
+      assert decision.reasons == []
+  ```
+
+- [ ] **Step 3: Verify the test fails for the current implementation**
+
+  Run:
+
+  ```bash
+  pytest tests/unit/test_land_watch_fast_path.py::test_fast_path_allows_review_required_when_admin_bypass_is_required -q
+  ```
+
+  Expected: FAIL because `PrInfo` does not yet accept `review_decision` or
+  `FastPathDecision` does not expose `requires_admin_bypass`.
+
+### Task 2: Implement Review-Required Bypass Metadata
+
+**Files:**
+- Modify: `.codex/skills/land/land_watch.py`
+- Modify: `tests/unit/test_land_watch_fast_path.py`
+
+- [ ] **Step 1: Extend the dataclasses**
+
+  Add `review_decision` to `PrInfo` and bypass metadata to
+  `FastPathDecision`:
+
+  ```python
+  @dataclass
+  class PrInfo:
+      number: int
+      url: str
+      head_sha: str
+      mergeable: str | None
+      merge_state: str | None
+      review_decision: str | None = None
+
+
+  @dataclass
+  class FastPathDecision:
+      can_fast_path: bool
+      reasons: list[str]
+      requires_admin_bypass: bool = False
+      admin_bypass_reason: str | None = None
+  ```
+
+- [ ] **Step 2: Fetch `reviewDecision` from GitHub**
+
+  Update `get_pr_info()` to request and store `reviewDecision`:
+
+  ```python
+  data = await run_gh(
+      "pr",
+      "view",
+      "--json",
+      "number,url,headRefOid,mergeable,mergeStateStatus,reviewDecision",
+  )
+  ```
+
+- [ ] **Step 3: Add a narrow bypass predicate**
+
+  Add a helper that recognizes only BOR-34's review-policy shape:
+
+  ```python
+  def requires_review_admin_bypass(pr: PrInfo) -> bool:
+      return (
+          pr.mergeable == "MERGEABLE"
+          and pr.merge_state == "BLOCKED"
+          and pr.review_decision == "REVIEW_REQUIRED"
+      )
+  ```
+
+- [ ] **Step 4: Apply the predicate in `evaluate_fast_path`**
+
+  When merge state is not in `FAST_PATH_MERGE_STATES`, suppress the normal
+  `PR merge state is BLOCKED` reason only for `requires_review_admin_bypass(pr)`.
+  Return bypass metadata only when the final decision has no other reasons:
+
+  ```python
+  admin_bypass_reason = None
+  if pr.merge_state is None:
+      reasons.append("PR merge state is unknown")
+  elif pr.merge_state not in FAST_PATH_MERGE_STATES:
+      if requires_review_admin_bypass(pr):
+          admin_bypass_reason = (
+              "GitHub review requirement satisfied by Linear Merging"
+          )
+      else:
+          reasons.append(f"PR merge state is {pr.merge_state}")
+
+  can_fast_path = not reasons
+  return FastPathDecision(
+      can_fast_path=can_fast_path,
+      reasons=reasons,
+      requires_admin_bypass=bool(can_fast_path and admin_bypass_reason),
+      admin_bypass_reason=admin_bypass_reason if can_fast_path else None,
+  )
+  ```
+
+- [ ] **Step 5: Include bypass metadata in preflight output**
+
+  Extend JSON output with `requires_admin_bypass` and
+  `admin_bypass_reason`. In human output, add one line when admin bypass is
+  required:
+
+  ```python
+  if decision.requires_admin_bypass:
+      print(f"Administrator bypass required: {decision.admin_bypass_reason}")
+  ```
+
+- [ ] **Step 6: Verify targeted tests pass**
+
+  Run:
+
+  ```bash
+  pytest tests/unit/test_land_watch_fast_path.py -v
+  ```
+
+  Expected: all tests in the file pass.
+
+### Task 3: Update Landing Workflow Instructions
+
+**Files:**
+- Modify: `.codex/skills/land/SKILL.md`
+- Modify: `WORKFLOW.md`
+
+- [ ] **Step 1: Document the BOR-34 admin-bypass fast path**
+
+  State that `Merging` is the human approval signal, and that
+  `REVIEW_REQUIRED` may use `gh pr merge --admin` only when preflight reports
+  `requires_admin_bypass=true`.
+
+- [ ] **Step 2: Update command examples to parse preflight JSON**
+
+  Use:
+
+  ```bash
+  preflight_json=$(python3 .codex/skills/land/land_watch.py --preflight --json --handoff-note "$handoff_note")
+  requires_admin_bypass=$(printf '%s' "$preflight_json" | python3 -c 'import json,sys; print(str(json.load(sys.stdin).get("requires_admin_bypass", False)).lower())')
+  ```
+
+  Then call `gh pr merge --squash --admin` only when
+  `requires_admin_bypass=true`.
+
+- [ ] **Step 3: Keep permission failure explicit**
+
+  Document that a failed `--admin` merge is a real missing-permission blocker
+  and must be recorded in the workpad.
+
+### Task 4: Validate and Publish
+
+**Files:**
+- Test: `.codex/skills/land/land_watch.py`
+- Test: `tests/unit/test_land_watch_fast_path.py`
+- Test: `WORKFLOW.md`
+- Test: `.codex/skills/land/SKILL.md`
+
+- [ ] **Step 1: Run targeted unit tests**
+
+  ```bash
+  pytest tests/unit/test_land_watch_fast_path.py -v
+  ```
+
+- [ ] **Step 2: Run helper lint**
+
+  ```bash
+  ruff check .codex/skills/land/land_watch.py tests/unit/test_land_watch_fast_path.py
+  ```
+
+- [ ] **Step 3: Run Borg UI backend policy checks**
+
+  ```bash
+  ruff check app tests
+  ruff format --check app tests
+  ```
+
+- [ ] **Step 4: Run diff whitespace validation**
+
+  ```bash
+  git diff --check
+  ```
+
+- [ ] **Step 5: Commit, push, and open PR**
+
+  Use the repository `commit` and `push` skills. Fill the PR template with the
+  BOR-34 behavior, validation evidence, and no placeholder comments. Attach the
+  PR to Linear and add the `symphony` label.
+
+## Self-Review
+
+- Spec coverage: The plan covers `reviewDecision` ingestion, the narrow
+  `BLOCKED + REVIEW_REQUIRED` bypass predicate, admin-bypass metadata, workflow
+  command changes, targeted tests, and validation gates.
+- Placeholder scan: No `TBD`, `TODO`, or vague implementation placeholders are
+  present.
+- Type consistency: The plan uses `review_decision`, `requires_admin_bypass`,
+  and `admin_bypass_reason` consistently across test and implementation steps.

--- a/docs/engineering/specs/2026-05-18-bor-34-human-review-merge-bypass.md
+++ b/docs/engineering/specs/2026-05-18-bor-34-human-review-merge-bypass.md
@@ -1,0 +1,74 @@
+# BOR-34 Human Review Merge Bypass Spec
+
+## Context
+
+Symphony lands Borg UI pull requests through the local `land` skill when a Linear
+issue moves to `Merging`. That state is already the workflow's human approval
+signal, but GitHub can still report `reviewDecision=REVIEW_REQUIRED` because the
+PR is created by the same GitHub account that would otherwise approve it.
+
+The current fast landing helper evaluates PR head SHA, mergeability, check runs,
+and feedback activity. It does not read `reviewDecision`, so it treats GitHub's
+generic `mergeStateStatus=BLOCKED` as a full fallback case even when the only
+remaining blocker is the branch approval policy described in BOR-34.
+
+## Evidence
+
+- `WORKFLOW.md` routes `Merging` issues into `.codex/skills/land/SKILL.md`.
+- `.codex/skills/land/land_watch.py` fetches `mergeable` and
+  `mergeStateStatus`, but not `reviewDecision`.
+- A local reproduction call to `evaluate_fast_path` with unchanged head SHA,
+  green checks, no feedback, `mergeable=MERGEABLE`, and
+  `mergeStateStatus=BLOCKED` returns `can_fast_path=False` with reason
+  `PR merge state is BLOCKED`.
+- Local `gh pr view --help` lists `reviewDecision`, and
+  `gh pr merge --help` lists `--admin` for administrator bypass merges.
+
+## Decision
+
+Use the Linear `Merging` state as the human approval signal for BOR-34's review
+requirement case. The land preflight should fetch GitHub `reviewDecision` and
+return a fast-path decision with explicit administrator-bypass metadata only
+when all of these are true:
+
+- PR head SHA matches the Human Review handoff SHA.
+- `mergeable` is `MERGEABLE`.
+- `mergeStateStatus` is `BLOCKED`.
+- `reviewDecision` is `REVIEW_REQUIRED`.
+- GitHub checks exist and are green.
+- No human or Codex feedback appeared after the Human Review handoff.
+
+All other blockers stay conservative. Merge conflicts, missing or non-green
+checks, changed head SHA, missing handoff metadata, non-review `BLOCKED` states,
+unknown mergeability, and post-handoff feedback must still force fallback or
+block landing.
+
+When the preflight reports administrator bypass is required, the land skill
+should use `gh pr merge --admin`. If the authenticated GitHub account lacks
+permission to bypass branch protection, that command fails and the workflow must
+surface the permission blocker rather than pretending the PR was merged.
+
+## Alternatives Considered
+
+1. Create PRs as a separate bot account so the human can approve in GitHub.
+   This addresses the root workflow ergonomics, but it requires new credentials
+   and GitHub app/token changes outside this repository.
+
+2. Remove or relax the GitHub review requirement.
+   This is an external repository policy change and would weaken protections for
+   all PRs, not just Symphony-managed work that has reached Linear `Merging`.
+
+3. Treat every `mergeStateStatus=BLOCKED` as bypassable.
+   This is too broad because `BLOCKED` can represent other branch protection
+   failures. The implementation must require `reviewDecision=REVIEW_REQUIRED`
+   and separately verify checks and feedback before requesting admin bypass.
+
+## Validation
+
+- Add a regression test showing `BLOCKED + REVIEW_REQUIRED` can fast-path with
+  administrator-bypass metadata when all other preflight inputs are clean.
+- Keep or add coverage showing non-review `BLOCKED` states still require full
+  validation.
+- Run targeted unit tests for `land_watch.py`.
+- Run ruff checks for the helper and tests plus the repository backend
+  lint/format gates required by Borg UI policy.

--- a/tests/unit/test_land_watch_fast_path.py
+++ b/tests/unit/test_land_watch_fast_path.py
@@ -24,6 +24,7 @@ def pr_info(
     head_sha="abc1234",
     mergeable="MERGEABLE",
     merge_state="CLEAN",
+    review_decision="APPROVED",
 ):
     return land_watch.PrInfo(
         number=22,
@@ -31,6 +32,7 @@ def pr_info(
         head_sha=head_sha,
         mergeable=mergeable,
         merge_state=merge_state,
+        review_decision=review_decision,
     )
 
 
@@ -136,6 +138,19 @@ def test_fast_path_requires_full_validation_when_merge_state_is_not_clean():
     decision = green_decision(pr=pr_info(mergeable="MERGEABLE", merge_state="BLOCKED"))
 
     assert_requires_full_validation(decision, "PR merge state is BLOCKED")
+
+
+def test_fast_path_allows_review_required_when_admin_bypass_is_required():
+    decision = green_decision(
+        pr=pr_info(merge_state="BLOCKED", review_decision="REVIEW_REQUIRED")
+    )
+
+    assert decision.can_fast_path is True
+    assert decision.requires_admin_bypass is True
+    assert decision.admin_bypass_reason == (
+        "GitHub review requirement satisfied by Linear Merging"
+    )
+    assert decision.reasons == []
 
 
 def test_fast_path_requires_full_validation_when_merge_state_is_missing():


### PR DESCRIPTION
## Description
Adds BOR-34 handling to the Symphony land preflight so GitHub `reviewDecision=REVIEW_REQUIRED` is not treated as an automatic blocker after a Linear issue reaches `Merging`. The preflight now fetches `reviewDecision`, emits explicit `requires_admin_bypass` metadata for the narrow `MERGEABLE + BLOCKED + REVIEW_REQUIRED` case, and keeps the regular fallback path for conflicts, changed heads, failed or missing checks, feedback, and non-review blocked states.

The land skill and `WORKFLOW.md` now document that `gh pr merge --admin` is used only when the preflight proves that BOR-34 shape. If GitHub denies admin bypass, the workflow records the permission or branch-policy error as the landing blocker.

The branch was also merged with latest `origin/main` after Human Review. The only manual conflict was in `.codex/skills/land/SKILL.md`, resolved by preserving both main's validation-manifest guard and BOR-34's admin-bypass preflight path.

## Related Issue
Linear: BOR-34 — Symphony does not merge the PR after Human Review

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass locally

Commands run:
- `pytest tests/unit/test_land_watch_fast_path.py -v`
- `pytest tests/unit/test_land_watch_fast_path.py tests/unit/test_select_validation.py -v`
- `ruff check .codex/skills/land/land_watch.py tests/unit/test_land_watch_fast_path.py`
- `ruff check app tests scripts/select_validation.py .codex/skills/land/land_watch.py`
- `ruff format --check app tests scripts/select_validation.py`
- `python3 scripts/select_validation.py --base origin/main --format text`
- `cd frontend && npm run check:locales && npm run typecheck && npm run lint && npm run build`
- `cd docs && npm run build`
- `git diff --check`

Local full-unit validation caveat: `pytest tests/unit -v` was attempted after the merge from `origin/main`, but this shared host had concurrent heavy builds from other workspaces. The run observed an unrelated pre-existing metrics response-time assertion failure (`5.335s < 5.0s`) and was stopped after no additional failures appeared through 54%. PR CI is the required clean-room gate before merge.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; this changes the Symphony landing workflow and tests, not the Borg UI frontend.

## Additional Context
The implementation preserves missing admin merge permission as a real blocker. It does not broadly bypass every `mergeStateStatus=BLOCKED` response; it requires `reviewDecision=REVIEW_REQUIRED` plus otherwise-clean fast-path evidence.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
