### PR TITLE
Plan rclone storage integration

### DIFF
--- a/docs/engineering/mockups/2026-05-24-rclone-storage-integration.html
+++ b/docs/engineering/mockups/2026-05-24-rclone-storage-integration.html
@@ -140,7 +140,7 @@
         padding: 9px 12px;
         font-weight: 650;
         font-size: 14px;
-        cursor: default;
+        cursor: pointer;
         display: inline-flex;
         align-items: center;
         gap: 8px;
@@ -341,7 +341,7 @@
         font-size: 12px;
         color: var(--muted);
         font-weight: 700;
-        cursor: default;
+        cursor: pointer;
       }
 
       .segment.active {

--- a/docs/engineering/mockups/2026-05-24-rclone-storage-integration.html
+++ b/docs/engineering/mockups/2026-05-24-rclone-storage-integration.html
@@ -662,14 +662,17 @@
                     <input id="provider" value="S3-compatible storage" />
                   </div>
                   <div class="field full">
-                    <label for="remote-path">Remote repository path</label>
+                    <label for="remote-path"
+                      >Remote repository path inside remote</label
+                    >
                     <input
                       id="remote-path"
                       class="mono"
-                      value="prod-s3:borg-ui/repositories/production-app"
+                      value="borg-ui/repositories/production-app"
                     />
                     <p class="helper">
-                      This path is reserved for one Borg repository mirror.
+                      Stored as a path inside the selected remote. Full target:
+                      prod-s3:borg-ui/repositories/production-app.
                     </p>
                   </div>
                   <div class="field full">
@@ -720,7 +723,7 @@
                     >
                   </div>
                   <div class="status-row">
-                    <strong>Rclone mirror</strong>
+                    <strong>Rclone target</strong>
                     <span class="mono"
                       >prod-s3:borg-ui/repositories/production-app</span
                     >
@@ -853,7 +856,7 @@
               <span><span class="chip green">Synced 12 minutes ago</span></span>
             </div>
             <div class="status-row">
-              <strong>Remote</strong>
+              <strong>Remote target</strong>
               <span class="mono"
                 >prod-s3:borg-ui/repositories/production-app</span
               >

--- a/docs/engineering/mockups/2026-05-24-rclone-storage-integration.html
+++ b/docs/engineering/mockups/2026-05-24-rclone-storage-integration.html
@@ -304,7 +304,8 @@
       }
 
       input,
