### PR TITLE
docs: document rootless Podman permissions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,11 @@ What they mean:
 - `/home/borg/.cache/borg`: Borg cache. Keep it for performance.
 - `/local`: host data exposed to Borg UI for local backups and repositories.
 
+Borg UI may update ownership for app-managed paths such as `/data`, `/backups`,
+`/home/borg`, and Borg's cache. It does not chown source bind mounts such as
+`/local`; make sure the configured runtime user can read the host source path
+before starting backups.
+
 If you mount a different container path, update `LOCAL_MOUNT_POINTS`.
 
 Example:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -290,6 +290,44 @@ LOCAL_STORAGE_PATH=/mnt/usb-drive
 TZ=America/Chicago
 ```
 
+### Rootless Podman
+
+Rootless Podman maps container users differently from Docker. In a typical
+rootless Podman container, UID 0 inside the container maps to the host user
+running `podman`, while non-root container users map to a subordinate UID/GID
+range. If a bind-mounted source such as `/local` appears as `root:nogroup` in
+the container and the default `borg` user cannot read it, run Borg UI as
+container root:
+
+```bash
+podman run -d \
+  --name borg-web-ui \
+  -p 8081:8081 \
+  -e PUID=0 \
+  -e PGID=0 \
+  -e REDIS_HOST=disabled \
+  -v borg_data:/data \
+  -v borg_cache:/home/borg/.cache/borg \
+  -v "$HOME/ofl-w:/local:ro,Z" \
+  -v "$HOME/bk:/backups:rw,Z" \
+  ainullcode/borg-ui:latest
+```
+
+With rootless Podman, `PUID=0` and `PGID=0` mean container root, not host root.
+That container root is mapped back to the user that started Podman, so it can
+read that user's bind-mounted files without giving the container host-root
+privileges.
+
+Use `:Z` for private SELinux labels, or `:z` if the same host path is shared
+with multiple containers. Omit the label option on hosts that do not use
+SELinux.
+
+Do not fix source path access by changing ownership of `/local` from inside
+the container. Borg UI does not chown source bind mounts such as `/local`
+because they are user data, may be read-only, and may be shared with other host
+processes. It only adjusts ownership for app-managed paths such as `/data`,
+`/backups`, `/home/borg`, and Borg's cache.
+
 ## Redis
 
 Redis is used as an archive-browsing cache. It is not required for backups or restores.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -67,6 +67,17 @@ Set `PUID` and `PGID` to match the host user that should own restored files and
 write backup repositories. Also confirm the host path is mounted read/write
 when Borg UI needs to write to it.
 
+For rootless Podman, if a source bind mount such as `/local` appears as
+`root:nogroup` and the default non-root `borg` user cannot read it, set
+`PUID=0` and `PGID=0`. In rootless Podman, container root maps to the host user
+running `podman`, not to host root. If SELinux is enforcing, add `:Z` to private
+bind mounts or `:z` to shared bind mounts.
+
+Borg UI does not chown source bind mounts such as `/local`. Changing ownership
+from inside the container can modify user data on the host and can fail for
+read-only mounts. Fix access with host permissions, runtime UID/GID mapping, or
+the rootless Podman `PUID=0` / `PGID=0` mode above.
+
 ### Path not found
 
 Check the Docker volume mapping and use the container path, not the host path.

--- a/tests/unit/test_container_runtime_docs.py
+++ b/tests/unit/test_container_runtime_docs.py
@@ -5,9 +5,9 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_rootless_podman_permissions_are_documented() -> None:
-    installation = (ROOT / "docs" / "installation.md").read_text()
-    troubleshooting = (ROOT / "docs" / "troubleshooting.md").read_text()
-    configuration = (ROOT / "docs" / "configuration.md").read_text()
+    installation = (ROOT / "docs" / "installation.md").read_text(encoding="utf-8")
+    troubleshooting = (ROOT / "docs" / "troubleshooting.md").read_text(encoding="utf-8")
+    configuration = (ROOT / "docs" / "configuration.md").read_text(encoding="utf-8")
     combined_docs = "\n".join([installation, troubleshooting, configuration])
 
     assert "Rootless Podman" in installation

--- a/tests/unit/test_container_runtime_docs.py
+++ b/tests/unit/test_container_runtime_docs.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_rootless_podman_permissions_are_documented() -> None:
+    installation = (ROOT / "docs" / "installation.md").read_text()
+    troubleshooting = (ROOT / "docs" / "troubleshooting.md").read_text()
+    configuration = (ROOT / "docs" / "configuration.md").read_text()
+    combined_docs = "\n".join([installation, troubleshooting, configuration])
+
+    assert "Rootless Podman" in installation
+    assert "PUID=0" in combined_docs
+    assert "PGID=0" in combined_docs
+    assert "/local" in combined_docs
+    assert "source bind mounts" in combined_docs
+    assert "does not chown" in combined_docs
+    assert ":Z" in combined_docs or ":z" in combined_docs


### PR DESCRIPTION
## Description
Document the supported rootless Podman permissions path for local source bind mounts. The docs now explain why Borg UI does not chown source bind mounts such as /local, when to use PUID=0 and PGID=0 with rootless Podman, and how SELinux :Z/:z labels apply.

## Related Issue
Fixes #102

Linear: BOR-55

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] UI/UX improvement
- [x] Test addition/improvement
- [ ] Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass

Validation run:
- `ruff check app tests`
- `ruff format --check app tests`
- `pytest tests/unit/test_container_runtime_docs.py -q`
- `git diff --check origin/main...HEAD`

A broader `pytest tests/unit -v` run was attempted before the first push and manually interrupted after 120 tests passed in about 4m51s because it was too slow for this docs-only change. GitHub Actions completed Backend / Unit Tests successfully on the latest commit.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; docs-only change.

## Additional Context
This addresses the GitHub issue's Podman-specific permission confusion without changing runtime ownership behavior. Chowning /local from inside the container would be unsafe for read-only mounts and host-owned source data. CodeRabbit's encoding nitpick was addressed in the docs regression test.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.