### PR TITLE
Add Symphony Linear ticket metadata bootstrap

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -205,7 +205,7 @@ For BOR-70 only, complete a one-time backfill before moving the issue to
    skip metadata changes and route directly.
 4. Route to the matching flow:
    - `Backlog` -> do not modify issue content/state; stop and wait for human to move it to `Todo`.
-   - `Todo` -> run the Linear metadata bootstrap, immediately move to `In Progress`, then ensure bootstrap workpad comment exists (create if missing), then start execution flow.
+   - `Todo` -> immediately move to `In Progress`, then ensure bootstrap workpad comment exists (create if missing), then start execution flow.
      - If PR is already attached, start by reviewing all open PR comments and deciding required changes vs explicit pushback responses.
    - `In Progress` -> continue execution flow from current scratchpad comment.
    - `Human Review` -> wait and poll for decision/review updates.
@@ -217,7 +217,6 @@ For BOR-70 only, complete a one-time backfill before moving the issue to
    - If a branch PR exists and is `CLOSED` or `MERGED`, treat prior branch work as non-reusable for this run.
    - Create a fresh branch from `origin/main` and restart execution flow as a new attempt.
 6. For `Todo` tickets, do startup sequencing in this exact order:
-   - run the Linear metadata bootstrap
    - `update_issue(..., state: "In Progress")`
    - find/create `## Codex Workpad` bootstrap comment
    - only then begin analysis/planning/implementation work.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -157,7 +157,13 @@ terminal state.
    - `Desired outcome`
    - `Acceptance criteria`
    - `Validation`
-   - `Notes` or `Original request` when needed to preserve important context
+   - `Notes` when needed to preserve important context
+   Derive the `Problem`, `Desired outcome`, and `Acceptance criteria` from the
+   original request, linked issue/PR context, and existing ticket comments. Do
+   not use generic boilerplate acceptance criteria such as "the title and labels
+   clearly identify the work" unless that is the actual user-requested outcome.
+   Preserve the raw original request in a collapsed `<details>` appendix or
+   block quote so it remains available for audit without dominating the ticket.
 4. Preserve every substantive requirement, constraint, and ticket-authored
    `Validation`, `Test Plan`, or `Testing` section. Do not weaken acceptance
    criteria while rewriting rough text.
@@ -174,9 +180,10 @@ terminal state.
    rewritten `description`, and either `labelIds` or `addedLabelIds` as
    appropriate. Use `addedLabelIds` when preserving existing labels, and
    `labelIds` only when replacing the full label set is intentional.
-7. After the workpad exists, record a short metadata bootstrap note in the
-   workpad with the title chosen, labels applied or created, and any skipped
-   field with the reason.
+7. If a workpad already exists, record the metadata bootstrap note immediately
+   with the title chosen, labels applied or created, and any skipped field with
+   the reason. For `Todo`, defer this note until after the `## Codex Workpad`
+   comment is created during the Todo startup sequence.
 
 ### BOR-70 previous-ticket backfill
 
@@ -186,7 +193,9 @@ For BOR-70 only, complete a one-time backfill before moving the issue to
 1. Query previous Borg UI project tickets, excluding BOR-70 and any issue that
    Linear reports as uneditable or inaccessible.
 2. Apply the same title, description, and label policy from the Linear metadata
-   bootstrap to each previous ticket.
+   bootstrap to each previous ticket, including request-specific problem,
+   outcome, and acceptance criteria. Do not replace rough descriptions with a
+   repeated generic template.
 3. Create missing labels with `issueLabelCreate` when needed, then apply them
    with `issueUpdate` using `addedLabelIds` unless a full replacement is
    explicitly safer.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -79,7 +79,9 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 
 ## Default posture
 
-- Start by determining the ticket's current status, then follow the matching flow for that status.
+- Start by determining the ticket's current status, running the Linear
+  metadata bootstrap when the state allows it, then following the matching flow
+  for that status.
 - Start every task by opening the tracking workpad comment and bringing it up to date before doing new implementation work.
 - Spend extra effort up front on planning and verification design before implementation.
 - Reproduce first: always confirm the current behavior/issue signal before changing code so the fix target is explicit.
@@ -136,13 +138,74 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 - `Rework` -> reviewer requested changes; planning + implementation required.
 - `Done` -> terminal state; no further action required.
 