-      select {
+      select,
+      output.readonly {
         width: 100%;
         border: 1px solid var(--line);
         border-radius: 8px;
@@ -333,17 +334,29 @@
 
       .segment {
         text-align: center;
+        border: 0;
         border-radius: 6px;
         padding: 8px 6px;
+        background: transparent;
         font-size: 12px;
         color: var(--muted);
         font-weight: 700;
+        cursor: default;
       }
 
       .segment.active {
         background: #fff;
         color: var(--text);
         box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
+      }
+
+      .segment:focus-visible {
+        outline: 2px solid var(--blue);
+        outline-offset: 2px;
+      }
+
+      output.readonly {
+        display: block;
       }
 
       .notice {
@@ -677,14 +690,12 @@
                   </div>
                   <div class="field full">
                     <label for="cache-path">Local Borg cache path</label>
-                    <input
-                      id="cache-path"
-                      class="mono"
-                      value="/data/rclone-cache/repositories/production-app"
-                    />
+                    <output id="cache-path" class="readonly mono"
+                      >/data/rclone-cache/repositories/production-app</output
+                    >
                     <p class="helper">
-                      Borg reads and writes here before Borg UI mirrors to
-                      rclone.
+                      Server-derived path. Borg reads and writes here before
+                      Borg UI mirrors to rclone.
                     </p>
                   </div>
                   <div class="field full">
@@ -694,9 +705,27 @@
                       role="group"
                       aria-label="Sync policy"
                     >
-                      <div class="segment active">After Borg job</div>
-                      <div class="segment">Manual</div>
-                      <div class="segment">Scheduled</div>
+                      <button
+                        type="button"
+                        class="segment active"
+                        aria-pressed="true"
+                      >
+                        After Borg job
+                      </button>
+                      <button
+                        type="button"
+                        class="segment"
+                        aria-pressed="false"
+                      >
+                        Manual
+                      </button>
+                      <button
+                        type="button"
+                        class="segment"
+                        aria-pressed="false"
+                      >
+                        Scheduled
+                      </button>
                     </div>
                   </div>
                 </div>

--- a/docs/engineering/mockups/2026-05-24-rclone-storage-integration.html
+++ b/docs/engineering/mockups/2026-05-24-rclone-storage-integration.html
@@ -1,0 +1,870 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Borg UI Rclone Storage Mockup</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f8fafc;
+        --surface: #ffffff;
+        --surface-muted: #f1f5f9;
+        --line: #d8e0ea;
+        --line-strong: #9fb0c3;
+        --text: #0f172a;
+        --muted: #64748b;
+        --blue: #2563eb;
+        --blue-soft: #eff6ff;
+        --green: #059669;
+        --green-soft: #ecfdf5;
+        --amber: #b45309;
+        --amber-soft: #fffbeb;
+        --red: #dc2626;
+        --red-soft: #fef2f2;
+        --shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font-family:
+          Inter,
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+        line-height: 1.45;
+      }
+
+      .app {
+        min-height: 100vh;
+        display: grid;
+        grid-template-columns: 236px minmax(0, 1fr);
+      }
+
+      .sidebar {
+        background: #111827;
+        color: #cbd5e1;
+        padding: 20px 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 22px;
+      }
+
+      .brand {
+        color: #fff;
+        font-weight: 700;
+        letter-spacing: 0;
+        font-size: 17px;
+      }
+
+      .nav {
+        display: grid;
+        gap: 4px;
+      }
+
+      .nav a {
+        color: #cbd5e1;
+        text-decoration: none;
+        padding: 9px 10px;
+        border-radius: 8px;
+        font-size: 14px;
+        display: flex;
+        align-items: center;
+        gap: 9px;
+      }
+
+      .nav a.active {
+        color: #fff;
+        background: rgba(255, 255, 255, 0.1);
+      }
+
+      .nav-dot {
+        width: 9px;
+        height: 9px;
+        border-radius: 999px;
+        border: 2px solid currentColor;
+        flex: 0 0 auto;
+      }
+
+      main {
+        min-width: 0;
+        padding: 26px;
+      }
+
+      .topbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        margin-bottom: 18px;
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        margin: 0;
+      }
+
+      h1 {
+        font-size: 24px;
+        letter-spacing: 0;
+      }
+
+      .subtle {
+        color: var(--muted);
+        font-size: 14px;
+      }
+
+      .toolbar {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      button,
+      .button {
+        border: 1px solid var(--line);
+        background: var(--surface);
+        color: var(--text);
+        border-radius: 8px;
+        padding: 9px 12px;
+        font-weight: 650;
+        font-size: 14px;
+        cursor: default;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        white-space: nowrap;
+      }
+
+      .button.primary {
+        background: var(--blue);
+        border-color: var(--blue);
+        color: #fff;
+      }
+
+      .shell {
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        box-shadow: var(--shadow);
+        overflow: hidden;
+      }
+
+      .wizard-head {
+        border-bottom: 1px solid var(--line);
+        padding: 18px 20px;
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+      }
+
+      .steps {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+
+      .step {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        padding: 6px 9px;
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 650;
+      }
+
+      .step.active {
+        color: var(--blue);
+        background: var(--blue-soft);
+        border-color: #bfdbfe;
+      }
+
+      .step.done {
+        color: var(--green);
+        background: var(--green-soft);
+        border-color: #bbf7d0;
+      }
+
+      .wizard-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) 360px;
+        min-height: 680px;
+      }
+
+      .wizard-body {
+        padding: 20px;
+        display: grid;
+        gap: 22px;
+        align-content: start;
+      }
+
+      .side-panel {
+        border-left: 1px solid var(--line);
+        background: #fbfdff;
+        padding: 20px;
+        display: grid;
+        align-content: start;
+        gap: 18px;
+      }
+
+      .section-title {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        margin-bottom: 12px;
+      }
+
+      .section-title h2 {
+        font-size: 16px;
+      }
+
+      .location-grid {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .option {
+        min-height: 132px;
+        border: 1px solid var(--line);
+        background: var(--surface);
+        border-radius: 8px;
+        padding: 14px;
+        display: grid;
+        gap: 10px;
+        align-content: start;
+      }
+
+      .option.selected {
+        border-color: var(--blue);
+        background: var(--blue-soft);
+        box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.15);
+      }
+
+      .option-icon {
+        width: 34px;
+        height: 34px;
+        border-radius: 8px;
+        display: grid;
+        place-items: center;
+        background: var(--surface-muted);
+        color: var(--muted);
+        font-weight: 800;
+      }
+
+      .option.selected .option-icon {
+        background: var(--blue);
+        color: #fff;
+      }
+
+      .option h3 {
+        font-size: 14px;
+      }
+
+      .option p {
+        font-size: 12px;
+        color: var(--muted);
+      }
+
+      .form-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 14px;
+      }
+
+      .field {
+        display: grid;
+        gap: 6px;
+      }
+
+      .field.full {
+        grid-column: 1 / -1;
+      }
+
+      label {
+        font-size: 12px;
+        font-weight: 700;
+        color: #334155;
+      }
+
+      input,
+      select {
+        width: 100%;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 10px 11px;
+        background: #fff;
+        color: var(--text);
+        font: inherit;
+        font-size: 14px;
+      }
+
+      .helper {
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .segmented {
+        border: 1px solid var(--line);
+        background: var(--surface-muted);
+        border-radius: 8px;
+        padding: 3px;
+        display: inline-grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        width: 100%;
+        gap: 3px;
+      }
+
+      .segment {
+        text-align: center;
+        border-radius: 6px;
+        padding: 8px 6px;
+        font-size: 12px;
+        color: var(--muted);
+        font-weight: 700;
+      }
+
+      .segment.active {
+        background: #fff;
+        color: var(--text);
+        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
+      }
+
+      .notice {
+        border: 1px solid #fed7aa;
+        background: var(--amber-soft);
+        color: #7c2d12;
+        border-radius: 8px;
+        padding: 12px;
+        font-size: 13px;
+        display: flex;
+        gap: 10px;
+      }
+
+      .notice.info {
+        border-color: #bfdbfe;
+        background: var(--blue-soft);
+        color: #1e3a8a;
+      }
+
+      .status-list {
+        display: grid;
+        gap: 10px;
+      }
+
+      .status-row {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 11px 12px;
+        background: #fff;
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 12px;
+      }
+
+      .status-row strong {
+        display: block;
+        font-size: 13px;
+      }
+
+      .status-row span {
+        display: block;
+        color: var(--muted);
+        font-size: 12px;
+        margin-top: 2px;
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        border-radius: 999px;
+        padding: 4px 8px;
+        font-size: 12px;
+        font-weight: 700;
+        border: 1px solid var(--line);
+        white-space: nowrap;
+      }
+
+      .chip.green {
+        background: var(--green-soft);
+        border-color: #bbf7d0;
+        color: var(--green);
+      }
+
+      .chip.blue {
+        background: var(--blue-soft);
+        border-color: #bfdbfe;
+        color: var(--blue);
+      }
+
+      .chip.amber {
+        background: var(--amber-soft);
+        border-color: #fde68a;
+        color: var(--amber);
+      }
+
+      .route {
+        display: grid;
+        gap: 8px;
+      }
+
+      .route-item {
+        border: 1px solid var(--line);
+        background: #fff;
+        border-radius: 8px;
+        padding: 10px;
+        display: flex;
+        gap: 9px;
+        align-items: center;
+      }
+
+      .route-index {
+        width: 24px;
+        height: 24px;
+        border-radius: 999px;
+        background: var(--surface-muted);
+        display: grid;
+        place-items: center;
+        color: #334155;
+        font-size: 12px;
+        font-weight: 800;
+        flex: 0 0 auto;
+      }
+
+      .route-item strong {
+        display: block;
+        font-size: 13px;
+      }
+
+      .route-item span {
+        display: block;
+        color: var(--muted);
+        font-size: 12px;
+        margin-top: 1px;
+      }
+
+      .summary {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+      }
+
+      .summary .status-row {
+        display: block;
+      }
+
+      .repo-card {
+        margin-top: 22px;
+        border: 1px solid var(--line);
+        background: #fff;
+        border-radius: 8px;
+        padding: 16px;
+        display: grid;
+        gap: 14px;
+      }
+
+      .repo-head {
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        align-items: start;
+      }
+
+      .repo-head h2 {
+        font-size: 16px;
+      }
+
+      .repo-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .button.small {
+        padding: 7px 9px;
+        font-size: 12px;
+      }
+
+      .mono {
+        font-family:
+          "SFMono-Regular", Consolas, "Liberation Mono", Menlo, ui-monospace,
+          monospace;
+      }
+
+      @media (max-width: 1180px) {
+        .location-grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+
+        .wizard-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .side-panel {
+          border-left: 0;
+          border-top: 1px solid var(--line);
+        }
+      }
+
+      @media (max-width: 760px) {
+        .app {
+          grid-template-columns: 1fr;
+        }
+
+        .sidebar {
+          display: none;
+        }
+
+        main {
+          padding: 16px;
+        }
+
+        .topbar,
+        .wizard-head,
+        .repo-head {
+          align-items: stretch;
+          flex-direction: column;
+        }
+
+        .toolbar,
+        .repo-actions {
+          width: 100%;
+        }
+
+        .toolbar .button,
+        .repo-actions .button {
+          justify-content: center;
+          flex: 1;
+        }
+
+        .location-grid,
+        .form-grid,
+        .summary {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar">
+        <div class="brand">Borg UI</div>
+        <nav class="nav" aria-label="Main">
+          <a href="#"><span class="nav-dot"></span>Dashboard</a>
+          <a href="#"><span class="nav-dot"></span>Backup Plans</a>
+          <a class="active" href="#"
+            ><span class="nav-dot"></span>Repositories</a
+          >
+          <a href="#"><span class="nav-dot"></span>Remote Machines</a>
+          <a href="#"><span class="nav-dot"></span>Managed Agents</a>
+          <a href="#"><span class="nav-dot"></span>Settings</a>
+        </nav>
+      </aside>
+
+      <main>
+        <header class="topbar">
+          <div>
+            <h1>Repositories</h1>
+            <p class="subtle">
+              Storage targets, archive health, and maintenance
+            </p>
+          </div>
+          <div class="toolbar">
+            <button class="button">Import existing</button>
+            <button class="button primary">New repository</button>
+          </div>
+        </header>
+
+        <section class="shell" aria-label="Create repository wizard">
+          <div class="wizard-head">
+            <div>
+              <h2>Create repository</h2>
+              <p class="subtle">Production App Archives</p>
+            </div>
+            <div class="steps" aria-label="Wizard steps">
+              <span class="step done">1 Basics</span>
+              <span class="step active">2 Location</span>
+              <span class="step">3 Security</span>
+              <span class="step">4 Review</span>
+            </div>
+          </div>
+
+          <div class="wizard-grid">
+            <div class="wizard-body">
+              <section>
+                <div class="section-title">
+                  <h2>Repository location</h2>
+                  <span class="chip blue">Pro feature</span>
+                </div>
+                <div class="location-grid">
+                  <article class="option">
+                    <div class="option-icon">B</div>
+                    <h3>Borg UI server</h3>
+                    <p>
+                      Use a filesystem path mounted into the Borg UI container.
+                    </p>
+                  </article>
+                  <article class="option">
+                    <div class="option-icon">S</div>
+                    <h3>Remote machine</h3>
+                    <p>Store the Borg repository on an SSH-connected host.</p>
+                  </article>
+                  <article class="option">
+                    <div class="option-icon">A</div>
+                    <h3>Managed agent</h3>
+                    <p>
+                      Run Borg on a registered agent and use its local path.
+                    </p>
+                  </article>
+                  <article class="option selected">
+                    <div class="option-icon">R</div>
+                    <h3>Cloud storage</h3>
+                    <p>Mirror a local Borg cache to an rclone remote.</p>
+                  </article>
+                </div>
+              </section>
+
+              <section>
+                <div class="section-title">
+                  <h2>Rclone target</h2>
+                  <span class="chip green">Remote tested</span>
+                </div>
+                <div class="form-grid">
+                  <div class="field">
+                    <label for="remote">Remote</label>
+                    <select id="remote">
+                      <option>prod-s3 - Amazon S3 compatible</option>
+                    </select>
+                    <p class="helper">
+                      Uses the managed rclone config stored under /data/rclone.
+                    </p>
+                  </div>
+                  <div class="field">
+                    <label for="provider">Provider</label>
+                    <input id="provider" value="S3-compatible storage" />
+                  </div>
+                  <div class="field full">
+                    <label for="remote-path">Remote repository path</label>
+                    <input
+                      id="remote-path"
+                      class="mono"
+                      value="prod-s3:borg-ui/repositories/production-app"
+                    />
+                    <p class="helper">
+                      This path is reserved for one Borg repository mirror.
+                    </p>
+                  </div>
+                  <div class="field full">
+                    <label for="cache-path">Local Borg cache path</label>
+                    <input
+                      id="cache-path"
+                      class="mono"
+                      value="/data/rclone-cache/repositories/production-app"
+                    />
+                    <p class="helper">
+                      Borg reads and writes here before Borg UI mirrors to
+                      rclone.
+                    </p>
+                  </div>
+                  <div class="field full">
+                    <label>Sync policy</label>
+                    <div
+                      class="segmented"
+                      role="group"
+                      aria-label="Sync policy"
+                    >
+                      <div class="segment active">After Borg job</div>
+                      <div class="segment">Manual</div>
+                      <div class="segment">Scheduled</div>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <div class="notice info">
+                <strong>Storage flow</strong>
+                <span>
+                  Borg writes to the local cache. Borg UI runs rclone sync only
+                  after the Borg transaction is closed.
+                </span>
+              </div>
+
+              <section>
+                <div class="section-title">
+                  <h2>Review route</h2>
+                  <span class="chip amber">Cache needs 1.2 TB free</span>
+                </div>
+                <div class="summary">
+                  <div class="status-row">
+                    <strong>Repository path</strong>
+                    <span class="mono"
+                      >/data/rclone-cache/repositories/production-app</span
+                    >
+                  </div>
+                  <div class="status-row">
+                    <strong>Rclone mirror</strong>
+                    <span class="mono"
+                      >prod-s3:borg-ui/repositories/production-app</span
+                    >
+                  </div>
+                  <div class="status-row">
+                    <strong>Operation mode</strong>
+                    <span>Local Borg cache with remote mirror</span>
+                  </div>
+                  <div class="status-row">
+                    <strong>Recovery</strong>
+                    <span
+                      >Hydrate cache from remote, then run Borg operations
+                      locally</span
+                    >
+                  </div>
+                </div>
+              </section>
+            </div>
+
+            <aside class="side-panel" aria-label="Route preview">
+              <section>
+                <div class="section-title">
+                  <h2>Route preview</h2>
+                </div>
+                <div class="route">
+                  <div class="route-item">
+                    <div class="route-index">1</div>
+                    <div>
+                      <strong>Sources</strong>
+                      <span>/srv/app, /etc/borg-ui</span>
+                    </div>
+                  </div>
+                  <div class="route-item">
+                    <div class="route-index">2</div>
+                    <div>
+                      <strong>Borg UI server</strong>
+                      <span>Runs borg create against the local cache</span>
+                    </div>
+                  </div>
+                  <div class="route-item">
+                    <div class="route-index">3</div>
+                    <div>
+                      <strong>Local cache</strong>
+                      <span class="mono"
+                        >/data/rclone-cache/repositories/production-app</span
+                      >
+                    </div>
+                  </div>
+                  <div class="route-item">
+                    <div class="route-index">4</div>
+                    <div>
+                      <strong>Rclone sync</strong>
+                      <span>Runs after Borg exits successfully</span>
+                    </div>
+                  </div>
+                  <div class="route-item">
+                    <div class="route-index">5</div>
+                    <div>
+                      <strong>Remote mirror</strong>
+                      <span class="mono"
+                        >prod-s3:borg-ui/repositories/production-app</span
+                      >
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <section>
+                <div class="section-title">
+                  <h2>Preflight</h2>
+                </div>
+                <div class="status-list">
+                  <div class="status-row">
+                    <div>
+                      <strong>Rclone binary</strong>
+                      <span>/usr/bin/rclone</span>
+                    </div>
+                    <span class="chip green">Ready</span>
+                  </div>
+                  <div class="status-row">
+                    <div>
+                      <strong>Remote path</strong>
+                      <span>Borg UI-owned prefix</span>
+                    </div>
+                    <span class="chip green">Safe</span>
+                  </div>
+                  <div class="status-row">
+                    <div>
+                      <strong>Last remote test</strong>
+                      <span>24 May 2026, 10:42</span>
+                    </div>
+                    <span class="chip green">Passed</span>
+                  </div>
+                </div>
+              </section>
+
+              <div class="notice">
+                <strong>Sync failure</strong>
+                <span>
+                  A successful Borg backup can finish with a warning if the
+                  mirror fails. The repository remains pending until the next
+                  successful sync.
+                </span>
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        <section class="repo-card" aria-label="Repository card state">
+          <div class="repo-head">
+            <div>
+              <h2>Production App Archives</h2>
+              <p class="subtle mono">
+                /data/rclone-cache/repositories/production-app
+              </p>
+            </div>
+            <div class="repo-actions">
+              <button class="button small">Run backup</button>
+              <button class="button small">Run sync now</button>
+              <button class="button small">Hydrate cache</button>
+            </div>
+          </div>
+          <div class="summary">
+            <div class="status-row">
+              <strong>Storage</strong>
+              <span><span class="chip blue">Rclone mirror</span></span>
+            </div>
+            <div class="status-row">
+              <strong>Sync state</strong>
+              <span><span class="chip green">Synced 12 minutes ago</span></span>
+            </div>
+            <div class="status-row">
+              <strong>Remote</strong>
+              <span class="mono"
+                >prod-s3:borg-ui/repositories/production-app</span
+              >
+            </div>
+            <div class="status-row">
+              <strong>Last backup</strong>
+              <span>Completed with remote mirror verified</span>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/docs/engineering/plans/2026-05-24-rclone-storage-integration.md
+++ b/docs/engineering/plans/2026-05-24-rclone-storage-integration.md
@@ -1,0 +1,311 @@
+# Rclone Storage Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development or superpowers:executing-plans to
+> implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for
+> tracking.
+
+**Goal:** Implement server-owned rclone-backed repositories using a local Borg
+cache that Borg UI mirrors to an rclone remote.
+
+**Architecture:** Keep Borg operations on a normal local repository path and
+add an rclone storage layer that owns remote configuration, cache hydration,
+post-Borg mirror jobs, status reporting, and UI setup. Existing SSH and managed
+agent repository routes remain unchanged.
+
+**Tech Stack:** FastAPI, SQLAlchemy migrations, pytest, Borg CLI wrappers,
+rclone CLI wrappers, React/Vite/MUI, Vitest, Storybook screenshots.
+
+---
+
+## Task 1: Rclone Settings And Availability
+
+**Files:**
+
+- Modify: `app/config.py`
+- Modify: `docs/configuration.md`
+- Modify: `Dockerfile.runtime-base`
+- Modify: `.github/workflows/docker-runtime-base.yml`
+- Test: `tests/unit/test_config.py`
+- Test: `tests/unit/test_dockerfile_borg2_fuse.py`
+
+- [ ] Write config tests for `RCLONE_CONFIG_ROOT`, `RCLONE_CACHE_ROOT`,
+      `RCLONE_SYNC_TIMEOUT`, `RCLONE_HYDRATE_TIMEOUT`,
+      `RCLONE_DEFAULT_TRANSFERS`, and `RCLONE_DEFAULT_CHECKERS`.
+- [ ] Add settings with defaults:
+  - `RCLONE_CONFIG_ROOT=/data/rclone`
+  - `RCLONE_CACHE_ROOT=/data/rclone-cache`
+  - `RCLONE_SYNC_TIMEOUT=14400`
+  - `RCLONE_HYDRATE_TIMEOUT=14400`
+  - `RCLONE_DEFAULT_TRANSFERS=4`
+  - `RCLONE_DEFAULT_CHECKERS=8`
+- [ ] Add rclone to the runtime base image and smoke it with
+      `docker run --rm borg-ui-runtime-base:smoke-test rclone version`.
+- [ ] Document the settings in `docs/configuration.md`.
+- [ ] Run
+      `pytest tests/unit/test_config.py tests/unit/test_dockerfile_borg2_fuse.py -q`.
+
+## Task 2: Database Model
+
+**Files:**
+
+- Modify: `app/database/models.py`
+- Create: `app/database/migrations/113_add_rclone_storage.py`
+- Test: `tests/unit/test_database_operations.py`
+
+- [ ] Add migration tests or model-shape checks for the new tables.
+- [ ] Create `rclone_remotes` with fields for name, provider, config source,
+      config path, redacted config, test status, timestamps, and error text.
+- [ ] Create `repository_storage` with fields for repository id, backend,
+      rclone remote id, remote path, cache path, sync policy, sync status, last
+      sync/hydrate/check timestamps, last error, and extra flags.
+- [ ] Create `rclone_sync_jobs` with repository id, direction, status,
+      started/completed timestamps, bytes/files counters, log path, and error text.
+- [ ] Add SQLAlchemy relationships from `Repository` to storage metadata.
+- [ ] Run `pytest tests/unit/test_database_operations.py -q`.
+
+## Task 3: Rclone Command Wrapper
+
+**Files:**
+
+- Create: `app/services/rclone_service.py`
+- Test: `tests/unit/test_rclone_service.py`
+
+- [ ] Write command-builder tests for `version`, `listremotes`, `lsjson`,
+      `about`, `sync`, and `check`.
+- [ ] Write tests proving commands are argv lists and never shell strings.
+- [ ] Write redaction tests for config paths, tokens, secrets, access keys,
+      secret keys, and remote paths in logs.
+- [ ] Implement `RcloneService` with subprocess execution, timeout handling,
+      JSON parsing, structured result objects, and log redaction.
+- [ ] Add a typed `RcloneUnavailable` error for missing binaries.
+- [ ] Run `pytest tests/unit/test_rclone_service.py -q`.
+
+## Task 4: Remote Management API
+
+**Files:**
+
+- Create: `app/api/rclone.py`
+- Modify: `app/main.py`
+- Modify: `app/services/rclone_service.py`
+- Test: `tests/unit/test_api_rclone.py`
+
+- [ ] Write API tests for unauthenticated access, list remotes, create managed
+      remote, test remote, browse remote, rclone unavailable, and redacted output.
+- [ ] Add `GET /api/rclone/status`.
+- [ ] Add `GET /api/rclone/remotes`.
+- [ ] Add `POST /api/rclone/remotes`.
+- [ ] Add `POST /api/rclone/remotes/{id}/test`.
+- [ ] Add `GET /api/rclone/remotes/{id}/browse`.
+- [ ] Persist managed configs under `RCLONE_CONFIG_ROOT` with restrictive file
+      permissions.
+- [ ] Run `pytest tests/unit/test_api_rclone.py -q`.
+
+## Task 5: Repository Storage Service
+
+**Files:**
+
+- Create: `app/services/rclone_repository_service.py`
+- Modify: `app/services/repository_command_lock.py`
+- Test: `tests/unit/test_rclone_repository_service.py`
+
+- [ ] Write tests for cache path derivation under `RCLONE_CACHE_ROOT`.
+- [ ] Write tests that reject non-empty remote paths unless they are verified
+      Borg repositories or Borg UI-owned paths.
+- [ ] Write create-flow tests: local Borg init succeeds, initial sync succeeds,
+      storage status becomes `current`.
+- [ ] Write import-flow tests: remote Borg repository hydrates into a temp cache,
+      Borg verification succeeds, temp cache promotes atomically.
+- [ ] Write failure tests: sync failure leaves repository usable locally but
+      marks storage status `failed`; hydration failure does not replace old cache.
+- [ ] Implement create, import, sync, hydrate, and status helpers.
+- [ ] Ensure all mutable Borg and rclone operations use the repository command
+      lock.
+- [ ] Run `pytest tests/unit/test_rclone_repository_service.py -q`.
+
+## Task 6: Repository API Integration
+
+**Files:**
+
+- Modify: `app/api/repositories.py`
+- Modify: `app/api/v2/repositories.py`
+- Modify: `app/services/repository_service.py`
+- Modify: `app/services/v2/repository_service.py`
+- Test: `tests/unit/test_api_repositories.py`
+- Test: `tests/unit/test_api_v2_repositories.py`
+
+- [ ] Add request fields for `storage_backend`, `rclone_remote_id`,
+      `rclone_remote_path`, `rclone_cache_path`, `rclone_sync_policy`, and
+      `rclone_extra_flags`.
+- [ ] Add response serialization for rclone storage metadata.
+- [ ] Route create/import payloads with `storage_backend: "rclone"` through
+      `RcloneRepositoryService`.
+- [ ] Preserve existing local, SSH, and agent repository behavior.
+- [ ] Reject rclone storage for managed-agent repositories in this slice.
+- [ ] Add manual endpoints:
+  - `POST /api/repositories/{id}/rclone/sync`
+  - `POST /api/repositories/{id}/rclone/hydrate`
+  - `GET /api/repositories/{id}/rclone/status`
+- [ ] Run
+      `pytest tests/unit/test_api_repositories.py tests/unit/test_api_v2_repositories.py -q`.
+
+## Task 7: Backup And Maintenance Mirror Hooks
+
+**Files:**
+
+- Modify: `app/services/backup_service.py`
+- Modify: `app/services/backup_plan_execution_service.py`
+- Modify: `app/services/check_service.py`
+- Modify: `app/services/prune_service.py`
+- Modify: `app/services/compact_service.py`
+- Modify: `app/services/delete_archive_service.py`
+- Modify: `app/services/repository_wipe_service.py`
+- Test: `tests/unit/test_backup_service.py`
+- Test: `tests/unit/test_api_backup_plans.py`
+- Test: relevant maintenance service tests
+
+- [ ] Write backup tests proving rclone repositories hydrate before Borg when
+      cache is missing or stale.
+- [ ] Write backup tests proving sync runs after successful Borg writes.
+- [ ] Write tests proving Borg success plus sync failure becomes a warning and
+      storage status `failed`.
+- [ ] Add post-mutation mirror hooks to check/prune/compact/delete/wipe paths
+      where the Borg operation mutates repository files.
+- [ ] Keep read-only list/info/browse operations from triggering sync unless
+      hydration occurred.
+- [ ] Run
+      `pytest tests/unit/test_backup_service.py tests/unit/test_api_backup_plans.py -q`.
+
+## Task 8: Frontend Types And API Client
+
+**Files:**
+
+- Modify: `frontend/src/types/index.ts`
+- Modify: `frontend/src/services/api.ts`
+- Modify: `frontend/src/pages/repositories-page/types.ts`
+- Test: existing API client tests if available
+
+- [ ] Add `RcloneRemote`, `RcloneStorage`, `RcloneStatus`, and rclone request
+      types.
+- [ ] Add `rcloneAPI` methods for status, remotes, test, browse, repository
+      sync, repository hydrate, and repository status.
+- [ ] Extend repository types with rclone storage fields.
+- [ ] Run `cd frontend && npm run typecheck`.
+
+## Task 9: Repository Wizard UI
+
+**Files:**
+
+- Modify: `frontend/src/components/RepositoryWizard.tsx`
+- Modify: `frontend/src/components/wizard/WizardStepLocation.tsx`
+- Modify: `frontend/src/components/wizard/WizardStepReview.tsx`
+- Modify: `frontend/src/components/wizard/WizardStepLocation.stories.tsx`
+- Modify: `frontend/src/components/wizard/WizardStepReview.stories.tsx`
+- Test: `frontend/src/components/__tests__/RepositoryWizard.test.tsx`
+
+- [ ] Write failing tests for selecting rclone location and submitting rclone
+      storage fields.
+- [ ] Add the "Cloud storage (rclone)" location option beside Borg UI server,
+      SSH remote, and managed agent.
+- [ ] Add remote selector, remote path field, browse action, local cache path
+      preview, sync policy selector, and advanced flags section.
+- [ ] Show unavailable state when `GET /api/rclone/status` reports missing
+      binary.
+- [ ] Update review to show route:
+      `Sources -> Borg UI server -> local cache -> rclone sync -> remote`.
+- [ ] Add Storybook stories for configured rclone, unavailable rclone, and
+      remote path warning states.
+- [ ] Run
+      `cd frontend && npm test -- --run src/components/__tests__/RepositoryWizard.test.tsx`.
+
+## Task 10: Repository Card And Status UX
+
+**Files:**
+
+- Modify: `frontend/src/components/RepositoryCard.tsx`
+- Modify: `frontend/src/components/RepositoryCard.stories.tsx`
+- Modify: `frontend/src/pages/repositories-page/RepositoryGroups.tsx`
+- Test: relevant repository-card tests if present
+
+- [ ] Add chips for `Rclone mirror`, `Synced`, `Sync pending`,
+      `Sync failed`, and `Hydration required`.
+- [ ] Add repository actions for `Run sync now` and `Hydrate cache` when the
+      current status permits them.
+- [ ] Keep cards compact and use balanced outline/background emphasis rather
+      than heavy left accent borders.
+- [ ] Add stories for current, pending, failed, and hydration-required states.
+- [ ] Run targeted frontend tests for repository card behavior.
+
+## Task 11: Documentation
+
+**Files:**
+
+- Create: `docs/rclone-storage.md`
+- Modify: `docs/usage-guide.md`
+- Modify: `docs/disaster-recovery.md`
+- Modify: `docs/configuration.md`
+- Modify: `docs/plan-content.json` only if feature availability copy changes
+
+- [ ] Document the local-cache-plus-remote-mirror model.
+- [ ] Document disk sizing requirements for `RCLONE_CACHE_ROOT`.
+- [ ] Document disaster recovery: install rclone, configure remote, sync remote
+      path to local directory, then use Borg/Borg UI.
+- [ ] Document sync failure states and safe retry behavior.
+- [ ] Document why direct rclone mount is not the supported default.
+
+## Task 12: Storybook Snapshots And Runtime Validation
+
+**Files:**
+
+- Update: `frontend/storybook-snapshots/**`
+- Add or update smoke tests under `tests/smoke/` if a local rclone binary is
+  available in CI.
+
+- [ ] Run `cd frontend && npm run snapshots`.
+- [ ] Add a smoke test using an rclone local filesystem remote:
+  - configure local remote rooted at a temp directory
+  - create rclone repository
+  - run one backup
+  - assert remote has Borg repository files
+  - remove cache
+  - hydrate cache
+  - list archives
+- [ ] If CI cannot guarantee rclone, skip the smoke test with a clear
+      `shutil.which("rclone")` guard and keep unit coverage mandatory.
+
+## Task 13: Required Validation And Handoff
+
+**Files:**
+
+- Use `.github/PULL_REQUEST_TEMPLATE.md` when opening the PR.
+
+- [ ] Run `ruff check app tests`.
+- [ ] Run `ruff format --check app tests`.
+- [ ] Run all targeted backend pytest commands from earlier tasks.
+- [ ] Run the rclone smoke test when rclone is available.
+- [ ] Run `cd frontend && npm run check:locales`.
+- [ ] Run `cd frontend && npm run typecheck`.
+- [ ] Run `cd frontend && npm run lint`.
+- [ ] Run `cd frontend && npm run build`.
+- [ ] Run all targeted Vitest commands from earlier tasks.
+- [ ] Run `cd frontend && npm run snapshots`.
+- [ ] Launch Borg UI and capture walkthrough evidence for:
+  - repository wizard rclone location
+  - remote test/browse
+  - review route preview
+  - repository card sync status
+  - manual sync or hydrate action
+- [ ] Commit scoped changes, push the branch, create/update PR from the repo
+      template, apply `symphony`, complete PR feedback sweep, and move Linear to
+      Human Review only after checks are green.
+
+## Plan Self-Review
+
+- Spec coverage: tasks cover packaging, data model, command wrapper, APIs,
+  repository runtime, backup/maintenance hooks, frontend wizard, status cards,
+  docs, smoke validation, and handoff.
+- Placeholder scan: no task relies on undefined files or open-ended "handle
+  errors" steps without tests.
+- Type consistency: `storage_backend`, rclone remote metadata, cache path,
+  remote path, sync policy, and sync status are used consistently across
+  backend, frontend, and docs.

--- a/docs/engineering/plans/2026-05-24-rclone-storage-integration.md
+++ b/docs/engineering/plans/2026-05-24-rclone-storage-integration.md
@@ -114,8 +114,12 @@ rclone CLI wrappers, React/Vite/MUI, Vitest, Storybook screenshots.
 - [ ] Write tests for cache path derivation under `RCLONE_CACHE_ROOT`.
 - [ ] Write tests that reject non-empty remote paths unless they are verified
       Borg repositories or Borg UI-owned paths.
-- [ ] Write tests that command builders compose the full rclone target from
-      `rclone_remote_id` plus relative `rclone_remote_path`.
+- [ ] Write tests that command builders compose the full rclone target through
+      remote-name lookup by `rclone_remote_id` plus relative
+      `rclone_remote_path`.
+- [ ] Assert the remote resolver is called and the resolved remote name, not the
+      raw database id, is used in `<remote_name>:<relative_path>` command
+      targets.
 - [ ] Write create-flow tests: local Borg init succeeds, initial sync succeeds,
       storage status becomes `current`.
 - [ ] Write import-flow tests: remote Borg repository hydrates into a temp cache,
@@ -139,11 +143,12 @@ rclone CLI wrappers, React/Vite/MUI, Vitest, Storybook screenshots.
 - Test: `tests/unit/test_api_v2_repositories.py`
 
 - [ ] Add request fields for `storage_backend`, `rclone_remote_id`,
-      `rclone_remote_path`, `rclone_cache_path`, `rclone_sync_policy`, and
-      `rclone_extra_flags`.
+      `rclone_remote_path`, `rclone_sync_policy`, and `rclone_extra_flags`.
+- [ ] Reject client-provided `rclone_cache_path`; derive the cache path
+      server-side from `RCLONE_CACHE_ROOT` and repository identity.
 - [ ] Add response serialization for rclone storage metadata, including a
-      derived `rclone_target` preview while keeping submitted
-      `rclone_remote_path` relative.
+      derived `rclone_target` preview and read-only cache path while keeping
+      submitted `rclone_remote_path` relative.
 - [ ] Route create/import payloads with `storage_backend: "rclone"` through
       `RcloneRepositoryService`.
 - [ ] Preserve existing local, SSH, and agent repository behavior.
@@ -214,8 +219,8 @@ rclone CLI wrappers, React/Vite/MUI, Vitest, Storybook screenshots.
 - [ ] Add the "Cloud storage (rclone)" location option beside Borg UI server,
       SSH remote, and managed agent.
 - [ ] Add remote selector, relative remote path field, browse action, derived
-      target preview, local cache path preview, sync policy selector, and
-      advanced flags section.
+      target preview, server-derived local cache path preview, sync policy
+      selector, and advanced flags section.
 - [ ] Show unavailable state when `GET /api/rclone/status` reports missing
       binary.
 - [ ] Update review to show route:
@@ -314,5 +319,5 @@ rclone CLI wrappers, React/Vite/MUI, Vitest, Storybook screenshots.
 - Placeholder scan: no task relies on undefined files or open-ended "handle
   errors" steps without tests.
 - Type consistency: `storage_backend`, rclone remote metadata, relative remote
-  path, derived target preview, cache path, sync policy, and sync status are
-  used consistently across backend, frontend, and docs.
+  path, derived target preview, server-derived cache path, sync policy, and
+  sync status are used consistently across backend, frontend, and docs.

--- a/docs/engineering/plans/2026-05-24-rclone-storage-integration.md
+++ b/docs/engineering/plans/2026-05-24-rclone-storage-integration.md
@@ -57,8 +57,10 @@ rclone CLI wrappers, React/Vite/MUI, Vitest, Storybook screenshots.
 - [ ] Create `rclone_remotes` with fields for name, provider, config source,
       config path, redacted config, test status, timestamps, and error text.
 - [ ] Create `repository_storage` with fields for repository id, backend,
-      rclone remote id, remote path, cache path, sync policy, sync status, last
-      sync/hydrate/check timestamps, last error, and extra flags.
+      rclone remote id, relative remote path, cache path, sync policy, sync
+      status, last sync/hydrate/check timestamps, last error, and extra flags.
+- [ ] Store `rclone_remote_path` as a relative path only and expose any full
+      `<remote_name>:<relative_path>` value as a derived read-only preview.
 - [ ] Create `rclone_sync_jobs` with repository id, direction, status,
       started/completed timestamps, bytes/files counters, log path, and error text.
 - [ ] Add SQLAlchemy relationships from `Repository` to storage metadata.
@@ -112,6 +114,8 @@ rclone CLI wrappers, React/Vite/MUI, Vitest, Storybook screenshots.
 - [ ] Write tests for cache path derivation under `RCLONE_CACHE_ROOT`.
 - [ ] Write tests that reject non-empty remote paths unless they are verified
       Borg repositories or Borg UI-owned paths.
+- [ ] Write tests that command builders compose the full rclone target from
+      `rclone_remote_id` plus relative `rclone_remote_path`.
 - [ ] Write create-flow tests: local Borg init succeeds, initial sync succeeds,
       storage status becomes `current`.
 - [ ] Write import-flow tests: remote Borg repository hydrates into a temp cache,
@@ -137,7 +141,9 @@ rclone CLI wrappers, React/Vite/MUI, Vitest, Storybook screenshots.
 - [ ] Add request fields for `storage_backend`, `rclone_remote_id`,
       `rclone_remote_path`, `rclone_cache_path`, `rclone_sync_policy`, and
       `rclone_extra_flags`.
-- [ ] Add response serialization for rclone storage metadata.
+- [ ] Add response serialization for rclone storage metadata, including a
+      derived `rclone_target` preview while keeping submitted
+      `rclone_remote_path` relative.
 - [ ] Route create/import payloads with `storage_backend: "rclone"` through
       `RcloneRepositoryService`.
 - [ ] Preserve existing local, SSH, and agent repository behavior.
@@ -207,8 +213,9 @@ rclone CLI wrappers, React/Vite/MUI, Vitest, Storybook screenshots.
       storage fields.
 - [ ] Add the "Cloud storage (rclone)" location option beside Borg UI server,
       SSH remote, and managed agent.
-- [ ] Add remote selector, remote path field, browse action, local cache path
-      preview, sync policy selector, and advanced flags section.
+- [ ] Add remote selector, relative remote path field, browse action, derived
+      target preview, local cache path preview, sync policy selector, and
+      advanced flags section.
 - [ ] Show unavailable state when `GET /api/rclone/status` reports missing
       binary.
 - [ ] Update review to show route:
@@ -306,6 +313,6 @@ rclone CLI wrappers, React/Vite/MUI, Vitest, Storybook screenshots.
   docs, smoke validation, and handoff.
 - Placeholder scan: no task relies on undefined files or open-ended "handle
   errors" steps without tests.
-- Type consistency: `storage_backend`, rclone remote metadata, cache path,
-  remote path, sync policy, and sync status are used consistently across
-  backend, frontend, and docs.
+- Type consistency: `storage_backend`, rclone remote metadata, relative remote
+  path, derived target preview, cache path, sync policy, and sync status are
+  used consistently across backend, frontend, and docs.

--- a/docs/engineering/specs/2026-05-24-rclone-storage-integration.md
+++ b/docs/engineering/specs/2026-05-24-rclone-storage-integration.md
@@ -1,0 +1,353 @@
+# Rclone Storage Integration Spec
+
+## Goal
+
+Add a first-class Borg UI design for rclone-backed repository storage so users
+can use S3-compatible buckets, Backblaze B2, Google Drive, WebDAV, SFTP, and
+other rclone providers as off-site backup targets without turning Borg UI into
+a generic file-sync product.
+
+## Current Signal
+
+- GitHub issue
+  [#211](https://github.com/karanhudia/borg-ui/issues/211) requests rclone as
+  an optional backend and suggests selecting an existing rclone remote, a remote
+  path, and extra flags.
+- Repository setup currently models repository location as Borg UI server local
+  storage or SSH remote storage. `WizardStepLocation` uses
+  `repositoryLocation: "local" | "ssh"`, and the backend repository model stores
+  `repository_type`, `connection_id`, `remote_path`, `executor_type`, and
+  optional `agent_machine_id`.
+- `docs/plan-content.json` already lists `rclone_support` as a coming-soon Pro
+  feature, but the app has no rclone-specific model, API, service, UI path, or
+  validation.
+- Current SSH repository docs explain direct Borg-over-SSH and remote-direct
+  backups, but not cloud/object storage destinations.
+
+## Product Decision
+
+The recommended default is not "Borg writes directly to the cloud bucket."
+The first supported rclone mode should be a local Borg repository cache that
+Borg UI mirrors to the rclone remote after Borg operations finish.
+
+This means:
+
+1. Borg always reads and writes a normal local filesystem repository under a
+   persistent Borg UI cache root.
+2. After successful Borg writes, Borg UI runs an rclone mirror job from that
+   local repository directory to the configured remote path.
+3. For restore, browse, check, prune, and compact, Borg UI uses the local cache
+   when it is present and marked current. If the cache is missing or stale, Borg
+   UI hydrates it from the remote first.
+4. The rclone remote is the durable off-site copy, while the local cache is the
+   operational working copy.
+
+This is the safest MVP because Borg repositories are filesystem-based,
+transactional stores with locks, indexes, hints, and append-only segment files.
+Rclone can mount remotes through FUSE, but rclone's own mount documentation says
+write-heavy applications need VFS write/full caching for non-sequential writes.
+Object storage providers also vary in directory semantics, latency, modtime
+support, and consistency. A direct mount mode can be considered later as an
+advanced experimental option for known-good providers, but it should not be the
+default storage contract.
+
+Official references:
+
+- Rclone usage and remote path syntax:
+  https://rclone.org/docs/
+- Rclone `copy` and `sync` behavior:
+  https://rclone.org/commands/rclone_copy/ and
+  https://rclone.org/commands/rclone_sync/
+- Rclone mount behavior and VFS cache constraints:
+  https://rclone.org/commands/rclone_mount/
+- Borg repository file structure and lock semantics:
+  https://borgbackup.readthedocs.io/en/stable/internals/data-structures.html
+
+## Scope
+
+- Add an rclone storage target concept for repositories.
+- Add rclone remote configuration discovery, test, browse, and health checks.
+- Add a local-cache-plus-remote-mirror runtime path for create, import,
+  backup, restore, archive browsing, check, prune, compact, and break-lock
+  where those operations are supported today.
+- Add UI for selecting rclone as a repository location and configuring the
+  provider, remote path, local cache, sync policy, and advanced flags.
+- Add status surfaces for cache state, last sync, pending sync, failed sync,
+  hydration, and drift/conflict protection.
+- Add docs and smoke tests that prove a repository can be created locally,
+  mirrored to an rclone remote, hydrated into an empty cache, and read by Borg.
+
+## Out Of Scope
+
+- Making Borg UI a general-purpose rclone file manager.
+- Bidirectional sync between local cache and remote after independent remote
+  edits. The remote path is owned by Borg UI once configured.
+- Direct rclone mount as the default repository backend.
+- Provider-specific S3, B2, Google Drive, or WebDAV clients inside Borg UI.
+  Borg UI should delegate provider protocol behavior to rclone.
+- Multi-writer or active/active Borg UI instances sharing one rclone remote.
+- Running rclone-backed repositories on managed agents in the first slice.
+  Agent support should be a later extension after server-owned rclone is stable.
+
+## Storage Model
+
+Add explicit rclone storage records instead of overloading SSH fields:
+
+- `rclone_remotes`
+  - `id`
+  - `name`
+  - `provider`
+  - `config_source`: `managed`, `imported`, or `external_file`
+  - `config_path`
+  - `redacted_config`
+  - `last_tested_at`
+  - `last_test_status`
+  - `last_error`
+- `repository_storage`
+  - `repository_id`
+  - `backend`: `local`, `ssh`, `agent_local`, or `rclone`
+  - `rclone_remote_id`
+  - `rclone_remote_path`
+  - `cache_path`
+  - `sync_policy`: `after_success`, `manual`, or `scheduled`
+  - `sync_direction`: always `cache_to_remote` for normal operations
+  - `sync_status`: `current`, `pending`, `syncing`, `failed`, `hydrating`
+  - `last_synced_at`
+  - `last_hydrated_at`
+  - `last_remote_check_at`
+  - `last_sync_error`
+  - `extra_flags`
+
+Keep `repositories.path` as the Borg path that existing Borg services use. For
+rclone repositories, this should be the local cache path. The new storage row
+describes where the repository is mirrored.
+
+## Runtime Flow
+
+### Create New Rclone Repository
+
+1. User selects "Cloud storage (rclone)" in the repository location step.
+2. User picks an existing rclone remote or creates/imports one.
+3. User enters a remote path such as `prod-s3:borg-ui/repositories/app`.
+4. Borg UI derives a local cache path such as
+   `/data/rclone-cache/repositories/<repository-id>`.
+5. Borg UI runs `borg init` against the local cache path.
+6. Borg UI writes a Borg UI ownership marker under the cache metadata area.
+7. Borg UI runs a first mirror job from cache to remote.
+8. Repository is marked `current` only after the mirror succeeds.
+
+### Import Existing Rclone Repository
+
+1. User selects an rclone remote and remote path.
+2. Borg UI validates the remote path by listing the Borg repository files
+   (`README`, `config`, `data/`) through rclone.
+3. Borg UI hydrates a local cache from the remote into a job-scoped temporary
+   cache directory.
+4. Borg UI runs `borg info` or `borg2 repo-info` on the hydrated cache using
+   the provided passphrase/keyfile.
+5. Borg UI atomically promotes the hydrated cache to the repository cache path
+   and creates the repository record.
+
+### Backup
+
+1. Acquire the existing repository command lock.
+2. Refuse to run if the repository is currently hydrating or syncing.
+3. If cache state is missing or stale, hydrate from the remote first.
+4. Run Borg against the local cache.
+5. If Borg succeeds or exits with accepted warnings, run the mirror job.
+6. Mark the backup result separately from mirror result:
+   - Borg failed: job failed, no mirror.
+   - Borg succeeded and mirror succeeded: job completed.
+   - Borg succeeded and mirror failed: backup job completed with warnings,
+     repository sync status `failed`, retry available.
+
+### Read Operations
+
+Archive list, archive browse, info, restore, check, prune, compact, delete
+archive, and break-lock should use the local cache under the same command lock.
+Operations that mutate the repository must trigger a remote mirror afterward.
+Read-only operations can run without a mirror unless they hydrate or repair
+cache state.
+
+### Hydration
+
+Hydration copies remote contents into a temporary local cache directory, verifies
+with Borg, then promotes it. A failed hydration must leave the previous cache in
+place. If no previous cache exists, the repository remains unavailable until a
+successful hydration.
+
+### Sync Command Choice
+
+Use `rclone sync` for repository mirrors after a successful Borg transaction so
+the remote path exactly matches the local Borg repository tree. Use `rclone copy`
+only for non-destructive diagnostics or future migration helpers. Because sync
+can delete remote files that are absent locally, Borg UI must require an empty
+or verified Borg-owned remote path before enabling normal sync.
+
+## Backend Design
+
+- Add `app/services/rclone_service.py` for subprocess-safe rclone command
+  execution. It should never use shell strings.
+- Add `app/services/rclone_repository_service.py` for create/import/hydrate/sync
+  orchestration and ownership-marker validation.
+- Add a small command builder layer for:
+  - `rclone version`
+  - `rclone listremotes`
+  - `rclone lsf` or `lsjson`
+  - `rclone about`
+  - `rclone sync`
+  - `rclone check`
+- Add database migrations for rclone remotes, repository storage metadata, and
+  rclone sync jobs.
+- Add API routes:
+  - `GET /api/rclone/status`
+  - `GET /api/rclone/remotes`
+  - `POST /api/rclone/remotes`
+  - `POST /api/rclone/remotes/{id}/test`
+  - `GET /api/rclone/remotes/{id}/browse`
+  - `POST /api/repositories/{id}/rclone/sync`
+  - `POST /api/repositories/{id}/rclone/hydrate`
+  - `GET /api/repositories/{id}/rclone/status`
+- Update existing repository APIs so rclone-backed repositories serialize
+  storage metadata and route mutation operations through mirror hooks.
+- Update Docker/runtime packaging to include rclone or provide a clear
+  unavailable state if the host image does not include it. The product path is
+  much cleaner if the official runtime image includes rclone.
+- Add settings for:
+  - `RCLONE_CONFIG_ROOT` defaulting to `/data/rclone`
+  - `RCLONE_CACHE_ROOT` defaulting to `/data/rclone-cache`
+  - `RCLONE_SYNC_TIMEOUT`
+  - `RCLONE_HYDRATE_TIMEOUT`
+  - `RCLONE_DEFAULT_TRANSFERS`
+  - `RCLONE_DEFAULT_CHECKERS`
+
+## Secret Handling
+
+- Treat rclone config as sensitive. Rclone's obfuscation is not a replacement
+  for Borg UI secret handling.
+- Store managed rclone configs under `/data/rclone` with restrictive file
+  permissions.
+- Redact tokens, keys, passwords, endpoints, and bucket names from logs unless
+  the field is explicitly safe to display.
+- Keep Borg passphrases/keyfiles in the existing Borg UI repository secret path.
+- Never put rclone credentials into generated command previews.
+- Add export/import handling so rclone metadata can be exported without raw
+  credentials by default.
+
+## Frontend Design
+
+Use the existing operational dashboard style:
+
+- Small, dense controls.
+- MUI cards with balanced outlines and subtle background tint.
+- Existing icon language from MUI/lucide.
+- No heavy left accent borders.
+- No decorative gradients or marketing-style hero sections.
+
+### Repository Location Step
+
+Add a fourth location option:
+
+- Borg UI server
+- Remote machine (SSH)
+- Managed agent
+- Cloud storage (rclone)
+
+When rclone is selected, the wizard shows:
+
+- Remote selector with test status.
+- Provider badge and remote name.
+- Remote path field with browse action.
+- Local cache path preview, editable by advanced users.
+- Sync policy selector:
+  - Sync after successful Borg job (default)
+  - Manual sync
+  - Scheduled sync
+- Advanced rclone flags in a collapsed section.
+- Clear copy that Borg writes to the local cache first and Borg UI mirrors the
+  repository to the rclone remote.
+
+### Review Step
+
+Show a route preview:
+
+`Sources -> Borg UI server Borg process -> local cache -> rclone sync -> remote`
+
+Review must call out:
+
+- Local cache path.
+- Remote path.
+- Last remote test status.
+- Whether sync is automatic or manual.
+- Local disk requirement: cache should be sized for the full repository.
+- Warning if the remote path is not empty or not verified as Borg-owned.
+
+### Repository Card
+
+Add storage chips and actions:
+
+- `Rclone mirror`
+- `Synced 12 minutes ago`
+- `Sync pending`
+- `Sync failed`
+- `Hydrate cache`
+- `Run sync now`
+
+The card should keep existing repository action density and avoid turning sync
+state into a large alert unless the repository is unavailable.
+
+## UX Mockup
+
+The HTML mockup for this spec is stored at:
+
+`docs/engineering/mockups/2026-05-24-rclone-storage-integration.html`
+
+It shows:
+
+- Rclone as a repository location.
+- Remote/provider configuration.
+- Local cache and sync policy.
+- Review route preview.
+- Repository card sync status.
+
+## Validation Plan For Implementation
+
+- Backend unit tests for rclone command builders and redaction.
+- Backend unit tests for remote path ownership checks and dangerous sync
+  prevention.
+- Backend unit tests for repository create/import/hydrate/sync state
+  transitions.
+- Backend API tests for remotes, browse, test, manual sync, and hydrate.
+- Integration test with an rclone local filesystem remote:
+  - create repository cache
+  - mirror to remote
+  - delete cache
+  - hydrate from remote
+  - list archives with Borg
+- Frontend tests for location selection, payload shape, disabled/unavailable
+  states, sync status rendering, and review route preview.
+- Storybook stories for create, import, failed sync, hydration required, and
+  unavailable rclone binary states.
+- Storybook snapshots for all changed stories.
+- Runtime walkthrough through create -> backup -> mirror -> cache delete ->
+  hydrate -> archive list.
+
+## Rollout
+
+- Gate behind `rclone_storage_beta_enabled` and the existing Pro plan feature
+  entry for `rclone_support`.
+- Start with server-owned rclone repositories only.
+- Add telemetry-safe counters for rclone repository count and sync failure
+  categories, without provider credentials or paths.
+- Mark direct mount as unsupported in UI copy until a separate spec proves it
+  safe for selected providers.
+
+## Self-Review
+
+- Acceptance coverage: the spec answers direct-vs-sync architecture, backend
+  scope, frontend scope, security, rollout, validation, and failure modes.
+- Scope boundary: direct rclone mount, managed-agent rclone, and bidirectional
+  sync are explicitly out of scope for the first implementation slice.
+- UI consistency: design follows Borg UI's existing repository wizard, compact
+  status chips, and balanced-outline surfaces rather than a new marketing
+  visual language.

--- a/docs/engineering/specs/2026-05-24-rclone-storage-integration.md
+++ b/docs/engineering/specs/2026-05-24-rclone-storage-integration.md
@@ -35,7 +35,7 @@ This means:
 1. Borg always reads and writes a normal local filesystem repository under a
    persistent Borg UI cache root.
 2. After successful Borg writes, Borg UI runs an rclone mirror job from that
-   local repository directory to the configured remote path.
+   local repository directory to the configured rclone target.
 3. For restore, browse, check, prune, and compact, Borg UI uses the local cache
    when it is present and marked current. If the cache is missing or stale, Borg
    UI hydrates it from the remote first.
@@ -106,8 +106,9 @@ Add explicit rclone storage records instead of overloading SSH fields:
 - `repository_storage`
   - `repository_id`
   - `backend`: `local`, `ssh`, `agent_local`, or `rclone`
-  - `rclone_remote_id`
-  - `rclone_remote_path`
+  - `rclone_remote_id`: selected `rclone_remotes.id`
+  - `rclone_remote_path`: relative path inside the remote, without a
+    `remote:` prefix
   - `cache_path`
   - `sync_policy`: `after_success`, `manual`, or `scheduled`
   - `sync_direction`: always `cache_to_remote` for normal operations
@@ -122,13 +123,24 @@ Keep `repositories.path` as the Borg path that existing Borg services use. For
 rclone repositories, this should be the local cache path. The new storage row
 describes where the repository is mirrored.
 
+Canonical target shape:
+
+- Persist `rclone_remote_id` as the configured remote identifier.
+- Persist `rclone_remote_path` as a relative path such as
+  `borg-ui/repositories/app`.
+- Compose the full rclone target only inside backend command builders by
+  resolving the remote name and joining `<remote_name>:<rclone_remote_path>`.
+- API responses may include a derived, read-only `rclone_target` preview such
+  as `prod-s3:borg-ui/repositories/app`, but clients must not submit that full
+  URI back as `rclone_remote_path`.
+
 ## Runtime Flow
 
 ### Create New Rclone Repository
 
 1. User selects "Cloud storage (rclone)" in the repository location step.
 2. User picks an existing rclone remote or creates/imports one.
-3. User enters a remote path such as `prod-s3:borg-ui/repositories/app`.
+3. User enters a relative remote path such as `borg-ui/repositories/app`.
 4. Borg UI derives a local cache path such as
    `/data/rclone-cache/repositories/<repository-id>`.
 5. Borg UI runs `borg init` against the local cache path.
@@ -138,9 +150,10 @@ describes where the repository is mirrored.
 
 ### Import Existing Rclone Repository
 
-1. User selects an rclone remote and remote path.
-2. Borg UI validates the remote path by listing the Borg repository files
-   (`README`, `config`, `data/`) through rclone.
+1. User selects an rclone remote and relative remote path.
+2. Borg UI composes the full rclone target server-side and validates it by
+   listing the Borg repository files (`README`, `config`, `data/`) through
+   rclone.
 3. Borg UI hydrates a local cache from the remote into a job-scoped temporary
    cache directory.
 4. Borg UI runs `borg info` or `borg2 repo-info` on the hydrated cache using
@@ -179,10 +192,11 @@ successful hydration.
 ### Sync Command Choice
 
 Use `rclone sync` for repository mirrors after a successful Borg transaction so
-the remote path exactly matches the local Borg repository tree. Use `rclone copy`
-only for non-destructive diagnostics or future migration helpers. Because sync
-can delete remote files that are absent locally, Borg UI must require an empty
-or verified Borg-owned remote path before enabling normal sync.
+the composed rclone target exactly matches the local Borg repository tree. Use
+`rclone copy` only for non-destructive diagnostics or future migration helpers.
+Because sync can delete remote files that are absent locally, Borg UI must
+require an empty or verified Borg-owned relative remote path before enabling
+normal sync.
 
 ## Backend Design
 
@@ -257,7 +271,7 @@ When rclone is selected, the wizard shows:
 
 - Remote selector with test status.
 - Provider badge and remote name.
-- Remote path field with browse action.
+- Relative remote path field with browse action.
 - Local cache path preview, editable by advanced users.
 - Sync policy selector:
   - Sync after successful Borg job (default)
@@ -276,7 +290,7 @@ Show a route preview:
 Review must call out:
 
 - Local cache path.
-- Remote path.
+- Relative remote path and derived full rclone target preview.
 - Last remote test status.
 - Whether sync is automatic or manual.
 - Local disk requirement: cache should be sized for the full repository.

--- a/docs/engineering/specs/2026-05-24-rclone-storage-integration.md
+++ b/docs/engineering/specs/2026-05-24-rclone-storage-integration.md
@@ -109,7 +109,7 @@ Add explicit rclone storage records instead of overloading SSH fields:
   - `rclone_remote_id`: selected `rclone_remotes.id`
   - `rclone_remote_path`: relative path inside the remote, without a
     `remote:` prefix
-  - `cache_path`
+  - `cache_path`: server-derived path under `RCLONE_CACHE_ROOT`
   - `sync_policy`: `after_success`, `manual`, or `scheduled`
   - `sync_direction`: always `cache_to_remote` for normal operations
   - `sync_status`: `current`, `pending`, `syncing`, `failed`, `hydrating`
@@ -133,6 +133,9 @@ Canonical target shape:
 - API responses may include a derived, read-only `rclone_target` preview such
   as `prod-s3:borg-ui/repositories/app`, but clients must not submit that full
   URI back as `rclone_remote_path`.
+- Derive `cache_path` server-side from `RCLONE_CACHE_ROOT` and repository
+  identity. Clients must not submit a custom cache path in create or import
+  requests.
 
 ## Runtime Flow
 
@@ -272,7 +275,7 @@ When rclone is selected, the wizard shows:
 - Remote selector with test status.
 - Provider badge and remote name.
 - Relative remote path field with browse action.
-- Local cache path preview, editable by advanced users.
+- Server-derived, read-only local cache path preview.
 - Sync policy selector:
   - Sync after successful Borg job (default)
   - Manual sync


### PR DESCRIPTION
## Description
Adds durable planning artifacts for BOR-65's rclone integration direction:

- Product and architecture spec for rclone-backed repository storage.
- Implementation plan covering backend, frontend, packaging, validation, rollout, and handoff.
- Static HTML mockup showing the repository wizard path, route preview, derived read-only cache path, semantic sync-policy controls, pointer affordance, and repository card sync status.

The recommended architecture keeps Borg operations on a normal local repository cache and mirrors that cache to rclone after Borg transactions complete. Direct rclone mount is documented as out of scope for the first slice.

## Related Issue
Linear: BOR-65
Refs #211

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] UI/UX improvement
- [ ] Test addition/improvement
- [ ] Refactoring

## Testing
- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass

Commands run:

- `cd docs && npm run build`
- `cd frontend && npx prettier --check ../docs/engineering/specs/2026-05-24-rclone-storage-integration.md ../docs/engineering/plans/2026-05-24-rclone-storage-integration.md ../docs/engineering/mockups/2026-05-24-rclone-storage-integration.html`
- `cd frontend && node --input-type=module -e "jsdom mockup validation: relative path, read-only cache output, semantic sync-policy buttons, and pointer cursor"`
- `git diff --check origin/main...HEAD`

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Static HTML mockup added at `docs/engineering/mockups/2026-05-24-rclone-storage-integration.html`.

## Additional Context
This PR intentionally does not implement runtime rclone behavior. It resolves the planning scope requested in BOR-65 so the future implementation can proceed from an explicit storage model, security posture, UI direction, and validation plan.

---

By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
