### PR TITLE
Reuse archive browser for cloud storage browsing

### DIFF
--- a/app/api/rclone.py
+++ b/app/api/rclone.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import configparser
 import json
 import logging
+import math
 import re
 from datetime import datetime, timezone
 from pathlib import Path
@@ -115,6 +116,33 @@ def _stringify_config_value(value: Any) -> str:
     if isinstance(value, (dict, list)):
         return json.dumps(value, separators=(",", ":"))
     return str(value)
+
+
+def _normalize_browse_entry_path(value: Any) -> str:
+    return "/".join(part for part in str(value or "").strip().split("/") if part)
+
+
+def _compose_browse_entry_path(relative_path: str, item: dict[str, Any]) -> str:
+    item_path = _normalize_browse_entry_path(item.get("Path") or item.get("Name"))
+    if not item_path:
+        return relative_path
+    if not relative_path:
+        return item_path
+    if item_path == relative_path or item_path.startswith(f"{relative_path}/"):
+        return item_path
+    return f"{relative_path}/{item_path}"
+
+
+def _serialize_browse_entry_size(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        size = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(size) or size < 0:
+        return None
+    return int(size)
 
 
 def _managed_config_values(
@@ -472,9 +500,9 @@ async def browse_remote(
         "entries": [
             {
                 "name": item.get("Name"),
-                "path": item.get("Path"),
+                "path": _compose_browse_entry_path(relative_path, item),
                 "is_dir": bool(item.get("IsDir")),
-                "size": item.get("Size"),
+                "size": _serialize_browse_entry_size(item.get("Size")),
                 "modified": item.get("ModTime"),
             }
             for item in entries

--- a/docs/engineering/plans/2026-05-28-cloud-storage-archive-browser-reuse.md
+++ b/docs/engineering/plans/2026-05-28-cloud-storage-archive-browser-reuse.md
@@ -1,0 +1,129 @@
+# Cloud Storage Archive Browser Reuse Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reuse the archive browsing UI for Cloud Storage remote browsing.
+
+**Architecture:** Extract the archive contents browser chrome into a shared
+presentational component that accepts normalized file entries, loading state,
+breadcrumbs, and optional archive-specific row adornments. Keep archive and
+rclone data fetching in their existing callers.
+
+**Tech Stack:** React, TypeScript, MUI, TanStack Query, lucide-react, Vitest,
+Storybook snapshots.
+
+---
+
+## Implementation Tasks
+
+### Task 1: Capture Cloud Storage Navigation Test
+
+**Files:**
+
+- Modify: `frontend/src/pages/__tests__/CloudStorage.test.tsx`
+
+- [ ] Add a test named `navigates folders in the reusable browse dialog`.
+- [ ] Mock `rcloneAPI.browseRemote` so path `''` returns a directory named
+      `borg-ui`, and path `borg-ui` returns `archive.tar`.
+- [ ] Render `<CloudStorage />`, click `Browse remote`, click the `borg-ui`
+      folder button, and expect `rcloneAPI.browseRemote` to have been called
+      with `(10, 'borg-ui')`.
+- [ ] Expect the dialog to show `archive.tar` and a breadcrumb button for
+      `Root`.
+- [ ] Run:
+
+```bash
+cd frontend && npm test -- src/pages/__tests__/CloudStorage.test.tsx --run
+```
+
+Expected before implementation: the new test fails because folder rows are not
+buttons and no non-root browse call is made.
+
+### Task 2: Extract Reusable Browser Component
+
+**Files:**
+
+- Create: `frontend/src/components/StorageBrowserDialog.tsx`
+- Create: `frontend/src/utils/storageBrowserPaths.ts`
+- Modify: `frontend/src/components/ArchiveContentsDialog.tsx`
+- Test: `frontend/src/components/__tests__/ArchiveContentsDialog.test.tsx`
+
+- [ ] Create `StorageBrowserDialog` with exported `StorageBrowserItem` and
+      a shared `normalizeBrowserPath` utility.
+- [ ] Render a responsive dialog with title/subtitle, breadcrumbs, loading
+      skeletons, directory-first file rows, empty-root and empty-directory
+      states, optional banner, optional row badge/tooltip, and optional file
+      download action.
+- [ ] Use semantic button rows for folders so folder navigation is
+      keyboard-accessible.
+- [ ] Replace the inline browser markup in `ArchiveContentsDialog` with
+      `StorageBrowserDialog`, mapping archive API items into
+      `StorageBrowserItem`.
+- [ ] Preserve archive behavior: reset path on archive open/change, call
+      `getArchiveContents(archive.id, archive.name, path)`, show canary badge
+      and banner, and call `onDownloadFile(archive.name, file.path)`.
+- [ ] Run:
+
+```bash
+cd frontend && npm test -- src/components/__tests__/ArchiveContentsDialog.test.tsx --run
+```
+
+Expected after implementation: archive tests continue to pass.
+
+### Task 3: Use Shared Browser In Cloud Storage
+
+**Files:**
+
+- Modify: `frontend/src/pages/CloudStorage.tsx`
+- Modify: `frontend/src/pages/CloudStorage.stories.tsx`
+- Modify: `frontend/src/pages/__tests__/CloudStorage.test.tsx`
+
+- [ ] Import `StorageBrowserDialog` and map rclone entries to
+      `StorageBrowserItem` with `directory` or `file` type.
+- [ ] Change the browse mutation variable to `{ remote, path }`, call
+      `rcloneAPI.browseRemote(remote.id, path)`, and update `browseState` with
+      the returned path and entries.
+- [ ] Pass `onNavigate` from the dialog to browse the current remote at the
+      selected folder or breadcrumb path.
+- [ ] Update the `BrowseDialog` Storybook story to show a nested path and
+      entries that demonstrate breadcrumbs.
+- [ ] Re-run:
+
+```bash
+cd frontend && npm test -- src/pages/__tests__/CloudStorage.test.tsx --run
+```
+
+Expected after implementation: the new Cloud Storage navigation test passes.
+
+### Task 4: Validation And Handoff
+
+**Files:**
+
+- Modify generated snapshots under `frontend/storybook-snapshots/`.
+
+- [ ] Run targeted tests:
+
+```bash
+cd frontend && npm test -- src/pages/__tests__/CloudStorage.test.tsx src/components/__tests__/ArchiveContentsDialog.test.tsx --run
+```
+
+- [ ] Run required frontend validation:
+
+```bash
+cd frontend && npm run check:locales
+cd frontend && npm run typecheck
+cd frontend && npm run lint
+cd frontend && npm run build
+```
+
+- [ ] Run snapshots:
+
+```bash
+cd frontend && npm run snapshots
+```
+
+- [ ] Run a local Storybook or app walkthrough that opens the Cloud Storage
+      browse dialog, clicks a folder, and returns via breadcrumb.
+- [ ] Update the Linear workpad with validation evidence, commit, push, create
+      or update the PR, sweep feedback/checks, and move BOR-81 to Human Review
+      only after all gates pass.

--- a/docs/engineering/specs/2026-05-28-cloud-storage-archive-browser-reuse.md
+++ b/docs/engineering/specs/2026-05-28-cloud-storage-archive-browser-reuse.md
@@ -1,0 +1,62 @@
+# Cloud Storage Archive Browser Reuse Spec
+
+## Problem
+
+Cloud Storage can open a rclone remote, but the browse dialog is a flat list. A
+folder row is rendered as static text and the page only calls the rclone browse
+endpoint for the remote root. Archive contents already provide the expected
+browser interaction: breadcrumb navigation, directory-first rows, loading and
+empty states, and file metadata.
+
+## Desired Outcome
+
+Cloud Storage should browse rclone remotes through the same reusable file
+browser UI used by archive contents. Opening a remote starts at the root,
+clicking folders loads that folder path, breadcrumbs return to parent paths,
+and archive contents keep their existing behavior.
+
+## Approach
+
+- Extract the reusable presentational browser from `ArchiveContentsDialog` into
+  a shared component under `frontend/src/components/`.
+- Keep data loading in each caller. Archive browsing continues to use
+  `BorgApiClient.getArchiveContents`, while Cloud Storage uses
+  `rcloneAPI.browseRemote(remote.id, path)`.
+- Normalize paths to a root-relative string for the shared component. Archive
+  items may arrive with leading slashes; Cloud Storage entries usually do not.
+- Preserve archive-specific canary labels and warning banner through optional
+  row badge/banner props rather than embedding rclone behavior in archive code.
+- Keep the Cloud Storage page layout consistent with the existing operational
+  dashboard UI: dense controls, balanced borders, lucide icons, semantic
+  buttons, visible focus/hover states, and no heavy left accent borders.
+
+## Acceptance Criteria
+
+- Cloud Storage folder rows are keyboard-accessible buttons that load the
+  selected rclone path.
+- The browse dialog shows breadcrumbs from root to the current cloud path and
+  can navigate back to parent/root paths.
+- The Cloud Storage browser reuses the extracted archive browser component
+  instead of duplicating the archive browsing rows.
+- Archive contents still browse folders, show breadcrumbs, preserve canary
+  labeling, and allow file downloads.
+- Storybook demonstrates the Cloud Storage browser in a nested folder state.
+- Frontend validation and snapshots are updated for the changed UI.
+
+## Validation
+
+- Add a failing Vitest test that clicks a Cloud Storage folder and expects
+  `rcloneAPI.browseRemote(remote.id, folderPath)` plus the nested listing.
+- Run the targeted Cloud Storage and archive contents tests.
+- Run `cd frontend && npm run check:locales`.
+- Run `cd frontend && npm run typecheck`.
+- Run `cd frontend && npm run lint`.
+- Run `cd frontend && npm run build`.
+- Run `cd frontend && npm run snapshots`.
+- Run a local app or Storybook walkthrough of the Cloud Storage browse path.
+
+## Notes
+
+The existing `docs/engineering/specs/2026-05-27-cloud-storage-navigation.md`
+describes creation of the Cloud Storage page. This spec narrows BOR-81 to the
+browser reuse/navigation gap on that page.

--- a/frontend/src/components/ArchiveContentsDialog.tsx
+++ b/frontend/src/components/ArchiveContentsDialog.tsx
@@ -1,25 +1,13 @@
-import React, { useState, useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { alpha, Box, Typography } from '@mui/material'
+import { ShieldCheck } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import {
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Button,
-  Chip,
-  Typography,
-  Stack,
-  Box,
-  Skeleton,
-  IconButton,
-  Tooltip,
-  alpha,
-} from '@mui/material'
-import ResponsiveDialog from './ResponsiveDialog'
-import { FolderOpen, Folder, FileText, Inbox, ShieldCheck } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 import { BorgApiClient, type Repository } from '../services/borgApi/client'
 import { Archive } from '../types'
 import { formatDateCompact, formatBytes as formatBytesUtil } from '../utils/dateUtils'
+import { normalizeBrowserPath } from '../utils/storageBrowserPaths'
+import StorageBrowserDialog, { type StorageBrowserItem } from './StorageBrowserDialog'
 
 interface ArchiveContentsDialogProps {
   open: boolean
@@ -27,16 +15,6 @@ interface ArchiveContentsDialogProps {
   repository: Repository | null
   onClose: () => void
   onDownloadFile?: (archiveName: string, filePath: string) => void
-}
-
-interface FileItem {
-  name: string
-  path: string
-  size?: number | null
-  mtime?: string
-  type: string
-  managed?: boolean
-  managed_type?: string
 }
 
 interface RawFileItem {
@@ -52,19 +30,12 @@ interface RawFileItem {
 const RESTORE_CANARY_MANAGED_TYPE = 'restore_canary'
 
 function isRestoreCanaryPath(path?: string) {
-  const normalized = (path || '').replace(/^\/+/, '').replace(/\/+$/, '')
+  const normalized = normalizeBrowserPath(path)
   return normalized === '.borg-ui' || normalized.startsWith('.borg-ui/')
 }
 
-function isRestoreCanaryItem(item: Pick<FileItem, 'path' | 'managed_type'>) {
+function isRestoreCanaryItem(item: Pick<RawFileItem, 'path' | 'managed_type'>) {
   return item.managed_type === RESTORE_CANARY_MANAGED_TYPE || isRestoreCanaryPath(item.path)
-}
-
-function normalizeArchivePath(path: string) {
-  if (!path || path === '/') {
-    return '/'
-  }
-  return `/${path.replace(/^\/+/, '').replace(/\/+$/, '')}`
 }
 
 export default function ArchiveContentsDialog({
@@ -75,483 +46,94 @@ export default function ArchiveContentsDialog({
   onDownloadFile,
 }: ArchiveContentsDialogProps) {
   const { t } = useTranslation()
-  const [currentPath, setCurrentPath] = useState('/')
+  const [currentPath, setCurrentPath] = useState('')
 
-  // Reset path when archive changes
   useEffect(() => {
     if (open && archive) {
-      setCurrentPath('/')
+      setCurrentPath('')
     }
   }, [open, archive])
 
-  // Fetch archive contents
   const { data: archiveContents, isFetching } = useQuery({
     queryKey: ['archive-contents', repository?.id, archive?.name, currentPath],
     queryFn: async () => {
       if (!repository || !archive) {
         throw new Error('Repository or archive not selected')
       }
-      const path = currentPath === '/' ? '' : currentPath.slice(1)
-      return new BorgApiClient(repository).getArchiveContents(archive.id, archive.name, path)
+      return new BorgApiClient(repository).getArchiveContents(archive.id, archive.name, currentPath)
     },
     enabled: !!archive && !!repository && open,
     staleTime: 5 * 60 * 1000,
   })
 
-  // File browser helper functions
-  const getFilesInCurrentPath = () => {
-    if (!archiveContents?.data?.items) return { folders: [], files: [] }
+  const canaryDescription = t('archiveContents.managedCanaryDescription')
+  const items = useMemo<StorageBrowserItem[] | null>(() => {
+    if (!archiveContents?.data?.items) return null
 
-    const items = archiveContents.data.items
-    const folders: FileItem[] = []
-    const files: FileItem[] = []
-
-    items.forEach((item: RawFileItem) => {
-      if (item.type === 'directory') {
-        folders.push({
-          name: item.name,
-          path: item.path,
-          size: item.size,
-          type: 'd',
-          managed: item.managed,
-          managed_type: item.managed_type,
-        })
-      } else {
-        files.push({
-          name: item.name,
-          path: item.path,
-          size: item.size,
-          mtime: item.mtime,
-          type: 'f',
-          managed: item.managed,
-          managed_type: item.managed_type,
-        })
+    return (archiveContents.data.items as RawFileItem[]).map((item) => {
+      const managedCanary = isRestoreCanaryItem(item)
+      return {
+        name: item.name,
+        path: normalizeBrowserPath(item.path),
+        size: item.size,
+        modified: item.mtime,
+        downloadPath: item.path,
+        type: item.type === 'directory' ? 'directory' : 'file',
+        badgeLabel: managedCanary ? t('archiveContents.managedCanaryLabel') : undefined,
+        tooltip: managedCanary ? canaryDescription : undefined,
+        tone: managedCanary ? 'info' : undefined,
       }
     })
+  }, [archiveContents?.data?.items, canaryDescription, t])
 
-    return { folders, files }
-  }
-
-  const navigateToPath = (path: string) => {
-    setCurrentPath(normalizeArchivePath(path))
-  }
-
-  const getBreadcrumbs = () => {
-    if (currentPath === '/') return [{ label: t('archiveContents.root'), path: '/' }]
-
-    const parts = currentPath.split('/').filter(Boolean)
-    const breadcrumbs = [{ label: t('archiveContents.root'), path: '/' }]
-
-    let accumulatedPath = ''
-    parts.forEach((part) => {
-      accumulatedPath += `/${part}`
-      breadcrumbs.push({ label: part, path: accumulatedPath })
-    })
-
-    return breadcrumbs
-  }
-
-  const { folders, files } = getFilesInCurrentPath()
   const isInsideCanaryPath = isRestoreCanaryPath(currentPath)
-  const canaryDescription = t('archiveContents.managedCanaryDescription')
 
   return (
-    <ResponsiveDialog
+    <StorageBrowserDialog
       open={open}
-      onClose={onClose}
-      maxWidth="md"
-      fullWidth
-      PaperProps={{
-        sx: {
-          maxHeight: '80vh',
-        },
-      }}
-    >
-      <DialogTitle>
-        <Stack direction="row" alignItems="center" spacing={2}>
-          <FolderOpen size={24} />
-          <Box>
-            <Typography variant="h6" fontWeight={600}>
-              {t('archiveContents.title')}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {archive?.name}
-            </Typography>
-          </Box>
-        </Stack>
-      </DialogTitle>
-      <DialogContent
-        dividers
-        sx={{
-          height: 600,
-          display: 'flex',
-          flexDirection: 'column',
-        }}
-      >
-        <Stack spacing={2} sx={{ height: '100%', overflow: 'hidden' }}>
-          {/* Breadcrumb Navigation — always visible, updates immediately on navigation */}
+      title={t('archiveContents.title')}
+      subtitle={archive?.name}
+      currentPath={currentPath}
+      items={items}
+      isLoading={isFetching}
+      rootLabel={t('archiveContents.root')}
+      closeLabel={t('common.buttons.close')}
+      emptyDirectoryLabel={t('archiveContents.emptyDirectory')}
+      emptyRootTitle={t('archiveContents.emptyArchive')}
+      emptyRootDescription={t('archiveContents.emptyArchiveDesc')}
+      noInfoLabel={t('archiveContents.noInfo')}
+      showModifiedColumn
+      banner={
+        isInsideCanaryPath ? (
           <Box
             sx={{
               display: 'flex',
-              alignItems: 'center',
-              flexWrap: 'wrap',
-              gap: 0.5,
+              alignItems: 'flex-start',
+              gap: 1,
+              px: 1.5,
+              py: 1,
+              borderRadius: 1,
+              bgcolor: (theme) => alpha(theme.palette.info.main, 0.08),
+              border: '1px solid',
+              borderColor: (theme) => alpha(theme.palette.info.main, 0.25),
               flexShrink: 0,
             }}
           >
-            {getBreadcrumbs().map((crumb, index) => (
-              <React.Fragment key={crumb.path}>
-                {index > 0 && (
-                  <Typography variant="body2" color="text.secondary">
-                    /
-                  </Typography>
-                )}
-                <Typography
-                  variant="body2"
-                  onClick={() => navigateToPath(crumb.path)}
-                  sx={{
-                    cursor: 'pointer',
-                    color: 'primary.main',
-                    textDecoration: 'underline',
-                    '&:hover': { color: 'primary.dark' },
-                  }}
-                >
-                  {crumb.label}
-                </Typography>
-              </React.Fragment>
-            ))}
+            <ShieldCheck size={17} style={{ marginTop: 2, flexShrink: 0 }} />
+            <Typography variant="body2" color="text.secondary">
+              {t('archiveContents.managedCanaryBanner')}
+            </Typography>
           </Box>
-
-          {isInsideCanaryPath && (
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'flex-start',
-                gap: 1,
-                px: 1.5,
-                py: 1,
-                borderRadius: 1,
-                bgcolor: (theme) => alpha(theme.palette.info.main, 0.08),
-                border: '1px solid',
-                borderColor: (theme) => alpha(theme.palette.info.main, 0.25),
-                flexShrink: 0,
-              }}
-            >
-              <ShieldCheck size={17} style={{ marginTop: 2, flexShrink: 0 }} />
-              <Typography variant="body2" color="text.secondary">
-                {t('archiveContents.managedCanaryBanner')}
-              </Typography>
-            </Box>
-          )}
-
-          {/* Content area — skeleton while loading, list or empty state when ready */}
-          <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-            {isFetching ? (
-              <Stack spacing={0.5}>
-                {[
-                  { width: '55%', isFolder: true },
-                  { width: '40%', isFolder: true },
-                  { width: '70%', isFolder: true },
-                  { width: '62%', isFolder: false },
-                  { width: '48%', isFolder: false },
-                  { width: '75%', isFolder: false },
-                  { width: '33%', isFolder: false },
-                ].map((row, i) => (
-                  <Box
-                    key={i}
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 1.5,
-                      p: 1.5,
-                      borderRadius: 1,
-                      bgcolor: (theme) =>
-                        row.isFolder ? alpha(theme.palette.primary.main, 0.05) : 'action.hover',
-                    }}
-                  >
-                    <Skeleton variant="rounded" width={20} height={20} sx={{ flexShrink: 0 }} />
-                    <Skeleton variant="text" sx={{ flex: 1, maxWidth: row.width }} />
-                    <Skeleton variant="text" width={52} />
-                  </Box>
-                ))}
-              </Stack>
-            ) : archiveContents?.data?.items ? (
-              archiveContents.data.items.length > 0 ? (
-                <Box sx={{ flex: 1, overflow: 'hidden' }}>
-                  <Box sx={{ height: '100%', overflowY: 'auto' }}>
-                    {folders.length === 0 && files.length === 0 ? (
-                      <Box sx={{ textAlign: 'center', py: 4 }}>
-                        <Typography variant="body2" color="text.secondary">
-                          {t('archiveContents.emptyDirectory')}
-                        </Typography>
-                      </Box>
-                    ) : (
-                      <Stack spacing={0.5}>
-                        {/* Folders */}
-                        {folders.map((folder, index) => {
-                          const managedCanary = isRestoreCanaryItem(folder)
-                          return (
-                            <Tooltip
-                              key={`folder-${index}`}
-                              title={managedCanary ? canaryDescription : ''}
-                              arrow
-                              disableHoverListener={!managedCanary}
-                            >
-                              <Box
-                                onClick={() => navigateToPath(folder.path)}
-                                sx={{
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'space-between',
-                                  p: 1.5,
-                                  borderRadius: 1,
-                                  cursor: 'pointer',
-                                  userSelect: 'none',
-                                  border: '1px solid',
-                                  borderColor: (theme) =>
-                                    managedCanary
-                                      ? alpha(theme.palette.info.main, 0.35)
-                                      : 'transparent',
-                                  backgroundColor: (theme) =>
-                                    managedCanary
-                                      ? alpha(theme.palette.info.main, 0.08)
-                                      : alpha(theme.palette.primary.main, 0.1),
-                                  '&:hover': {
-                                    backgroundColor: (theme) =>
-                                      managedCanary
-                                        ? alpha(theme.palette.info.main, 0.14)
-                                        : alpha(theme.palette.primary.main, 0.2),
-                                  },
-                                }}
-                              >
-                                <Stack
-                                  direction="row"
-                                  spacing={1.5}
-                                  alignItems="center"
-                                  sx={{ color: 'text.primary', flex: 1, minWidth: 0 }}
-                                >
-                                  {managedCanary ? <ShieldCheck size={20} /> : <Folder size={20} />}
-                                  <Typography variant="body2" fontWeight={500} noWrap>
-                                    {folder.name}
-                                  </Typography>
-                                  {managedCanary && (
-                                    <Chip
-                                      label={t('archiveContents.managedCanaryLabel')}
-                                      size="small"
-                                      color="info"
-                                      variant="outlined"
-                                      sx={{ height: 22, flexShrink: 0 }}
-                                    />
-                                  )}
-                                </Stack>
-                                {folder.size !== null && folder.size !== undefined ? (
-                                  <Typography variant="body2" color="text.secondary" sx={{ ml: 2 }}>
-                                    {formatBytesUtil(folder.size)}
-                                  </Typography>
-                                ) : null}
-                              </Box>
-                            </Tooltip>
-                          )
-                        })}
-
-                        {/* Files */}
-                        {files.map((file, index) => {
-                          const managedCanary = isRestoreCanaryItem(file)
-                          return (
-                            <Tooltip
-                              key={`file-${index}`}
-                              title={managedCanary ? canaryDescription : ''}
-                              arrow
-                              disableHoverListener={!managedCanary}
-                            >
-                              <Box
-                                sx={{
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'space-between',
-                                  p: 1.5,
-                                  borderRadius: 1,
-                                  userSelect: 'none',
-                                  border: '1px solid',
-                                  borderColor: (theme) =>
-                                    managedCanary
-                                      ? alpha(theme.palette.info.main, 0.35)
-                                      : 'transparent',
-                                  backgroundColor: (theme) =>
-                                    managedCanary
-                                      ? alpha(theme.palette.info.main, 0.06)
-                                      : theme.palette.action.hover,
-                                  '&:hover': {
-                                    backgroundColor: (theme) =>
-                                      managedCanary
-                                        ? alpha(theme.palette.info.main, 0.12)
-                                        : theme.palette.action.selected,
-                                  },
-                                }}
-                              >
-                                <Stack
-                                  direction="row"
-                                  spacing={1.5}
-                                  alignItems="center"
-                                  sx={{ flex: 1, minWidth: 0, color: 'text.primary' }}
-                                >
-                                  {managedCanary ? (
-                                    <ShieldCheck size={20} />
-                                  ) : (
-                                    <FileText size={20} />
-                                  )}
-                                  <Typography
-                                    variant="body2"
-                                    sx={{
-                                      overflow: 'hidden',
-                                      textOverflow: 'ellipsis',
-                                      whiteSpace: 'nowrap',
-                                    }}
-                                  >
-                                    {file.name}
-                                  </Typography>
-                                  {managedCanary && (
-                                    <Chip
-                                      label={t('archiveContents.managedCanaryLabel')}
-                                      size="small"
-                                      color="info"
-                                      variant="outlined"
-                                      sx={{ height: 22, flexShrink: 0 }}
-                                    />
-                                  )}
-                                </Stack>
-                                <Stack direction="row" spacing={2} alignItems="center">
-                                  <Typography
-                                    variant="body2"
-                                    color="text.secondary"
-                                    sx={{
-                                      minWidth: 165,
-                                      textAlign: 'right',
-                                      fontFamily: 'monospace',
-                                      fontSize: '0.8rem',
-                                      whiteSpace: 'nowrap',
-                                    }}
-                                  >
-                                    {file.mtime ? formatDateCompact(file.mtime) : '-'}
-                                  </Typography>
-                                  <Typography
-                                    variant="body2"
-                                    color="text.secondary"
-                                    sx={{ width: 80, textAlign: 'right' }}
-                                  >
-                                    {file.size ? formatBytesUtil(file.size) : '0 B'}
-                                  </Typography>
-                                  {onDownloadFile && (
-                                    <IconButton
-                                      size="small"
-                                      sx={{ color: 'text.secondary' }}
-                                      onClick={() => {
-                                        if (archive) {
-                                          onDownloadFile(archive.name, file.path)
-                                        }
-                                      }}
-                                      title={t('archiveContents.downloadFile')}
-                                    >
-                                      <svg
-                                        width="16"
-                                        height="16"
-                                        viewBox="0 0 24 24"
-                                        fill="none"
-                                        stroke="currentColor"
-                                        strokeWidth="2"
-                                      >
-                                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                                        <polyline points="7 10 12 15 17 10" />
-                                        <line x1="12" y1="15" x2="12" y2="3" />
-                                      </svg>
-                                    </IconButton>
-                                  )}
-                                </Stack>
-                              </Box>
-                            </Tooltip>
-                          )
-                        })}
-                      </Stack>
-                    )}
-                  </Box>
-                </Box>
-              ) : (
-                <Box
-                  sx={{
-                    flex: 1,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    textAlign: 'center',
-                    py: 4,
-                    px: 3,
-                  }}
-                >
-                  <Box
-                    sx={{
-                      width: 72,
-                      height: 72,
-                      borderRadius: '50%',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      bgcolor: (theme) => alpha(theme.palette.text.secondary, 0.08),
-                      mb: 2.5,
-                    }}
-                  >
-                    <Inbox size={32} style={{ opacity: 0.5 }} />
-                  </Box>
-                  <Typography variant="h6" fontWeight={600} gutterBottom>
-                    {t('archiveContents.emptyArchive')}
-                  </Typography>
-                  <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    sx={{ maxWidth: 380, lineHeight: 1.7 }}
-                  >
-                    {t('archiveContents.emptyArchiveDesc')}
-                  </Typography>
-                </Box>
-              )
-            ) : (
-              <Box
-                sx={{
-                  flex: 1,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  textAlign: 'center',
-                  py: 4,
-                  px: 3,
-                }}
-              >
-                <Box
-                  sx={{
-                    width: 72,
-                    height: 72,
-                    borderRadius: '50%',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    bgcolor: (theme) => alpha(theme.palette.text.secondary, 0.08),
-                    mb: 2.5,
-                  }}
-                >
-                  <Inbox size={32} style={{ opacity: 0.5 }} />
-                </Box>
-                <Typography variant="body1" color="text.secondary">
-                  {t('archiveContents.noInfo')}
-                </Typography>
-              </Box>
-            )}
-          </Box>
-        </Stack>
-      </DialogContent>
-      <DialogActions sx={{ display: { xs: 'none', md: 'flex' } }}>
-        <Button onClick={onClose}>{t('common.buttons.close')}</Button>
-      </DialogActions>
-    </ResponsiveDialog>
+        ) : null
+      }
+      onClose={onClose}
+      onNavigate={(path) => setCurrentPath(normalizeBrowserPath(path))}
+      onDownloadFile={
+        onDownloadFile && archive ? (filePath) => onDownloadFile(archive.name, filePath) : undefined
+      }
+      downloadLabel={t('archiveContents.downloadFile')}
+      formatSize={formatBytesUtil}
+      formatModified={formatDateCompact}
+    />
   )
 }

--- a/frontend/src/components/StorageBrowserDialog.tsx
+++ b/frontend/src/components/StorageBrowserDialog.tsx
@@ -1,0 +1,484 @@
+import type { ReactNode } from 'react'
+import {
+  alpha,
+  Box,
+  Button,
+  Chip,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Skeleton,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import { Download, FileText, Folder, FolderOpen, Inbox, ShieldCheck } from 'lucide-react'
+import ResponsiveDialog from './ResponsiveDialog'
+import { normalizeBrowserPath } from '../utils/storageBrowserPaths'
+
+export interface StorageBrowserItem {
+  name: string
+  path: string
+  type: 'directory' | 'file'
+  size?: number | null
+  modified?: string | null
+  downloadPath?: string
+  badgeLabel?: string
+  tooltip?: string
+  tone?: 'info'
+}
+
+interface StorageBrowserDialogProps {
+  open: boolean
+  title: string
+  subtitle?: string | null
+  currentPath: string
+  items?: StorageBrowserItem[] | null
+  isLoading?: boolean
+  rootLabel: string
+  closeLabel: string
+  emptyDirectoryLabel: string
+  noInfoLabel?: string
+  emptyRootTitle?: string
+  emptyRootDescription?: string
+  banner?: ReactNode
+  maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  showModifiedColumn?: boolean
+  onClose: () => void
+  onNavigate: (path: string) => void
+  onDownloadFile?: (path: string) => void
+  downloadLabel?: string
+  formatSize?: (size: number) => string
+  formatModified?: (modified: string) => string
+}
+
+function buildBreadcrumbs(path: string, rootLabel: string) {
+  const normalized = normalizeBrowserPath(path)
+  const parts = normalized ? normalized.split('/').filter(Boolean) : []
+  const breadcrumbs = [{ label: rootLabel, path: '' }]
+
+  let accumulatedPath = ''
+  parts.forEach((part) => {
+    accumulatedPath = accumulatedPath ? `${accumulatedPath}/${part}` : part
+    breadcrumbs.push({ label: part, path: accumulatedPath })
+  })
+
+  return breadcrumbs
+}
+
+function defaultFormatSize(size: number) {
+  if (size === 0) return '0 B'
+
+  const unit = 1024
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  const unitIndex = Math.min(Math.floor(Math.log(size) / Math.log(unit)), units.length - 1)
+  return `${(size / Math.pow(unit, unitIndex)).toFixed(1)} ${units[unitIndex]}`
+}
+
+function StorageBrowserEmptyState({
+  title,
+  description,
+  fallback,
+}: {
+  title?: string
+  description?: string
+  fallback: string
+}) {
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+        py: 4,
+        px: 3,
+      }}
+    >
+      <Box
+        sx={{
+          width: 72,
+          height: 72,
+          borderRadius: '50%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          bgcolor: (theme) => alpha(theme.palette.text.secondary, 0.08),
+          mb: 2.5,
+        }}
+      >
+        <Inbox size={32} style={{ opacity: 0.5 }} />
+      </Box>
+      {title ? (
+        <Typography variant="h6" fontWeight={600} gutterBottom>
+          {title}
+        </Typography>
+      ) : null}
+      <Typography
+        variant={title ? 'body2' : 'body1'}
+        color="text.secondary"
+        sx={{ maxWidth: 380, lineHeight: 1.7 }}
+      >
+        {description || fallback}
+      </Typography>
+    </Box>
+  )
+}
+
+export default function StorageBrowserDialog({
+  open,
+  title,
+  subtitle,
+  currentPath,
+  items,
+  isLoading = false,
+  rootLabel,
+  closeLabel,
+  emptyDirectoryLabel,
+  noInfoLabel,
+  emptyRootTitle,
+  emptyRootDescription,
+  banner,
+  maxWidth = 'md',
+  showModifiedColumn = false,
+  onClose,
+  onNavigate,
+  onDownloadFile,
+  downloadLabel,
+  formatSize = defaultFormatSize,
+  formatModified,
+}: StorageBrowserDialogProps) {
+  const normalizedPath = normalizeBrowserPath(currentPath)
+  const breadcrumbs = buildBreadcrumbs(normalizedPath, rootLabel)
+  const folders = (items || []).filter((item) => item.type === 'directory')
+  const files = (items || []).filter((item) => item.type === 'file')
+  const hasItems = folders.length > 0 || files.length > 0
+  const hasModifiedColumn =
+    showModifiedColumn || files.some((file) => Boolean(file.modified || formatModified))
+
+  const renderSize = (size?: number | null) =>
+    size === null || size === undefined ? null : formatSize(size)
+
+  return (
+    <ResponsiveDialog
+      open={open}
+      onClose={onClose}
+      maxWidth={maxWidth}
+      fullWidth
+      PaperProps={{
+        sx: {
+          maxHeight: '80vh',
+        },
+      }}
+      footer={
+        <DialogActions sx={{ display: { xs: 'none', md: 'flex' } }}>
+          <Button onClick={onClose}>{closeLabel}</Button>
+        </DialogActions>
+      }
+    >
+      <DialogTitle>
+        <Stack direction="row" alignItems="center" spacing={2}>
+          <FolderOpen size={24} />
+          <Box sx={{ minWidth: 0 }}>
+            <Typography variant="h6" fontWeight={600}>
+              {title}
+            </Typography>
+            {subtitle ? (
+              <Typography variant="body2" color="text.secondary" noWrap>
+                {subtitle}
+              </Typography>
+            ) : null}
+          </Box>
+        </Stack>
+      </DialogTitle>
+      <DialogContent
+        dividers
+        sx={{
+          height: 600,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <Stack spacing={2} sx={{ height: '100%', overflow: 'hidden' }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+              gap: 0.5,
+              flexShrink: 0,
+            }}
+          >
+            {breadcrumbs.map((crumb, index) => (
+              <Box key={crumb.path || 'root'} sx={{ display: 'flex', alignItems: 'center' }}>
+                {index > 0 ? (
+                  <Typography variant="body2" color="text.secondary" sx={{ mx: 0.5 }}>
+                    /
+                  </Typography>
+                ) : null}
+                <Button
+                  size="small"
+                  variant="text"
+                  onClick={() => onNavigate(crumb.path)}
+                  disabled={crumb.path === normalizedPath}
+                  sx={{
+                    minWidth: 0,
+                    px: 0.5,
+                    textTransform: 'none',
+                    fontWeight: crumb.path === normalizedPath ? 700 : 500,
+                  }}
+                >
+                  {crumb.label}
+                </Button>
+              </Box>
+            ))}
+          </Box>
+
+          {banner}
+
+          <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+            {isLoading ? (
+              <Stack spacing={0.5}>
+                {[
+                  { width: '55%', isFolder: true },
+                  { width: '40%', isFolder: true },
+                  { width: '70%', isFolder: true },
+                  { width: '62%', isFolder: false },
+                  { width: '48%', isFolder: false },
+                  { width: '75%', isFolder: false },
+                  { width: '33%', isFolder: false },
+                ].map((row, index) => (
+                  <Box
+                    key={index}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1.5,
+                      p: 1.5,
+                      borderRadius: 1,
+                      bgcolor: (theme) =>
+                        row.isFolder ? alpha(theme.palette.primary.main, 0.05) : 'action.hover',
+                    }}
+                  >
+                    <Skeleton variant="rounded" width={20} height={20} sx={{ flexShrink: 0 }} />
+                    <Skeleton variant="text" sx={{ flex: 1, maxWidth: row.width }} />
+                    <Skeleton variant="text" width={52} />
+                  </Box>
+                ))}
+              </Stack>
+            ) : items ? (
+              hasItems ? (
+                <Box sx={{ flex: 1, overflow: 'hidden' }}>
+                  <Box sx={{ height: '100%', overflowY: 'auto' }}>
+                    <Stack spacing={0.5}>
+                      {folders.map((folder) => {
+                        const highlighted = folder.tone === 'info'
+                        return (
+                          <Tooltip
+                            key={folder.path || folder.name}
+                            title={folder.tooltip || ''}
+                            arrow
+                            disableHoverListener={!folder.tooltip}
+                          >
+                            <Box
+                              component="button"
+                              type="button"
+                              onClick={() => onNavigate(normalizeBrowserPath(folder.path))}
+                              sx={{
+                                width: '100%',
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'space-between',
+                                gap: 1.5,
+                                p: 1.5,
+                                borderRadius: 1,
+                                cursor: 'pointer',
+                                userSelect: 'none',
+                                textAlign: 'left',
+                                font: 'inherit',
+                                color: 'text.primary',
+                                border: '1px solid',
+                                borderColor: (theme) =>
+                                  highlighted
+                                    ? alpha(theme.palette.info.main, 0.35)
+                                    : 'transparent',
+                                backgroundColor: (theme) =>
+                                  highlighted
+                                    ? alpha(theme.palette.info.main, 0.08)
+                                    : alpha(theme.palette.primary.main, 0.1),
+                                '&:hover': {
+                                  backgroundColor: (theme) =>
+                                    highlighted
+                                      ? alpha(theme.palette.info.main, 0.14)
+                                      : alpha(theme.palette.primary.main, 0.2),
+                                },
+                                '&:focus-visible': {
+                                  outline: '2px solid',
+                                  outlineColor: 'primary.main',
+                                  outlineOffset: 2,
+                                },
+                              }}
+                            >
+                              <Stack
+                                direction="row"
+                                spacing={1.5}
+                                alignItems="center"
+                                sx={{ minWidth: 0, flex: 1 }}
+                              >
+                                {highlighted ? <ShieldCheck size={20} /> : <Folder size={20} />}
+                                <Typography variant="body2" fontWeight={500} noWrap>
+                                  {folder.name}
+                                </Typography>
+                                {folder.badgeLabel ? (
+                                  <Chip
+                                    label={folder.badgeLabel}
+                                    size="small"
+                                    color={folder.tone || 'default'}
+                                    variant="outlined"
+                                    sx={{ height: 22, flexShrink: 0 }}
+                                  />
+                                ) : null}
+                              </Stack>
+                              {renderSize(folder.size) ? (
+                                <Typography variant="body2" color="text.secondary" sx={{ ml: 2 }}>
+                                  {renderSize(folder.size)}
+                                </Typography>
+                              ) : null}
+                            </Box>
+                          </Tooltip>
+                        )
+                      })}
+
+                      {files.map((file) => {
+                        const highlighted = file.tone === 'info'
+                        return (
+                          <Tooltip
+                            key={file.path || file.name}
+                            title={file.tooltip || ''}
+                            arrow
+                            disableHoverListener={!file.tooltip}
+                          >
+                            <Box
+                              sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'space-between',
+                                gap: 1.5,
+                                p: 1.5,
+                                borderRadius: 1,
+                                userSelect: 'none',
+                                border: '1px solid',
+                                borderColor: (theme) =>
+                                  highlighted
+                                    ? alpha(theme.palette.info.main, 0.35)
+                                    : 'transparent',
+                                backgroundColor: (theme) =>
+                                  highlighted
+                                    ? alpha(theme.palette.info.main, 0.06)
+                                    : theme.palette.action.hover,
+                                '&:hover': {
+                                  backgroundColor: (theme) =>
+                                    highlighted
+                                      ? alpha(theme.palette.info.main, 0.12)
+                                      : theme.palette.action.selected,
+                                },
+                              }}
+                            >
+                              <Stack
+                                direction="row"
+                                spacing={1.5}
+                                alignItems="center"
+                                sx={{ flex: 1, minWidth: 0, color: 'text.primary' }}
+                              >
+                                {highlighted ? <ShieldCheck size={20} /> : <FileText size={20} />}
+                                <Typography
+                                  variant="body2"
+                                  sx={{
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                  }}
+                                >
+                                  {file.name}
+                                </Typography>
+                                {file.badgeLabel ? (
+                                  <Chip
+                                    label={file.badgeLabel}
+                                    size="small"
+                                    color={file.tone || 'default'}
+                                    variant="outlined"
+                                    sx={{ height: 22, flexShrink: 0 }}
+                                  />
+                                ) : null}
+                              </Stack>
+                              <Stack direction="row" spacing={2} alignItems="center">
+                                {hasModifiedColumn ? (
+                                  <Typography
+                                    variant="body2"
+                                    color="text.secondary"
+                                    sx={{
+                                      minWidth: 165,
+                                      textAlign: 'right',
+                                      fontFamily: 'monospace',
+                                      fontSize: '0.8rem',
+                                      whiteSpace: 'nowrap',
+                                    }}
+                                  >
+                                    {file.modified && formatModified
+                                      ? formatModified(file.modified)
+                                      : '-'}
+                                  </Typography>
+                                ) : null}
+                                {renderSize(file.size) ? (
+                                  <Typography
+                                    variant="body2"
+                                    color="text.secondary"
+                                    sx={{ width: 80, textAlign: 'right' }}
+                                  >
+                                    {renderSize(file.size)}
+                                  </Typography>
+                                ) : null}
+                                {onDownloadFile ? (
+                                  <IconButton
+                                    size="small"
+                                    sx={{ color: 'text.secondary' }}
+                                    onClick={() => onDownloadFile(file.downloadPath || file.path)}
+                                    title={downloadLabel}
+                                    aria-label={downloadLabel}
+                                  >
+                                    <Download size={16} />
+                                  </IconButton>
+                                ) : null}
+                              </Stack>
+                            </Box>
+                          </Tooltip>
+                        )
+                      })}
+                    </Stack>
+                  </Box>
+                </Box>
+              ) : normalizedPath ? (
+                <Box sx={{ textAlign: 'center', py: 4 }}>
+                  <Typography variant="body2" color="text.secondary">
+                    {emptyDirectoryLabel}
+                  </Typography>
+                </Box>
+              ) : (
+                <StorageBrowserEmptyState
+                  title={emptyRootTitle}
+                  description={emptyRootDescription}
+                  fallback={emptyDirectoryLabel}
+                />
+              )
+            ) : (
+              <StorageBrowserEmptyState fallback={noInfoLabel || emptyDirectoryLabel} />
+            )}
+          </Box>
+        </Stack>
+      </DialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/frontend/src/components/StorageBrowserDialog.tsx
+++ b/frontend/src/components/StorageBrowserDialog.tsx
@@ -159,8 +159,12 @@ export default function StorageBrowserDialog({
   const hasModifiedColumn =
     showModifiedColumn || files.some((file) => Boolean(file.modified || formatModified))
 
-  const renderSize = (size?: number | null) =>
-    size === null || size === undefined ? null : formatSize(size)
+  const renderSize = (size?: number | null) => {
+    if (typeof size !== 'number' || !Number.isFinite(size) || size < 0) {
+      return null
+    }
+    return formatSize(size)
+  }
 
   return (
     <ResponsiveDialog

--- a/frontend/src/components/__tests__/StorageBrowserDialog.test.tsx
+++ b/frontend/src/components/__tests__/StorageBrowserDialog.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import { renderWithProviders, screen } from '../../test/test-utils'
+import StorageBrowserDialog from '../StorageBrowserDialog'
+
+describe('StorageBrowserDialog', () => {
+  it('does not render invalid negative item sizes as NaN undefined', () => {
+    renderWithProviders(
+      <StorageBrowserDialog
+        open
+        title="Browse prod-s3"
+        currentPath="borg-ui"
+        rootLabel="Root"
+        closeLabel="Close"
+        emptyDirectoryLabel="Empty directory"
+        onClose={vi.fn()}
+        onNavigate={vi.fn()}
+        items={[
+          {
+            name: 'snapshots',
+            path: 'borg-ui/snapshots',
+            type: 'directory',
+            size: -1,
+          },
+          {
+            name: 'manifest.json',
+            path: 'borg-ui/manifest.json',
+            type: 'file',
+            size: Number.NaN,
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText('snapshots')).toBeInTheDocument()
+    expect(screen.getByText('manifest.json')).toBeInTheDocument()
+    expect(screen.queryByText(/NaN undefined/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/CloudStorage.stories.tsx
+++ b/frontend/src/pages/CloudStorage.stories.tsx
@@ -115,15 +115,21 @@ export const BrowseDialog: Story = {
         remotes={remotes}
         browseState={{
           remote: remotes[0],
-          path: '',
+          path: 'borg-ui',
           entries: [
-            { name: 'borg-ui', path: 'borg-ui', is_dir: true, size: null, modified: null },
             {
-              name: 'README.md',
-              path: 'README.md',
+              name: 'archives',
+              path: 'borg-ui/archives',
+              is_dir: true,
+              size: null,
+              modified: null,
+            },
+            {
+              name: 'manifest.json',
+              path: 'borg-ui/manifest.json',
               is_dir: false,
               size: 128,
-              modified: null,
+              modified: '2026-05-27T12:00:00Z',
             },
           ],
         }}

--- a/frontend/src/pages/CloudStorage.tsx
+++ b/frontend/src/pages/CloudStorage.tsx
@@ -14,10 +14,6 @@ import {
   DialogContentText,
   DialogTitle,
   IconButton,
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
   Paper,
   Skeleton,
   Stack,
@@ -30,8 +26,6 @@ import {
   AlertTriangle,
   CheckCircle,
   Cloud,
-  File,
-  Folder,
   HardDrive,
   Plus,
   RefreshCw,
@@ -48,6 +42,8 @@ import type { RcloneRemoteCreateInput } from '../components/wizard/RcloneRemoteD
 import OperationalCard from '../components/OperationalCard'
 import PageHeader from '../components/PageHeader'
 import ListToolbar from '../components/ListToolbar'
+import StorageBrowserDialog, { type StorageBrowserItem } from '../components/StorageBrowserDialog'
+import { normalizeBrowserPath } from '../utils/storageBrowserPaths'
 
 interface BrowseEntry {
   name: string
@@ -91,7 +87,7 @@ interface CloudStorageContentProps {
   onCloseDeleteRemote?: () => void
   onConfirmDeleteRemote?: () => Promise<void> | void
   onTestRemote?: (remote: RcloneRemote) => void
-  onBrowseRemote?: (remote: RcloneRemote) => void
+  onBrowseRemote?: (remote: RcloneRemote, path?: string) => void
   onCloseBrowse?: () => void
 }
 
@@ -561,6 +557,17 @@ export function CloudStorageContent({
   const totalAfterFilter = processedRemotes.groups.reduce((sum, g) => sum + g.remotes.length, 0)
   const hasUnfilteredRemotes = remotes.length > 0
   const showToolbar = isLoading || hasUnfilteredRemotes
+  const browseItems = useMemo<StorageBrowserItem[] | null>(() => {
+    if (!browseState) return null
+
+    return browseState.entries.map((entry) => ({
+      name: entry.name,
+      path: normalizeBrowserPath(entry.path || entry.name),
+      type: entry.is_dir ? 'directory' : 'file',
+      size: entry.size,
+      modified: entry.modified,
+    }))
+  }, [browseState])
 
   return (
     <Box component="section" aria-label={t('cloudStorage.title')}>
@@ -800,35 +807,25 @@ export function CloudStorageContent({
         </DialogActions>
       </Dialog>
 
-      <Dialog open={!!browseState} onClose={onCloseBrowse} maxWidth="sm" fullWidth>
-        <DialogTitle>
-          {t('cloudStorage.browseTitle', { name: browseState?.remote.name })}
-        </DialogTitle>
-        <DialogContent dividers>
-          {isBrowsing ? (
-            <Stack direction="row" spacing={1.5} alignItems="center">
-              <CircularProgress size={18} />
-              <Typography>{t('cloudStorage.browsing')}</Typography>
-            </Stack>
-          ) : browseState?.entries.length ? (
-            <List dense>
-              {browseState.entries.map((entry) => (
-                <ListItem key={entry.path || entry.name} disableGutters>
-                  <ListItemIcon sx={{ minWidth: 34 }}>
-                    {entry.is_dir ? <Folder size={18} /> : <File size={18} />}
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={entry.name}
-                    secondary={entry.is_dir ? t('cloudStorage.directory') : t('cloudStorage.file')}
-                  />
-                </ListItem>
-              ))}
-            </List>
-          ) : (
-            <Typography color="text.secondary">{t('cloudStorage.noEntries')}</Typography>
-          )}
-        </DialogContent>
-      </Dialog>
+      <StorageBrowserDialog
+        open={!!browseState}
+        title={t('cloudStorage.browseTitle', { name: browseState?.remote.name })}
+        subtitle={browseState?.remote.provider}
+        currentPath={browseState?.path || ''}
+        items={browseItems}
+        isLoading={isBrowsing}
+        rootLabel={t('archiveContents.root')}
+        closeLabel={t('common.buttons.close')}
+        emptyDirectoryLabel={t('cloudStorage.noEntries')}
+        noInfoLabel={t('cloudStorage.noEntries')}
+        maxWidth="md"
+        onClose={() => onCloseBrowse?.()}
+        onNavigate={(path) => {
+          if (browseState) {
+            onBrowseRemote?.(browseState.remote, path)
+          }
+        }}
+      />
     </Box>
   )
 }
@@ -922,17 +919,29 @@ export default function CloudStorage() {
   })
 
   const browseRemoteMutation = useMutation({
-    mutationFn: async (remote: RcloneRemote) => {
-      setBrowseState({ remote, path: '', entries: [] })
-      const response = await rcloneAPI.browseRemote(remote.id, '')
+    mutationFn: async ({ remote, path }: { remote: RcloneRemote; path: string }) => {
+      const normalizedPath = normalizeBrowserPath(path)
+      setBrowseState({ remote, path: normalizedPath, entries: [] })
+      const response = await rcloneAPI.browseRemote(remote.id, normalizedPath)
       return {
         remote,
-        path: response.data.path || '',
+        path: normalizeBrowserPath(response.data.path || normalizedPath),
         entries: (response.data.entries || []) as BrowseEntry[],
       }
     },
     onSuccess: ({ remote, path, entries }) => {
-      setBrowseState({ remote, path, entries })
+      const normalizedPath = normalizeBrowserPath(path)
+      setBrowseState((current) => {
+        if (
+          !current ||
+          current.remote.id !== remote.id ||
+          normalizeBrowserPath(current.path) !== normalizedPath
+        ) {
+          return current
+        }
+
+        return { remote, path: normalizedPath, entries }
+      })
     },
     onError: (error: unknown) => {
       toast.error(getApiMessage(error, t('cloudStorage.browseFailed')))
@@ -1012,7 +1021,7 @@ export default function CloudStorage() {
         await deleteRemoteMutation.mutateAsync()
       }}
       onTestRemote={(remote) => testRemoteMutation.mutate(remote)}
-      onBrowseRemote={(remote) => browseRemoteMutation.mutate(remote)}
+      onBrowseRemote={(remote, path = '') => browseRemoteMutation.mutate({ remote, path })}
       onCloseBrowse={() => setBrowseState(null)}
     />
   )

--- a/frontend/src/pages/CloudStorage.tsx
+++ b/frontend/src/pages/CloudStorage.tsx
@@ -43,7 +43,7 @@ import OperationalCard from '../components/OperationalCard'
 import PageHeader from '../components/PageHeader'
 import ListToolbar from '../components/ListToolbar'
 import StorageBrowserDialog, { type StorageBrowserItem } from '../components/StorageBrowserDialog'
-import { normalizeBrowserPath } from '../utils/storageBrowserPaths'
+import { joinBrowserPath, normalizeBrowserPath } from '../utils/storageBrowserPaths'
 
 interface BrowseEntry {
   name: string
@@ -562,7 +562,7 @@ export function CloudStorageContent({
 
     return browseState.entries.map((entry) => ({
       name: entry.name,
-      path: normalizeBrowserPath(entry.path || entry.name),
+      path: joinBrowserPath(browseState.path, entry.path || entry.name),
       type: entry.is_dir ? 'directory' : 'file',
       size: entry.size,
       modified: entry.modified,

--- a/frontend/src/pages/__tests__/CloudStorage.test.tsx
+++ b/frontend/src/pages/__tests__/CloudStorage.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AxiosResponse } from 'axios'
 import {
+  act,
   fireEvent,
   renderWithProviders,
   screen,
@@ -94,20 +95,20 @@ describe('CloudStorage', () => {
   })
 
   it('adds a managed rclone remote from the page action', async () => {
-    const user = userEvent.setup()
     renderWithProviders(<CloudStorage />, { initialRoute: '/cloud-storage' })
 
     await screen.findByText('prod-s3')
-    await user.click(await screen.findByRole('button', { name: /Add remote/i }))
-    await user.clear(screen.getByLabelText(/Remote name/i))
-    await user.type(screen.getByLabelText(/Remote name/i), 'local-test')
-    await user.clear(screen.getByLabelText(/^Provider/i))
-    await user.type(screen.getByLabelText(/^Provider/i), 'local')
-    await user.clear(screen.getByLabelText(/Config JSON/i))
+    fireEvent.click(await screen.findByRole('button', { name: /Add remote/i }))
+    fireEvent.change(screen.getByLabelText(/Remote name/i), {
+      target: { value: 'local-test' },
+    })
+    fireEvent.change(screen.getByLabelText(/^Provider/i), {
+      target: { value: 'local' },
+    })
     fireEvent.change(screen.getByLabelText(/Config JSON/i), {
       target: { value: '{"type":"local"}' },
     })
-    await user.click(screen.getByRole('button', { name: /Create remote/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Create remote/i }))
 
     await waitFor(() => {
       expect(rcloneAPI.createRemote).toHaveBeenCalledWith({
@@ -129,7 +130,11 @@ describe('CloudStorage', () => {
       expect(rcloneAPI.testRemote).toHaveBeenCalledWith(10)
     })
 
-    fireEvent.click(within(card).getByRole('button', { name: /Browse remote/i }))
+    await waitFor(() => {
+      expect(rcloneAPI.listRemotes).toHaveBeenCalledTimes(2)
+    })
+    const refreshedCard = await screen.findByTestId('cloud-storage-remote-prod-s3')
+    fireEvent.click(within(refreshedCard).getByRole('button', { name: /Browse remote/i }))
     await waitFor(() => {
       expect(rcloneAPI.browseRemote).toHaveBeenCalledWith(10, '')
     })
@@ -137,6 +142,118 @@ describe('CloudStorage', () => {
     expect(screen.getByText('borg-ui')).toBeInTheDocument()
     expect(screen.getByText('README')).toBeInTheDocument()
   })
+
+  it('navigates folders in the reusable browse dialog', async () => {
+    vi.mocked(rcloneAPI.browseRemote).mockImplementation((_remoteId, path = '') => {
+      return Promise.resolve({
+        data: {
+          remote_id: 10,
+          path,
+          entries:
+            path === ''
+              ? [{ name: 'borg-ui', path: 'borg-ui', is_dir: true, size: null, modified: null }]
+              : [
+                  {
+                    name: 'archive.tar',
+                    path: 'borg-ui/archive.tar',
+                    is_dir: false,
+                    size: 2048,
+                    modified: '2026-05-27T12:00:00Z',
+                  },
+                ],
+        },
+      } as AxiosResponse)
+    })
+
+    renderWithProviders(<CloudStorage />, { initialRoute: '/cloud-storage' })
+
+    const card = await screen.findByTestId('cloud-storage-remote-prod-s3')
+    fireEvent.click(within(card).getByRole('button', { name: /Browse remote/i }))
+
+    expect(await screen.findByRole('dialog', { name: /Browse prod-s3/i })).toBeInTheDocument()
+    expect(await screen.findByText('borg-ui')).toBeInTheDocument()
+    const folderButton = screen.getByRole('button', { name: /borg-ui/i })
+    fireEvent.click(folderButton)
+
+    await waitFor(() => {
+      expect(rcloneAPI.browseRemote).toHaveBeenCalledWith(10, 'borg-ui')
+    })
+    expect(await screen.findByText('archive.tar')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Root/i })).toBeInTheDocument()
+  }, 60000)
+
+  it('ignores stale browse responses after navigating away', async () => {
+    let resolveFolderBrowse!: (value: AxiosResponse) => void
+    const folderBrowse = new Promise<AxiosResponse>((resolve) => {
+      resolveFolderBrowse = resolve
+    })
+    let rootBrowseCount = 0
+
+    vi.mocked(rcloneAPI.browseRemote).mockImplementation((_remoteId, path = '') => {
+      if (path === 'borg-ui') {
+        return folderBrowse
+      }
+
+      rootBrowseCount += 1
+      return Promise.resolve({
+        data: {
+          remote_id: 10,
+          path: '',
+          entries:
+            rootBrowseCount === 1
+              ? [{ name: 'borg-ui', path: 'borg-ui', is_dir: true, size: null, modified: null }]
+              : [
+                  {
+                    name: 'root-readme',
+                    path: 'root-readme',
+                    is_dir: false,
+                    size: 512,
+                    modified: null,
+                  },
+                ],
+        },
+      } as AxiosResponse)
+    })
+
+    renderWithProviders(<CloudStorage />, { initialRoute: '/cloud-storage' })
+
+    const card = await screen.findByTestId('cloud-storage-remote-prod-s3')
+    fireEvent.click(within(card).getByRole('button', { name: /Browse remote/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /borg-ui/i }))
+
+    await waitFor(() => {
+      expect(rcloneAPI.browseRemote).toHaveBeenCalledWith(10, 'borg-ui')
+    })
+    const rootBreadcrumb = screen.getByRole('button', { name: /^Root$/i })
+    await waitFor(() => {
+      expect(rootBreadcrumb).toBeEnabled()
+    })
+    fireEvent.click(rootBreadcrumb)
+
+    expect(await screen.findByText('root-readme')).toBeInTheDocument()
+
+    await act(async () => {
+      resolveFolderBrowse({
+        data: {
+          remote_id: 10,
+          path: 'borg-ui',
+          entries: [
+            {
+              name: 'archive.tar',
+              path: 'borg-ui/archive.tar',
+              is_dir: false,
+              size: 2048,
+              modified: null,
+            },
+          ],
+        },
+      } as AxiosResponse)
+      await folderBrowse
+    })
+
+    expect(screen.getByText('root-readme')).toBeInTheDocument()
+    expect(screen.queryByText('archive.tar')).not.toBeInTheDocument()
+  }, 60000)
 
   it('edits a remote from the remote card', async () => {
     const user = userEvent.setup()

--- a/frontend/src/pages/__tests__/CloudStorage.test.tsx
+++ b/frontend/src/pages/__tests__/CloudStorage.test.tsx
@@ -121,10 +121,11 @@ describe('CloudStorage', () => {
   }, 60000)
 
   it('tests and browses a remote from the remote card', async () => {
+    const user = userEvent.setup()
     renderWithProviders(<CloudStorage />, { initialRoute: '/cloud-storage' })
 
     const card = await screen.findByTestId('cloud-storage-remote-prod-s3')
-    fireEvent.click(within(card).getByRole('button', { name: /Test connection/i }))
+    await user.click(within(card).getByRole('button', { name: /Test connection/i }))
 
     await waitFor(() => {
       expect(rcloneAPI.testRemote).toHaveBeenCalledWith(10)
@@ -134,7 +135,7 @@ describe('CloudStorage', () => {
       expect(rcloneAPI.listRemotes).toHaveBeenCalledTimes(2)
     })
     const refreshedCard = await screen.findByTestId('cloud-storage-remote-prod-s3')
-    fireEvent.click(within(refreshedCard).getByRole('button', { name: /Browse remote/i }))
+    await user.click(within(refreshedCard).getByRole('button', { name: /Browse remote/i }))
     await waitFor(() => {
       expect(rcloneAPI.browseRemote).toHaveBeenCalledWith(10, '')
     })
@@ -144,6 +145,7 @@ describe('CloudStorage', () => {
   })
 
   it('navigates folders in the reusable browse dialog', async () => {
+    const user = userEvent.setup()
     vi.mocked(rcloneAPI.browseRemote).mockImplementation((_remoteId, path = '') => {
       return Promise.resolve({
         data: {
@@ -168,12 +170,12 @@ describe('CloudStorage', () => {
     renderWithProviders(<CloudStorage />, { initialRoute: '/cloud-storage' })
 
     const card = await screen.findByTestId('cloud-storage-remote-prod-s3')
-    fireEvent.click(within(card).getByRole('button', { name: /Browse remote/i }))
+    await user.click(within(card).getByRole('button', { name: /Browse remote/i }))
 
     expect(await screen.findByRole('dialog', { name: /Browse prod-s3/i })).toBeInTheDocument()
     expect(await screen.findByText('borg-ui')).toBeInTheDocument()
     const folderButton = screen.getByRole('button', { name: /borg-ui/i })
-    fireEvent.click(folderButton)
+    await user.click(folderButton)
 
     await waitFor(() => {
       expect(rcloneAPI.browseRemote).toHaveBeenCalledWith(10, 'borg-ui')
@@ -182,7 +184,54 @@ describe('CloudStorage', () => {
     expect(screen.getByRole('button', { name: /Root/i })).toBeInTheDocument()
   }, 60000)
 
+  it('keeps nested rclone paths rooted under the current folder when API entries are relative', async () => {
+    const user = userEvent.setup()
+    vi.mocked(rcloneAPI.browseRemote).mockImplementation((_remoteId, path = '') => {
+      return Promise.resolve({
+        data: {
+          remote_id: 10,
+          path,
+          entries:
+            path === ''
+              ? [{ name: 'borg-ui', path: 'borg-ui', is_dir: true, size: null, modified: null }]
+              : path === 'borg-ui'
+                ? [{ name: 'snapshots', path: 'snapshots', is_dir: true, size: -1, modified: null }]
+                : [
+                    {
+                      name: 'manifest.json',
+                      path: 'manifest.json',
+                      is_dir: false,
+                      size: 128,
+                      modified: null,
+                    },
+                  ],
+        },
+      } as AxiosResponse)
+    })
+
+    renderWithProviders(<CloudStorage />, { initialRoute: '/cloud-storage' })
+
+    const card = await screen.findByTestId('cloud-storage-remote-prod-s3')
+    await user.click(within(card).getByRole('button', { name: /Browse remote/i }))
+    await waitFor(() => {
+      expect(rcloneAPI.browseRemote).toHaveBeenCalledWith(10, '')
+    })
+    await user.click(await screen.findByRole('button', { name: /borg-ui/i }, { timeout: 10000 }))
+
+    const nestedFolder = await screen.findByRole(
+      'button',
+      { name: /snapshots/i },
+      { timeout: 10000 }
+    )
+    await user.click(nestedFolder)
+
+    await waitFor(() => {
+      expect(rcloneAPI.browseRemote).toHaveBeenCalledWith(10, 'borg-ui/snapshots')
+    })
+  }, 60000)
+
   it('ignores stale browse responses after navigating away', async () => {
+    const user = userEvent.setup()
     let resolveFolderBrowse!: (value: AxiosResponse) => void
     const folderBrowse = new Promise<AxiosResponse>((resolve) => {
       resolveFolderBrowse = resolve
@@ -218,8 +267,11 @@ describe('CloudStorage', () => {
     renderWithProviders(<CloudStorage />, { initialRoute: '/cloud-storage' })
 
     const card = await screen.findByTestId('cloud-storage-remote-prod-s3')
-    fireEvent.click(within(card).getByRole('button', { name: /Browse remote/i }))
-    fireEvent.click(await screen.findByRole('button', { name: /borg-ui/i }))
+    await user.click(within(card).getByRole('button', { name: /Browse remote/i }))
+    await waitFor(() => {
+      expect(rcloneAPI.browseRemote).toHaveBeenCalledWith(10, '')
+    })
+    await user.click(await screen.findByRole('button', { name: /borg-ui/i }, { timeout: 10000 }))
 
     await waitFor(() => {
       expect(rcloneAPI.browseRemote).toHaveBeenCalledWith(10, 'borg-ui')
@@ -228,7 +280,7 @@ describe('CloudStorage', () => {
     await waitFor(() => {
       expect(rootBreadcrumb).toBeEnabled()
     })
-    fireEvent.click(rootBreadcrumb)
+    await user.click(rootBreadcrumb)
 
     expect(await screen.findByText('root-readme')).toBeInTheDocument()
 

--- a/frontend/src/utils/storageBrowserPaths.ts
+++ b/frontend/src/utils/storageBrowserPaths.ts
@@ -4,3 +4,16 @@ export function normalizeBrowserPath(path?: string | null) {
   }
   return path.replace(/^\/+/, '').replace(/\/+$/, '')
 }
+
+export function joinBrowserPath(basePath?: string | null, childPath?: string | null) {
+  const base = normalizeBrowserPath(basePath)
+  const child = normalizeBrowserPath(childPath)
+
+  if (!child) {
+    return base
+  }
+  if (!base || child === base || child.startsWith(`${base}/`)) {
+    return child
+  }
+  return `${base}/${child}`
+}

--- a/frontend/src/utils/storageBrowserPaths.ts
+++ b/frontend/src/utils/storageBrowserPaths.ts
@@ -1,0 +1,6 @@
+export function normalizeBrowserPath(path?: string | null) {
+  if (!path || path === '/') {
+    return ''
+  }
+  return path.replace(/^\/+/, '').replace(/\/+$/, '')
+}

--- a/tests/unit/test_api_rclone.py
+++ b/tests/unit/test_api_rclone.py
@@ -390,6 +390,51 @@ def test_browse_remote_returns_redacted_entries(
 
 
 @pytest.mark.unit
+def test_browse_remote_returns_paths_relative_to_remote_root(
+    test_client: TestClient, admin_headers, test_db, monkeypatch
+):
+    remote = RcloneRemote(name="prod-s3", provider="s3", config_source="managed")
+    test_db.add(remote)
+    test_db.commit()
+    test_db.refresh(remote)
+
+    monkeypatch.setattr(
+        "app.api.rclone.rclone_service.lsjson",
+        AsyncMock(
+            return_value=[
+                {"Name": "snapshots", "Path": "snapshots", "IsDir": True, "Size": -1},
+                {"Name": "manifest.json", "Path": "manifest.json", "IsDir": False},
+            ]
+        ),
+    )
+
+    response = test_client.get(
+        f"/api/rclone/remotes/{remote.id}/browse",
+        headers=admin_headers,
+        params={"path": "borg-ui"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["path"] == "borg-ui"
+    assert response.json()["entries"] == [
+        {
+            "name": "snapshots",
+            "path": "borg-ui/snapshots",
+            "is_dir": True,
+            "size": None,
+            "modified": None,
+        },
+        {
+            "name": "manifest.json",
+            "path": "borg-ui/manifest.json",
+            "is_dir": False,
+            "size": None,
+            "modified": None,
+        },
+    ]
+
+
+@pytest.mark.unit
 def test_repository_rclone_status_endpoint(
     test_client: TestClient, admin_headers, test_db
 ):


### PR DESCRIPTION
## Description
Extracts the archive contents browser into a reusable `StorageBrowserDialog` and uses it for Cloud Storage remote browsing. Cloud Storage folders are semantic buttons with root/current-path breadcrumbs, while archive contents keep canary labels, canary banner, metadata, and download behavior.

This update also addresses review feedback from the cloud storage browse path: rclone browse entries are normalized to remote-root-relative paths even when rclone returns target-relative child paths, and invalid negative or non-finite browse sizes are suppressed before they can render as `NaN undefined`.

## Related Issue
Linear: https://linear.app/nullcodeai/issue/BOR-81/reuse-archive-browser-for-cloud-storage-browsing

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [x] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass

Validation run:
- `cd frontend && npx vitest src/pages/__tests__/CloudStorage.test.tsx -t "navigates folders in the reusable browse dialog" --run --testTimeout=30000` failed before the original implementation because `borg-ui` was not an accessible button.
- `cd frontend && npx vitest src/pages/__tests__/CloudStorage.test.tsx -t "keeps nested rclone paths rooted" --run --testTimeout=60000` failed before the review fix because the nested browse call was not root-relative.
- `cd frontend && npx vitest src/components/__tests__/StorageBrowserDialog.test.tsx --run --testTimeout=30000` failed before the review fix with visible `NaN undefined` size text.
- `pytest tests/unit/test_api_rclone.py -k browse_remote_returns_paths_relative_to_remote_root -q` failed before the review fix because nested entries returned target-relative paths and `-1` size directly.
- `cd frontend && npx vitest src/pages/__tests__/CloudStorage.test.tsx --run --testTimeout=60000` passed, 9 tests.
- `cd frontend && npx vitest src/components/__tests__/ArchiveContentsDialog.test.tsx src/components/__tests__/StorageBrowserDialog.test.tsx --run --testTimeout=60000` passed, 15 tests.
- `pytest tests/unit/test_api_rclone.py -q` passed, 26 tests.
- `ruff check app tests` passed.
- `ruff format --check app tests` passed.
- `cd frontend && npm run check:locales` passed.
- `cd frontend && npm run typecheck` passed.
- `cd frontend && npm run format:check` passed.
- `cd frontend && npm run lint` passed.
- `cd frontend && npm run build` passed with existing Vite dynamic/static import and chunk-size warnings.
- `cd frontend && npm run snapshots` was skipped for this review reply per owner PR feedback to skip Playwright.
- Local runtime walkthrough: `DEV_PORT=8083 ./scripts/dev.sh` launched the backend and frontend; a local `bor81local` rclone remote browsed root -> `bor-81-rclone` -> `borg-ui` -> `snapshots`, and `/api/rclone/remotes/1/browse?path=bor-81-rclone/borg-ui/snapshots` returned `bor-81-rclone/borg-ui/snapshots/manifest.json`.

## Checklist
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
The Cloud Storage Storybook browse story renders a nested folder state. Snapshot regeneration was skipped for this review reply because the owner explicitly requested skipping Playwright while addressing the reported navigation and invalid-size defects.

## Additional Context
The nested navigation defect came from rclone returning child `Path` values relative to the listed target. The backend now serializes browse entries relative to the remote root, and the frontend also defensively joins relative child paths against the current browser path.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified storage browser UI for archive and cloud storage remote browsing with folder navigation, breadcrumbs, and file downloads.

* **Refactor**
  * Archive browsing dialog refactored to use shared `StorageBrowserDialog` component.

* **Tests**
  * Added tests for storage browser component, path normalization, and cloud storage remote navigation with nested folders.

* **Documentation**
  * Added implementation plan and engineering specification for shared storage browsing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/karanhudia/borg-ui/pull/548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->