### PR TITLE
Fix managed agent Borg 2 installation

### DIFF
--- a/app/api/agent_installer.py
+++ b/app/api/agent_installer.py
@@ -121,11 +121,25 @@ install -d -o borg-ui-agent -g borg-ui-agent -m 0750 /var/lib/borg-ui-agent
 verify_borg_major() {
   local binary_name="$1"
   local expected_major="$2"
-  local binary_path output major
+  local binary_path
 
   binary_path="$(command -v "${binary_name}" 2>/dev/null || true)"
   if [[ -z "${binary_path}" ]]; then
     echo "Required Borg binary '${binary_name}' was not found." >&2
+    return 1
+  fi
+
+  verify_borg_path "${binary_path}" "${binary_name}" "${expected_major}"
+}
+
+verify_borg_path() {
+  local binary_path="$1"
+  local binary_name="$2"
+  local expected_major="$3"
+  local output major
+
+  if [[ ! -x "${binary_path}" ]]; then
+    echo "Required Borg binary '${binary_name}' was not executable at ${binary_path}." >&2
     return 1
   fi
 
@@ -162,6 +176,14 @@ install_borg2() {
     exit 1
   fi
 
+  if [[ -x "${BORG2_VENV}/bin/borg" ]]; then
+    echo "Existing Borg 2 virtualenv detected; linking without reinstalling."
+    verify_borg_path "${BORG2_VENV}/bin/borg" "borg2" "2"
+    ln -s "${BORG2_VENV}/bin/borg" "${BORG2_LINK}"
+    verify_borg_major "borg2" "2"
+    return
+  fi
+
   apt-get install -y \
     build-essential \
     libacl1-dev \
@@ -174,7 +196,7 @@ install_borg2() {
 
   python3 -m venv "${BORG2_VENV}"
   "${BORG2_VENV}/bin/python" -m pip install --upgrade pip wheel
-  "${BORG2_VENV}/bin/pip" install --pre "borgbackup>=2,<3"
+  "${BORG2_VENV}/bin/pip" install --pre "borgbackup>=2.0.0b1,<3"
   ln -s "${BORG2_VENV}/bin/borg" "${BORG2_LINK}"
   verify_borg_major "borg2" "2"
 }

--- a/tests/unit/test_agent_installer_api.py
+++ b/tests/unit/test_agent_installer_api.py
@@ -27,6 +27,28 @@ def test_agent_installer_script_supports_borg_install_modes(test_client: TestCli
     assert 'verify_borg_major "borg2" "2"' in response.text
 
 
+def test_agent_installer_script_allows_borg2_prereleases(test_client: TestClient):
+    response = test_client.get("/agent/install.sh")
+
+    assert (
+        '"${BORG2_VENV}/bin/pip" install --pre "borgbackup>=2.0.0b1,<3"'
+        in response.text
+    )
+    assert '"borgbackup>=2,<3"' not in response.text
+
+
+def test_agent_installer_script_reuses_existing_borg2_venv(
+    test_client: TestClient,
+):
+    response = test_client.get("/agent/install.sh")
+
+    assert 'if [[ -x "${BORG2_VENV}/bin/borg" ]]; then' in response.text
+    assert "Existing Borg 2 virtualenv detected; linking without reinstalling." in (
+        response.text
+    )
+    assert 'ln -s "${BORG2_VENV}/bin/borg" "${BORG2_LINK}"' in response.text
+
+
 def test_agent_installer_script_keeps_agent_ref_separate_from_os_release(
     test_client: TestClient,
 ):


### PR DESCRIPTION
## Description
Fixes managed-agent Borg 2 installation when `--borg-version 2` or `--borg-version both` is selected. The installer now uses an explicit Borg 2 beta lower bound so pip can resolve the available `2.0.0b*` releases, and it reuses an already-created installer Borg 2 virtualenv before repeating apt/build/pip work.

## Related Issue
BOR-63: https://linear.app/nullcodeai/issue/BOR-63/agent-installation-is-broken

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `pytest tests/unit/test_agent_installer_api.py -q`
- `ruff check app tests`
- `ruff format --check app tests`
- served installer router proof that verifies `borgbackup>=2.0.0b1,<3`, rejects the old `borgbackup>=2,<3`, confirms `2.0.0b21` matches the new spec, and passes `bash -n`
- `git diff --check`

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Code is self-explanatory; no additional comments were needed
- [x] Documentation changes are not required for this installer bug fix
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; this is a backend installer script fix.

## Additional Context
The root cause was the version specifier, not the missing `--pre` flag. `borgbackup>=2,<3` excludes `2.0.0b*` prereleases because they are lower than the final `2.0.0`; `borgbackup>=2.0.0b1,<3` includes the current Borg 2 beta releases.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