+## Linear Metadata Bootstrap
+
+Run this before ordinary implementation work for `Todo`, `In Progress`,
+`Code Review Reply`, and `Rework` issues. Do not run it for `Backlog`,
+`Human Review`, `Merging`, `Done`, `Duplicate`, `Canceled`, or any other
+terminal state.
+
+1. Fetch the issue title, description, labels, comments, project, team, and
+   available team labels.
+2. Rewrite the Linear issue title into a concise, outcome-oriented title that
+   a future engineer can understand without reading the original rough intake.
+   Do not include the Linear identifier in the title; Linear already displays
+   it.
+3. Rewrite the Linear issue description into durable Markdown using the
+   relevant sections for the issue:
+   - `Problem`
+   - `Desired outcome`
+   - `Acceptance criteria`
+   - `Validation`
+   - `Notes` or `Original request` when needed to preserve important context
+4. Preserve every substantive requirement, constraint, and ticket-authored
+   `Validation`, `Test Plan`, or `Testing` section. Do not weaken acceptance
+   criteria while rewriting rough text.
+5. Classify labels before implementation:
+   - Use existing type labels when they fit: `Bug` for regressions or broken
+     behavior, `Feature` for new capability, and `Improvement` for workflow,
+     documentation, polish, performance, reliability, or maintainability work.
+   - Add a clear domain label when useful for future filtering, for example
+     `Symphony`, `Frontend`, `Backend`, `Documentation`, `Infrastructure`,
+     `Security`, `Managed Agents`, or `Backup/Restore`.
+   - If an appropriate label does not exist, create the missing label with
+     `issueLabelCreate`, then apply it.
+6. Update Linear with `issueUpdate`, setting the rewritten `title`,
+   rewritten `description`, and either `labelIds` or `addedLabelIds` as
+   appropriate. Use `addedLabelIds` when preserving existing labels, and
+   `labelIds` only when replacing the full label set is intentional.
+7. After the workpad exists, record a short metadata bootstrap note in the
+   workpad with the title chosen, labels applied or created, and any skipped
+   field with the reason.
+
+### BOR-70 previous-ticket backfill
+
+For BOR-70 only, complete a one-time backfill before moving the issue to
+`Human Review`:
+
+1. Query previous Borg UI project tickets, excluding BOR-70 and any issue that
+   Linear reports as uneditable or inaccessible.
+2. Apply the same title, description, and label policy from the Linear metadata
+   bootstrap to each previous ticket.
+3. Create missing labels with `issueLabelCreate` when needed, then apply them
+   with `issueUpdate` using `addedLabelIds` unless a full replacement is
+   explicitly safer.
+4. Do not change issue state, assignee, comments, attachments, PR links,
+   project, milestone, or workpad content while backfilling previous tickets.
+5. Record updated, skipped, and failed counts in the BOR-70 workpad. For every
+   skipped or failed issue, record the identifier and concise reason.
+
 ## Step 0: Determine current ticket state and route
 
 1. Fetch the issue by explicit ticket ID.
 2. Read the current state.
-3. Route to the matching flow:
+3. If the current state is `Todo`, `In Progress`, `Code Review Reply`, or
+   `Rework`, run the Linear metadata bootstrap before routing. If the state is
+   `Backlog`, `Human Review`, `Merging`, `Done`, `Duplicate`, or `Canceled`,
+   skip metadata changes and route directly.
+4. Route to the matching flow:
    - `Backlog` -> do not modify issue content/state; stop and wait for human to move it to `Todo`.
-   - `Todo` -> immediately move to `In Progress`, then ensure bootstrap workpad comment exists (create if missing), then start execution flow.
+   - `Todo` -> run the Linear metadata bootstrap, immediately move to `In Progress`, then ensure bootstrap workpad comment exists (create if missing), then start execution flow.
      - If PR is already attached, start by reviewing all open PR comments and deciding required changes vs explicit pushback responses.
    - `In Progress` -> continue execution flow from current scratchpad comment.
    - `Human Review` -> wait and poll for decision/review updates.
@@ -150,14 +213,15 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
    - `Merging` -> on entry, open and follow `.codex/skills/land/SKILL.md`; do not call `gh pr merge` directly.
    - `Rework` -> run rework flow.
    - `Done` -> do nothing and shut down.
-4. Check whether a PR already exists for the current branch and whether it is closed.
+5. Check whether a PR already exists for the current branch and whether it is closed.
    - If a branch PR exists and is `CLOSED` or `MERGED`, treat prior branch work as non-reusable for this run.
    - Create a fresh branch from `origin/main` and restart execution flow as a new attempt.
