### PR TITLE
Move backup cache guidance to troubleshooting

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -16,6 +16,7 @@ export default defineConfig({
   title: 'Borg Web UI',
   description: 'A modern web interface for Borg Backup management',
   cleanUrls: true,
+  srcExclude: ['engineering/**', 'superpowers/**'],
   lastUpdated: true,
   appearance: 'dark',
   head: [['link', { rel: 'icon', href: withBase('/favicon.png') }]],
@@ -75,6 +76,7 @@ export default defineConfig({
       {
         text: 'Operations',
         items: [
+          { text: 'Troubleshooting', link: '/troubleshooting' },
           { text: 'Disaster Recovery', link: '/disaster-recovery' },
           { text: 'Export and Import', link: '/export-import' },
           { text: 'Script Parameters', link: '/script-parameters' },

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -15,7 +15,7 @@ There are two separate caches involved in normal Docker deployments:
 - Borg UI archive cache: Redis or the in-memory fallback used by archive browsing.
 - Borg files cache: Borg's own cache under `/home/borg/.cache/borg`, used by `borg create` to avoid reprocessing unchanged files during backups.
 
-Redis does not make backup creation faster. If backup jobs are slow after a container pull or restart, troubleshoot the Borg files cache and source mounts first.
+Redis does not make backup creation faster. If backup jobs are slow after a container pull or restart, troubleshoot the Borg files cache and source mounts first. See [Slow first backup after a pull or restart](troubleshooting#slow-first-backup-after-a-pull-or-restart).
 
 ## Backends
 
@@ -155,22 +155,9 @@ Expected for very large archives. Cache helps repeated browsing; it does not rem
 
 ### Slow first backup after a pull or restart
 
-`docker compose pull` does not remove Docker volumes or bind mounts by itself. A backup that is slow only for the first run after a container update usually means Borg could not fully reuse its files cache for that run.
+This is usually a Borg files cache or source mount stability issue, not a Redis archive cache issue. See [Slow first backup after a pull or restart](troubleshooting#slow-first-backup-after-a-pull-or-restart).
 
-Check these items:
+## Related
 
-- Keep `/home/borg/.cache/borg` mounted to persistent storage. A named volume such as `borg_cache:/home/borg/.cache/borg` or a stable host bind mount such as `./cache:/home/borg/.cache/borg` is fine.
-- Keep source directories mounted at the same container paths. Borg's files cache uses absolute filenames, so changing `/local/photos` to `/photos`, or moving the same host path between container paths, can make a later backup behave like a first scan.
-- Make sure the cache is writable by the configured `PUID` and `PGID`. Permission problems can prevent Borg from updating or reading cache state.
-- If the source path is an SSHFS, FUSE, network, or removable-drive mount with unstable inode numbers, Borg's default files-cache mode can treat unchanged files as modified. In that case, set repository custom Borg flags to a mode that ignores inode numbers, for example `--files-cache=mtime,size`. Use this only when you understand the reduced change-detection safety for that filesystem.
-- After an image update that changes the bundled Borg version, the first backup may need extra cache validation or rebuild work. Later runs should speed up again if the cache volume and source mount paths stay stable.
-
-Useful checks from the Docker host:
-
-```bash
-docker exec borg-web-ui sh -lc 'id borg && ls -ld /home/borg/.cache/borg'
-docker exec borg-web-ui sh -lc 'find /home/borg/.cache/borg -maxdepth 2 -type f | head'
-docker compose ps redis
-```
-
-If Redis restarted, archive browsing cache is cold, but that should not by itself slow `borg create` backup jobs.
+- [Troubleshooting](troubleshooting)
+- [Installation](installation)

--- a/docs/docker-hooks.md
+++ b/docs/docker-hooks.md
@@ -57,8 +57,7 @@ The proxy container still mounts the host socket, but Borg UI talks to the proxy
 ## Docker CLI
 
 The socket or socket proxy exposes the Docker daemon, but scripts still need the `docker` command inside the Borg UI container.
-
-If a hook fails with `docker: command not found`, install `docker.io` from:
+Install `docker.io` from:
 
 ```text
 Settings > System > Packages
@@ -126,8 +125,6 @@ if docker ps -a --format '{{.Names}}' | grep -qx "$container"; then
 fi
 ```
 
-Use a post-backup hook that runs on failure as well as success if the pre-backup hook stops a service.
-
 ## Safer Pattern
 
 Prefer application-native dump commands when possible.
@@ -154,8 +151,21 @@ Then back up `/local/db-dumps`.
 - Keep scripts idempotent.
 - Make post-backup cleanup run on failure.
 
+## Troubleshooting
+
+### docker: command not found
+
+Install `docker.io` from Settings > System > Packages, or use a custom image
+that includes the Docker CLI.
+
+### Container stays stopped after a backup failure
+
+Use a post-backup hook that runs on failure as well as success if the pre-backup
+hook stops a service.
+
 ## Related
 
+- [Troubleshooting](troubleshooting)
 - [Script Parameters](script-parameters)
 - [Installation](installation)
 - [Security](security)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -361,10 +361,11 @@ docker compose up -d
 
 Do not delete `borg_data` or `borg_cache` unless you intentionally want to remove application state or Borg cache data.
 
-If the first backup after an image pull or container recreate is slower than later backups, check the Borg files cache and source mount stability. Pulling the image does not erase mounted cache data, but Borg may need to rebuild or revalidate cache entries when the cache mount is missing, permissions changed, source paths changed, inode numbers are unstable, or the bundled Borg version changed. See [Slow first backup after a pull or restart](cache#slow-first-backup-after-a-pull-or-restart).
+If the first backup after an image pull or container recreate is slower than later backups, see [Slow first backup after a pull or restart](troubleshooting#slow-first-backup-after-a-pull-or-restart).
 
 ## Next
 
 - [Usage Guide](usage-guide)
 - [Configuration](configuration)
+- [Troubleshooting](troubleshooting)
 - [Security](security)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,102 @@
+---
+title: Troubleshooting
+nav_order: 8
+description: "Common Borg UI troubleshooting checks"
+---
+
+# Troubleshooting
+
+Use this page for issues that cross installation, Docker, cache, paths, and
+repository operations. Feature-specific pages still keep focused
+troubleshooting sections for that feature.
+
+## Docker and Backup Performance
+
+### Slow first backup after a pull or restart
+
+`docker compose pull` and container recreates do not remove Docker volumes or
+bind mounts by themselves. A backup that is slow only for the first run after a
+container update usually means Borg could not fully reuse its files cache for
+that run.
+
+Keep the two cache layers separate when troubleshooting:
+
+- Borg UI archive cache: Redis or the in-memory fallback used by archive
+  browsing.
+- Borg files cache: Borg's own cache under `/home/borg/.cache/borg`, used by
+  `borg create` to avoid reprocessing unchanged files during backups.
+
+Redis does not make backup creation faster. If Redis restarted, archive
+browsing cache is cold, but that should not by itself slow `borg create`
+backup jobs.
+
+Check these items:
+
+- Keep `/home/borg/.cache/borg` mounted to persistent storage. A named volume
+  such as `borg_cache:/home/borg/.cache/borg` or a stable host bind mount such
+  as `./cache:/home/borg/.cache/borg` is fine.
+- Keep source directories mounted at the same container paths. Borg's files
+  cache uses absolute filenames, so changing `/local/photos` to `/photos`, or
+  moving the same host path between container paths, can make a later backup
+  behave like a first scan.
+- Make sure the cache is writable by the configured `PUID` and `PGID`.
+  Permission problems can prevent Borg from updating or reading cache state.
+- If the source path is an SSHFS, FUSE, network, or removable-drive mount with
+  unstable inode numbers, Borg's default files-cache mode can treat unchanged
+  files as modified. In that case, set repository custom Borg flags to a mode
+  that ignores inode numbers, for example `--files-cache=mtime,size`. Use this
+  only when you understand the reduced change-detection safety for that
+  filesystem.
+- After an image update that changes the bundled Borg version, the first backup
+  may need extra cache validation or rebuild work. Later runs should speed up
+  again if the cache volume and source mount paths stay stable.
+
+Useful checks from the Docker host:
+
+```bash
+docker exec borg-web-ui sh -lc 'id borg && ls -ld /home/borg/.cache/borg'
+docker exec borg-web-ui sh -lc 'find /home/borg/.cache/borg -maxdepth 2 -type f | head'
+docker compose ps redis
+```
+
+## Paths and Permissions
+
+### Permission denied
+
+Set `PUID` and `PGID` to match the host user that should own restored files and
+write backup repositories. Also confirm the host path is mounted read/write
+when Borg UI needs to write to it.
+
+### Path not found
+
+Check the Docker volume mapping and use the container path, not the host path.
+For example, if `/mnt/usb-drive` is mounted as `/local`, use `/local/...`
+inside Borg UI.
+
+If you mount a different container path, include it in `LOCAL_MOUNT_POINTS` so
+the file browser exposes the path.
+
+## Repository Operations
+
+### Repository locked
+
+Do not break locks blindly. First confirm no backup, restore, check, prune,
+compact, mount, or external Borg process is using the repository.
+
+Break the lock only when you are certain the previous Borg process is gone.
+
+### Slow archive browsing
+
+The first browse of a large archive can be slow because Borg has to list archive
+contents. Make sure Redis is running for repeated browsing and see
+[Cache](cache).
+
+## More Troubleshooting
+
+- [Authentication and SSO](authentication#troubleshooting)
+- [Cache](cache#troubleshooting)
+- [Docker Hooks](docker-hooks#troubleshooting)
+- [Metrics](METRICS#troubleshooting)
+- [Mounting Archives](mounting#troubleshooting)
+- [Notifications](notifications#troubleshooting)
+- [Remote Machines](ssh-keys#troubleshooting)

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -269,18 +269,10 @@ Admins can delete supported job entries and associated log files. This removes U
 
 ## Troubleshooting
 
-### Permission denied
+Common path, permission, lock, and archive-browsing issues are covered on the
+[Troubleshooting](troubleshooting) page:
 
-Set `PUID` and `PGID` to match the host user that owns the mounted files.
-
-### Path not found
-
-Check the Docker volume mapping and use the container path, not the host path.
-
-### Repository locked
-
-Do not break locks blindly. First confirm no backup, restore, check, prune, compact, mount, or external Borg process is using the repository.
-
-### Slow archive browsing
-
-The first browse of a large archive can be slow. Make sure Redis is running and see [Cache](cache).
+- [Permission denied](troubleshooting#permission-denied)
+- [Path not found](troubleshooting#path-not-found)
+- [Repository locked](troubleshooting#repository-locked)
+- [Slow archive browsing](troubleshooting#slow-archive-browsing)


### PR DESCRIPTION
## Description
- Added a global Troubleshooting page for cross-cutting Docker, cache, path, permission, and repository-lock issues.
- Moved the slow first backup guidance out of the Cache details into the new troubleshooting page while preserving Redis archive cache vs Borg files cache guidance.
- Linked Installation and Cache to the new troubleshooting anchor and added a Docker Hooks troubleshooting section.
- Excluded internal engineering and superpowers work notes from the public VitePress source set so docs builds validate the published docs pages.

## Related Issue
- Linear BOR-51: https://linear.app/nullcodeai/issue/BOR-51/move-docker-backup-cache-guidance-to-a-troubleshooting-page

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable; docs-only change)
- [ ] All existing tests pass (not run; docs-only change)

Validation run:
- `git diff --check`
- `cd docs && npm run build`

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (not applicable; docs-only change)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes (not run; docs-only change)

## Screenshots (if applicable)
Not applicable; documentation-only change.

## Additional Context
The docs build initially failed because VitePress traversed unlinked internal engineering notes with repo-relative code links. The PR excludes those internal note directories from the public docs source set and keeps the sidebar focused on user-facing docs.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.