### PR TITLE
Validate borg-ui-agent systemd service identity

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -85,13 +85,83 @@ Linux systemd and macOS launchd templates are available under `agent/install/`.
 Adjust paths to match the virtual environment and config location used on the
 target machine.
 
-Linux systemd example:
+### Linux systemd
+
+The default Linux unit runs as a dedicated system user and group named
+`borg-ui-agent`. Create that account before installing or enabling the unit:
+
+```bash
+sudo useradd --system --user-group --home-dir /var/lib/borg-ui-agent \
+  --create-home --shell /usr/sbin/nologin borg-ui-agent
+sudo install -d -o borg-ui-agent -g borg-ui-agent -m 0750 /etc/borg-ui-agent
+```
+
+Install the agent into the path used by the template:
+
+```bash
+sudo install -d -m 0755 /opt/borg-ui-agent
+sudo python3.11 -m venv /opt/borg-ui-agent/.venv
+sudo /opt/borg-ui-agent/.venv/bin/pip install .
+```
+
+Register the agent config at the service path:
+
+```bash
+sudo -u borg-ui-agent /opt/borg-ui-agent/.venv/bin/borg-ui-agent \
+  --config /etc/borg-ui-agent/config.toml \
+  register \
+  --server http://borg-ui-host:7879 \
+  --token borgui_enroll_example \
+  --name laptop
+```
+
+Validate the service account, executable, and config path before enabling the
+unit:
+
+```bash
+sudo /opt/borg-ui-agent/.venv/bin/borg-ui-agent service-check \
+  --user borg-ui-agent \
+  --group borg-ui-agent \
+  --exec /opt/borg-ui-agent/.venv/bin/borg-ui-agent \
+  --config /etc/borg-ui-agent/config.toml
+```
+
+Install and start the unit:
 
 ```bash
 sudo cp agent/install/systemd/borg-ui-agent.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now borg-ui-agent
 ```
+
+If you choose a different service user, group, virtual environment, or config
+path, update both `agent/install/systemd/borg-ui-agent.service` and the
+`service-check` arguments before enabling the unit.
+
+### Troubleshooting Linux service startup
+
+`status=217/USER` or `Failed at step USER` means systemd could not use the
+configured `User=` or `Group=`. Check the account and run the service setup
+validator:
+
+```bash
+getent passwd borg-ui-agent
+getent group borg-ui-agent
+sudo /opt/borg-ui-agent/.venv/bin/borg-ui-agent service-check \
+  --user borg-ui-agent \
+  --group borg-ui-agent \
+  --exec /opt/borg-ui-agent/.venv/bin/borg-ui-agent \
+  --config /etc/borg-ui-agent/config.toml
+```
+
+For a missing default user, `service-check` exits before `systemctl enable` with
+a message like:
+
+```text
+borg-ui-agent: Service user 'borg-ui-agent' does not exist. Create it with: sudo useradd --system --user-group --home-dir /var/lib/borg-ui-agent --create-home --shell /usr/sbin/nologin borg-ui-agent
+```
+
+### macOS launchd
 
 macOS launchd example:
 
