### PR TITLE
Preserve Borg slash-dot SSH repository paths

### DIFF
--- a/app/utils/ssh_paths.py
+++ b/app/utils/ssh_paths.py
@@ -29,6 +29,39 @@ def resolve_sshfs_source_path(path: str, default_path: Optional[str] = None) -> 
     return resolved_path
 
 
+def _normalize_command_path(path: str) -> str:
+    normalized_path = (path or "").strip() or "/"
+    if not normalized_path.startswith("/"):
+        normalized_path = f"/{normalized_path}"
+
+    if normalized_path == "/." or normalized_path.startswith("/./"):
+        tail = normalized_path[3:] if normalized_path.startswith("/./") else ""
+        if not tail:
+            return "/."
+
+        normalized_tail = posixpath.normpath(f"/{tail}").lstrip("/")
+        return f"/./{normalized_tail}" if normalized_tail else "/."
+
+    return posixpath.normpath(normalized_path)
+
+
+def _join_command_prefix(normalized_prefix: str, normalized_path: str) -> str:
+    tail = normalized_path.lstrip("/")
+    if not tail:
+        return normalized_prefix
+    if normalized_prefix == "/.":
+        return f"/./{tail}"
+    if normalized_prefix.startswith("/./"):
+        visible_prefix = f"/{normalized_prefix[3:]}"
+        if normalized_path == visible_prefix:
+            return normalized_prefix
+        if normalized_path.startswith(f"{visible_prefix}/"):
+            remainder = normalized_path[len(visible_prefix) :].lstrip("/")
+            return f"{normalized_prefix.rstrip('/')}/{remainder}"
+        return f"{normalized_prefix.rstrip('/')}/{tail}"
+    return posixpath.normpath(posixpath.join(normalized_prefix, tail))
+
+
 def apply_ssh_command_prefix(path: str, ssh_path_prefix: Optional[str] = None) -> str:
     """
     Apply an SSH-only command path prefix.
@@ -36,23 +69,18 @@ def apply_ssh_command_prefix(path: str, ssh_path_prefix: Optional[str] = None) -
     This is used for shell/Borg SSH commands and must not be used for SFTP or
     SSHFS source-path resolution.
     """
-    normalized_path = (path or "").strip() or "/"
-    if not normalized_path.startswith("/"):
-        normalized_path = f"/{normalized_path}"
-    normalized_path = posixpath.normpath(normalized_path)
+    normalized_path = _normalize_command_path(path)
 
     normalized_prefix = (ssh_path_prefix or "").strip()
     if not normalized_prefix:
         return normalized_path
-    if not normalized_prefix.startswith("/"):
-        normalized_prefix = f"/{normalized_prefix}"
-    normalized_prefix = posixpath.normpath(normalized_prefix)
+    normalized_prefix = _normalize_command_path(normalized_prefix)
 
     if normalized_path == normalized_prefix or normalized_path.startswith(
         f"{normalized_prefix}/"
     ):
         return normalized_path
+    if normalized_path.startswith("/./"):
+        return normalized_path
 
-    return posixpath.normpath(
-        posixpath.join(normalized_prefix, normalized_path.lstrip("/"))
-    )
+    return _join_command_prefix(normalized_prefix, normalized_path)

--- a/tests/unit/test_api_repositories.py
+++ b/tests/unit/test_api_repositories.py
@@ -35,6 +35,7 @@ from app.database.models import (
     SSHConnection,
     SystemSettings,
 )
+from app.api.repositories import _build_repository_path_from_connection
 
 
 def _discard_background_coro(coro):
@@ -68,6 +69,33 @@ def _base_repository_payload(**overrides):
     }
     payload.update(overrides)
     return payload
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("ssh_path_prefix", "raw_path", "expected_path"),
+    [
+        ("/.", "/xxx/yyy", "ssh://backup@rsync.example.com:22/./xxx/yyy"),
+        ("/./xxx", "/xxx/yyy", "ssh://backup@rsync.example.com:22/./xxx/yyy"),
+    ],
+)
+def test_build_repository_path_from_connection_preserves_borg_slashdot_prefix(
+    test_db, ssh_path_prefix, raw_path, expected_path
+):
+    connection = SSHConnection(
+        host="rsync.example.com",
+        username="backup",
+        port=22,
+        ssh_path_prefix=ssh_path_prefix,
+    )
+    test_db.add(connection)
+    test_db.commit()
+    test_db.refresh(connection)
+
+    assert (
+        _build_repository_path_from_connection(raw_path, connection.id, test_db)
+        == expected_path
+    )
 
 
 def _agent_machine_with_capabilities(*capabilities: str) -> AgentMachine:

--- a/tests/unit/test_ssh_paths.py
+++ b/tests/unit/test_ssh_paths.py
@@ -27,3 +27,11 @@ class TestSshPaths:
             apply_ssh_command_prefix("/volume1/share/komodo", "/volume1")
             == "/volume1/share/komodo"
         )
+
+    def test_apply_ssh_command_prefix_preserves_borg_slashdot_prefix(self):
+        assert apply_ssh_command_prefix("/xxx/yyy", "/.") == "/./xxx/yyy"
+        assert apply_ssh_command_prefix("/./xxx/yyy", "/.") == "/./xxx/yyy"
+
+    def test_apply_ssh_command_prefix_does_not_double_borg_slashdot_prefix(self):
+        assert apply_ssh_command_prefix("/xxx/yyy", "/./xxx") == "/./xxx/yyy"
+        assert apply_ssh_command_prefix("/xxx/yyy", "/./xxx/yyy") == "/./xxx/yyy"


### PR DESCRIPTION
## Description
Preserves Borg's `/./` path boundary when Borg UI applies SSH command path prefixes for remote repositories. This keeps restricted Borg server paths such as `--restrict-to-path /./xxx/yyy` intact when repository URLs are built from a browsed `/xxx/yyy` path.

The change also avoids double-prefixing when a configured slash-dot prefix already includes the visible browsed path.

## Related Issue
Fixes #501
Linear: BOR-47

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `ruff check app tests`
- `ruff format --check app tests`
- `git diff --check`
- `pytest tests/unit/test_ssh_paths.py tests/unit/test_api_repositories.py::test_build_repository_path_from_connection_preserves_borg_slashdot_prefix tests/unit/test_api_repositories.py::TestRepositoriesUpdate::test_update_ssh_repository_path_reconstruction -q`
- `pytest tests/unit -q`

## Checklist
- [x] I have read the [CONTRIBUTING](.github/CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

Documentation changes were not needed because this is a backend path-construction fix. The broad unit suite still emits existing deprecation/runtime warnings unrelated to this change.

## Screenshots (if applicable)
Not applicable; no UI changes.

## Additional Context
This is specifically for Borg SSH repository URLs where `/./` is semantically meaningful and must not be collapsed by POSIX path normalization.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.