### PR TITLE
Document BorgBase onboarding paths

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -52,6 +52,7 @@ export default defineConfig({
           { text: 'Installation', link: '/installation' },
           { text: 'Configuration', link: '/configuration' },
           { text: 'Usage Guide', link: '/usage-guide' },
+          { text: 'Provider Guides', link: '/provider-guides' },
           { text: 'Licensing', link: '/licensing' },
         ],
       },

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -1,0 +1,71 @@
+---
+title: Provider Guides
+nav_order: 5
+description: "Use Borg UI with BorgBase, hosted Borg services, NAS devices, and existing Borg repositories"
+---
+
+# Provider Guides
+
+Borg UI manages Borg repositories and backup workflows. It does not replace the
+storage provider. Use the path below that matches where your repository already
+lives or where you want new archives to be stored.
+
+| Setup | Use in Borg UI |
+| --- | --- |
+| Local disk or mounted share | Mount the host path into the Borg UI container and use the container path. |
+| NAS or Linux server over SSH | Add a Remote Machine, then create or import an SSH repository. |
+| Hosted Borg service | Add the provider as a Remote Machine and keep the provider's repository path exactly as given. |
+| Existing Borg repository | Use Import Existing. Choose Full mode if Borg UI should run backups, or Observability-only if another tool already writes archives. |
+
+## BorgBase
+
+BorgBase repositories are SSH repositories, but they are not normal servers with
+a general-purpose filesystem. BorgBase repository URLs commonly look like this:
+
+```text
+ssh://abcd@abcd.repo.borgbase.com/./repo
+```
+
+Map that URL into Borg UI like this:
+
+```text
+Host: abcd.repo.borgbase.com
+Port: 22
+Username: abcd
+Default path: /./repo
+Repository path: /./repo
+```
+
+Keep the `/./repo` path from BorgBase. Do not shorten it to `/repo`; the `./`
+segment is part of the hosted SSH path Borg uses for that repository.
+
+Typical flow:
+
+1. Create or import the Borg UI system SSH key.
+2. Add the Borg UI public key to BorgBase.
+3. Create or select the repository in BorgBase.
+4. Add a Remote Machine in Borg UI using the host, username, port, and default path from the BorgBase URL.
+5. Create a remote repository or use Import Existing with the same repository path.
+6. Save, then verify that archives can be listed or that repository creation succeeds.
+
+## Other Hosted Borg Providers
+
+Hosted Borg providers often use SSH URLs with provider-specific path syntax, for
+example a `./` segment or a path relative to a restricted account. Keep that
+syntax when entering the Remote Machine default path and repository path.
+
+If verification fails:
+
+- compare the provider's full SSH URL with the host, username, port, and path in Borg UI
+- preserve any `./` path segment from the provider URL
+- confirm the Borg UI public key is authorized by the provider
+- use Import Existing when the repository was created outside Borg UI
+
+## Existing Scripts or Cron Backups
+
+If scripts, cron, or another backup tool already writes to a Borg repository,
+import the repository instead of recreating it.
+
+Use Full mode when Borg UI should take over backup runs and schedules. Use
+Observability-only mode when Borg UI should browse archives, restore files, run
+checks, and show health without writing new backup archives.

--- a/docs/ssh-keys.md
+++ b/docs/ssh-keys.md
@@ -93,6 +93,15 @@ For Hetzner Storage Box-style paths, keep the provider-specific path syntax:
 ssh://u123456@u123456.your-storagebox.de:23/./backup-repo
 ```
 
+For BorgBase, repository URLs commonly use `/./repo`:
+
+```text
+ssh://abcd@abcd.repo.borgbase.com/./repo
+```
+
+Use `/./repo` as the Remote Machine default path and repository path. Do not
+shorten it to `/repo`. See [Provider Guides](provider-guides).
+
 ## Remote Direct Backups
 
 When a backup plan uses an SSH source and an SSH repository on the same SSH

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -84,6 +84,8 @@ Remote repositories use a Remote Machine connection.
 
 Use remote repositories when the Borg archive should live on another server or off-site storage.
 
+For BorgBase and other hosted Borg providers, see [Provider Guides](provider-guides).
+
 ## Import an Existing Repository
 
 Use Import Existing when a Borg repository already exists and you want Borg UI to manage or monitor it.
@@ -95,6 +97,8 @@ Use Import Existing when a Borg repository already exists and you want Borg UI t
 5. Save, then verify archives can be listed.
 
 Full mode lets Borg UI run backups for the repository. Observability-only mode is for repositories backed up by something else; Borg UI can browse archives, restore files, run checks, and show health, but it will not run backups or scheduled backups for that repository.
+
+If the repository comes from BorgBase or another hosted Borg service, keep the provider's repository path exactly as given. See [Provider Guides](provider-guides).
 
 ## Repository vs Backup Plan
 


### PR DESCRIPTION
## Description
Adds a concise Provider Guides documentation page for users coming from BorgBase, hosted Borg services, NAS/SSH targets, or existing Borg repositories. The BorgBase section maps a repository URL such as `ssh://abcd@abcd.repo.borgbase.com/./repo` into Borg UI fields and calls out that `/./repo` should be preserved.

The PR also adds the page to the VitePress Getting Started sidebar and links it from the Usage Guide and Remote Machines repository path guidance.

## Related Issue
Linear: https://linear.app/nullcodeai/issue/BOR-77/document-borgbase-onboarding-paths

Related GitHub issue: #212

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable: docs-only change)
- [ ] All existing tests pass (not run: app code unchanged)

Validation run:
- `cd docs && npm run build`
- `git diff --check`
- Inspected generated VitePress output for `provider-guides`, `usage-guide`, and `ssh-keys` to confirm sidebar/link/content rendering.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (not applicable: documentation-only change)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes (not applicable: docs-only change)

## Screenshots (if applicable)
Not applicable; documentation content only.

## Additional Context
This follows the latest discussion in GitHub issue #212 where BorgBase setup worked after preserving the `/./repo` path instead of shortening it to `/repo`.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