@@ -100,9 +170,9 @@ sudo cp agent/install/launchd/com.borg-ui.agent.plist /Library/LaunchDaemons/
 sudo launchctl bootstrap system /Library/LaunchDaemons/com.borg-ui.agent.plist
 ```
 
-Review the template before enabling it. The default service assumes the agent is
-installed under `/opt/borg-ui-agent/.venv` and uses
-`/etc/borg-ui-agent/config.toml`.
+Review the template before enabling it. The default Linux service assumes the
+agent is installed under `/opt/borg-ui-agent/.venv`, runs as
+`borg-ui-agent:borg-ui-agent`, and uses `/etc/borg-ui-agent/config.toml`.
 
 ## Current Job Support
 

--- a/agent/borg_ui_agent/cli.py
+++ b/agent/borg_ui_agent/cli.py
@@ -14,6 +14,14 @@ from agent.borg_ui_agent.config import (
     save_config,
 )
 from agent.borg_ui_agent.runtime import AgentRuntime, get_capabilities
+from agent.borg_ui_agent.service_setup import (
+    DEFAULT_SERVICE_CONFIG,
+    DEFAULT_SERVICE_EXECUTABLE,
+    DEFAULT_SERVICE_GROUP,
+    DEFAULT_SERVICE_USER,
+    ServiceSetupError,
+    validate_service_setup,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -33,6 +41,22 @@ def build_parser() -> argparse.ArgumentParser:
     run = subparsers.add_parser("run")
     run.add_argument("--poll-interval", type=int, default=15)
     run.add_argument("--max-iterations", type=int, default=None)
+
+    service_check = subparsers.add_parser("service-check")
+    service_check.add_argument("--user", default=DEFAULT_SERVICE_USER)
+    service_check.add_argument("--group", default=DEFAULT_SERVICE_GROUP)
+    service_check.add_argument(
+        "--exec",
+        dest="executable",
+        type=Path,
+        default=DEFAULT_SERVICE_EXECUTABLE,
+    )
+    service_check.add_argument(
+        "--config",
+        dest="service_config",
+        type=Path,
+        default=DEFAULT_SERVICE_CONFIG,
+    )
 
     return parser
 
@@ -109,6 +133,21 @@ def _run(args: argparse.Namespace) -> int:
     return 0
 
 
+def _service_check(args: argparse.Namespace) -> int:
+    validate_service_setup(
+        user=args.user,
+        group=args.group,
+        executable_path=args.executable,
+        config_path=args.service_config,
+    )
+    print(
+        "borg-ui-agent service setup OK: "
+        f"user={args.user} group={args.group} "
+        f"exec={args.executable} config={args.service_config}"
+    )
+    return 0
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -123,7 +162,9 @@ def main(argv: Optional[list[str]] = None) -> int:
             return _unregister(args)
         if args.command == "run":
             return _run(args)
-    except (AgentClientError, OSError, KeyError) as exc:
+        if args.command == "service-check":
+            return _service_check(args)
+    except (AgentClientError, OSError, KeyError, ServiceSetupError) as exc:
         parser.exit(1, f"borg-ui-agent: {exc}\n")
     parser.error(f"unknown command: {args.command}")
     return 2

--- a/agent/borg_ui_agent/service_setup.py
+++ b/agent/borg_ui_agent/service_setup.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import grp
+import os
+import pwd
+from pathlib import Path
+
+DEFAULT_SERVICE_USER = "borg-ui-agent"
+DEFAULT_SERVICE_GROUP = "borg-ui-agent"
+DEFAULT_SERVICE_EXECUTABLE = Path("/opt/borg-ui-agent/.venv/bin/borg-ui-agent")
+DEFAULT_SERVICE_CONFIG = Path("/etc/borg-ui-agent/config.toml")
+
+
+class ServiceSetupError(RuntimeError):
+    """Raised when the Linux service setup is not ready for systemd."""
+
+
+def _user_creation_hint(user: str, group: str) -> str:
+    if user == group:
+        return (
+            "sudo useradd --system --user-group --home-dir "
+            f"/var/lib/borg-ui-agent --create-home --shell /usr/sbin/nologin {user}"
+        )
+    return (
+        "sudo useradd --system --gid "
+        f"{group} --home-dir /var/lib/borg-ui-agent --create-home "
+        f"--shell /usr/sbin/nologin {user}"
+    )
+
+
+def validate_service_identity(user: str, group: str) -> None:
+    service_user = user.strip()
+    service_group = group.strip()
+    if not service_user:
+        raise ServiceSetupError("Service user must not be empty.")
+    if not service_group:
+        raise ServiceSetupError("Service group must not be empty.")
+
+    try:
+        pwd.getpwnam(service_user)
+    except KeyError as exc:
+        raise ServiceSetupError(
+            f"Service user '{service_user}' does not exist. Create it with: "
+            f"{_user_creation_hint(service_user, service_group)}"
+        ) from exc
+
+    try:
+        grp.getgrnam(service_group)
+    except KeyError as exc:
+        raise ServiceSetupError(
+            f"Service group '{service_group}' does not exist. Create it with: "
+            f"sudo groupadd --system {service_group}"
+        ) from exc
+
+
+def validate_service_paths(executable_path: Path, config_path: Path) -> None:
+    if not executable_path.exists():
+        raise ServiceSetupError(
+            f"Agent executable '{executable_path}' does not exist. "
+            "Install the agent virtual environment before enabling the service, "
+            "then pass the matching path with --exec."
+        )
+    if not executable_path.is_file():
+        raise ServiceSetupError(
+            f"Agent executable '{executable_path}' is not a file. "
+            "Pass the installed borg-ui-agent executable path with --exec."
+        )
+    if not os.access(executable_path, os.X_OK):
+        raise ServiceSetupError(
+            f"Agent executable '{executable_path}' is not executable. "
+            "Fix permissions before enabling the service."
+        )
+    if not config_path.exists():
+        raise ServiceSetupError(
+            f"Agent config '{config_path}' does not exist. "
+            f"Register the agent with --config {config_path} before enabling "
+            "the service."
+        )
+    if not config_path.is_file():
+        raise ServiceSetupError(
+            f"Agent config '{config_path}' is not a file. "
+            "Pass the registered agent config path with --config."
+        )
+
+
+def validate_service_setup(
+    *,
+    user: str,
+    group: str,
+    executable_path: Path,
+    config_path: Path,
+) -> None:
+    validate_service_identity(user, group)
+    validate_service_paths(executable_path, config_path)

--- a/agent/install/systemd/borg-ui-agent.service
+++ b/agent/install/systemd/borg-ui-agent.service
@@ -5,6 +5,8 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+# Create and validate this account before enabling the unit:
+# /opt/borg-ui-agent/.venv/bin/borg-ui-agent service-check --user borg-ui-agent --group borg-ui-agent
 User=borg-ui-agent
 Group=borg-ui-agent
 ExecStart=/opt/borg-ui-agent/.venv/bin/borg-ui-agent --config /etc/borg-ui-agent/config.toml run

--- a/docs/engineering/plans/2026-05-21-borg-ui-agent-service-user-hardening.md
+++ b/docs/engineering/plans/2026-05-21-borg-ui-agent-service-user-hardening.md
@@ -1,0 +1,243 @@
+# Borg UI Agent Service User Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Linux `borg-ui-agent` service setup fail fast with clear
+service user and group diagnostics before systemd reaches `status=217/USER`.
+
+**Architecture:** Keep the shipped systemd unit simple, add a Python service
+setup validator inside the existing agent package, expose it as a
+`borg-ui-agent service-check` CLI command, and make the documented Linux install
+path create and validate the expected account before enabling the unit.
+
+**Tech Stack:** Python 3.11 stdlib `pwd`/`grp`/`pathlib`, argparse, pytest,
+Markdown documentation, systemd unit template.
+
+---
+
+### Task 1: Service Setup Validator And CLI
+
+**Files:**
+- Create: `agent/borg_ui_agent/service_setup.py`
+- Modify: `agent/borg_ui_agent/cli.py`
+- Test: `tests/unit/agent/test_service_setup.py`
+
+- [ ] **Step 1: Write failing service user and group validation tests**
+
+```python
+from pathlib import Path
+
+import pytest
+
+from agent.borg_ui_agent.service_setup import (
+    DEFAULT_SERVICE_GROUP,
+    DEFAULT_SERVICE_USER,
+    ServiceSetupError,
+    validate_service_identity,
+)
+
+
+def test_validate_service_identity_reports_missing_user(monkeypatch):
+    def missing_user(name):
+        raise KeyError(name)
+
+    monkeypatch.setattr("agent.borg_ui_agent.service_setup.pwd.getpwnam", missing_user)
+
+    with pytest.raises(ServiceSetupError) as exc:
+        validate_service_identity(DEFAULT_SERVICE_USER, DEFAULT_SERVICE_GROUP)
+
+    assert "Service user 'borg-ui-agent' does not exist" in str(exc.value)
+    assert "sudo useradd --system --user-group" in str(exc.value)
+```
+
+Run:
+
+```bash
+pytest tests/unit/agent/test_service_setup.py -q
+```
+
+Expected result: fails because `agent.borg_ui_agent.service_setup` does not
+exist yet.
+
+- [ ] **Step 2: Implement the minimal validator**
+
+Create `agent/borg_ui_agent/service_setup.py` with:
+
+```python
+from __future__ import annotations
+
+import grp
+import os
+import pwd
+from pathlib import Path
+
+DEFAULT_SERVICE_USER = "borg-ui-agent"
+DEFAULT_SERVICE_GROUP = "borg-ui-agent"
+DEFAULT_SERVICE_EXECUTABLE = Path("/opt/borg-ui-agent/.venv/bin/borg-ui-agent")
+DEFAULT_SERVICE_CONFIG = Path("/etc/borg-ui-agent/config.toml")
+
+
+class ServiceSetupError(RuntimeError):
+    pass
+
+
+def validate_service_identity(user: str, group: str) -> None:
+    if not user.strip():
+        raise ServiceSetupError("Service user must not be empty.")
+    if not group.strip():
+        raise ServiceSetupError("Service group must not be empty.")
+    try:
+        pwd.getpwnam(user)
+    except KeyError as exc:
+        raise ServiceSetupError(
+            f"Service user '{user}' does not exist. Create it with: "
+            f"sudo useradd --system --user-group --home-dir "
+            f"/var/lib/borg-ui-agent --shell /usr/sbin/nologin {user}"
+        ) from exc
+    try:
+        grp.getgrnam(group)
+    except KeyError as exc:
+        raise ServiceSetupError(
+            f"Service group '{group}' does not exist. Create it with: "
+            f"sudo groupadd --system {group}"
+        ) from exc
+```
+
+- [ ] **Step 3: Add path validation and CLI coverage**
+
+Add tests showing `validate_service_paths()` rejects a missing executable and
+that `borg-ui-agent service-check --user ... --group ... --exec ... --config ...`
+prints an OK line when all inputs exist.
+
+Run:
+
+```bash
+pytest tests/unit/agent/test_service_setup.py -q
+```
+
+Expected result: fails until `validate_service_paths()` and the CLI subcommand
+are implemented.
+
+- [ ] **Step 4: Wire the CLI command**
+
+Modify `agent/borg_ui_agent/cli.py` so `build_parser()` adds:
+
+```python
+service_check = subparsers.add_parser("service-check")
+service_check.add_argument("--user", default=DEFAULT_SERVICE_USER)
+service_check.add_argument("--group", default=DEFAULT_SERVICE_GROUP)
+service_check.add_argument("--exec", dest="executable", type=Path, default=DEFAULT_SERVICE_EXECUTABLE)
+service_check.add_argument("--config", dest="service_config", type=Path, default=DEFAULT_SERVICE_CONFIG)
+```
+
+Add `_service_check(args)` to call `validate_service_setup()` and print a
+single success line containing the validated user, group, executable, and config
+paths. Include `ServiceSetupError` in the existing CLI error handling tuple.
+
+Run:
+
+```bash
+pytest tests/unit/agent/test_service_setup.py -q
+```
+
+Expected result: all service setup tests pass.
+
+### Task 2: Linux Service Documentation And Template Notes
+
+**Files:**
+- Modify: `agent/README.md`
+- Modify: `docs/managed-agents.md`
+- Modify: `agent/install/systemd/borg-ui-agent.service`
+
+- [ ] **Step 1: Document the required Linux service account**
+
+Document this account setup before copying/enabling the unit:
+
+```bash
+sudo useradd --system --user-group --home-dir /var/lib/borg-ui-agent \
+  --create-home --shell /usr/sbin/nologin borg-ui-agent
+sudo install -d -o borg-ui-agent -g borg-ui-agent -m 0750 /etc/borg-ui-agent
+```
+
+- [ ] **Step 2: Document the pre-enable validation command**
+
+Document this command immediately before `systemctl daemon-reload`:
+
+```bash
+sudo /opt/borg-ui-agent/.venv/bin/borg-ui-agent service-check \
+  --user borg-ui-agent \
+  --group borg-ui-agent \
+  --exec /opt/borg-ui-agent/.venv/bin/borg-ui-agent \
+  --config /etc/borg-ui-agent/config.toml
+```
+
+Expected invalid-user output includes:
+
+```text
+borg-ui-agent: Service user 'borg-ui-agent' does not exist.
+```
+
+- [ ] **Step 3: Add troubleshooting guidance**
+
+Add a short troubleshooting section that maps systemd `status=217/USER` and
+`Failed at step USER` to a missing or invalid `User=`/`Group=` value and tells
+operators to run:
+
+```bash
+getent passwd borg-ui-agent
+getent group borg-ui-agent
+sudo /opt/borg-ui-agent/.venv/bin/borg-ui-agent service-check
+```
+
+- [ ] **Step 4: Annotate the service template**
+
+Add comments above `User=` and `Group=` in
+`agent/install/systemd/borg-ui-agent.service` saying the account must exist and
+should be validated with `borg-ui-agent service-check` before enabling the unit.
+
+### Task 3: Validation And Handoff
+
+**Files:**
+- Validate: `agent/borg_ui_agent/service_setup.py`
+- Validate: `agent/borg_ui_agent/cli.py`
+- Validate: `tests/unit/agent/test_service_setup.py`
+- Validate: `agent/README.md`
+- Validate: `docs/managed-agents.md`
+- Validate: `agent/install/systemd/borg-ui-agent.service`
+
+- [ ] Run targeted tests:
+
+```bash
+pytest tests/unit/agent/test_service_setup.py -q
+```
+
+- [ ] Run the broader agent regression test:
+
+```bash
+pytest tests/unit/test_agent_runtime.py tests/unit/agent/test_service_setup.py -q
+```
+
+- [ ] Run backend policy checks:
+
+```bash
+ruff check app tests
+ruff format --check app tests
+```
+
+- [ ] Run local service-check proof with temporary files:
+
+```bash
+tmpdir="$(mktemp -d)"
+install -m 0755 "$(command -v true)" "$tmpdir/borg-ui-agent"
+install -m 0600 /dev/null "$tmpdir/config.toml"
+python3 -m agent.borg_ui_agent.cli service-check \
+  --user "$(id -un)" \
+  --group "$(id -gn)" \
+  --exec "$tmpdir/borg-ui-agent" \
+  --config "$tmpdir/config.toml"
+rm -rf "$tmpdir"
+```
+
+Expected result: command exits 0 and prints `borg-ui-agent service setup OK`.

--- a/docs/managed-agents.md
+++ b/docs/managed-agents.md
@@ -77,13 +77,65 @@ heartbeat.
 Linux systemd and macOS launchd templates are included in the repository under
 `agent/install/`.
 
-For Linux, edit `agent/install/systemd/borg-ui-agent.service` so `ExecStart`,
-`User`, `Group`, and the config path match the client machine. Then install it:
+### Linux systemd
+
+The default Linux unit expects a system user and group named `borg-ui-agent`:
+
+```bash
+sudo useradd --system --user-group --home-dir /var/lib/borg-ui-agent \
+  --create-home --shell /usr/sbin/nologin borg-ui-agent
+sudo install -d -o borg-ui-agent -g borg-ui-agent -m 0750 /etc/borg-ui-agent
+```
+
+Install the agent into the path used by
+`agent/install/systemd/borg-ui-agent.service`, then register the service config:
+
+```bash
+sudo install -d -m 0755 /opt/borg-ui-agent
+sudo python3.11 -m venv /opt/borg-ui-agent/.venv
+sudo /opt/borg-ui-agent/.venv/bin/pip install .
+sudo -u borg-ui-agent /opt/borg-ui-agent/.venv/bin/borg-ui-agent \
+  --config /etc/borg-ui-agent/config.toml \
+  register \
+  --server http://borg-ui-host:7879 \
+  --token borgui_enroll_example \
+  --name laptop
+```
+
+Validate the service setup before enabling it. This catches a missing or
+invalid service user/group before systemd reaches `status=217/USER`:
+
+```bash
+sudo /opt/borg-ui-agent/.venv/bin/borg-ui-agent service-check \
+  --user borg-ui-agent \
+  --group borg-ui-agent \
+  --exec /opt/borg-ui-agent/.venv/bin/borg-ui-agent \
+  --config /etc/borg-ui-agent/config.toml
+```
+
+Then install and start the unit:
 
 ```bash
 sudo cp agent/install/systemd/borg-ui-agent.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now borg-ui-agent
