### PR TITLE
Document Docker socket proxy hook access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,8 +56,11 @@ services:
       # - /home/user:/home:rw
       # (also set: LOCAL_MOUNT_POINTS=/disk1,/home)
 
-      # Optional: Docker container management in backup scripts
-      # Required for stopping/starting containers during backups
+      # Optional: Docker container management in backup scripts.
+      # Direct socket access is simple but gives Borg UI broad host-level
+      # Docker control. For a reduced app-container surface, remove/comment
+      # this mount, start the docker-socket-proxy profile below, and set
+      # DOCKER_HOST=tcp://docker-socket-proxy:2375 in the app environment.
       # See: docs/docker-hooks.md
       - /var/run/docker.sock:/var/run/docker.sock:rw
 
@@ -83,6 +86,12 @@ services:
       # Sub-path for reverse proxy deployment (e.g., /borg-ui)
       # Leave empty or unset for root deployment. See docs/reverse-proxy.md for NGINX config.
       # - BASE_PATH=/borg-ui
+
+      # Docker socket proxy alternative for backup hook scripts:
+      # 1. Remove/comment the /var/run/docker.sock app volume above.
+      # 2. Start with: docker compose --profile docker-socket-proxy up -d
+      # 3. Uncomment this so hook scripts use the proxy instead of a socket mount.
+      # - DOCKER_HOST=tcp://docker-socket-proxy:2375
 
       # Borg operation timeouts in seconds (uncomment to customize for large repos)
       # Increase these for very large repositories with long cache build times
@@ -160,6 +169,35 @@ services:
       timeout: 3s
       retries: 3
       start_period: 10s
+
+    networks:
+      - borg_network
+
+  docker-socket-proxy:
+    image: ghcr.io/tecnativa/docker-socket-proxy:0.4.2
+    container_name: borg-docker-socket-proxy
+    profiles: ["docker-socket-proxy"]
+    restart: unless-stopped
+    privileged: true
+
+    # Keep this service internal to the Compose network. Do not publish port
+    # 2375 to the host or internet.
+    expose:
+      - "2375"
+
+    environment:
+      # Minimal permissions for typical hook scripts that run docker ps,
+      # docker stop/start, or docker restart. Disable anything your scripts
+      # do not need.
+      - CONTAINERS=1
+      - INFO=1
+      - POST=1
+      - ALLOW_START=1
+      - ALLOW_STOP=1
+      - ALLOW_RESTARTS=1
+
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
 
     networks:
       - borg_network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,8 +59,9 @@ services:
       # Optional: Docker container management in backup scripts.
       # Direct socket access is simple but gives Borg UI broad host-level
       # Docker control. For a reduced app-container surface, remove/comment
-      # this mount, start the docker-socket-proxy profile below, and set
-      # DOCKER_HOST=tcp://docker-socket-proxy:2375 in the app environment.
+      # this mount, uncomment the docker-socket-proxy service sample below,
+      # start the docker-socket-proxy profile, and set DOCKER_HOST in the app
+      # environment.
       # See: docs/docker-hooks.md
       - /var/run/docker.sock:/var/run/docker.sock:rw
 
@@ -89,8 +90,9 @@ services:
 
       # Docker socket proxy alternative for backup hook scripts:
       # 1. Remove/comment the /var/run/docker.sock app volume above.
-      # 2. Start with: docker compose --profile docker-socket-proxy up -d
-      # 3. Uncomment this so hook scripts use the proxy instead of a socket mount.
+      # 2. Uncomment the docker-socket-proxy service sample below.
+      # 3. Start with: docker compose --profile docker-socket-proxy up -d
+      # 4. Uncomment this so hook scripts use the proxy instead of a socket mount.
       # - DOCKER_HOST=tcp://docker-socket-proxy:2375
 
       # Borg operation timeouts in seconds (uncomment to customize for large repos)
@@ -173,34 +175,35 @@ services:
     networks:
       - borg_network
 