-5. For `Todo` tickets, do startup sequencing in this exact order:
+6. For `Todo` tickets, do startup sequencing in this exact order:
+   - run the Linear metadata bootstrap
    - `update_issue(..., state: "In Progress")`
    - find/create `## Codex Workpad` bootstrap comment
    - only then begin analysis/planning/implementation work.
-6. Add a short comment if state and issue content are inconsistent, then proceed with the safest flow.
+7. Add a short comment if state and issue content are inconsistent, then proceed with the safest flow.
 
 ## Step 1: Start/continue execution (Todo or In Progress)
 
@@ -356,7 +420,9 @@ Use this only when completion is blocked by missing required tools or missing au
 - If the branch PR is already closed/merged, do not reuse that branch or prior implementation state for continuation.
 - For closed/merged branch PRs, create a new branch from `origin/main` and restart from reproduction/planning as if starting fresh.
 - If issue state is `Backlog`, do not modify it; wait for human to move to `Todo`.
-- Do not edit the issue body/description for planning or progress tracking.
+- Do not edit the issue body/description for planning or progress tracking;
+  only the Linear metadata bootstrap may rewrite issue title/description as
+  explicit ticket metadata work.
 - Use exactly one persistent workpad comment (`## Codex Workpad`) per issue.
 - If comment editing is unavailable in-session, use the update script. Only report blocked if both MCP editing and script-based editing are unavailable.
 - Temporary proof edits are allowed only for local verification and must be reverted before commit.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -162,8 +162,10 @@ terminal state.
    original request, linked issue/PR context, and existing ticket comments. Do
    not use generic boilerplate acceptance criteria such as "the title and labels
    clearly identify the work" unless that is the actual user-requested outcome.
-   Preserve the raw original request in a collapsed `<details>` appendix or
-   block quote so it remains available for audit without dominating the ticket.
+   Preserve the raw original request in a Markdown block quote appendix so it
+   remains available for audit without dominating the ticket. Do not use literal
+   `<details>` markup in Linear descriptions; Linear can show those tags as
+   visible text instead of collapsing them.
 4. Preserve every substantive requirement, constraint, and ticket-authored
    `Validation`, `Test Plan`, or `Testing` section. Do not weaken acceptance
    criteria while rewriting rough text.

--- a/docs/engineering/plans/2026-05-27-symphony-linear-ticket-metadata-bootstrap.md
+++ b/docs/engineering/plans/2026-05-27-symphony-linear-ticket-metadata-bootstrap.md
@@ -28,7 +28,10 @@ ruff.
 Create tests that assert the workflow has a required metadata bootstrap before
 Step 0, that it mentions `issueUpdate`, `issueLabelCreate`, title/description
 rewrites, label creation, and previous-ticket backfill. Also assert
-`docs/symphony.md` documents the operator behavior.
+`docs/symphony.md` documents the operator behavior, that descriptions derive
+the problem, desired outcome, and acceptance criteria from the original request,
+and that raw original request text is preserved in a collapsed or quoted
+appendix instead of repeated as the primary ticket body.
 
 - [ ] **Step 2: Run the test to verify it fails**
 
@@ -50,7 +53,9 @@ Expected: failures show the metadata bootstrap and docs text are missing.
 Insert a `## Linear metadata bootstrap` section before Step 0. Require active
 issues to polish the title and description using Linear `issueUpdate`, assign
 labels using `labelIds`/`addedLabelIds`, and create missing labels using
-`issueLabelCreate`.
+`issueLabelCreate`. Explicitly prohibit repeated generic acceptance criteria;
+the rewritten problem, desired outcome, and acceptance criteria must be derived
+from the original request and linked context.
 
 - [ ] **Step 2: Integrate startup sequencing**
 
@@ -92,8 +97,9 @@ labels.
 - [ ] **Step 2: Backfill previous tickets**
 
 Query previous Borg UI project issues, apply the same title/description/label
-policy where the issue is still editable, and record counts/skips in the
-workpad.
+policy where the issue is still editable, replace repeated generic descriptions
+with request-specific problem/outcome/acceptance criteria, preserve raw request
+text in a collapsed or quoted appendix, and record counts/skips in the workpad.
 
 ### Task 5: Validate And Publish
 