+```
+
+If you choose a different service user, group, binary path, or config path, edit
+the systemd unit and pass the same values to `service-check`.
+
+If `systemctl status borg-ui-agent` shows `status=217/USER` or
+`Failed at step USER`, systemd could not use the configured `User=` or `Group=`.
+Run:
+
+```bash
+getent passwd borg-ui-agent
+getent group borg-ui-agent
+sudo /opt/borg-ui-agent/.venv/bin/borg-ui-agent service-check \
+  --user borg-ui-agent \
+  --group borg-ui-agent \
+  --exec /opt/borg-ui-agent/.venv/bin/borg-ui-agent \
+  --config /etc/borg-ui-agent/config.toml
 ```
 
 For macOS, edit `agent/install/launchd/com.borg-ui.agent.plist` so the binary,

--- a/tests/unit/agent/test_service_setup.py
+++ b/tests/unit/agent/test_service_setup.py
@@ -1,0 +1,198 @@
+import getpass
+import grp
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agent.borg_ui_agent.cli import main
+from agent.borg_ui_agent.service_setup import (
+    DEFAULT_SERVICE_GROUP,
+    DEFAULT_SERVICE_USER,
+    ServiceSetupError,
+    validate_service_identity,
+    validate_service_paths,
+    validate_service_setup,
+)
+
+
+def test_validate_service_identity_reports_missing_user(monkeypatch):
+    def missing_user(name):
+        raise KeyError(name)
+
+    monkeypatch.setattr("agent.borg_ui_agent.service_setup.pwd.getpwnam", missing_user)
+
+    with pytest.raises(ServiceSetupError) as exc:
+        validate_service_identity(DEFAULT_SERVICE_USER, DEFAULT_SERVICE_GROUP)
+
+    message = str(exc.value)
+    assert "Service user 'borg-ui-agent' does not exist" in message
+    assert "sudo useradd --system --user-group" in message
+    assert "borg-ui-agent" in message
+
+
+def test_validate_service_identity_reports_missing_group(monkeypatch):
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.service_setup.pwd.getpwnam",
+        lambda name: SimpleNamespace(pw_name=name),
+    )
+
+    def missing_group(name):
+        raise KeyError(name)
+
+    monkeypatch.setattr("agent.borg_ui_agent.service_setup.grp.getgrnam", missing_group)
+
+    with pytest.raises(ServiceSetupError) as exc:
+        validate_service_identity(DEFAULT_SERVICE_USER, DEFAULT_SERVICE_GROUP)
+
+    message = str(exc.value)
+    assert "Service group 'borg-ui-agent' does not exist" in message
+    assert "sudo groupadd --system borg-ui-agent" in message
+
+
+def test_validate_service_identity_accepts_existing_user_and_group(monkeypatch):
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.service_setup.pwd.getpwnam",
+        lambda name: SimpleNamespace(pw_name=name),
+    )
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.service_setup.grp.getgrnam",
+        lambda name: SimpleNamespace(gr_name=name),
+    )
+
+    validate_service_identity(DEFAULT_SERVICE_USER, DEFAULT_SERVICE_GROUP)
+
+
+def test_validate_service_paths_reports_missing_executable(tmp_path: Path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("", encoding="utf-8")
+
+    with pytest.raises(ServiceSetupError) as exc:
+        validate_service_paths(
+            executable_path=tmp_path / "missing-borg-ui-agent",
+            config_path=config_path,
+        )
+
+    message = str(exc.value)
+    assert "Agent executable" in message
+    assert "does not exist" in message
+    assert (
+        "Install the agent virtual environment before enabling the service" in message
+    )
+
+
+def test_validate_service_paths_reports_non_executable_binary(tmp_path: Path):
+    executable_path = tmp_path / "borg-ui-agent"
+    executable_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable_path.chmod(0o644)
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("", encoding="utf-8")
+
+    with pytest.raises(ServiceSetupError) as exc:
+        validate_service_paths(
+            executable_path=executable_path,
+            config_path=config_path,
+        )
+
+    assert f"Agent executable '{executable_path}' is not executable" in str(exc.value)
+
+
+def test_validate_service_paths_reports_missing_config(tmp_path: Path):
+    executable_path = tmp_path / "borg-ui-agent"
+    executable_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable_path.chmod(0o755)
+
+    with pytest.raises(ServiceSetupError) as exc:
+        validate_service_paths(
+            executable_path=executable_path,
+            config_path=tmp_path / "config.toml",
+        )
+
+    message = str(exc.value)
+    assert "Agent config" in message
+    assert "does not exist" in message
+    assert "Register the agent with --config" in message
+
+
+def test_validate_service_setup_accepts_existing_identity_and_paths(
+    monkeypatch, tmp_path: Path
+):
+    executable_path = tmp_path / "borg-ui-agent"
+    executable_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable_path.chmod(0o755)
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.service_setup.pwd.getpwnam",
+        lambda name: SimpleNamespace(pw_name=name),
+    )
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.service_setup.grp.getgrnam",
+        lambda name: SimpleNamespace(gr_name=name),
+    )
+
+    validate_service_setup(
+        user=DEFAULT_SERVICE_USER,
+        group=DEFAULT_SERVICE_GROUP,
+        executable_path=executable_path,
+        config_path=config_path,
+    )
+
+
+def test_service_check_cli_reports_success_for_valid_setup(capsys, tmp_path: Path):
+    executable_path = tmp_path / "borg-ui-agent"
+    executable_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable_path.chmod(0o755)
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("", encoding="utf-8")
+    current_group = grp.getgrgid(os.getgid()).gr_name
+
+    result = main(
+        [
+            "service-check",
+            "--user",
+            getpass.getuser(),
+            "--group",
+            current_group,
+            "--exec",
+            str(executable_path),
+            "--config",
+            str(config_path),
+        ]
+    )
+
+    output = capsys.readouterr()
+    assert result == 0
+    assert "borg-ui-agent service setup OK" in output.out
+    assert f"user={getpass.getuser()}" in output.out
+    assert f"group={current_group}" in output.out
+
+
+def test_service_check_cli_exits_with_clear_missing_user_error(capsys, tmp_path: Path):
+    executable_path = tmp_path / "borg-ui-agent"
+    executable_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable_path.chmod(0o755)
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        main(
+            [
+                "service-check",
+                "--user",
+                "__borg_ui_missing_user__",
+                "--group",
+                grp.getgrgid(os.getgid()).gr_name,
+                "--exec",
+                str(executable_path),
+                "--config",
+                str(config_path),
+            ]
+        )
+
+    output = capsys.readouterr()
+    assert exc.value.code == 1
+    assert "borg-ui-agent: Service user '__borg_ui_missing_user__' does not exist" in (
+        output.err
+    )


### PR DESCRIPTION
## Description
Adds a `borg-ui-agent service-check` command that validates the configured Linux service user, group, executable path, and config path before operators enable the systemd unit. Updates the Linux managed-agent install docs to create the expected `borg-ui-agent:borg-ui-agent` system account, run the validator, and troubleshoot `status=217/USER` / `Failed at step USER` directly.

## Related Issue
Fixes BOR-45

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `pytest tests/unit/agent/test_service_setup.py -q`
- `pytest tests/unit/test_agent_runtime.py tests/unit/agent/test_service_setup.py -q`
- `ruff check agent tests/unit/agent/test_service_setup.py`
- `ruff format --check agent tests/unit/agent/test_service_setup.py`
- `ruff check app tests`
- `ruff format --check app tests`
- `python3 -m agent.borg_ui_agent.cli service-check --user "$(id -un)" --group "$(id -gn)" --exec ./dev.sh --config pyproject.toml`
- Missing-user service-check proof with `__borg_ui_missing_user__`, expecting exit 1 and a clear service-user creation message
- `systemd-analyze --recursive-errors=no verify --root=<fake-root> /etc/systemd/system/borg-ui-agent.service` with the documented `/opt` executable and `/etc` config paths present in the fake root

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable. This change is CLI, docs, and systemd service setup behavior only.

## Additional Context
The previous unit template set `User=borg-ui-agent` and `Group=borg-ui-agent`, but the documented install path did not create or validate that account before `systemctl enable --now`. On hosts without the account, systemd fails before `ExecStart` with `status=217/USER`, so the validation needs to happen during service setup rather than inside the service process.