-  docker-socket-proxy:
-    image: ghcr.io/tecnativa/docker-socket-proxy:0.4.2
-    container_name: borg-docker-socket-proxy
-    profiles: ["docker-socket-proxy"]
-    restart: unless-stopped
-    privileged: true
-
-    # Keep this service internal to the Compose network. Do not publish port
-    # 2375 to the host or internet.
-    expose:
-      - "2375"
-
-    environment:
-      # Minimal permissions for typical hook scripts that run docker ps,
-      # docker stop/start, or docker restart. Disable anything your scripts
-      # do not need.
-      - CONTAINERS=1
-      - INFO=1
-      - POST=1
-      - ALLOW_START=1
-      - ALLOW_STOP=1
-      - ALLOW_RESTARTS=1
-
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-
-    networks:
-      - borg_network
+  # Uncomment this service to run a Docker socket proxy for backup hook scripts.
+  # docker-socket-proxy:
+  #   image: ghcr.io/tecnativa/docker-socket-proxy:0.4.2
+  #   container_name: borg-docker-socket-proxy
+  #   profiles: ["docker-socket-proxy"]
+  #   restart: unless-stopped
+  #   privileged: true
+  #
+  #   # Keep this service internal to the Compose network. Do not publish port
+  #   # 2375 to the host or internet.
+  #   expose:
+  #     - "2375"
+  #
+  #   environment:
+  #     # Minimal permissions for typical hook scripts that run docker ps,
+  #     # docker stop/start, or docker restart. Disable anything your scripts
+  #     # do not need.
+  #     - CONTAINERS=1
+  #     - INFO=1
+  #     - POST=1
+  #     - ALLOW_START=1
+  #     - ALLOW_STOP=1
+  #     - ALLOW_RESTARTS=1
+  #
+  #   volumes:
+  #     - /var/run/docker.sock:/var/run/docker.sock:ro
+  #
+  #   networks:
+  #     - borg_network
 
 networks:
   borg_network:

--- a/docs/docker-hooks.md
+++ b/docs/docker-hooks.md
@@ -1,10 +1,14 @@
 # Docker Hooks
 
-Borg UI can run pre-backup and post-backup scripts. If the Docker socket is mounted, those scripts can stop, start, inspect, or restart containers.
+Borg UI can run pre-backup and post-backup scripts. If the Docker CLI is configured inside the Borg UI container, those scripts can stop, start, inspect, or restart containers.
 
 Use this only when you need consistent backups of stateful containers.
 
 ## Enable Docker Access
+
+Use one of these patterns.
+
+### Direct Socket Mount
 
 Add the Docker socket to the Borg UI container:
 
@@ -15,9 +19,44 @@ volumes:
 
 This gives the Borg UI container control over the host Docker daemon. Treat it as host-level access.
 
+### Docker Socket Proxy
+
+To avoid mounting the Docker socket into the Borg UI app container, run a Docker socket proxy such as [Tecnativa/docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy) on the same Docker network and point the app container's Docker CLI at it:
+
+```yaml
+services:
+  app:
+    environment:
+      - DOCKER_HOST=tcp://docker-socket-proxy:2375
+    # Remove the /var/run/docker.sock mount from the app service when using this.
+
+  docker-socket-proxy:
+    image: ghcr.io/tecnativa/docker-socket-proxy:0.4.2
+    profiles: ["docker-socket-proxy"]
+    restart: unless-stopped
+    privileged: true
+    environment:
+      - CONTAINERS=1
+      - INFO=1
+      - POST=1
+      - ALLOW_START=1
+      - ALLOW_STOP=1
+      - ALLOW_RESTARTS=1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+```
+
+Start that profile with:
+
+```bash
+docker compose --profile docker-socket-proxy up -d
+```
+
+The proxy container still mounts the host socket, but Borg UI talks to the proxy over `DOCKER_HOST=tcp://docker-socket-proxy:2375` instead of mounting the socket directly. Keep the proxy on an internal Docker network only. Do not publish port `2375` to the host or internet.
+
 ## Docker CLI
 
