### PR TITLE
Track no-fix pip-audit findings

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -83,14 +83,14 @@ jobs:
           # - GHSA-wp53-j4wj-2cfg: python-multipart (fix requires Python 3.10+)
           # - GHSA-wj6h-64fc-37mp: ecdsa (no fix available)
           # - CVE-2026-4539: pygments (transitive via structlog, no fix released yet)
-          # - PYSEC-2025-183: PyJWT (no fix available)
-          # - PYSEC-2026-89: markdown (transitive via Apprise, no fix available)
+          # Tracked no-fix findings under active review:
+          # - security/pip-audit-known-vulns.json
+          mapfile -t known_no_fix_ignore_args < <(python3 scripts/pip_audit_known_vulns.py ignore-args)
           pip-audit -r requirements.txt \
             --ignore-vuln GHSA-wp53-j4wj-2cfg \
             --ignore-vuln GHSA-wj6h-64fc-37mp \
             --ignore-vuln CVE-2026-4539 \
-            --ignore-vuln PYSEC-2025-183 \
-            --ignore-vuln PYSEC-2026-89
+            "${known_no_fix_ignore_args[@]}"
 
       - name: Generate pip-audit report
         if: always()

--- a/docs/engineering/plans/2026-05-21-track-no-fix-pip-audit-findings.md
+++ b/docs/engineering/plans/2026-05-21-track-no-fix-pip-audit-findings.md
@@ -1,0 +1,115 @@
+# Track No-Fix pip-audit Findings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the PyJWT and markdown no-fix `pip-audit` findings out of temporary workflow inline ignores and into a tested, reviewable tracking file.
+
+**Architecture:** Keep package pins unchanged while the advisory data has no fixed versions. Store no-fix findings in a small JSON file, render them into `pip-audit --ignore-vuln` arguments with a tested Python helper, and have the security workflow consume that helper.
+
+**Tech Stack:** Python 3.11, pytest, GitHub Actions, pip-audit.
+
+---
+
+### Task 1: Helper Contract
+
+**Files:**
+- Create: `tests/unit/test_pip_audit_known_vulns.py`
+- Create: `scripts/pip_audit_known_vulns.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from pathlib import Path
+
+import pytest
+
+from scripts.pip_audit_known_vulns import build_ignore_args, load_known_vulns
+
+
+def test_build_ignore_args_preserves_file_order(tmp_path: Path) -> None:
+    known_vulns_file = tmp_path / "known-vulns.json"
+    known_vulns_file.write_text(
+        """[
+  {"id": "PYSEC-2025-183", "package": "PyJWT", "version": "2.12.1"},
+  {"id": "PYSEC-2026-89", "package": "markdown", "version": "3.10.2"}
+]""",
+        encoding="utf-8",
+    )
+
+    assert build_ignore_args(load_known_vulns(known_vulns_file)) == [
+        "--ignore-vuln",
+        "PYSEC-2025-183",
+        "--ignore-vuln",
+        "PYSEC-2026-89",
+    ]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/unit/test_pip_audit_known_vulns.py -v`
+Expected: FAIL because `scripts.pip_audit_known_vulns` does not exist yet.
+
+- [ ] **Step 3: Implement minimal helper**
+
+Create `scripts/pip_audit_known_vulns.py` with `load_known_vulns`, `build_ignore_args`, and an `ignore-args` CLI command that prints one shell argument per line.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/unit/test_pip_audit_known_vulns.py -v`
+Expected: PASS.
+
+### Task 2: Tracked Findings and Workflow
+
+**Files:**
+- Create: `security/pip-audit-known-vulns.json`
+- Modify: `.github/workflows/security.yml`
+
+- [ ] **Step 1: Add tracked no-fix findings**
+
+Create `security/pip-audit-known-vulns.json` with `PYSEC-2025-183` and `PYSEC-2026-89`, their package/version, OSV URL, review date, and no-fixed-version reason.
+
+- [ ] **Step 2: Load tracked findings in the workflow**
+
+Replace the workflow's inline comments and `--ignore-vuln` entries for the two ticketed IDs with a note pointing to `security/pip-audit-known-vulns.json` and a bash array loaded from `python scripts/pip_audit_known_vulns.py ignore-args`.
+
+- [ ] **Step 3: Validate helper output**
+
+Run: `python3 scripts/pip_audit_known_vulns.py ignore-args`
+Expected:
+
+```text
+--ignore-vuln
+PYSEC-2025-183
+--ignore-vuln
+PYSEC-2026-89
+```
+
+### Task 3: Security Validation
+
+**Files:**
+- No additional source edits.
+
+- [ ] **Step 1: Reconfirm fixed-version signal**
+
+Run package/advisory checks against current PyPI/OSV and record whether fixed versions exist.
+
+- [ ] **Step 2: Prove workflow-equivalent audit passes**
+
+Run the workflow-equivalent `pip-audit -r requirements.txt` command with existing non-ticket ignores plus the helper-rendered tracked no-fix ignores. Expected: exit 0 for the gating command.
+
+- [ ] **Step 3: Prove unignored audit still exposes the no-fix findings**
+
+Run `pip-audit` without the tracked no-fix helper and confirm it still reports `PYSEC-2025-183` and `PYSEC-2026-89` with empty fix versions.
+
+### Task 4: Repository Validation and Handoff
+
+**Files:**
+- No additional source edits.
+
+- [ ] **Step 1: Run required checks**
+
+Run `ruff check app tests`, `ruff format --check app tests`, `pytest tests/unit/test_pip_audit_known_vulns.py -v`, and `git diff --check`.
+
+- [ ] **Step 2: Commit and publish**
+
+Commit the plan, helper, tracked findings, tests, and workflow change. Push the branch, open a PR with the repository template, add the `symphony` label, attach/link it to BOR-44, and run the PR feedback/check sweep before moving back to `Human Review`.

--- a/scripts/pip_audit_known_vulns.py
+++ b/scripts/pip_audit_known_vulns.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Render tracked no-fix pip-audit findings as CLI ignore arguments."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+DEFAULT_KNOWN_VULNS_FILE = (
+    Path(__file__).resolve().parents[1] / "security" / "pip-audit-known-vulns.json"
+)
+
+
+def load_known_vulns(path: Path) -> list[dict[str, Any]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError(f"{path} must contain a JSON list")
+
+    known_vulns: list[dict[str, Any]] = []
+    for index, entry in enumerate(data, start=1):
+        if not isinstance(entry, dict):
+            raise ValueError(f"known vuln entry {index} must be a JSON object")
+
+        vuln_id = str(entry.get("id", "")).strip()
+        if not vuln_id:
+            raise ValueError(f"known vuln entry {index} must include a non-empty id")
+        if any(char.isspace() for char in vuln_id):
+            raise ValueError(f"known vuln entry {index} id must not contain whitespace")
+
+        known_vulns.append({**entry, "id": vuln_id})
+
+    return known_vulns
+
+
+def build_ignore_args(known_vulns: list[dict[str, Any]]) -> list[str]:
+    ignore_args: list[str] = []
+    for entry in known_vulns:
+        ignore_args.extend(["--ignore-vuln", entry["id"]])
+    return ignore_args
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Render tracked no-fix pip-audit findings."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    ignore_args_parser = subparsers.add_parser(
+        "ignore-args",
+        help="Print one pip-audit ignore argument per line for shell arrays.",
+    )
+    ignore_args_parser.add_argument(
+        "--file",
+        type=Path,
+        default=DEFAULT_KNOWN_VULNS_FILE,
+        help="Path to the tracked known vulnerabilities JSON file.",
+    )
+
+    args = parser.parse_args(argv)
+    if args.command == "ignore-args":
+        for value in build_ignore_args(load_known_vulns(args.file)):
+            print(value)
+        return 0
+
+    parser.error(f"unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/security/pip-audit-known-vulns.json
+++ b/security/pip-audit-known-vulns.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "PYSEC-2025-183",
+    "package": "PyJWT",
+    "version": "2.12.1",
+    "reason": "No fixed version is published in OSV or PyPI as of 2026-05-21.",
+    "reviewed_at": "2026-05-21",
+    "source": "https://osv.dev/vulnerability/PYSEC-2025-183"
+  },
+  {
+    "id": "PYSEC-2026-89",
+    "package": "markdown",
+    "version": "3.10.2",
+    "reason": "No fixed version is published in OSV or PyPI as of 2026-05-21.",
+    "reviewed_at": "2026-05-21",
+    "source": "https://osv.dev/vulnerability/PYSEC-2026-89"
+  }
+]

--- a/tests/unit/test_pip_audit_known_vulns.py
+++ b/tests/unit/test_pip_audit_known_vulns.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.pip_audit_known_vulns import build_ignore_args, load_known_vulns
+
+
+def test_build_ignore_args_preserves_file_order(tmp_path: Path) -> None:
+    known_vulns_file = tmp_path / "known-vulns.json"
+    known_vulns_file.write_text(
+        """[
+  {"id": "PYSEC-2025-183", "package": "PyJWT", "version": "2.12.1"},
+  {"id": "PYSEC-2026-89", "package": "markdown", "version": "3.10.2"}
+]""",
+        encoding="utf-8",
+    )
+
+    assert build_ignore_args(load_known_vulns(known_vulns_file)) == [
+        "--ignore-vuln",
+        "PYSEC-2025-183",
+        "--ignore-vuln",
+        "PYSEC-2026-89",
+    ]
+
+
+def test_load_known_vulns_rejects_blank_ids(tmp_path: Path) -> None:
+    known_vulns_file = tmp_path / "known-vulns.json"
+    known_vulns_file.write_text(
+        """[
+  {"id": "PYSEC-2025-183"},
+  {"id": "   "}
+]""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="entry 2"):
+        load_known_vulns(known_vulns_file)


### PR DESCRIPTION
## Description
Move the PyJWT and markdown no-fix pip-audit findings out of temporary inline workflow ignores and into a tracked JSON file consumed by a small helper script.

The workflow still fails for untracked backend vulnerabilities, while these two no-fix findings are reviewable in `security/pip-audit-known-vulns.json` until upstream publishes fixed versions.

## Related Issue
Linear: https://linear.app/nullcodeai/issue/BOR-44/track-no-fix-pip-audit-findings-for-pyjwt-and-markdown

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `ruff check app tests`
- `ruff format --check app tests`
- `ruff check scripts/pip_audit_known_vulns.py tests/unit/test_pip_audit_known_vulns.py`
- `ruff format --check scripts/pip_audit_known_vulns.py tests/unit/test_pip_audit_known_vulns.py`
- `pytest tests/unit/test_pip_audit_known_vulns.py -v`
- `git diff --check origin/main...HEAD`
- `python3 scripts/pip_audit_known_vulns.py ignore-args`
- workflow-equivalent `.venv/bin/pip-audit -r requirements.txt` with existing fixed ignores plus tracked no-fix helper args
- OSV API check for `PYSEC-2025-183` and `PYSEC-2026-89` fixed events
- unignored pip-audit JSON proof for both ticketed findings and empty fix metadata

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable. This is a backend security workflow change.

## Additional Context
Current PyPI metadata still lists PyJWT `2.12.1` and Markdown `3.10.2` as the latest releases. OSV currently reports no fixed events for `PYSEC-2025-183` or `PYSEC-2026-89`, and `pip-audit` reports both findings with no fix metadata when the tracked no-fix helper is not used.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