--- a/docs/engineering/plans/2026-05-27-symphony-linear-ticket-metadata-bootstrap.md
+++ b/docs/engineering/plans/2026-05-27-symphony-linear-ticket-metadata-bootstrap.md
@@ -1,0 +1,119 @@
+# Symphony Linear Ticket Metadata Bootstrap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:executing-plans to implement this plan task-by-task. Subagent
+> execution is not used here because BOR-70 is running as an unattended
+> single-workspace orchestration session.
+
+**Goal:** Add a repository-owned Symphony workflow contract requiring Linear
+ticket title, description, and label cleanup before active work proceeds.
+
+**Architecture:** Keep the change in the orchestration prompt and setup docs.
+`WORKFLOW.md` defines the metadata bootstrap, previous-ticket backfill, and
+guardrail exceptions. `docs/symphony.md` documents operator expectations. A
+focused pytest file guards the contract text.
+
+**Tech Stack:** Markdown workflow contract, Linear GraphQL operations, pytest,
+ruff.
+
+---
+
+### Task 1: Workflow Contract Test
+
+**Files:**
+- Create: `tests/unit/test_workflow_ticket_metadata_setup.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create tests that assert the workflow has a required metadata bootstrap before
+Step 0, that it mentions `issueUpdate`, `issueLabelCreate`, title/description
+rewrites, label creation, and previous-ticket backfill. Also assert
+`docs/symphony.md` documents the operator behavior.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+pytest tests/unit/test_workflow_ticket_metadata_setup.py -v
+```
+
+Expected: failures show the metadata bootstrap and docs text are missing.
+
+### Task 2: Workflow Metadata Bootstrap
+
+**Files:**
+- Modify: `WORKFLOW.md`
+
+- [ ] **Step 1: Add the required bootstrap section**
+
+Insert a `## Linear metadata bootstrap` section before Step 0. Require active
+issues to polish the title and description using Linear `issueUpdate`, assign
+labels using `labelIds`/`addedLabelIds`, and create missing labels using
+`issueLabelCreate`.
+
+- [ ] **Step 2: Integrate startup sequencing**
+
+Update Step 0 and the Todo startup order so metadata cleanup runs before normal
+implementation work while preserving `Backlog` and terminal-state safety.
+
+- [ ] **Step 3: Add the BOR-70 backfill step**
+
+Require BOR-70 to query previous Borg UI tickets, apply the same metadata
+policy, create missing labels as needed, and record updated/skipped counts in
+the workpad.
+
+### Task 3: Setup Documentation
+
+**Files:**
+- Modify: `docs/symphony.md`
+
+- [ ] **Step 1: Document startup metadata cleanup**
+
+Add operator-facing text explaining that Symphony updates Linear titles,
+descriptions, and labels before execution.
+
+- [ ] **Step 2: Document backfill behavior**
+
+Add text explaining that BOR-70 performs the one-time previous-ticket backfill
+and that future backfills should use the same metadata bootstrap policy.
+
+### Task 4: Linear Metadata Backfill
+
+**Files:**
+- Update: Linear issue metadata through `linear_graphql`
+- Update: Linear workpad only
+
+- [ ] **Step 1: Update BOR-70 metadata**
+
+Rewrite BOR-70 title/description to durable wording and apply appropriate
+labels.
+
+- [ ] **Step 2: Backfill previous tickets**
+
+Query previous Borg UI project issues, apply the same title/description/label
+policy where the issue is still editable, and record counts/skips in the
+workpad.
+
+### Task 5: Validate And Publish
+
+**Files:**
+- Update: Linear workpad
+- Use: `.github/PULL_REQUEST_TEMPLATE.md`
+
+- [ ] **Step 1: Run validation**
+
+Run:
+
+```bash
+pytest tests/unit/test_workflow_ticket_metadata_setup.py -v
+ruff check app tests
+ruff format --check app tests
+git diff --check
+```
+
+- [ ] **Step 2: Commit and push**
+
+Use the repository `commit` and `push` skills. Create or update the PR, fill the
+PR template, add the `symphony` label, attach it to BOR-70, sweep PR feedback
+and checks, then move Linear to `Human Review`.

--- a/docs/engineering/plans/2026-05-27-symphony-linear-ticket-metadata-bootstrap.md
+++ b/docs/engineering/plans/2026-05-27-symphony-linear-ticket-metadata-bootstrap.md
@@ -30,7 +30,7 @@ Step 0, that it mentions `issueUpdate`, `issueLabelCreate`, title/description
 rewrites, label creation, and previous-ticket backfill. Also assert
 `docs/symphony.md` documents the operator behavior, that descriptions derive
 the problem, desired outcome, and acceptance criteria from the original request,
-and that raw original request text is preserved in a collapsed or quoted
+and that raw original request text is preserved in a Markdown block quote
 appendix instead of repeated as the primary ticket body.
 
 - [ ] **Step 2: Run the test to verify it fails**
