### PR TITLE
Document archive browsing limits

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,6 +147,28 @@ Priority for UI-managed timeout settings:
 2. environment variable
 3. built-in default
 
+## Archive Browsing Limits
+
+Admins can change archive browsing safety limits in
+Settings > System > Archive Browsing Limits, or by opening `/settings/system`
+directly.
+
+Use these settings when browsing a very large archive fails with an archive
+size or line-limit error. `Max Files to Load` controls how many archive entries
+Borg UI will read before stopping the `borg list` process. `Max Memory (MB)`
+limits the estimated memory used while building the archive browser response.
+
+Defaults and allowed ranges:
+
+| Setting | Default | Allowed range |
+| --- | --- | --- |
+| Max Files to Load | `1,000,000` | `100,000` to `50,000,000` |
+| Max Memory (MB) | `1,024` | `100` to `16,384` |
+
+Raise these values only when the server has enough RAM for the archive being
+browsed. Very high limits can make Borg UI use much more memory while it builds
+the file tree.
+
 ## System Packages
 
 Admins can install extra system packages from Settings > System > Packages.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -109,6 +109,22 @@ The first browse of a large archive can be slow because Borg has to list archive
 contents. Make sure Redis is running for repeated browsing and see
 [Cache](cache).
 
+### Archive browsing fails with "Line limit exceeded"
+
+When an archive contains more entries than Borg UI's safety limit, logs can show
+messages such as `Line limit exceeded, terminating command`,
+`Archive too large for safe browsing`, or an HTTP `413` response from an
+archive browse endpoint.
+
+An administrator can raise the limit in
+Settings > System > Archive Browsing Limits, or by opening `/settings/system`
+directly and updating `Max Files to Load`. If the archive also needs more memory
+to build the file tree, increase `Max Memory (MB)` there as well.
+
+Increase these values gradually. Very large archives can require substantial
+RAM, and setting the limits too high can cause the Borg UI server to run out of
+memory. For more detail, see [Configuration](configuration#archive-browsing-limits).
+
 ## More Troubleshooting
 
 - [Authentication and SSO](authentication#troubleshooting)


### PR DESCRIPTION
## Description
Document where administrators can update archive browsing safety limits and add troubleshooting guidance for archives that exceed the default browse line limit.

## Related Issue
Fixes #542

Related Linear issue: BOR-69

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass

Validation run:
- `git diff --check`
- `cd docs && npm ci`
- `cd docs && npm run build`

No unit tests were added because this PR only changes Markdown documentation. GitHub Actions completed successfully for the full PR check suite.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

Unit tests were not run locally because this is a docs-only change; the docs site build passed locally and the PR unit-test checks passed in CI.

## Screenshots (if applicable)
Not applicable; documentation-only change.

## Additional Context
The linked issue reports `Line limit exceeded, terminating command` after the default one-million archive entry limit. The app already exposes these controls under Settings > System > Archive Browsing Limits at `/settings/system`.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