-The socket exposes the Docker daemon, but scripts still need the `docker` command inside the Borg UI container.
+The socket or socket proxy exposes the Docker daemon, but scripts still need the `docker` command inside the Borg UI container.
 
 If a hook fails with `docker: command not found`, install `docker.io` from:
 
@@ -108,6 +147,8 @@ Then back up `/local/db-dumps`.
 ## Security Rules
 
 - Do not mount the Docker socket unless hooks need it.
+- Prefer a Docker socket proxy when hooks only need a limited Docker API surface.
+- If you use a socket proxy, expose only the API sections required by your scripts and keep port `2375` private to the Docker network.
 - Do not run unreviewed scripts.
 - Use repository-specific parameters for container names.
 - Keep scripts idempotent.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -314,7 +314,7 @@ volumes:
   - /var/run/docker.sock:/var/run/docker.sock:rw
 ```
 
-This grants powerful host access to the Borg UI container. See [Docker Hooks](docker-hooks).
+This grants powerful host access to the Borg UI container. You can avoid mounting the socket into the app container by running a Docker socket proxy and setting `DOCKER_HOST=tcp://docker-socket-proxy:2375` for Borg UI instead. See [Docker Hooks](docker-hooks).
 
 ## Optional FUSE Access
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -41,7 +41,7 @@ volumes:
   - /var/run/docker.sock:/var/run/docker.sock:rw
 ```
 
-Do not mount it for normal backups.
+Do not mount it for normal backups. If hook scripts only need limited Docker container actions, prefer a Docker socket proxy and set Borg UI's Docker CLI endpoint with `DOCKER_HOST=tcp://docker-socket-proxy:2375`.
 
 ## Authentication Modes
 

--- a/tests/unit/test_docker_socket_proxy_docs.py
+++ b/tests/unit/test_docker_socket_proxy_docs.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_docker_hooks_docs_explain_socket_proxy_option() -> None:
+    docs = (ROOT / "docs" / "docker-hooks.md").read_text()
+
+    assert "docker-socket-proxy" in docs
+    assert "DOCKER_HOST=tcp://docker-socket-proxy:2375" in docs
+    assert "Tecnativa/docker-socket-proxy" in docs
+
+
+def test_compose_file_points_hook_users_to_socket_proxy_option() -> None:
+    compose = (ROOT / "docker-compose.yml").read_text()
+
+    assert "docker-socket-proxy" in compose
+    assert "DOCKER_HOST=tcp://docker-socket-proxy:2375" in compose

--- a/tests/unit/test_docker_socket_proxy_docs.py
+++ b/tests/unit/test_docker_socket_proxy_docs.py
@@ -17,3 +17,6 @@ def test_compose_file_points_hook_users_to_socket_proxy_option() -> None:
 
     assert "docker-socket-proxy" in compose
     assert "DOCKER_HOST=tcp://docker-socket-proxy:2375" in compose
+    assert "\n  docker-socket-proxy:" not in compose
+    assert "\n  # docker-socket-proxy:" in compose
+    assert "Uncomment this service" in compose


### PR DESCRIPTION
## Description
Documented Docker socket proxy support for backup hook scripts. The app already passes `DOCKER_HOST` through to hook execution, so this PR adds the missing operator guidance: direct socket mount versus socket proxy, a commented optional `docker-socket-proxy` Compose service sample, and security notes for keeping port 2375 internal.

## Related Issue
Fixes #77
Related Linear ticket: BOR-50

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `git diff --check`
- `ruff check app tests`
- `ruff format --check app tests`
- `pytest tests/unit/test_docker_socket_proxy_docs.py tests/unit/test_script_executor.py::TestScriptExecutor::test_environment_variables -q`
- `docker compose config`
- `docker compose --profile docker-socket-proxy config`

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; this is a documentation and Compose configuration change.

## Additional Context
The implementation keeps Borg UI application behavior unchanged. The current script executor already inherits the app container environment, which allows hook scripts to use `DOCKER_HOST=tcp://docker-socket-proxy:2375` when operators configure that endpoint. The packaged Compose file keeps the proxy service commented so operators opt in by uncommenting the sample.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