@@ -99,7 +99,7 @@ labels.
 Query previous Borg UI project issues, apply the same title/description/label
 policy where the issue is still editable, replace repeated generic descriptions
 with request-specific problem/outcome/acceptance criteria, preserve raw request
-text in a collapsed or quoted appendix, and record counts/skips in the workpad.
+text in a Markdown block quote appendix, and record counts/skips in the workpad.
 
 ### Task 5: Validate And Publish
 

--- a/docs/engineering/specs/2026-05-27-symphony-linear-ticket-metadata-bootstrap.md
+++ b/docs/engineering/specs/2026-05-27-symphony-linear-ticket-metadata-bootstrap.md
@@ -26,9 +26,11 @@ bootstrap before normal implementation work:
 - rewrite the description into durable sections that preserve original intent,
   acceptance criteria, validation requirements, and important constraints;
 - derive the problem, desired outcome, and acceptance criteria from the rough
-  request and linked context instead of using repeated generic boilerplate;
-- preserve the raw original request in a collapsed or quoted appendix so the
-  rewritten ticket body leads with actionable work;
+  request and linked context instead of using repeated generic boilerplate
+  (generic lines such as 'the title and labels clearly identify the work'); see
+  `WORKFLOW.md` for concrete examples;
+- preserve the raw original request in a Markdown block quote appendix so the
+  rewritten ticket body leads with actionable work in Linear;
 - choose an appropriate type label from the existing labels when possible;
 - create and apply an additional label when the existing label set is
   insufficient for a clear workflow or domain classification;

--- a/docs/engineering/specs/2026-05-27-symphony-linear-ticket-metadata-bootstrap.md
+++ b/docs/engineering/specs/2026-05-27-symphony-linear-ticket-metadata-bootstrap.md
@@ -1,0 +1,72 @@
+# Symphony Linear Ticket Metadata Bootstrap Spec
+
+## Goal
+
+Make Symphony normalize Linear ticket metadata before execution so rough intake
+tickets become understandable, durable work items with useful labels.
+
+## Current Behavior
+
+`WORKFLOW.md` starts by fetching the issue state and routing by status. It asks
+the agent to keep a workpad current, but it does not require the agent to
+rewrite rough ticket titles, rewrite rough descriptions, create or assign
+labels, or backfill older Borg UI tickets. A reproduction grep before edits
+only found `title/description` in the follow-up issue guardrail.
+
+The Symphony runtime itself is not vendored into this repository. Borg UI owns
+the repository contract in `WORKFLOW.md` and operator documentation in
+`docs/symphony.md`.
+
+## Desired Behavior
+
+For every active issue Symphony picks up, the prompt requires a Linear metadata
+bootstrap before normal implementation work:
+
+- rewrite the title into a concise outcome-oriented title;
+- rewrite the description into durable sections that preserve original intent,
+  acceptance criteria, validation requirements, and important constraints;
+- choose an appropriate type label from the existing labels when possible;
+- create and apply an additional label when the existing label set is
+  insufficient for a clear workflow or domain classification;
+- record the bootstrap result in the single workpad after the workpad exists;
+- preserve `Backlog`, terminal, and planning-only guardrails.
+
+The prompt also documents a one-time backfill step for BOR-70: query previous
+Borg UI project tickets, apply the same metadata logic, create missing labels
+as needed, and record counts and any skips in the workpad.
+
+## Repository Scope
+
+- Update `WORKFLOW.md` to add the metadata bootstrap sequence and backfill
+  requirements.
+- Update `docs/symphony.md` so operators know Symphony now updates Linear
+  titles, descriptions, and labels during issue startup.
+- Add a focused unit test that treats the workflow and setup docs as the
+  repository-owned Symphony contract.
+- Execute the BOR-70 Linear metadata update/backfill through the available
+  Linear GraphQL tooling and record evidence in the workpad.
+
+No Borg UI app runtime or frontend changes are required.
+
+## Acceptance Criteria
+
+- `WORKFLOW.md` requires active tickets to run a Linear metadata bootstrap
+  before implementation work.
+- The bootstrap requires title and description updates through Linear.
+- The bootstrap requires label assignment and creating missing labels when the
+  existing label set is not enough.
+- The BOR-70 previous-ticket backfill is documented as a required one-time
+  step with count/skip reporting in the workpad.
+- `docs/symphony.md` documents the title, description, label, and backfill
+  behavior for operators.
+- Focused pytest coverage fails before the workflow/docs change and passes
+  after it.
+
+## Validation
+
+- `pytest tests/unit/test_workflow_ticket_metadata_setup.py -v`
+- `ruff check app tests`
+- `ruff format --check app tests`
+- `git diff --check`
+- Linear workpad evidence showing BOR-70 metadata was updated and previous
+  ticket backfill was run or explicitly skipped with reason.

