### PR TITLE
Document app navigation workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ These instructions apply to the entire repository.
 - Save durable specs and implementation plans under `docs/engineering/specs/` and `docs/engineering/plans/` with dated, slugged filenames such as `YYYY-MM-DD-feature-name.md`.
 - Keep process proportional: small mechanical fixes can use a concise inline plan plus targeted tests or verification instead of a full written spec.
 - Do not create generic `design.md` files by default; use feature-specific specs only when a written spec is warranted.
+- When sidebar tabs, navigation groups, or the main user flow change, update the relevant user docs in the same change so navigation guidance stays current.
 
 ## UI Workflow
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -52,6 +52,7 @@ export default defineConfig({
           { text: 'Installation', link: '/installation' },
           { text: 'Configuration', link: '/configuration' },
           { text: 'Usage Guide', link: '/usage-guide' },
+          { text: 'Sidebar Navigation', link: '/sidebar-navigation' },
           { text: 'Licensing', link: '/licensing' },
         ],
       },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -52,7 +52,7 @@ export default defineConfig({
           { text: 'Installation', link: '/installation' },
           { text: 'Configuration', link: '/configuration' },
           { text: 'Usage Guide', link: '/usage-guide' },
-          { text: 'Sidebar Navigation', link: '/sidebar-navigation' },
+          { text: 'Navigation', link: '/navigation' },
           { text: 'Provider Guides', link: '/provider-guides' },
           { text: 'Licensing', link: '/licensing' },
         ],

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,10 +1,10 @@
 ---
-title: Sidebar Navigation
+title: Navigation
 nav_order: 5
-description: "What each Borg UI sidebar tab is for and how to follow the product flow"
+description: "What each Borg UI tab is for and how to follow the product flow"
 ---
 
-# Sidebar Navigation
+# Navigation
 
 Use the sidebar as the main path through Borg UI. Some tabs appear only when
 your account has the right permission, the feature is enabled, or the current

--- a/docs/sidebar-navigation.md
+++ b/docs/sidebar-navigation.md
@@ -1,0 +1,84 @@
+---
+title: Sidebar Navigation
+nav_order: 5
+description: "What each Borg UI sidebar tab is for and how to follow the product flow"
+---
+
+# Sidebar Navigation
+
+Use the sidebar as the main path through Borg UI. Some tabs appear only when
+your account has the right permission, the feature is enabled, or the current
+license supports it.
+
+## Normal Path
+
+For a new setup, follow the sidebar in this order:
+
+1. Open Dashboard to check overall health.
+2. Add storage targets from Repositories, Cloud Storage, or Remote Machines.
+3. Create a plan from Plans.
+4. Configure automatic runs from the plan schedule or the Schedule page.
+5. Watch work in Activity and browse results in Archives.
+6. Adjust preferences, notifications, and system options from Settings.
+
+## Overview
+
+| Sidebar area | Tab | Use it for |
+| --- | --- | --- |
+| Main | Dashboard | Check repository health, recent activity, backup freshness, and restore-check status. |
+| Main | Activity | Review job history, live or recent logs, failures, and completed backup, restore, check, prune, compact, script, or package work. |
+| Hosts | Remote Machines | Add SSH-connected machines for remote repositories, remote backup sources, and SSH restore destinations. |
+| Hosts | Managed Agents | Enroll and manage Borg UI agents on remote machines. This appears when managed agents are enabled. |
+| Targets | Repositories | Create, import, inspect, maintain, and restore from Borg repositories. A repository is the storage target. |
+| Targets | Cloud Storage | Configure reusable rclone remotes for S3-compatible or other cloud-backed repository locations. |
+| Backups | Plans | Define what to back up, where it should go, when it should run, and what maintenance should run afterward. |
+| Backups | Manual Backup | Run older repository-based backups or legacy backup jobs. New workflows should usually start from Plans. |
+| Backups | Schedule | Review scheduled repository work, scheduled restore checks, and plan schedules from one operational view. |
+| Backups | Archives | Browse archives, select files or folders, restore data, and run archive-level actions. |
+
+## Settings
+
+Settings are grouped so personal preferences stay separate from operational
+administration.
+
+### Personal
+
+| Tab | Use it for |
+| --- | --- |
+| Account | Update profile details, password, passkeys, two-factor authentication, and account security. |
+| Users | Manage users and repository access. This appears for accounts that can manage users. |
+| Appearance | Choose theme and display preferences. |
+| Preferences | Set personal UI behavior and default preferences. |
+| Notifications | Configure backup, restore, schedule, check, and report notifications. |
+
+### System
+
+| Tab | Use it for |
+| --- | --- |
+| Licensing | Manage license status and plan-gated capabilities. |
+| System | Configure runtime settings, backup health thresholds, timeouts, beta flags, and maintenance controls. |
+| Monitoring & Reports | Configure backup reports, monitoring behavior, and recent activity included in reports. |
+| MQTT | Configure MQTT and Home Assistant integration. This appears when MQTT is enabled. |
+| Cache | Configure Redis/cache behavior and clear cache entries when needed. |
+| Logs | Review log storage and cleanup controls. |
+| Packages | Install or inspect optional runtime packages when package management is available. |
+
+### Management
+
+| Tab | Use it for |
+| --- | --- |
+| Mounts | Manage archive mount points and mount-related operations. |
+| Scripts | Manage reusable scripts for pre-backup, post-backup, and operational hooks. |
+| Export/Import | Export Borg UI configuration or import supported configuration data. |
+
+### Advanced
+
+| Tab | Use it for |
+| --- | --- |
+| Beta | Enable or disable beta features before they appear in the main sidebar. |
+
+## Where To Go Next
+
+- For a first backup, continue with the [Usage Guide](usage-guide#create-a-backup-plan).
+- For SSH targets or remote sources, see [Remote Machines](ssh-keys).
+- For notification setup, see [Notifications](notifications).

--- a/docs/sidebar-navigation.md
+++ b/docs/sidebar-navigation.md
@@ -16,7 +16,7 @@ For a new setup, follow the sidebar in this order:
 
 1. Open Dashboard to check overall health.
 2. Add storage targets from Repositories, Cloud Storage, or Remote Machines.
-3. Create a plan from Plans.
+3. Create a plan from Backup Plans.
 4. Configure automatic runs from the plan schedule or the Schedule page.
 5. Watch work in Activity and browse results in Archives.
 6. Adjust preferences, notifications, and system options from Settings.
@@ -31,8 +31,8 @@ For a new setup, follow the sidebar in this order:
 | Hosts | Managed Agents | Enroll and manage Borg UI agents on remote machines. This appears when managed agents are enabled. |
 | Targets | Repositories | Create, import, inspect, maintain, and restore from Borg repositories. A repository is the storage target. |
 | Targets | Cloud Storage | Configure reusable rclone remotes for S3-compatible or other cloud-backed repository locations. |
-| Backups | Plans | Define what to back up, where it should go, when it should run, and what maintenance should run afterward. |
-| Backups | Manual Backup | Run older repository-based backups or legacy backup jobs. New workflows should usually start from Plans. |
+| Backups | Backup Plans | Define what to back up, where it should go, when it should run, and what maintenance should run afterward. |
+| Backups | Backup | Run older repository-based backups or legacy backup jobs. New workflows should usually start from Backup Plans. |
 | Backups | Schedule | Review scheduled repository work, scheduled restore checks, and plan schedules from one operational view. |
 | Backups | Archives | Browse archives, select files or folders, restore data, and run archive-level actions. |
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -9,8 +9,8 @@ description: "Create repositories, build backup plans, browse archives, and rest
 This guide covers the normal path after installation.
 
 If you are unsure where to start in the app, use the
-[Sidebar Navigation](sidebar-navigation) guide to understand what each sidebar
-tab is for. This usage guide focuses on the common backup and restore flow.
+[Navigation](navigation) guide to understand what each sidebar tab is for. This
+usage guide focuses on the common backup and restore flow.
 
 ## First Login
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -8,6 +8,10 @@ description: "Create repositories, build backup plans, browse archives, and rest
 
 This guide covers the normal path after installation.
 
+If you are unsure where to start in the app, use the
+[Sidebar Navigation](sidebar-navigation) guide to understand what each sidebar
+tab is for. This usage guide focuses on the common backup and restore flow.
+
 ## First Login
 
 Open Borg UI:


### PR DESCRIPTION
## Description
Adds a dedicated Navigation docs page that explains the current Borg UI sidebar areas, tab purposes, permission/feature-gated tabs, and the suggested first-time workflow. The usage guide links to that reference without duplicating the full list, and the VitePress docs sidebar exposes the new page under Getting Started.

Also updates AGENTS.md so future sidebar tab, navigation group, or main user-flow changes include matching user docs updates.

## Related Issue
Linear: [BOR-83](https://linear.app/nullcodeai/issue/BOR-83/document-sidebar-navigation-workflow)

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass

Validation run:
- `cd docs && npm ci`
- `cd docs && npm run build`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `gh pr checks 546`

GitHub Actions passed all PR checks for the latest commit, including backend, frontend, smoke, coverage, security, and CI summary jobs.

No unit tests were added because this change only updates documentation and repository agent instructions.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; this is a documentation-only change.

## Additional Context
The new docs page was cross-checked against `frontend/src/components/AppSidebar.tsx` so the tab list matches the current sidebar implementation, including the exact `Backup Plans` and `Backup` labels. Review feedback on the page name was addressed by shortening the user-facing label to `Navigation`.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