--- a/docs/engineering/specs/2026-05-27-symphony-linear-ticket-metadata-bootstrap.md
+++ b/docs/engineering/specs/2026-05-27-symphony-linear-ticket-metadata-bootstrap.md
@@ -25,6 +25,10 @@ bootstrap before normal implementation work:
 - rewrite the title into a concise outcome-oriented title;
 - rewrite the description into durable sections that preserve original intent,
   acceptance criteria, validation requirements, and important constraints;
+- derive the problem, desired outcome, and acceptance criteria from the rough
+  request and linked context instead of using repeated generic boilerplate;
+- preserve the raw original request in a collapsed or quoted appendix so the
+  rewritten ticket body leads with actionable work;
 - choose an appropriate type label from the existing labels when possible;
 - create and apply an additional label when the existing label set is
   insufficient for a clear workflow or domain classification;
@@ -53,6 +57,8 @@ No Borg UI app runtime or frontend changes are required.
 - `WORKFLOW.md` requires active tickets to run a Linear metadata bootstrap
   before implementation work.
 - The bootstrap requires title and description updates through Linear.
+- The bootstrap requires request-specific descriptions and acceptance criteria,
+  not generic metadata boilerplate.
 - The bootstrap requires label assignment and creating missing labels when the
   existing label set is not enough.
 - The BOR-70 previous-ticket backfill is documented as a required one-time

--- a/docs/symphony.md
+++ b/docs/symphony.md
@@ -68,12 +68,32 @@ http://localhost:4000
 - Create an isolated workspace under `~/code/borg-ui-symphony-workspaces`.
 - Clone Borg UI into the issue workspace.
 - Start `codex app-server` in the workspace.
+- Run the Linear ticket metadata bootstrap before active implementation work:
+  Codex updates the Linear issue title, description, and labels so rough intake
+  tickets become durable work items.
+- Create and apply a missing label when the existing label set is insufficient
+  for the issue type or domain.
 - Instruct Codex to keep a single `## Codex Workpad` comment on the Linear
   issue.
 - Move validated PR work to `Human Review`.
 - Address in-place PR feedback when a human moves an issue to
   `Code Review Reply`.
 - Land approved work only after a human moves the issue to `Merging`.
+
+## Linear Ticket Metadata Bootstrap
+
+Before active implementation, the workflow prompt tells Codex to update the
+Linear issue title, description, and labels through Linear. Titles should be
+concise outcomes. Descriptions should preserve the original request while
+adding durable sections for the problem, desired outcome, acceptance criteria,
+validation, and any important notes. Labeling uses existing `Bug`, `Feature`,
+and `Improvement` labels when they fit, and creates a missing label when the
+existing label set is insufficient for filtering the issue by type or domain.
+
+BOR-70 includes a one-time BOR-70 previous-ticket backfill: previous Borg UI
+project tickets should be updated with the same title, description, and label
+policy, while leaving states, comments, attachments, PR links, and workpads
+unchanged. The backfill result is recorded in the BOR-70 workpad.
 
 ## Borg UI Validation Policy
 

--- a/docs/symphony.md
+++ b/docs/symphony.md
@@ -86,14 +86,21 @@ Before active implementation, the workflow prompt tells Codex to update the
 Linear issue title, description, and labels through Linear. Titles should be
 concise outcomes. Descriptions should preserve the original request while
 adding durable sections for the problem, desired outcome, acceptance criteria,
-validation, and any important notes. Labeling uses existing `Bug`, `Feature`,
-and `Improvement` labels when they fit, and creates a missing label when the
-existing label set is insufficient for filtering the issue by type or domain.
+validation, and any important notes. Codex must derive the `Problem`, `Desired
+outcome`, and `Acceptance criteria` from the original request rather than using
+generic boilerplate acceptance criteria. The original request remains available
+for audit in a collapsed `<details>` appendix or block quote so the rewritten
+ticket body stays focused on the actionable work. Labeling uses existing `Bug`,
+`Feature`, and `Improvement` labels when they fit, and creates a missing label
+when the existing label set is insufficient for filtering the issue by type or
+domain.
 
 BOR-70 includes a one-time BOR-70 previous-ticket backfill: previous Borg UI
 project tickets should be updated with the same title, description, and label
 policy, while leaving states, comments, attachments, PR links, and workpads
-unchanged. The backfill result is recorded in the BOR-70 workpad.
+unchanged. The backfill should avoid repeated generic descriptions and should
+replace them with request-specific problem, desired outcome, and acceptance
+criteria sections. The backfill result is recorded in the BOR-70 workpad.
 
 ## Borg UI Validation Policy
 

--- a/docs/symphony.md
+++ b/docs/symphony.md
@@ -89,11 +89,12 @@ adding durable sections for the problem, desired outcome, acceptance criteria,
 validation, and any important notes. Codex must derive the `Problem`, `Desired
 outcome`, and `Acceptance criteria` from the original request rather than using
 generic boilerplate acceptance criteria. The original request remains available
-for audit in a collapsed `<details>` appendix or block quote so the rewritten
-ticket body stays focused on the actionable work. Labeling uses existing `Bug`,
-`Feature`, and `Improvement` labels when they fit, and creates a missing label
-when the existing label set is insufficient for filtering the issue by type or
-domain.
+for audit in a Markdown block quote appendix so the rewritten ticket body stays
+focused on the actionable work. Codex should not use literal `<details>` markup
+in Linear descriptions because Linear can show those tags as visible text.
+Labeling uses existing `Bug`, `Feature`, and `Improvement` labels when they fit,
+and creates a missing label when the existing label set is insufficient for
+filtering the issue by type or domain.
 
 BOR-70 includes a one-time BOR-70 previous-ticket backfill: previous Borg UI
 project tickets should be updated with the same title, description, and label

--- a/tests/unit/test_workflow_ticket_metadata_setup.py
+++ b/tests/unit/test_workflow_ticket_metadata_setup.py
@@ -37,6 +37,33 @@ def test_metadata_bootstrap_updates_title_description_and_labels():
     assert "create the missing label" in normalized
 
 
+def test_metadata_bootstrap_derives_specific_description_from_original_request():
+    workflow = read("WORKFLOW.md")
+    docs = read("docs/symphony.md")
+    combined = squash(f"{workflow}\n{docs}")
+    lower_combined = combined.lower()
+
+    assert (
+        "derive the `problem`, `desired outcome`, and `acceptance criteria` "
+        "from the original request"
+    ) in lower_combined
+    assert "do not use generic boilerplate acceptance criteria" in lower_combined
+    assert "collapsed `<details>` appendix or block quote" in lower_combined
+
+
+def test_metadata_bootstrap_defers_todo_workpad_note_until_workpad_exists():
+    workflow = read("WORKFLOW.md")
+    normalized = squash(workflow)
+
+    assert (
+        "If a workpad already exists, record the metadata bootstrap note immediately"
+    ) in normalized
+    assert (
+        "For `Todo`, defer this note until after the `## Codex Workpad` comment "
+        "is created"
+    ) in normalized
+
+
 def test_todo_metadata_bootstrap_runs_once_before_status_routing():
     workflow = read("WORKFLOW.md")
     normalized = squash(workflow)

--- a/tests/unit/test_workflow_ticket_metadata_setup.py
+++ b/tests/unit/test_workflow_ticket_metadata_setup.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def squash(text: str) -> str:
+    return " ".join(text.split())
+
+
+def test_metadata_bootstrap_runs_before_status_routing():
+    workflow = read("WORKFLOW.md")
+
+    assert "## Linear Metadata Bootstrap" in workflow
+    assert workflow.index("## Linear Metadata Bootstrap") < workflow.index(
+        "## Step 0: Determine current ticket state and route"
+    )
+
+
+def test_metadata_bootstrap_updates_title_description_and_labels():
+    workflow = read("WORKFLOW.md")
+    normalized = squash(workflow)
+    lower_normalized = normalized.lower()
+
+    assert "rewrite the linear issue title" in lower_normalized
+    assert "rewrite the linear issue description" in lower_normalized
+    assert "issueUpdate" in workflow
+    assert "title" in workflow
+    assert "description" in workflow
+    assert "labelIds" in workflow
+    assert "addedLabelIds" in workflow
+    assert "issueLabelCreate" in workflow
+    assert "create the missing label" in normalized
+
+
+def test_todo_startup_sequence_includes_metadata_before_state_move():
+    workflow = read("WORKFLOW.md")
+    normalized = squash(workflow)
+
+    assert (
+        "For `Todo` tickets, do startup sequencing in this exact order: - run "
+        "the Linear metadata bootstrap - `update_issue(..., state: "
+        '"In Progress")`'
+    ) in normalized
+
+
+def test_previous_ticket_backfill_is_required_for_bor_70():
+    workflow = read("WORKFLOW.md")
+    normalized = squash(workflow)
+    lower_normalized = normalized.lower()
+
+    assert "BOR-70 previous-ticket backfill" in workflow
+    assert "query previous borg ui project tickets" in lower_normalized
+    assert "apply the same title, description, and label policy" in lower_normalized
+    assert "updated, skipped, and failed counts" in normalized
+
+
+def test_symphony_docs_document_metadata_bootstrap_and_backfill():
+    docs = read("docs/symphony.md")
+    normalized = squash(docs)
+
+    assert "Linear ticket metadata bootstrap" in docs
+    assert "updates the Linear issue title, description, and labels" in normalized
+    assert "creates a missing label when the existing label set is insufficient" in (
+        normalized
+    )
+    assert "BOR-70 previous-ticket backfill" in docs

--- a/tests/unit/test_workflow_ticket_metadata_setup.py
+++ b/tests/unit/test_workflow_ticket_metadata_setup.py
@@ -48,7 +48,21 @@ def test_metadata_bootstrap_derives_specific_description_from_original_request()
         "from the original request"
     ) in lower_combined
     assert "do not use generic boilerplate acceptance criteria" in lower_combined
-    assert "collapsed `<details>` appendix or block quote" in lower_combined
+    assert "markdown block quote appendix" in lower_combined
+    assert "collapsed `<details>` appendix" not in lower_combined
+    assert "literal `<details>` markup" in lower_combined
+
+
+def test_spec_names_generic_boilerplate_example():
+    spec = read(
+        "docs/engineering/specs/2026-05-27-symphony-linear-ticket-metadata-bootstrap.md"
+    )
+    normalized = squash(spec)
+
+    assert (
+        "generic lines such as 'the title and labels clearly identify the work'"
+    ) in normalized
+    assert "see `WORKFLOW.md` for concrete examples" in normalized
 
 
 def test_metadata_bootstrap_defers_todo_workpad_note_until_workpad_exists():

--- a/tests/unit/test_workflow_ticket_metadata_setup.py
+++ b/tests/unit/test_workflow_ticket_metadata_setup.py
@@ -37,14 +37,21 @@ def test_metadata_bootstrap_updates_title_description_and_labels():
     assert "create the missing label" in normalized
 
 
-def test_todo_startup_sequence_includes_metadata_before_state_move():
+def test_todo_metadata_bootstrap_runs_once_before_status_routing():
     workflow = read("WORKFLOW.md")
     normalized = squash(workflow)
 
     assert (
-        "For `Todo` tickets, do startup sequencing in this exact order: - run "
-        "the Linear metadata bootstrap - `update_issue(..., state: "
-        '"In Progress")`'
+        "If the current state is `Todo`, `In Progress`, `Code Review Reply`, or "
+        "`Rework`, run the Linear metadata bootstrap before routing."
+    ) in normalized
+    assert (
+        "`Todo` -> immediately move to `In Progress`, then ensure bootstrap "
+        "workpad comment exists"
+    ) in normalized
+    assert (
+        "For `Todo` tickets, do startup sequencing in this exact order: - "
+        '`update_issue(..., state: "In Progress")`'
     ) in normalized
 
 


### PR DESCRIPTION
## Description
Adds a required Symphony workflow bootstrap that normalizes Linear ticket titles, descriptions, and labels before active implementation work. Documents the operator behavior, adds BOR-70 backfill guidance, and guards the workflow/docs contract with focused pytest coverage.

The latest review fixes make the metadata policy stricter: descriptions must derive the problem, desired outcome, and acceptance criteria from the original request instead of using generic boilerplate. Raw intake is now preserved in a Linear-safe Markdown block quote appendix instead of literal details markup, and Todo workpad notes are deferred until the workpad exists.

## Related Issue
Linear: https://linear.app/nullcodeai/issue/BOR-70/add-symphony-linear-ticket-metadata-bootstrap

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] UI/UX improvement
- [x] Test addition/improvement
- [ ] Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `pytest tests/unit/test_workflow_ticket_metadata_setup.py tests/unit/test_workflow_code_review_reply_mode.py -v`
- `ruff check app tests`
- `ruff format --check app tests`
- `git diff --check`

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable. This is a workflow and documentation change.

## Additional Context
The BOR-70 Linear metadata backfill has been run three times. The final pass updated BOR-5 through BOR-69 so previous tickets no longer contain repeated generic description/acceptance-criteria boilerplate, and each previous ticket now preserves the raw original request in a quoted Markdown appendix without literal details tags.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
