### PR TITLE
Refresh Borg UI Postman collection

### DIFF
--- a/Borg_UI_API.postman_collection.json
+++ b/Borg_UI_API.postman_collection.json
@@ -1,849 +1,7111 @@
 {
-	"info": {
-		"name": "Borg UI API - Complete",
-		"description": "Comprehensive API collection for Borg UI\n\nFeatures:\n- Authentication & User Management\n- Dashboard & Metrics\n- Backup Operations\n- Repository Management (Local & SSH)\n- SSH Key Management\n- Archive Management\n- Real-time Updates (SSE)\n- Configuration Management\n\nNote: Logs and Health endpoints have been removed - logs are printed to console",
-		"version": "2.2.0",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
-	},
-	"auth": {
-		"type": "apikey",
-		"apikey": [
-			{
-				"key": "key",
-				"value": "X-Borg-Authorization",
-				"type": "string"
-			},
-			{
-				"key": "value",
-				"value": "Bearer {{access_token}}",
-				"type": "string"
-			},
-			{
-				"key": "in",
-				"value": "header",
-				"type": "string"
-			}
-		]
-	},
-	"variable": [
-		{
-			"key": "base_url",
-			"value": "http://localhost:8000",
-			"type": "string"
-		},
-		{
-			"key": "access_token",
-			"value": "",
-			"type": "string"
-		}
-	],
-	"item": [
-		{
-			"name": "1. Authentication",
-			"item": [
-				{
-					"name": "Login",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"if (pm.response.code === 200) {",
-									"    var jsonData = pm.response.json();",
-									"    pm.collectionVariables.set(\"access_token\", jsonData.access_token);",
-									"    console.log(\"✅ Token saved:\", jsonData.access_token);",
-									"}"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {"type": "noauth"},
-						"method": "POST",
-						"header": [{"key": "Content-Type", "value": "application/x-www-form-urlencoded"}],
-						"body": {
-							"mode": "urlencoded",
-							"urlencoded": [
-								{"key": "username", "value": "admin", "type": "text"},
-								{"key": "password", "value": "admin123", "type": "text"}
-							]
-						},
-						"url": {
-							"raw": "{{base_url}}/api/auth/login",
-							"host": ["{{base_url}}"],
-							"path": ["api", "auth", "login"]
-						},
-						"description": "Authenticate and receive JWT token"
-					}
-				},
-				{
-					"name": "Get Current User",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/auth/me",
-							"host": ["{{base_url}}"],
-							"path": ["api", "auth", "me"]
-						},
-						"description": "Get currently authenticated user info"
-					}
-				},
-				{
-					"name": "Refresh Token",
-					"request": {
-						"method": "POST",
-						"url": {
-							"raw": "{{base_url}}/api/auth/refresh",
-							"host": ["{{base_url}}"],
-							"path": ["api", "auth", "refresh"]
-						},
-						"description": "Refresh JWT token"
-					}
-				},
-				{
-					"name": "Logout",
-					"request": {
-						"method": "POST",
-						"url": {
-							"raw": "{{base_url}}/api/auth/logout",
-							"host": ["{{base_url}}"],
-							"path": ["api", "auth", "logout"]
-						}
-					}
-				},
-				{
-					"name": "Change Password",
-					"request": {
-						"method": "POST",
-						"header": [{"key": "Content-Type", "value": "application/json"}],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"old_password\": \"admin123\",\n  \"new_password\": \"newpassword123\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/auth/change-password",
-							"host": ["{{base_url}}"],
-							"path": ["api", "auth", "change-password"]
-						}
-					}
-				},
-				{
-					"name": "List Users (Admin)",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/auth/users",
-							"host": ["{{base_url}}"],
-							"path": ["api", "auth", "users"]
-						}
-					}
-				},
-				{
-					"name": "Create User (Admin)",
-					"request": {
-						"method": "POST",
-						"header": [{"key": "Content-Type", "value": "application/json"}],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"username\": \"newuser\",\n  \"email\": \"newuser@example.com\",\n  \"password\": \"password123\",\n  \"is_admin\": false\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/auth/users",
-							"host": ["{{base_url}}"],
-							"path": ["api", "auth", "users"]
-						}
-					}
-				},
-				{
-					"name": "Update User (Admin)",
-					"request": {
-						"method": "PUT",
-						"header": [{"key": "Content-Type", "value": "application/json"}],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"email\": \"updated@example.com\",\n  \"is_admin\": true\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/auth/users/:user_id",
-							"host": ["{{base_url}}"],
-							"path": ["api", "auth", "users", ":user_id"],
-							"variable": [{"key": "user_id", "value": "2"}]
-						}
-					}
-				},
-				{
-					"name": "Delete User (Admin)",
-					"request": {
-						"method": "DELETE",
-						"url": {
-							"raw": "{{base_url}}/api/auth/users/:user_id",
-							"host": ["{{base_url}}"],
-							"path": ["api", "auth", "users", ":user_id"],
-							"variable": [{"key": "user_id", "value": "2"}]
-						}
-					}
-				}
-			]
-		},
-		{
-			"name": "2. Dashboard",
-			"item": [
-				{
-					"name": "Get Dashboard Status",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/dashboard/status",
-							"host": ["{{base_url}}"],
-							"path": ["api", "dashboard", "status"]
-						},
-						"description": "Get overall backup status and quick stats"
-					}
-				},
-				{
-					"name": "Get Metrics",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/dashboard/metrics",
-							"host": ["{{base_url}}"],
-							"path": ["api", "dashboard", "metrics"]
-						},
-						"description": "Get system metrics and performance data"
-					}
-				},
-				{
-					"name": "Get Schedule",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/dashboard/schedule",
-							"host": ["{{base_url}}"],
-							"path": ["api", "dashboard", "schedule"]
-						},
-						"description": "Get upcoming scheduled backups"
-					}
-				},
-				{
-					"name": "Get Health",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/dashboard/health",
-							"host": ["{{base_url}}"],
-							"path": ["api", "dashboard", "health"]
-						},
-						"description": "Get system health status"
-					}
-				}
-			]
-		},
-		{
-			"name": "3. Backup Operations",
-			"item": [
-				{
-					"name": "Start Backup",
-					"request": {
-						"method": "POST",
-						"header": [{"key": "Content-Type", "value": "application/json"}],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"repository_id\": 1,\n  \"options\": {\n    \"dry_run\": false,\n    \"verbosity\": 1\n  }\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/backup/start",
-							"host": ["{{base_url}}"],
-							"path": ["api", "backup", "start"]
-						},
-						"description": "Start a new backup job"
-					}
-				},
-				{
-					"name": "Get Backup Status",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/backup/status/:job_id",
-							"host": ["{{base_url}}"],
-							"path": ["api", "backup", "status", ":job_id"],
-							"variable": [{"key": "job_id", "value": "1"}]
-						},
-						"description": "Get status of a backup job"
-					}
-				},
-				{
-					"name": "Cancel Backup",
-					"request": {
-						"method": "DELETE",
-						"url": {
-							"raw": "{{base_url}}/api/backup/cancel/:job_id",
-							"host": ["{{base_url}}"],
-							"path": ["api", "backup", "cancel", ":job_id"],
-							"variable": [{"key": "job_id", "value": "1"}]
-						},
-						"description": "Cancel a running backup job"
-					}
-				},
-				{
-					"name": "Get Backup Logs",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/backup/logs/:job_id",
-							"host": ["{{base_url}}"],
-							"path": ["api", "backup", "logs", ":job_id"],
-							"variable": [{"key": "job_id", "value": "1"}]
-						},
-						"description": "Get logs for a backup job"
-					}
-				}
-			]
-		},
-		{
-			"name": "4. Archives",
-			"item": [
-				{
-					"name": "List Archives",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/archives/list?repository_id=1",
-							"host": ["{{base_url}}"],
-							"path": ["api", "archives", "list"],
-							"query": [{"key": "repository_id", "value": "1"}]
-						},
-						"description": "List all archives in a repository"
-					}
-				},
-				{
-					"name": "Get Archive Info",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/archives/:archive_id/info",
-							"host": ["{{base_url}}"],
-							"path": ["api", "archives", ":archive_id", "info"],
-							"variable": [{"key": "archive_id", "value": "1"}]
-						},
-						"description": "Get detailed information about an archive"
-					}
-				},
-				{
-					"name": "Get Archive Contents",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/archives/:archive_id/contents?path=/",
-							"host": ["{{base_url}}"],
-							"path": ["api", "archives", ":archive_id", "contents"],
-							"variable": [{"key": "archive_id", "value": "1"}],
-							"query": [{"key": "path", "value": "/"}]
-						},
-						"description": "Browse contents of an archive"
-					}
-				},
-				{
-					"name": "Delete Archive",
-					"request": {
-						"method": "DELETE",
-						"url": {
-							"raw": "{{base_url}}/api/archives/:archive_id",
-							"host": ["{{base_url}}"],
-							"path": ["api", "archives", ":archive_id"],
-							"variable": [{"key": "archive_id", "value": "1"}]
-						},
-						"description": "Delete an archive"
-					}
-				}
-			]
-		},
-		{
-			"name": "5. Repositories",
-			"item": [
-				{
-					"name": "List Repositories",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/repositories",
-							"host": ["{{base_url}}"],
-							"path": ["api", "repositories"]
-						},
-						"description": "List all configured repositories"
-					}
-				},
-				{
-					"name": "Create Local Repository",
-					"request": {
-						"method": "POST",
-						"header": [{"key": "Content-Type", "value": "application/json"}],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"My Backup Repo\",\n  \"path\": \"/srv/borg_backup\",\n  \"encryption\": \"repokey\",\n  \"compression\": \"lz4\",\n  \"passphrase\": \"my-secure-passphrase\",\n  \"repository_type\": \"local\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/repositories/",
-							"host": ["{{base_url}}"],
-							"path": ["api", "repositories", ""]
-						},
-						"description": "Create a new local repository at any path (directory will be created automatically)"
-					}
-				},
-				{
-					"name": "Create SSH Repository",
-					"request": {
-						"method": "POST",
-						"header": [{"key": "Content-Type", "value": "application/json"}],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"Remote Backup Repo\",\n  \"path\": \"/mnt/mydisk/data/immich-backup\",\n  \"encryption\": \"repokey\",\n  \"compression\": \"lz4\",\n  \"passphrase\": \"my-secure-passphrase\",\n  \"repository_type\": \"ssh\",\n  \"host\": \"192.168.1.250\",\n  \"port\": 22,\n  \"username\": \"karanhudia\",\n  \"ssh_key_id\": 1\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/repositories/",
-							"host": ["{{base_url}}"],
-							"path": ["api", "repositories", ""]
-						},
-						"description": "Create a new SSH repository (will be formatted as ssh://username@host:port/path)"
-					}
-				},
-				{
-					"name": "Get Repository",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/repositories/:repo_id",
-							"host": ["{{base_url}}"],
-							"path": ["api", "repositories", ":repo_id"],
-							"variable": [{"key": "repo_id", "value": "1"}]
-						},
-						"description": "Get repository details"
-					}
-				},
-				{
-					"name": "Update Repository",
-					"request": {
-						"method": "PUT",
-						"header": [{"key": "Content-Type", "value": "application/json"}],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"Updated Repo Name\",\n  \"description\": \"Updated description\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/repositories/:repo_id",
-							"host": ["{{base_url}}"],
-							"path": ["api", "repositories", ":repo_id"],
-							"variable": [{"key": "repo_id", "value": "1"}]
-						},
-						"description": "Update repository settings"
-					}
-				},
-				{
-					"name": "Delete Repository",
-					"request": {
-						"method": "DELETE",
-						"url": {
-							"raw": "{{base_url}}/api/repositories/:repo_id",
-							"host": ["{{base_url}}"],
-							"path": ["api", "repositories", ":repo_id"],
-							"variable": [{"key": "repo_id", "value": "1"}]
-						},
-						"description": "Delete a repository"
-					}
-				},
-				{
-					"name": "Check Repository",
-					"request": {
-						"method": "POST",
-						"url": {
-							"raw": "{{base_url}}/api/repositories/:repo_id/check",
-							"host": ["{{base_url}}"],
-							"path": ["api", "repositories", ":repo_id", "check"],
-							"variable": [{"key": "repo_id", "value": "1"}]
-						},
-						"description": "Run integrity check on repository"
-					}
-				},
-				{
-					"name": "Compact Repository",
-					"request": {
-						"method": "POST",
-						"url": {
-							"raw": "{{base_url}}/api/repositories/:repo_id/compact",
-							"host": ["{{base_url}}"],
-							"path": ["api", "repositories", ":repo_id", "compact"],
-							"variable": [{"key": "repo_id", "value": "1"}]
-						},
-						"description": "Compact repository to free space"
-					}
-				},
-				{
-					"name": "Get Repository Stats",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/repositories/:repo_id/stats",
-							"host": ["{{base_url}}"],
-							"path": ["api", "repositories", ":repo_id", "stats"],
-							"variable": [{"key": "repo_id", "value": "1"}]
-						},
-						"description": "Get repository statistics"
-					}
-				}
-			]
-		},
-		{
-			"name": "6. SSH Keys",
-			"item": [
-				{
-					"name": "List SSH Keys",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/ssh-keys",
-							"host": ["{{base_url}}"],
-							"path": ["api", "ssh-keys"]
-						},
-						"description": "List all SSH keys"
-					}
-				},
-				{
-					"name": "Generate SSH Key",
-					"request": {
-						"method": "POST",
-						"header": [{"key": "Content-Type", "value": "application/json"}],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"my-backup-key\",\n  \"key_type\": \"rsa\",\n  \"description\": \"SSH key for backup server\",\n  \"passphrase\": \"\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/ssh-keys/generate",
-							"host": ["{{base_url}}"],
-							"path": ["api", "ssh-keys", "generate"]
-						},
-						"description": "Generate a new SSH key pair"
-					}
-				},
-				{
-					"name": "Quick SSH Setup",
-					"request": {
-						"method": "POST",
-						"header": [{"key": "Content-Type", "value": "application/json"}],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"quick-key\",\n  \"key_type\": \"rsa\",\n  \"host\": \"192.168.1.100\",\n  \"username\": \"backup_user\",\n  \"port\": 22,\n  \"password\": \"ssh-password\",\n  \"skip_deployment\": false\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/ssh-keys/quick-setup",
-							"host": ["{{base_url}}"],
-							"path": ["api", "ssh-keys", "quick-setup"]
-						},
-						"description": "Generate and deploy SSH key in one step"
-					}
-				},
-				{
-					"name": "Deploy SSH Key",
-					"request": {
-						"method": "POST",
-						"header": [{"key": "Content-Type", "value": "application/json"}],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"host\": \"192.168.1.100\",\n  \"username\": \"backup_user\",\n  \"port\": 22,\n  \"password\": \"ssh-password\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/ssh-keys/:key_id/deploy",
-							"host": ["{{base_url}}"],
-							"path": ["api", "ssh-keys", ":key_id", "deploy"],
-							"variable": [{"key": "key_id", "value": "1"}]
-						},
-						"description": "Deploy SSH key to remote server"
-					}
-				},
-				{
-					"name": "Test SSH Connection",
-					"request": {
-						"method": "POST",
-						"header": [{"key": "Content-Type", "value": "application/json"}],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"host\": \"192.168.1.100\",\n  \"username\": \"backup_user\",\n  \"port\": 22\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/ssh-keys/:key_id/test-connection",
-							"host": ["{{base_url}}"],
-							"path": ["api", "ssh-keys", ":key_id", "test-connection"],
-							"variable": [{"key": "key_id", "value": "1"}]
-						},
-						"description": "Test SSH connection with key"
-					}
-				},
-				{
-					"name": "Get SSH Connections",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/ssh-keys/connections",
-							"host": ["{{base_url}}"],
-							"path": ["api", "ssh-keys", "connections"]
-						},
-						"description": "Get list of SSH connections"
-					}
-				},
-				{
-					"name": "Get SSH Key Details",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/ssh-keys/:key_id",
-							"host": ["{{base_url}}"],
-							"path": ["api", "ssh-keys", ":key_id"],
-							"variable": [{"key": "key_id", "value": "1"}]
-						},
-						"description": "Get SSH key details"
-					}
-				},
-				{
-					"name": "Update SSH Key",
-					"request": {
-						"method": "PUT",
-						"header": [{"key": "Content-Type", "value": "application/json"}],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"updated-key-name\",\n  \"description\": \"Updated description\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/ssh-keys/:key_id",
-							"host": ["{{base_url}}"],
-							"path": ["api", "ssh-keys", ":key_id"],
-							"variable": [{"key": "key_id", "value": "1"}]
-						},
-						"description": "Update SSH key metadata"
-					}
-				},
-				{
-					"name": "Delete SSH Key",
-					"request": {
-						"method": "DELETE",
-						"url": {
-							"raw": "{{base_url}}/api/ssh-keys/:key_id",
-							"host": ["{{base_url}}"],
-							"path": ["api", "ssh-keys", ":key_id"],
-							"variable": [{"key": "key_id", "value": "1"}]
-						},
-						"description": "Delete an SSH key"
-					}
-				}
-			]
-		},
-		{
-			"name": "7. Configuration",
-			"item": [
-				{
-					"name": "Get Current Config",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/config/current",
-							"host": ["{{base_url}}"],
-							"path": ["api", "config", "current"]
-						},
-						"description": "Get current Borg configuration"
-					}
-				},
-				{
-					"name": "Update Config",
-					"request": {
-						"method": "PUT",
-						"header": [{"key": "Content-Type", "value": "application/json"}],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"location\": {\n    \"source_directories\": [\"/home\", \"/etc\"],\n    \"repositories\": [\"/backups/repo1\"]\n  }\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/config/update",
-							"host": ["{{base_url}}"],
-							"path": ["api", "config", "update"]
-						},
-						"description": "Update Borg configuration"
-					}
-				},
-				{
-					"name": "Validate Config",
-					"request": {
-						"method": "POST",
-						"header": [{"key": "Content-Type", "value": "application/json"}],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"config\": {}\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/config/validate",
-							"host": ["{{base_url}}"],
-							"path": ["api", "config", "validate"]
-						},
-						"description": "Validate configuration before saving"
-					}
-				},
-				{
-					"name": "Get Config Templates",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/config/templates",
-							"host": ["{{base_url}}"],
-							"path": ["api", "config", "templates"]
-						},
-						"description": "Get available configuration templates"
-					}
-				},
-				{
-					"name": "Backup Config",
-					"request": {
-						"method": "POST",
-						"url": {
-							"raw": "{{base_url}}/api/config/backup",
-							"host": ["{{base_url}}"],
-							"path": ["api", "config", "backup"]
-						},
-						"description": "Create backup of current configuration"
-					}
-				},
-				{
-					"name": "List Config Backups",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/config/backups",
-							"host": ["{{base_url}}"],
-							"path": ["api", "config", "backups"]
-						},
-						"description": "List configuration backups"
-					}
-				},
-				{
-					"name": "Get Config Backup",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/config/backups/:backup_id",
-							"host": ["{{base_url}}"],
-							"path": ["api", "config", "backups", ":backup_id"],
-							"variable": [{"key": "backup_id", "value": "1"}]
-						},
-						"description": "Get specific configuration backup"
-					}
-				},
-				{
-					"name": "Restore Config Backup",
-					"request": {
-						"method": "POST",
-						"url": {
-							"raw": "{{base_url}}/api/config/restore/:backup_id",
-							"host": ["{{base_url}}"],
-							"path": ["api", "config", "restore", ":backup_id"],
-							"variable": [{"key": "backup_id", "value": "1"}]
-						},
-						"description": "Restore configuration from backup"
-					}
-				}
-			]
-		},
-		{
-			"name": "8. Restore Operations",
-			"item": [
-				{
-					"name": "Preview Restore",
-					"request": {
-						"method": "POST",
-						"header": [{"key": "Content-Type", "value": "application/json"}],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"archive_id\": 1,\n  \"paths\": [\"/home/user/documents\"],\n  \"destination\": \"/restore\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/restore/preview",
-							"host": ["{{base_url}}"],
-							"path": ["api", "restore", "preview"]
-						},
-						"description": "Preview restore operation (dry run)"
-					}
-				}
-			]
-		},
-		{
-			"name": "9. Events (SSE)",
-			"item": [
-				{
-					"name": "Event Stream",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/events/stream",
-							"host": ["{{base_url}}"],
-							"path": ["api", "events", "stream"]
-						},
-						"description": "Server-Sent Events stream for real-time updates (backup progress, etc.)"
-					}
-				},
-				{
-					"name": "Get Active Connections",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/events/connections",
-							"host": ["{{base_url}}"],
-							"path": ["api", "events", "connections"]
-						},
-						"description": "Get active SSE connections count"
-					}
-				}
-			]
-		},
-		{
-			"name": "10. Settings",
-			"item": [
-				{
-					"name": "Get Profile",
-					"request": {
-						"method": "GET",
-						"url": {
-							"raw": "{{base_url}}/api/settings/profile",
-							"host": ["{{base_url}}"],
-							"path": ["api", "settings", "profile"]
-						},
-						"description": "Get user profile"
-					}
-				},
-				{
-					"name": "Update Profile",
-					"request": {
-						"method": "PUT",
-						"header": [{"key": "Content-Type", "value": "application/json"}],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"email\": \"newemail@example.com\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/settings/profile",
-							"host": ["{{base_url}}"],
-							"path": ["api", "settings", "profile"]
-						},
-						"description": "Update user profile"
-					}
-				},
-				{
-					"name": "System Cleanup",
-					"request": {
-						"method": "POST",
-						"url": {
-							"raw": "{{base_url}}/api/settings/system/cleanup",
-							"host": ["{{base_url}}"],
-							"path": ["api", "settings", "system", "cleanup"]
-						},
-						"description": "Run system cleanup tasks"
-					}
-				}
-			]
-		}
-	]
+  "info": {
+    "name": "Borg UI API",
+    "description": "Postman collection for the Borg UI backend API. This collection is organized from the current FastAPI route inventory as of 2026-05-28 and includes one request for each canonical available API route. Requests inherit the collection-level `X-Borg-Authorization: Bearer {{access_token}}` header unless marked no-auth. Run the Login request first to populate `access_token`.",
+    "version": "2.3.0",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "apikey",
+    "apikey": [
+      {
+        "key": "key",
+        "value": "X-Borg-Authorization",
+        "type": "string"
+      },
+      {
+        "key": "value",
+        "value": "Bearer {{access_token}}",
+        "type": "string"
+      },
+      {
+        "key": "in",
+        "value": "header",
+        "type": "string"
+      }
+    ]
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:8000",
+      "type": "string"
+    },
+    {
+      "key": "access_token",
+      "value": "",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "0. Service Health & Metadata",
+      "item": [
+        {
+          "name": "API Info",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api"
+              ]
+            },
+            "description": "Backend route: `GET /api`\n\nSource: `app/main.py:517`",
+            "auth": {
+              "type": "noauth"
+            }
+          }
+        },
+        {
+          "name": "Health Check",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/health",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "health"
+              ]
+            },
+            "description": "Backend route: `GET /health`\n\nSource: `app/main.py:511`",
+            "auth": {
+              "type": "noauth"
+            }
+          }
+        },
+        {
+          "name": "Get Metrics",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/metrics?x_borg_metrics_token=&authorization=",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "metrics"
+              ],
+              "query": [
+                {
+                  "key": "x_borg_metrics_token",
+                  "value": ""
+                },
+                {
+                  "key": "authorization",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Backend route: `GET /metrics`\n\nSource: `app/api/metrics.py:94`"
+          }
+        }
+      ]
+    },
+    {
+      "name": "1. Authentication",
+      "item": [
+        {
+          "name": "Get Authorization Model",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/auth/authorization-model",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "authorization-model"
+              ]
+            },
+            "description": "Backend route: `GET /api/auth/authorization-model`\n\nSource: `app/api/auth.py:740`"
+          }
+        },
+        {
+          "name": "Change Password",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/auth/change-password",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "change-password"
+              ]
+            },
+            "description": "Backend route: `POST /api/auth/change-password`\n\nSource: `app/api/auth.py:2264`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Get Auth Config",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/auth/config",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "config"
+              ]
+            },
+            "description": "Backend route: `GET /api/auth/config`\n\nSource: `app/api/auth.py:681`",
+            "auth": {
+              "type": "noauth"
+            }
+          }
+        },
+        {
+          "name": "List Auth Events",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/auth/events?limit=50",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "events"
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "50"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/auth/events`\n\nSource: `app/api/auth.py:1670`"
+          }
+        },
+        {
+          "name": "Login",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.collectionVariables.set(\"access_token\", jsonData.access_token);",
+                  "    console.log(\"Token saved:\", jsonData.access_token);",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "username",
+                  "value": "admin",
+                  "type": "text"
+                },
+                {
+                  "key": "password",
+                  "value": "admin123",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/api/auth/login",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "login"
+              ]
+            },
+            "description": "Authenticate and save the returned JWT to `access_token`.\n\nBackend route: `POST /api/auth/login`\n\nSource: `app/api/auth.py:746`"
+          }
+        },
+        {
+          "name": "Complete Login With Totp",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/auth/login/totp",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "login",
+                "totp"
+              ]
+            },
+            "description": "Backend route: `POST /api/auth/login/totp`\n\nSource: `app/api/auth.py:1505`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Logout",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/auth/logout",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "logout"
+              ]
+            },
+            "description": "Backend route: `POST /api/auth/logout`\n\nSource: `app/api/auth.py:1608`"
+          }
+        },
+        {
+          "name": "Get Current User Info",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/auth/me",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "me"
+              ]
+            },
+            "description": "Backend route: `GET /api/auth/me`\n\nSource: `app/api/auth.py:1700`"
+          }
+        },
+        {
+          "name": "Complete Oidc Login",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/auth/oidc/callback?code=&state=&error=",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "oidc",
+                "callback"
+              ],
+              "query": [
+                {
+                  "key": "code",
+                  "value": ""
+                },
+                {
+                  "key": "state",
+                  "value": ""
+                },
+                {
+                  "key": "error",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/auth/oidc/callback`\n\nSource: `app/api/auth.py:1201`",
+            "auth": {
+              "type": "noauth"
+            }
+          }
+        },
+        {
+          "name": "Exchange Oidc Login",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/auth/oidc/exchange",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "oidc",
+                "exchange"
+              ]
+            },
+            "description": "Backend route: `POST /api/auth/oidc/exchange`\n\nSource: `app/api/auth.py:1385`",
+            "auth": {
+              "type": "noauth"
+            },
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Unlink Oidc Account",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/auth/oidc/link",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "oidc",
+                "link"
+              ]
+            },
+            "description": "Backend route: `DELETE /api/auth/oidc/link`\n\nSource: `app/api/auth.py:1466`"
+          }
+        },
+        {
+          "name": "Begin Oidc Account Link",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/auth/oidc/link?return_to=",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "oidc",
+                "link"
+              ],
+              "query": [
+                {
+                  "key": "return_to",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/auth/oidc/link`\n\nSource: `app/api/auth.py:1158`",
+            "auth": {
+              "type": "noauth"
+            }
+          }
+        },
+        {
+          "name": "Begin Oidc Account Link API",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/auth/oidc/link",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "oidc",
+                "link"
+              ]
+            },
+            "description": "Backend route: `POST /api/auth/oidc/link`\n\nSource: `app/api/auth.py:1179`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Begin Oidc Login",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/auth/oidc/login?return_to=",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "oidc",
+                "login"
+              ],
+              "query": [
+                {
+                  "key": "return_to",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/auth/oidc/login`\n\nSource: `app/api/auth.py:1144`",
+            "auth": {
+              "type": "noauth"
+            }
+          }
+        },
+        {
+          "name": "Unlink Oidc Account",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/auth/oidc/unlink",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "oidc",
+                "unlink"
+              ]
+            },
+            "description": "Backend route: `POST /api/auth/oidc/unlink`\n\nSource: `app/api/auth.py:1466`"
+          }
+        },
+        {
+          "name": "List Passkeys",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/auth/passkeys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "passkeys"
+              ]
+            },
+            "description": "Backend route: `GET /api/auth/passkeys`\n\nSource: `app/api/auth.py:1830`"
+          }
+        },
+        {
+          "name": "Begin Passkey Authentication",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/auth/passkeys/authenticate/options",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "passkeys",
+                "authenticate",
+                "options"
+              ]
+            },
+            "description": "Backend route: `POST /api/auth/passkeys/authenticate/options`\n\nSource: `app/api/auth.py:1992`",
+            "auth": {
+              "type": "noauth"
+            }
+          }
+        },
+        {
+          "name": "Finish Passkey Authentication",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/auth/passkeys/authenticate/verify",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "passkeys",
+                "authenticate",
+                "verify"
+              ]
+            },
+            "description": "Backend route: `POST /api/auth/passkeys/authenticate/verify`\n\nSource: `app/api/auth.py:2013`",
+            "auth": {
+              "type": "noauth"
+            },
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Begin Passkey Registration",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/auth/passkeys/register/options",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "passkeys",
+                "register",
+                "options"
+              ]
+            },
+            "description": "Backend route: `POST /api/auth/passkeys/register/options`\n\nSource: `app/api/auth.py:1840`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Finish Passkey Registration",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/auth/passkeys/register/verify",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "passkeys",
+                "register",
+                "verify"
+              ]
+            },
+            "description": "Backend route: `POST /api/auth/passkeys/register/verify`\n\nSource: `app/api/auth.py:1886`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Delete Passkey",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/auth/passkeys/:passkey_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "passkeys",
+                ":passkey_id"
+              ],
+              "variable": [
+                {
+                  "key": "passkey_id",
+                  "value": "credential-id"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/auth/passkeys/{passkey_id}`\n\nSource: `app/api/auth.py:1962`"
+          }
+        },
+        {
+          "name": "Skip Password Setup",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/auth/password-setup/skip",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "password-setup",
+                "skip"
+              ]
+            },
+            "description": "Backend route: `POST /api/auth/password-setup/skip`\n\nSource: `app/api/auth.py:2296`"
+          }
+        },
+        {
+          "name": "Refresh Token",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/auth/refresh",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "refresh"
+              ]
+            },
+            "description": "Backend route: `POST /api/auth/refresh`\n\nSource: `app/api/auth.py:1712`"
+          }
+        },
+        {
+          "name": "Get Totp Status",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/auth/totp",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "totp"
+              ]
+            },
+            "description": "Backend route: `GET /api/auth/totp`\n\nSource: `app/api/auth.py:1727`"
+          }
+        },
+        {
+          "name": "Disable Totp",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/auth/totp/disable",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "totp",
+                "disable"
+              ]
+            },
+            "description": "Backend route: `POST /api/auth/totp/disable`\n\nSource: `app/api/auth.py:1793`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Enable Totp",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/auth/totp/enable",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "totp",
+                "enable"
+              ]
+            },
+            "description": "Backend route: `POST /api/auth/totp/enable`\n\nSource: `app/api/auth.py:1760`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Begin Totp Setup",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/auth/totp/setup",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "totp",
+                "setup"
+              ]
+            },
+            "description": "Backend route: `POST /api/auth/totp/setup`\n\nSource: `app/api/auth.py:1735`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Get Users",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/auth/users",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "users"
+              ]
+            },
+            "description": "Backend route: `GET /api/auth/users`\n\nSource: `app/api/auth.py:2135`"
+          }
+        },
+        {
+          "name": "Create New User",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/auth/users",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "users"
+              ]
+            },
+            "description": "Backend route: `POST /api/auth/users`\n\nSource: `app/api/auth.py:2144`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Delete User",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/auth/users/:user_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "users",
+                ":user_id"
+              ],
+              "variable": [
+                {
+                  "key": "user_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/auth/users/{user_id}`\n\nSource: `app/api/auth.py:2236`"
+          }
+        },
+        {
+          "name": "Update User",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/auth/users/:user_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "users",
+                ":user_id"
+              ],
+              "variable": [
+                {
+                  "key": "user_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `PUT /api/auth/users/{user_id}`\n\nSource: `app/api/auth.py:2187`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "2. Dashboard",
+      "item": [
+        {
+          "name": "Get Dashboard Metrics",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/dashboard/metrics",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "dashboard",
+                "metrics"
+              ]
+            },
+            "description": "Backend route: `GET /api/dashboard/metrics`\n\nSource: `app/api/dashboard.py:580`"
+          }
+        },
+        {
+          "name": "Get Dashboard Overview",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/dashboard/overview",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "dashboard",
+                "overview"
+              ]
+            },
+            "description": "Backend route: `GET /api/dashboard/overview`\n\nSource: `app/api/dashboard.py:643`"
+          }
+        },
+        {
+          "name": "Get Dashboard Schedule",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/dashboard/schedule",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "dashboard",
+                "schedule"
+              ]
+            },
+            "description": "Backend route: `GET /api/dashboard/schedule`\n\nSource: `app/api/dashboard.py:619`"
+          }
+        },
+        {
+          "name": "Get Dashboard Status",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/dashboard/status",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "dashboard",
+                "status"
+              ]
+            },
+            "description": "Backend route: `GET /api/dashboard/status`\n\nSource: `app/api/dashboard.py:547`"
+          }
+        }
+      ]
+    },
+    {
+      "name": "3. Backup Operations",
+      "item": [
+        {
+          "name": "Cancel Backup",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/backup/cancel/:job_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup",
+                "cancel",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/backup/cancel/{job_id}`\n\nSource: `app/api/backup.py:445`"
+          }
+        },
+        {
+          "name": "Get All Backup Jobs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/backup/jobs?limit=200&scheduled_only=false&manual_only=false&repository=",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup",
+                "jobs"
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "200"
+                },
+                {
+                  "key": "scheduled_only",
+                  "value": "false"
+                },
+                {
+                  "key": "manual_only",
+                  "value": "false"
+                },
+                {
+                  "key": "repository",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/backup/jobs`\n\nSource: `app/api/backup.py:307`"
+          }
+        },
+        {
+          "name": "Download Backup Logs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/backup/logs/:job_id/download",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup",
+                "logs",
+                ":job_id",
+                "download"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/backup/logs/{job_id}/download`\n\nSource: `app/api/backup.py:511`"
+          }
+        },
+        {
+          "name": "Stream Backup Logs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/backup/logs/:job_id/stream?offset=0",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup",
+                "logs",
+                ":job_id",
+                "stream"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ],
+              "query": [
+                {
+                  "key": "offset",
+                  "value": "0"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/backup/logs/{job_id}/stream`\n\nSource: `app/api/backup.py:625`"
+          }
+        },
+        {
+          "name": "Run Backup",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/backup/run",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup",
+                "run"
+              ]
+            },
+            "description": "Backend route: `POST /api/backup/run`\n\nSource: `app/api/backup.py:297`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Start Backup",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/backup/start",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup",
+                "start"
+              ]
+            },
+            "description": "Backend route: `POST /api/backup/start`\n\nSource: `app/api/backup.py:287`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Get Backup Status",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/backup/status/:job_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup",
+                "status",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/backup/status/{job_id}`\n\nSource: `app/api/backup.py:395`"
+          }
+        }
+      ]
+    },
+    {
+      "name": "4. Backup Plans",
+      "item": [
+        {
+          "name": "List Backup Plans",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/backup-plans",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup-plans"
+              ]
+            },
+            "description": "Backend route: `GET /api/backup-plans`\n\nSource: `app/api/backup_plans.py:826`"
+          }
+        },
+        {
+          "name": "Create Backup Plan",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/backup-plans",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup-plans"
+              ]
+            },
+            "description": "Backend route: `POST /api/backup-plans`\n\nSource: `app/api/backup_plans.py:1029`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Create Backup Plan From Repository",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/backup-plans/from-repository/:repo_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup-plans",
+                "from-repository",
+                ":repo_id"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/backup-plans/from-repository/{repo_id}`\n\nSource: `app/api/backup_plans.py:926`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "List Backup Plan Runs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/backup-plans/runs?limit=50",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup-plans",
+                "runs"
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "50"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/backup-plans/runs`\n\nSource: `app/api/backup_plans.py:844`"
+          }
+        },
+        {
+          "name": "Get Backup Plan Run",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/backup-plans/runs/:run_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup-plans",
+                "runs",
+                ":run_id"
+              ],
+              "variable": [
+                {
+                  "key": "run_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/backup-plans/runs/{run_id}`\n\nSource: `app/api/backup_plans.py:886`"
+          }
+        },
+        {
+          "name": "Cancel Backup Plan Run",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/backup-plans/runs/:run_id/cancel",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup-plans",
+                "runs",
+                ":run_id",
+                "cancel"
+              ],
+              "variable": [
+                {
+                  "key": "run_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/backup-plans/runs/{run_id}/cancel`\n\nSource: `app/api/backup_plans.py:903`"
+          }
+        },
+        {
+          "name": "Delete Backup Plan",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/backup-plans/:plan_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup-plans",
+                ":plan_id"
+              ],
+              "variable": [
+                {
+                  "key": "plan_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/backup-plans/{plan_id}`\n\nSource: `app/api/backup_plans.py:1241`"
+          }
+        },
+        {
+          "name": "Get Backup Plan",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/backup-plans/:plan_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup-plans",
+                ":plan_id"
+              ],
+              "variable": [
+                {
+                  "key": "plan_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/backup-plans/{plan_id}`\n\nSource: `app/api/backup_plans.py:1187`"
+          }
+        },
+        {
+          "name": "Update Backup Plan",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/backup-plans/:plan_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup-plans",
+                ":plan_id"
+              ],
+              "variable": [
+                {
+                  "key": "plan_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `PUT /api/backup-plans/{plan_id}`\n\nSource: `app/api/backup_plans.py:1202`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Run Backup Plan",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/backup-plans/:plan_id/run",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup-plans",
+                ":plan_id",
+                "run"
+              ],
+              "variable": [
+                {
+                  "key": "plan_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/backup-plans/{plan_id}/run`\n\nSource: `app/api/backup_plans.py:1068`"
+          }
+        },
+        {
+          "name": "List Backup Plan Runs For Plan",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/backup-plans/:plan_id/runs?limit=20",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup-plans",
+                ":plan_id",
+                "runs"
+              ],
+              "variable": [
+                {
+                  "key": "plan_id",
+                  "value": "1"
+                }
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "20"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/backup-plans/{plan_id}/runs`\n\nSource: `app/api/backup_plans.py:1104`"
+          }
+        },
+        {
+          "name": "Toggle Backup Plan",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/backup-plans/:plan_id/toggle",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "backup-plans",
+                ":plan_id",
+                "toggle"
+              ],
+              "variable": [
+                {
+                  "key": "plan_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/backup-plans/{plan_id}/toggle`\n\nSource: `app/api/backup_plans.py:1138`"
+          }
+        }
+      ]
+    },
+    {
+      "name": "5. Archives",
+      "item": [
+        {
+          "name": "Get Delete Job Status",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/archives/delete-jobs/:job_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "archives",
+                "delete-jobs",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/archives/delete-jobs/{job_id}`\n\nSource: `app/api/archives.py:384`"
+          }
+        },
+        {
+          "name": "Cancel Delete Job",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/archives/delete-jobs/:job_id/cancel",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "archives",
+                "delete-jobs",
+                ":job_id",
+                "cancel"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/archives/delete-jobs/{job_id}/cancel`\n\nSource: `app/api/archives.py:433`"
+          }
+        },
+        {
+          "name": "Download File From Archive",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/archives/download",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "archives",
+                "download"
+              ]
+            },
+            "description": "Backend route: `GET /api/archives/download`\n\nSource: `app/api/archives.py:324`"
+          }
+        },
+        {
+          "name": "List Archives",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/archives/list",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "archives",
+                "list"
+              ]
+            },
+            "description": "Backend route: `GET /api/archives/list`\n\nSource: `app/api/archives.py:44`"
+          }
+        },
+        {
+          "name": "Delete Archive",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/archives/:archive_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "archives",
+                ":archive_id"
+              ],
+              "variable": [
+                {
+                  "key": "archive_id",
+                  "value": "archive-name"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/archives/{archive_id}`\n\nSource: `app/api/archives.py:250`"
+          }
+        },
+        {
+          "name": "Get Archive Contents",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/archives/:archive_id/contents?path=",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "archives",
+                ":archive_id",
+                "contents"
+              ],
+              "variable": [
+                {
+                  "key": "archive_id",
+                  "value": "archive-name"
+                }
+              ],
+              "query": [
+                {
+                  "key": "path",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/archives/{archive_id}/contents`\n\nSource: `app/api/archives.py:208`"
+          }
+        },
+        {
+          "name": "Get Archive Info",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/archives/:archive_id/info?include_files=false&file_limit=1000",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "archives",
+                ":archive_id",
+                "info"
+              ],
+              "variable": [
+                {
+                  "key": "archive_id",
+                  "value": "archive-name"
+                }
+              ],
+              "query": [
+                {
+                  "key": "include_files",
+                  "value": "false"
+                },
+                {
+                  "key": "file_limit",
+                  "value": "1000"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/archives/{archive_id}/info`\n\nSource: `app/api/archives.py:82`"
+          }
+        }
+      ]
+    },
+    {
+      "name": "6. Restore Operations",
+      "item": [
+        {
+          "name": "Cancel Restore",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/restore/cancel/:job_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "restore",
+                "cancel",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/restore/cancel/{job_id}`\n\nSource: `app/api/restore.py:344`"
+          }
+        },
+        {
+          "name": "Get Restore Jobs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/restore/jobs?limit=50",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "restore",
+                "jobs"
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "50"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/restore/jobs`\n\nSource: `app/api/restore.py:243`"
+          }
+        },
+        {
+          "name": "Preview Restore",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/restore/preview",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "restore",
+                "preview"
+              ]
+            },
+            "description": "Backend route: `POST /api/restore/preview`\n\nSource: `app/api/restore.py:76`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Start Restore",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/restore/start",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "restore",
+                "start"
+              ]
+            },
+            "description": "Backend route: `POST /api/restore/start`\n\nSource: `app/api/restore.py:124`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Get Restore Status",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/restore/status/:job_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "restore",
+                "status",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/restore/status/{job_id}`\n\nSource: `app/api/restore.py:297`"
+          }
+        }
+      ]
+    },
+    {
+      "name": "7. Repositories",
+      "item": [
+        {
+          "name": "Get Repositories",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories"
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories`\n\nSource: `app/api/repositories.py:1590`"
+          }
+        },
+        {
+          "name": "Create Repository",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/repositories",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories"
+              ]
+            },
+            "description": "Backend route: `POST /api/repositories`\n\nSource: `app/api/repositories.py:1708`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Get Check Job Status",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/check-jobs/:job_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                "check-jobs",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/check-jobs/{job_id}`\n\nSource: `app/api/repositories.py:4458`"
+          }
+        },
+        {
+          "name": "Get Compact Job Status",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/compact-jobs/:job_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                "compact-jobs",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/compact-jobs/{job_id}`\n\nSource: `app/api/repositories.py:4598`"
+          }
+        },
+        {
+          "name": "Import Repository",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/import",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                "import"
+              ]
+            },
+            "description": "Backend route: `POST /api/repositories/import`\n\nSource: `app/api/repositories.py:2071`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Get Prune Job Status",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/prune-jobs/:job_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                "prune-jobs",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/prune-jobs/{job_id}`\n\nSource: `app/api/repositories.py:4646`"
+          }
+        },
+        {
+          "name": "Get Restore Check Job Status",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/restore-check-jobs/:job_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                "restore-check-jobs",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/restore-check-jobs/{job_id}`\n\nSource: `app/api/repositories.py:4516`"
+          }
+        },
+        {
+          "name": "Delete Repository",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/repositories/{repo_id}`\n\nSource: `app/api/repositories.py:3163`"
+          }
+        },
+        {
+          "name": "Get Repository",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/{repo_id}`\n\nSource: `app/api/repositories.py:2591`"
+          }
+        },
+        {
+          "name": "Update Repository",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `PUT /api/repositories/{repo_id}`\n\nSource: `app/api/repositories.py:2660`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "List Repository Archives",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/archives",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "archives"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/{repo_id}/archives`\n\nSource: `app/api/repositories.py:4076`"
+          }
+        },
+        {
+          "name": "Break Repository Lock",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/break-lock",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "break-lock"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/repositories/{repo_id}/break-lock`\n\nSource: `app/api/repositories.py:4256`"
+          }
+        },
+        {
+          "name": "Check Repository",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/check",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "check"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/repositories/{repo_id}/check`\n\nSource: `app/api/repositories.py:3320`"
+          }
+        },
+        {
+          "name": "Get Repository Check Jobs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/check-jobs?limit=10&scheduled_only=false",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "check-jobs"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "10"
+                },
+                {
+                  "key": "scheduled_only",
+                  "value": "false"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/{repo_id}/check-jobs`\n\nSource: `app/api/repositories.py:4483`"
+          }
+        },
+        {
+          "name": "Get Check Schedule",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/check-schedule",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "check-schedule"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/{repo_id}/check-schedule`\n\nSource: `app/api/repositories.py:5145`"
+          }
+        },
+        {
+          "name": "Update Check Schedule",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/check-schedule",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "check-schedule"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `PUT /api/repositories/{repo_id}/check-schedule`\n\nSource: `app/api/repositories.py:4804`"
+          }
+        },
+        {
+          "name": "Compact Repository",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/compact",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "compact"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/repositories/{repo_id}/compact`\n\nSource: `app/api/repositories.py:3489`"
+          }
+        },
+        {
+          "name": "Get Repository Compact Jobs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/compact-jobs?limit=10",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "compact-jobs"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "10"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/{repo_id}/compact-jobs`\n\nSource: `app/api/repositories.py:4623`"
+          }
+        },
+        {
+          "name": "Get Repository Info",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/info",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "info"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/{repo_id}/info`\n\nSource: `app/api/repositories.py:4163`"
+          }
+        },
+        {
+          "name": "Download Keyfile",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/keyfile",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "keyfile"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/{repo_id}/keyfile`\n\nSource: `app/api/repositories.py:2537`"
+          }
+        },
+        {
+          "name": "Upload Keyfile",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/keyfile",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "keyfile"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/repositories/{repo_id}/keyfile`\n\nSource: `app/api/repositories.py:2457`",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "file",
+                  "type": "file",
+                  "src": []
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Prune Repository",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/prune",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "prune"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/repositories/{repo_id}/prune`\n\nSource: `app/api/repositories.py:3567`"
+          }
+        },
+        {
+          "name": "Get Repository Prune Jobs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/prune-jobs?limit=10",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "prune-jobs"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "10"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/{repo_id}/prune-jobs`\n\nSource: `app/api/repositories.py:4671`"
+          }
+        },
+        {
+          "name": "Hydrate Repository Rclone",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/rclone/hydrate",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "rclone",
+                "hydrate"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/repositories/{repo_id}/rclone/hydrate`\n\nSource: `app/api/repositories.py:2434`"
+          }
+        },
+        {
+          "name": "Get Repository Rclone Status",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/rclone/status",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "rclone",
+                "status"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/{repo_id}/rclone/status`\n\nSource: `app/api/repositories.py:2395`"
+          }
+        },
+        {
+          "name": "Sync Repository Rclone",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/rclone/sync",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "rclone",
+                "sync"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/repositories/{repo_id}/rclone/sync`\n\nSource: `app/api/repositories.py:2411`"
+          }
+        },
+        {
+          "name": "Restore Check Repository",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/restore-check",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "restore-check"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/repositories/{repo_id}/restore-check`\n\nSource: `app/api/repositories.py:3418`"
+          }
+        },
+        {
+          "name": "Get Repository Restore Check Jobs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/restore-check-jobs?limit=10",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "restore-check-jobs"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "10"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/{repo_id}/restore-check-jobs`\n\nSource: `app/api/repositories.py:4554`"
+          }
+        },
+        {
+          "name": "Get Restore Check Schedule",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/restore-check-schedule",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "restore-check-schedule"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/{repo_id}/restore-check-schedule`\n\nSource: `app/api/repositories.py:5191`"
+          }
+        },
+        {
+          "name": "Update Restore Check Schedule",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/restore-check-schedule",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "restore-check-schedule"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `PUT /api/repositories/{repo_id}/restore-check-schedule`\n\nSource: `app/api/repositories.py:4948`"
+          }
+        },
+        {
+          "name": "Get Running Jobs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/running-jobs",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "running-jobs"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/{repo_id}/running-jobs`\n\nSource: `app/api/repositories.py:4694`"
+          }
+        },
+        {
+          "name": "Get Repository Statistics",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/stats",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "stats"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/{repo_id}/stats`\n\nSource: `app/api/repositories.py:3880`"
+          }
+        },
+        {
+          "name": "Execute Repository Wipe",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/wipe",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "wipe"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/repositories/{repo_id}/wipe`\n\nSource: `app/api/repositories.py:3771`"
+          }
+        },
+        {
+          "name": "Get Repository Wipe Job",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/wipe-jobs/:job_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "wipe-jobs",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                },
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/{repo_id}/wipe-jobs/{job_id}`\n\nSource: `app/api/repositories.py:3811`"
+          }
+        },
+        {
+          "name": "Cancel Repository Wipe Preview",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/wipe-jobs/:job_id/cancel",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "wipe-jobs",
+                ":job_id",
+                "cancel"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                },
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/repositories/{repo_id}/wipe-jobs/{job_id}/cancel`\n\nSource: `app/api/repositories.py:3850`"
+          }
+        },
+        {
+          "name": "Preview Repository Wipe",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repo_id/wipe-preview",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repo_id",
+                "wipe-preview"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/repositories/{repo_id}/wipe-preview`\n\nSource: `app/api/repositories.py:3743`"
+          }
+        }
+      ]
+    },
+    {
+      "name": "8. SSH Keys",
+      "item": [
+        {
+          "name": "Get Ssh Keys",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys"
+              ]
+            },
+            "description": "Backend route: `GET /api/ssh-keys`\n\nSource: `app/api/ssh_keys.py:393`"
+          }
+        },
+        {
+          "name": "Create Ssh Key",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys"
+              ]
+            },
+            "description": "Backend route: `POST /api/ssh-keys`\n\nSource: `app/api/ssh_keys.py:434`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Get Ssh Connections",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/connections",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                "connections"
+              ]
+            },
+            "description": "Backend route: `GET /api/ssh-keys/connections`\n\nSource: `app/api/ssh_keys.py:1066`"
+          }
+        },
+        {
+          "name": "List Backup Sources",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/connections/backup-sources",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                "connections",
+                "backup-sources"
+              ]
+            },
+            "description": "Backend route: `GET /api/ssh-keys/connections/backup-sources`\n\nSource: `app/api/ssh_keys.py:2540`"
+          }
+        },
+        {
+          "name": "Audit Ssh Connection Hosts",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/connections/host-audit",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                "connections",
+                "host-audit"
+              ]
+            },
+            "description": "Backend route: `GET /api/ssh-keys/connections/host-audit`\n\nSource: `app/api/ssh_keys.py:1176`"
+          }
+        },
+        {
+          "name": "Cleanup Ssh Connection Hosts",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/connections/host-cleanup?dry_run=true",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                "connections",
+                "host-cleanup"
+              ],
+              "query": [
+                {
+                  "key": "dry_run",
+                  "value": "true"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/ssh-keys/connections/host-cleanup`\n\nSource: `app/api/ssh_keys.py:1197`"
+          }
+        },
+        {
+          "name": "Delete Ssh Connection",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/connections/:connection_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                "connections",
+                ":connection_id"
+              ],
+              "variable": [
+                {
+                  "key": "connection_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/ssh-keys/connections/{connection_id}`\n\nSource: `app/api/ssh_keys.py:1711`"
+          }
+        },
+        {
+          "name": "Update Ssh Connection",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/connections/:connection_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                "connections",
+                ":connection_id"
+              ],
+              "variable": [
+                {
+                  "key": "connection_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `PUT /api/ssh-keys/connections/{connection_id}`\n\nSource: `app/api/ssh_keys.py:1328`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Toggle Backup Source",
+          "request": {
+            "method": "PATCH",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/connections/:connection_id/backup-source",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                "connections",
+                ":connection_id",
+                "backup-source"
+              ],
+              "variable": [
+                {
+                  "key": "connection_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `PATCH /api/ssh-keys/connections/{connection_id}/backup-source`\n\nSource: `app/api/ssh_keys.py:2463`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Redeploy Key To Connection",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/connections/:connection_id/redeploy",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                "connections",
+                ":connection_id",
+                "redeploy"
+              ],
+              "variable": [
+                {
+                  "key": "connection_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/ssh-keys/connections/{connection_id}/redeploy`\n\nSource: `app/api/ssh_keys.py:1617`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Refresh Connection Storage",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/connections/:connection_id/refresh-storage",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                "connections",
+                ":connection_id",
+                "refresh-storage"
+              ],
+              "variable": [
+                {
+                  "key": "connection_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/ssh-keys/connections/{connection_id}/refresh-storage`\n\nSource: `app/api/ssh_keys.py:1401`"
+          }
+        },
+        {
+          "name": "Test Existing Connection",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/connections/:connection_id/test",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                "connections",
+                ":connection_id",
+                "test"
+              ],
+              "variable": [
+                {
+                  "key": "connection_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/ssh-keys/connections/{connection_id}/test`\n\nSource: `app/api/ssh_keys.py:1508`"
+          }
+        },
+        {
+          "name": "Verify Borg Installation",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/connections/:connection_id/verify-borg",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                "connections",
+                ":connection_id",
+                "verify-borg"
+              ],
+              "variable": [
+                {
+                  "key": "connection_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/ssh-keys/connections/{connection_id}/verify-borg`\n\nSource: `app/api/ssh_keys.py:2579`"
+          }
+        },
+        {
+          "name": "Generate Ssh Key",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/generate",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                "generate"
+              ]
+            },
+            "description": "Backend route: `POST /api/ssh-keys/generate`\n\nSource: `app/api/ssh_keys.py:516`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Import Ssh Key",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/import",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                "import"
+              ]
+            },
+            "description": "Backend route: `POST /api/ssh-keys/import`\n\nSource: `app/api/ssh_keys.py:636`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Quick Ssh Setup",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/quick-setup",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                "quick-setup"
+              ]
+            },
+            "description": "Backend route: `POST /api/ssh-keys/quick-setup`\n\nSource: `app/api/ssh_keys.py:815`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Get System Key",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/system-key",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                "system-key"
+              ]
+            },
+            "description": "Backend route: `GET /api/ssh-keys/system-key`\n\nSource: `app/api/ssh_keys.py:351`"
+          }
+        },
+        {
+          "name": "Delete Ssh Key",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/:key_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                ":key_id"
+              ],
+              "variable": [
+                {
+                  "key": "key_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/ssh-keys/{key_id}`\n\nSource: `app/api/ssh_keys.py:1893`"
+          }
+        },
+        {
+          "name": "Get Ssh Key",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/:key_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                ":key_id"
+              ],
+              "variable": [
+                {
+                  "key": "key_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/ssh-keys/{key_id}`\n\nSource: `app/api/ssh_keys.py:1771`"
+          }
+        },
+        {
+          "name": "Update Ssh Key",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/:key_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                ":key_id"
+              ],
+              "variable": [
+                {
+                  "key": "key_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `PUT /api/ssh-keys/{key_id}`\n\nSource: `app/api/ssh_keys.py:1824`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Deploy Ssh Key",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/:key_id/deploy",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                ":key_id",
+                "deploy"
+              ],
+              "variable": [
+                {
+                  "key": "key_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/ssh-keys/{key_id}/deploy`\n\nSource: `app/api/ssh_keys.py:960`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Test Ssh Connection",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/ssh-keys/:key_id/test-connection",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "ssh-keys",
+                ":key_id",
+                "test-connection"
+              ],
+              "variable": [
+                {
+                  "key": "key_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/ssh-keys/{key_id}/test-connection`\n\nSource: `app/api/ssh_keys.py:1236`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "9. Schedule",
+      "item": [
+        {
+          "name": "Get Scheduled Jobs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/schedule",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "schedule"
+              ]
+            },
+            "description": "Backend route: `GET /api/schedule`\n\nSource: `app/api/schedule.py:362`"
+          }
+        },
+        {
+          "name": "Create Scheduled Job",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/schedule",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "schedule"
+              ]
+            },
+            "description": "Backend route: `POST /api/schedule`\n\nSource: `app/api/schedule.py:452`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Get Cron Presets",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/schedule/cron-presets",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "schedule",
+                "cron-presets"
+              ]
+            },
+            "description": "Backend route: `GET /api/schedule/cron-presets`\n\nSource: `app/api/schedule.py:826`"
+          }
+        },
+        {
+          "name": "Get Upcoming Jobs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/schedule/upcoming-jobs?hours=24",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "schedule",
+                "upcoming-jobs"
+              ],
+              "query": [
+                {
+                  "key": "hours",
+                  "value": "24"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/schedule/upcoming-jobs`\n\nSource: `app/api/schedule.py:890`"
+          }
+        },
+        {
+          "name": "Validate Cron Expression",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/schedule/validate-cron",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "schedule",
+                "validate-cron"
+              ]
+            },
+            "description": "Backend route: `POST /api/schedule/validate-cron`\n\nSource: `app/api/schedule.py:1667`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Delete Scheduled Job",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/schedule/:job_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "schedule",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/schedule/{job_id}`\n\nSource: `app/api/schedule.py:1265`"
+          }
+        },
+        {
+          "name": "Get Scheduled Job",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/schedule/:job_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "schedule",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/schedule/{job_id}`\n\nSource: `app/api/schedule.py:990`"
+          }
+        },
+        {
+          "name": "Update Scheduled Job",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/schedule/:job_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "schedule",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `PUT /api/schedule/{job_id}`\n\nSource: `app/api/schedule.py:1061`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Duplicate Scheduled Job",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/schedule/:job_id/duplicate",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "schedule",
+                ":job_id",
+                "duplicate"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/schedule/{job_id}/duplicate`\n\nSource: `app/api/schedule.py:1380`"
+          }
+        },
+        {
+          "name": "Run Scheduled Job Now",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/schedule/:job_id/run-now",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "schedule",
+                ":job_id",
+                "run-now"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/schedule/{job_id}/run-now`\n\nSource: `app/api/schedule.py:1535`"
+          }
+        },
+        {
+          "name": "Toggle Scheduled Job",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/schedule/:job_id/toggle",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "schedule",
+                ":job_id",
+                "toggle"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/schedule/{job_id}/toggle`\n\nSource: `app/api/schedule.py:1318`"
+          }
+        }
+      ]
+    },
+    {
+      "name": "10. Settings",
+      "item": [
+        {
+          "name": "Run Backup Monitoring Now",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/settings/backup-monitoring/run",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "backup-monitoring",
+                "run"
+              ]
+            },
+            "description": "Backend route: `POST /api/settings/backup-monitoring/run`\n\nSource: `app/api/settings.py:1265`"
+          }
+        },
+        {
+          "name": "Send Backup Report Now",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/settings/backup-reports/send",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "backup-reports",
+                "send"
+              ]
+            },
+            "description": "Backend route: `POST /api/settings/backup-reports/send`\n\nSource: `app/api/settings.py:1285`"
+          }
+        },
+        {
+          "name": "Clear Cache",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/settings/cache/clear?repository_id=1",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "cache",
+                "clear"
+              ],
+              "query": [
+                {
+                  "key": "repository_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/settings/cache/clear`\n\nSource: `app/api/settings.py:2094`"
+          }
+        },
+        {
+          "name": "Update Cache Settings",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/settings/cache/settings?cache_ttl_minutes=&cache_max_size_mb=&redis_url=&browse_max_items=&browse_max_memory_mb=",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "cache",
+                "settings"
+              ],
+              "query": [
+                {
+                  "key": "cache_ttl_minutes",
+                  "value": ""
+                },
+                {
+                  "key": "cache_max_size_mb",
+                  "value": ""
+                },
+                {
+                  "key": "redis_url",
+                  "value": ""
+                },
+                {
+                  "key": "browse_max_items",
+                  "value": ""
+                },
+                {
+                  "key": "browse_max_memory_mb",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Backend route: `PUT /api/settings/cache/settings`\n\nSource: `app/api/settings.py:2172`"
+          }
+        },
+        {
+          "name": "Get Cache Stats",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/settings/cache/stats",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "cache",
+                "stats"
+              ]
+            },
+            "description": "Backend route: `GET /api/settings/cache/stats`\n\nSource: `app/api/settings.py:2048`"
+          }
+        },
+        {
+          "name": "Change Password",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/settings/change-password",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "change-password"
+              ]
+            },
+            "description": "Backend route: `POST /api/settings/change-password`\n\nSource: `app/api/settings.py:1631`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Get My Permissions",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/settings/permissions/me",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "permissions",
+                "me"
+              ]
+            },
+            "description": "Backend route: `GET /api/settings/permissions/me`\n\nSource: `app/api/permissions.py:148`"
+          }
+        },
+        {
+          "name": "Get My Permission Scope",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/settings/permissions/me/scope",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "permissions",
+                "me",
+                "scope"
+              ]
+            },
+            "description": "Backend route: `GET /api/settings/permissions/me/scope`\n\nSource: `app/api/permissions.py:156`"
+          }
+        },
+        {
+          "name": "Get Preferences",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/settings/preferences",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "preferences"
+              ]
+            },
+            "description": "Backend route: `GET /api/settings/preferences`\n\nSource: `app/api/settings.py:1763`"
+          }
+        },
+        {
+          "name": "Update Preferences",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/settings/preferences",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "preferences"
+              ]
+            },
+            "description": "Backend route: `PUT /api/settings/preferences`\n\nSource: `app/api/settings.py:1779`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Get Profile",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/settings/profile",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "profile"
+              ]
+            },
+            "description": "Backend route: `GET /api/settings/profile`\n\nSource: `app/api/settings.py:1673`"
+          }
+        },
+        {
+          "name": "Update Profile",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/settings/profile",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "profile"
+              ]
+            },
+            "description": "Backend route: `PUT /api/settings/profile`\n\nSource: `app/api/settings.py:1702`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Refresh All Stats",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/settings/refresh-stats",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "refresh-stats"
+              ]
+            },
+            "description": "Backend route: `POST /api/settings/refresh-stats`\n\nSource: `app/api/settings.py:1216`"
+          }
+        },
+        {
+          "name": "Get System Settings",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/settings/system",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "system"
+              ]
+            },
+            "description": "Backend route: `GET /api/settings/system`\n\nSource: `app/api/settings.py:293`"
+          }
+        },
+        {
+          "name": "Update System Settings",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/settings/system",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "system"
+              ]
+            },
+            "description": "Backend route: `PUT /api/settings/system`\n\nSource: `app/api/settings.py:541`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Cleanup System",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/settings/system/cleanup",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "system",
+                "cleanup"
+              ]
+            },
+            "description": "Backend route: `POST /api/settings/system/cleanup`\n\nSource: `app/api/settings.py:1817`"
+          }
+        },
+        {
+          "name": "Manual Log Cleanup",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/settings/system/logs/cleanup",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "system",
+                "logs",
+                "cleanup"
+              ]
+            },
+            "description": "Backend route: `POST /api/settings/system/logs/cleanup`\n\nSource: `app/api/settings.py:1937`"
+          }
+        },
+        {
+          "name": "Get Log Storage Stats",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/settings/system/logs/storage",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "system",
+                "logs",
+                "storage"
+              ]
+            },
+            "description": "Backend route: `GET /api/settings/system/logs/storage`\n\nSource: `app/api/settings.py:1875`"
+          }
+        },
+        {
+          "name": "List Tokens",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/settings/tokens",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "tokens"
+              ]
+            },
+            "description": "Backend route: `GET /api/settings/tokens`\n\nSource: `app/api/tokens.py:47`"
+          }
+        },
+        {
+          "name": "Create Token",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/settings/tokens",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "tokens"
+              ]
+            },
+            "description": "Backend route: `POST /api/settings/tokens`\n\nSource: `app/api/tokens.py:56`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Revoke Token",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/settings/tokens/:token_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "tokens",
+                ":token_id"
+              ],
+              "variable": [
+                {
+                  "key": "token_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/settings/tokens/{token_id}`\n\nSource: `app/api/tokens.py:96`"
+          }
+        },
+        {
+          "name": "Get Users",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/settings/users",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "users"
+              ]
+            },
+            "description": "Backend route: `GET /api/settings/users`\n\nSource: `app/api/settings.py:1305`"
+          }
+        },
+        {
+          "name": "Create User",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/settings/users",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "users"
+              ]
+            },
+            "description": "Backend route: `POST /api/settings/users`\n\nSource: `app/api/settings.py:1340`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Delete User",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/settings/users/:user_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "users",
+                ":user_id"
+              ],
+              "variable": [
+                {
+                  "key": "user_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/settings/users/{user_id}`\n\nSource: `app/api/settings.py:1543`"
+          }
+        },
+        {
+          "name": "Update User",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/settings/users/:user_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "users",
+                ":user_id"
+              ],
+              "variable": [
+                {
+                  "key": "user_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `PUT /api/settings/users/{user_id}`\n\nSource: `app/api/settings.py:1430`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Get User Permissions",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/settings/users/:user_id/permissions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "users",
+                ":user_id",
+                "permissions"
+              ],
+              "variable": [
+                {
+                  "key": "user_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/settings/users/{user_id}/permissions`\n\nSource: `app/api/permissions.py:169`"
+          }
+        },
+        {
+          "name": "Assign Permission",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/settings/users/:user_id/permissions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "users",
+                ":user_id",
+                "permissions"
+              ],
+              "variable": [
+                {
+                  "key": "user_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/settings/users/{user_id}/permissions`\n\nSource: `app/api/permissions.py:216`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Get User Permission Scope",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/settings/users/:user_id/permissions/scope",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "users",
+                ":user_id",
+                "permissions",
+                "scope"
+              ],
+              "variable": [
+                {
+                  "key": "user_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/settings/users/{user_id}/permissions/scope`\n\nSource: `app/api/permissions.py:182`"
+          }
+        },
+        {
+          "name": "Update User Permission Scope",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/settings/users/:user_id/permissions/scope",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "users",
+                ":user_id",
+                "permissions",
+                "scope"
+              ],
+              "variable": [
+                {
+                  "key": "user_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `PUT /api/settings/users/{user_id}/permissions/scope`\n\nSource: `app/api/permissions.py:195`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Remove Permission",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/settings/users/:user_id/permissions/:repo_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "users",
+                ":user_id",
+                "permissions",
+                ":repo_id"
+              ],
+              "variable": [
+                {
+                  "key": "user_id",
+                  "value": "1"
+                },
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/settings/users/{user_id}/permissions/{repo_id}`\n\nSource: `app/api/permissions.py:287`"
+          }
+        },
+        {
+          "name": "Update Permission",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/settings/users/:user_id/permissions/:repo_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "users",
+                ":user_id",
+                "permissions",
+                ":repo_id"
+              ],
+              "variable": [
+                {
+                  "key": "user_id",
+                  "value": "1"
+                },
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `PUT /api/settings/users/{user_id}/permissions/{repo_id}`\n\nSource: `app/api/permissions.py:255`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Reset User Password",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/settings/users/:user_id/reset-password",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "settings",
+                "users",
+                ":user_id",
+                "reset-password"
+              ],
+              "variable": [
+                {
+                  "key": "user_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/settings/users/{user_id}/reset-password`\n\nSource: `app/api/settings.py:1593`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "11. Notifications",
+      "item": [
+        {
+          "name": "List Notification Settings",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/notifications",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "notifications"
+              ]
+            },
+            "description": "Backend route: `GET /api/notifications`\n\nSource: `app/api/notifications.py:130`"
+          }
+        },
+        {
+          "name": "Create Notification Setting",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/notifications",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "notifications"
+              ]
+            },
+            "description": "Backend route: `POST /api/notifications`\n\nSource: `app/api/notifications.py:163`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Test Notification",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/notifications/test",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "notifications",
+                "test"
+              ]
+            },
+            "description": "Backend route: `POST /api/notifications/test`\n\nSource: `app/api/notifications.py:259`"
+          }
+        },
+        {
+          "name": "Delete Notification Setting",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/notifications/:setting_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "notifications",
+                ":setting_id"
+              ],
+              "variable": [
+                {
+                  "key": "setting_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/notifications/{setting_id}`\n\nSource: `app/api/notifications.py:236`"
+          }
+        },
+        {
+          "name": "Get Notification Setting",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/notifications/:setting_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "notifications",
+                ":setting_id"
+              ],
+              "variable": [
+                {
+                  "key": "setting_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/notifications/{setting_id}`\n\nSource: `app/api/notifications.py:139`"
+          }
+        },
+        {
+          "name": "Update Notification Setting",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/notifications/:setting_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "notifications",
+                ":setting_id"
+              ],
+              "variable": [
+                {
+                  "key": "setting_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `PUT /api/notifications/{setting_id}`\n\nSource: `app/api/notifications.py:192`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "12. Activity",
+      "item": [
+        {
+          "name": "List Recent Activity",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/activity/recent?limit=200&job_type=backup&status=",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "activity",
+                "recent"
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "200"
+                },
+                {
+                  "key": "job_type",
+                  "value": "backup"
+                },
+                {
+                  "key": "status",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/activity/recent`\n\nSource: `app/api/activity.py:136`"
+          }
+        },
+        {
+          "name": "Delete Job",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/activity/:job_type/:job_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "activity",
+                ":job_type",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_type",
+                  "value": "backup"
+                },
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/activity/{job_type}/{job_id}`\n\nSource: `app/api/activity.py:955`"
+          }
+        },
+        {
+          "name": "Get Job Logs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/activity/:job_type/:job_id/logs?offset=0&limit=500",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "activity",
+                ":job_type",
+                ":job_id",
+                "logs"
+              ],
+              "variable": [
+                {
+                  "key": "job_type",
+                  "value": "backup"
+                },
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ],
+              "query": [
+                {
+                  "key": "offset",
+                  "value": "0"
+                },
+                {
+                  "key": "limit",
+                  "value": "500"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/activity/{job_type}/{job_id}/logs`\n\nSource: `app/api/activity.py:520`"
+          }
+        },
+        {
+          "name": "Download Job Logs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/activity/:job_type/:job_id/logs/download",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "activity",
+                ":job_type",
+                ":job_id",
+                "logs",
+                "download"
+              ],
+              "variable": [
+                {
+                  "key": "job_type",
+                  "value": "backup"
+                },
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/activity/{job_type}/{job_id}/logs/download`\n\nSource: `app/api/activity.py:813`"
+          }
+        }
+      ]
+    },
+    {
+      "name": "13. Filesystem & Source Discovery",
+      "item": [
+        {
+          "name": "Browse Archive Contents",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/browse/:repository_id/:archive_name?path=",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "browse",
+                ":repository_id",
+                ":archive_name"
+              ],
+              "variable": [
+                {
+                  "key": "repository_id",
+                  "value": "1"
+                },
+                {
+                  "key": "archive_name",
+                  "value": "archive-name"
+                }
+              ],
+              "query": [
+                {
+                  "key": "path",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/browse/{repository_id}/{archive_name}`\n\nSource: `app/api/browse.py:56`"
+          }
+        },
+        {
+          "name": "Browse Filesystem",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/filesystem/browse?path=/local&connection_type=local&ssh_key_id=&host=&username=&port=22",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "filesystem",
+                "browse"
+              ],
+              "query": [
+                {
+                  "key": "path",
+                  "value": "/local"
+                },
+                {
+                  "key": "connection_type",
+                  "value": "local"
+                },
+                {
+                  "key": "ssh_key_id",
+                  "value": ""
+                },
+                {
+                  "key": "host",
+                  "value": ""
+                },
+                {
+                  "key": "username",
+                  "value": ""
+                },
+                {
+                  "key": "port",
+                  "value": "22"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/filesystem/browse`\n\nSource: `app/api/filesystem.py:136`"
+          }
+        },
+        {
+          "name": "Create Folder",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/filesystem/create-folder",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "filesystem",
+                "create-folder"
+              ]
+            },
+            "description": "Backend route: `POST /api/filesystem/create-folder`\n\nSource: `app/api/filesystem.py:729`"
+          }
+        },
+        {
+          "name": "Validate Path",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/filesystem/validate-path?path=&connection_type=local&ssh_key_id=&host=&username=&port=22",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "filesystem",
+                "validate-path"
+              ],
+              "query": [
+                {
+                  "key": "path",
+                  "value": ""
+                },
+                {
+                  "key": "connection_type",
+                  "value": "local"
+                },
+                {
+                  "key": "ssh_key_id",
+                  "value": ""
+                },
+                {
+                  "key": "host",
+                  "value": ""
+                },
+                {
+                  "key": "username",
+                  "value": ""
+                },
+                {
+                  "key": "port",
+                  "value": "22"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/filesystem/validate-path`\n\nSource: `app/api/filesystem.py:593`"
+          }
+        },
+        {
+          "name": "Discover Databases",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/source-discovery/databases",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "source-discovery",
+                "databases"
+              ]
+            },
+            "description": "Backend route: `GET /api/source-discovery/databases`\n\nSource: `app/api/source_discovery.py:958`"
+          }
+        },
+        {
+          "name": "Scan Databases",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/source-discovery/databases/scan",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "source-discovery",
+                "databases",
+                "scan"
+              ]
+            },
+            "description": "Backend route: `POST /api/source-discovery/databases/scan`\n\nSource: `app/api/source_discovery.py:932`"
+          }
+        },
+        {
+          "name": "Discover Filesystem Snapshot Capabilities",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/source-discovery/filesystem-snapshots",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "source-discovery",
+                "filesystem-snapshots"
+              ]
+            },
+            "description": "Backend route: `GET /api/source-discovery/filesystem-snapshots`\n\nSource: `app/api/source_discovery.py:916`"
+          }
+        }
+      ]
+    },
+    {
+      "name": "14. Scripts",
+      "item": [
+        {
+          "name": "Get Repository Scripts",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repository_id/scripts",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repository_id",
+                "scripts"
+              ],
+              "variable": [
+                {
+                  "key": "repository_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/repositories/{repository_id}/scripts`\n\nSource: `app/api/scripts_library.py:833`"
+          }
+        },
+        {
+          "name": "Assign Script To Repository",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repository_id/scripts",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repository_id",
+                "scripts"
+              ],
+              "variable": [
+                {
+                  "key": "repository_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/repositories/{repository_id}/scripts`\n\nSource: `app/api/scripts_library.py:904`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Remove Script From Repository",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repository_id/scripts/:repo_script_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repository_id",
+                "scripts",
+                ":repo_script_id"
+              ],
+              "variable": [
+                {
+                  "key": "repository_id",
+                  "value": "1"
+                },
+                {
+                  "key": "repo_script_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/repositories/{repository_id}/scripts/{repo_script_id}`\n\nSource: `app/api/scripts_library.py:1156`"
+          }
+        },
+        {
+          "name": "Update Repository Script Assignment",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/repositories/:repository_id/scripts/:repo_script_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "repositories",
+                ":repository_id",
+                "scripts",
+                ":repo_script_id"
+              ],
+              "variable": [
+                {
+                  "key": "repository_id",
+                  "value": "1"
+                },
+                {
+                  "key": "repo_script_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `PUT /api/repositories/{repository_id}/scripts/{repo_script_id}`\n\nSource: `app/api/scripts_library.py:1045`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "List Scripts",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/scripts?category=&search=",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "scripts"
+              ],
+              "query": [
+                {
+                  "key": "category",
+                  "value": ""
+                },
+                {
+                  "key": "search",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/scripts`\n\nSource: `app/api/scripts_library.py:167`"
+          }
+        },
+        {
+          "name": "Create Script",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/scripts",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "scripts"
+              ]
+            },
+            "description": "Backend route: `POST /api/scripts`\n\nSource: `app/api/scripts_library.py:322`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Cleanup Orphaned Script Associations",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/scripts/cleanup-orphans",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "scripts",
+                "cleanup-orphans"
+              ]
+            },
+            "description": "Backend route: `POST /api/scripts/cleanup-orphans`\n\nSource: `app/api/scripts_library.py:1204`"
+          }
+        },
+        {
+          "name": "Test Script",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/scripts/test",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "scripts",
+                "test"
+              ]
+            },
+            "description": "Backend route: `POST /api/scripts/test`\n\nSource: `app/api/scripts.py:36`"
+          }
+        },
+        {
+          "name": "Delete Script",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/scripts/:script_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "scripts",
+                ":script_id"
+              ],
+              "variable": [
+                {
+                  "key": "script_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/scripts/{script_id}`\n\nSource: `app/api/scripts_library.py:556`"
+          }
+        },
+        {
+          "name": "Get Script",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/scripts/:script_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "scripts",
+                ":script_id"
+              ],
+              "variable": [
+                {
+                  "key": "script_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/scripts/{script_id}`\n\nSource: `app/api/scripts_library.py:217`"
+          }
+        },
+        {
+          "name": "Update Script",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/scripts/:script_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "scripts",
+                ":script_id"
+              ],
+              "variable": [
+                {
+                  "key": "script_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `PUT /api/scripts/{script_id}`\n\nSource: `app/api/scripts_library.py:432`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Test Script",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/scripts/:script_id/test",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "scripts",
+                ":script_id",
+                "test"
+              ],
+              "variable": [
+                {
+                  "key": "script_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/scripts/{script_id}/test`\n\nSource: `app/api/scripts_library.py:700`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "15. Rclone",
+      "item": [
+        {
+          "name": "List Remotes",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/rclone/remotes",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "rclone",
+                "remotes"
+              ]
+            },
+            "description": "Backend route: `GET /api/rclone/remotes`\n\nSource: `app/api/rclone.py:239`"
+          }
+        },
+        {
+          "name": "Create Remote",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/rclone/remotes",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "rclone",
+                "remotes"
+              ]
+            },
+            "description": "Backend route: `POST /api/rclone/remotes`\n\nSource: `app/api/rclone.py:249`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Delete Remote",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/rclone/remotes/:remote_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "rclone",
+                "remotes",
+                ":remote_id"
+              ],
+              "variable": [
+                {
+                  "key": "remote_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/rclone/remotes/{remote_id}`\n\nSource: `app/api/rclone.py:389`"
+          }
+        },
+        {
+          "name": "Update Remote",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/rclone/remotes/:remote_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "rclone",
+                "remotes",
+                ":remote_id"
+              ],
+              "variable": [
+                {
+                  "key": "remote_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `PUT /api/rclone/remotes/{remote_id}`\n\nSource: `app/api/rclone.py:305`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Browse Remote",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/rclone/remotes/:remote_id/browse?path=",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "rclone",
+                "remotes",
+                ":remote_id",
+                "browse"
+              ],
+              "variable": [
+                {
+                  "key": "remote_id",
+                  "value": "1"
+                }
+              ],
+              "query": [
+                {
+                  "key": "path",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/rclone/remotes/{remote_id}/browse`\n\nSource: `app/api/rclone.py:454`"
+          }
+        },
+        {
+          "name": "Test Remote",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/rclone/remotes/:remote_id/test",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "rclone",
+                "remotes",
+                ":remote_id",
+                "test"
+              ],
+              "variable": [
+                {
+                  "key": "remote_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/rclone/remotes/{remote_id}/test`\n\nSource: `app/api/rclone.py:429`"
+          }
+        },
+        {
+          "name": "Get Status",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/rclone/status",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "rclone",
+                "status"
+              ]
+            },
+            "description": "Backend route: `GET /api/rclone/status`\n\nSource: `app/api/rclone.py:231`"
+          }
+        }
+      ]
+    },
+    {
+      "name": "16. Packages",
+      "item": [
+        {
+          "name": "List Packages",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/packages",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "packages"
+              ]
+            },
+            "description": "Backend route: `GET /api/packages`\n\nSource: `app/api/packages.py:54`"
+          }
+        },
+        {
+          "name": "Create Package",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/packages",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "packages"
+              ]
+            },
+            "description": "Backend route: `POST /api/packages`\n\nSource: `app/api/packages.py:61`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "List Jobs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/packages/jobs",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "packages",
+                "jobs"
+              ]
+            },
+            "description": "Backend route: `GET /api/packages/jobs`\n\nSource: `app/api/packages.py:275`"
+          }
+        },
+        {
+          "name": "Get Job Status",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/packages/jobs/:job_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "packages",
+                "jobs",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/packages/jobs/{job_id}`\n\nSource: `app/api/packages.py:253`"
+          }
+        },
+        {
+          "name": "Delete Package",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/packages/:package_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "packages",
+                ":package_id"
+              ],
+              "variable": [
+                {
+                  "key": "package_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/packages/{package_id}`\n\nSource: `app/api/packages.py:203`"
+          }
+        },
+        {
+          "name": "Update Package",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/packages/:package_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "packages",
+                ":package_id"
+              ],
+              "variable": [
+                {
+                  "key": "package_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `PUT /api/packages/{package_id}`\n\nSource: `app/api/packages.py:151`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Install Package",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/packages/:package_id/install",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "packages",
+                ":package_id",
+                "install"
+              ],
+              "variable": [
+                {
+                  "key": "package_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/packages/{package_id}/install`\n\nSource: `app/api/packages.py:96`"
+          }
+        },
+        {
+          "name": "Reinstall Package",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/packages/:package_id/reinstall",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "packages",
+                ":package_id",
+                "reinstall"
+              ],
+              "variable": [
+                {
+                  "key": "package_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/packages/{package_id}/reinstall`\n\nSource: `app/api/packages.py:228`"
+          }
+        }
+      ]
+    },
+    {
+      "name": "17. Mounts",
+      "item": [
+        {
+          "name": "List Mounts",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/mounts",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "mounts"
+              ]
+            },
+            "description": "Backend route: `GET /api/mounts`\n\nSource: `app/api/mounts.py:242`"
+          }
+        },
+        {
+          "name": "Mount Borg Archive",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/mounts/borg",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "mounts",
+                "borg"
+              ]
+            },
+            "description": "Backend route: `POST /api/mounts/borg`\n\nSource: `app/api/mounts.py:76`"
+          }
+        },
+        {
+          "name": "Unmount Borg Archive",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/mounts/borg/unmount/:mount_id?force=false",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "mounts",
+                "borg",
+                "unmount",
+                ":mount_id"
+              ],
+              "variable": [
+                {
+                  "key": "mount_id",
+                  "value": "1"
+                }
+              ],
+              "query": [
+                {
+                  "key": "force",
+                  "value": "false"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/mounts/borg/unmount/{mount_id}`\n\nSource: `app/api/mounts.py:163`"
+          }
+        },
+        {
+          "name": "Get Mount Info",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/mounts/:mount_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "mounts",
+                ":mount_id"
+              ],
+              "variable": [
+                {
+                  "key": "mount_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/mounts/{mount_id}`\n\nSource: `app/api/mounts.py:307`"
+          }
+        }
+      ]
+    },
+    {
+      "name": "18. Managed Machines",
+      "item": [
+        {
+          "name": "List Agent Jobs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/managed-machines/agent-jobs",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "managed-machines",
+                "agent-jobs"
+              ]
+            },
+            "description": "Backend route: `GET /api/managed-machines/agent-jobs`\n\nSource: `app/api/managed_machines.py:439`"
+          }
+        },
+        {
+          "name": "Request Agent Job Cancel",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/managed-machines/agent-jobs/:job_id/cancel",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "managed-machines",
+                "agent-jobs",
+                ":job_id",
+                "cancel"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/managed-machines/agent-jobs/{job_id}/cancel`\n\nSource: `app/api/managed_machines.py:474`"
+          }
+        },
+        {
+          "name": "List Agent Job Logs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/managed-machines/agent-jobs/:job_id/logs",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "managed-machines",
+                "agent-jobs",
+                ":job_id",
+                "logs"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/managed-machines/agent-jobs/{job_id}/logs`\n\nSource: `app/api/managed_machines.py:450`"
+          }
+        },
+        {
+          "name": "List Agent Machines",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/managed-machines/agents",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "managed-machines",
+                "agents"
+              ]
+            },
+            "description": "Backend route: `GET /api/managed-machines/agents`\n\nSource: `app/api/managed_machines.py:312`"
+          }
+        },
+        {
+          "name": "Delete Agent Machine",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/managed-machines/agents/:agent_machine_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "managed-machines",
+                "agents",
+                ":agent_machine_id"
+              ],
+              "variable": [
+                {
+                  "key": "agent_machine_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/managed-machines/agents/{agent_machine_id}`\n\nSource: `app/api/managed_machines.py:413`"
+          }
+        },
+        {
+          "name": "Create Agent Backup Job",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/managed-machines/agents/:agent_machine_id/backup-jobs",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "managed-machines",
+                "agents",
+                ":agent_machine_id",
+                "backup-jobs"
+              ],
+              "variable": [
+                {
+                  "key": "agent_machine_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/managed-machines/agents/{agent_machine_id}/backup-jobs`\n\nSource: `app/api/managed_machines.py:329`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Browse Agent Machine Filesystem",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/managed-machines/agents/:agent_machine_id/filesystem/browse?path=/&include_hidden=false",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "managed-machines",
+                "agents",
+                ":agent_machine_id",
+                "filesystem",
+                "browse"
+              ],
+              "variable": [
+                {
+                  "key": "agent_machine_id",
+                  "value": "1"
+                }
+              ],
+              "query": [
+                {
+                  "key": "path",
+                  "value": "/"
+                },
+                {
+                  "key": "include_hidden",
+                  "value": "false"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/managed-machines/agents/{agent_machine_id}/filesystem/browse`\n\nSource: `app/api/managed_machines.py:370`"
+          }
+        },
+        {
+          "name": "Revoke Agent Machine",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/managed-machines/agents/:agent_machine_id/revoke",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "managed-machines",
+                "agents",
+                ":agent_machine_id",
+                "revoke"
+              ],
+              "variable": [
+                {
+                  "key": "agent_machine_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/managed-machines/agents/{agent_machine_id}/revoke`\n\nSource: `app/api/managed_machines.py:389`"
+          }
+        },
+        {
+          "name": "List Enrollment Tokens",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/managed-machines/enrollment-tokens",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "managed-machines",
+                "enrollment-tokens"
+              ]
+            },
+            "description": "Backend route: `GET /api/managed-machines/enrollment-tokens`\n\nSource: `app/api/managed_machines.py:271`"
+          }
+        },
+        {
+          "name": "Create Enrollment Token",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/managed-machines/enrollment-tokens",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "managed-machines",
+                "enrollment-tokens"
+              ]
+            },
+            "description": "Backend route: `POST /api/managed-machines/enrollment-tokens`\n\nSource: `app/api/managed_machines.py:227`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Revoke Enrollment Token",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/managed-machines/enrollment-tokens/:token_id/revoke",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "managed-machines",
+                "enrollment-tokens",
+                ":token_id",
+                "revoke"
+              ],
+              "variable": [
+                {
+                  "key": "token_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/managed-machines/enrollment-tokens/{token_id}/revoke`\n\nSource: `app/api/managed_machines.py:285`"
+          }
+        }
+      ]
+    },
+    {
+      "name": "19. Agents & Installer",
+      "item": [
+        {
+          "name": "Get Agent Installer",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/agent/install.sh",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "agent",
+                "install.sh"
+              ]
+            },
+            "description": "Backend route: `GET /agent/install.sh`\n\nSource: `app/api/agent_installer.py:271`",
+            "auth": {
+              "type": "noauth"
+            }
+          }
+        },
+        {
+          "name": "Heartbeat",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/agents/heartbeat",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "agents",
+                "heartbeat"
+              ]
+            },
+            "description": "Backend route: `POST /api/agents/heartbeat`\n\nSource: `app/api/agents.py:459`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Poll Jobs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/agents/jobs/poll?limit=",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "agents",
+                "jobs",
+                "poll"
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/agents/jobs/poll`\n\nSource: `app/api/agents.py:521`"
+          }
+        },
+        {
+          "name": "Mark Job Canceled",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/agents/jobs/:job_id/cancel",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "agents",
+                "jobs",
+                ":job_id",
+                "cancel"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/agents/jobs/{job_id}/cancel`\n\nSource: `app/api/agents.py:730`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Claim Job",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/agents/jobs/:job_id/claim",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "agents",
+                "jobs",
+                ":job_id",
+                "claim"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/agents/jobs/{job_id}/claim`\n\nSource: `app/api/agents.py:540`"
+          }
+        },
+        {
+          "name": "Complete Job",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/agents/jobs/:job_id/complete",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "agents",
+                "jobs",
+                ":job_id",
+                "complete"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/agents/jobs/{job_id}/complete`\n\nSource: `app/api/agents.py:656`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Fail Job",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/agents/jobs/:job_id/fail",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "agents",
+                "jobs",
+                ":job_id",
+                "fail"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/agents/jobs/{job_id}/fail`\n\nSource: `app/api/agents.py:690`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Upload Job Log",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/agents/jobs/:job_id/logs",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "agents",
+                "jobs",
+                ":job_id",
+                "logs"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/agents/jobs/{job_id}/logs`\n\nSource: `app/api/agents.py:621`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Update Job Progress",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/agents/jobs/:job_id/progress",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "agents",
+                "jobs",
+                ":job_id",
+                "progress"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/agents/jobs/{job_id}/progress`\n\nSource: `app/api/agents.py:595`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Start Job",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/agents/jobs/:job_id/start",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "agents",
+                "jobs",
+                ":job_id",
+                "start"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/agents/jobs/{job_id}/start`\n\nSource: `app/api/agents.py:559`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Register Agent",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/agents/register",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "agents",
+                "register"
+              ]
+            },
+            "description": "Backend route: `POST /api/agents/register`\n\nSource: `app/api/agents.py:404`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Unregister Agent",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/agents/unregister",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "agents",
+                "unregister"
+              ]
+            },
+            "description": "Backend route: `POST /api/agents/unregister`\n\nSource: `app/api/agents.py:505`"
+          }
+        }
+      ]
+    },
+    {
+      "name": "20. Configuration",
+      "item": [
+        {
+          "name": "Export Borgmatic Config",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/config/export/borgmatic",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "config",
+                "export",
+                "borgmatic"
+              ]
+            },
+            "description": "Backend route: `POST /api/config/export/borgmatic`\n\nSource: `app/routers/config.py:37`"
+          }
+        },
+        {
+          "name": "List Exportable Repositories",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/config/export/repositories",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "config",
+                "export",
+                "repositories"
+              ]
+            },
+            "description": "Backend route: `GET /api/config/export/repositories`\n\nSource: `app/routers/config.py:282`"
+          }
+        },
+        {
+          "name": "Import Borgmatic Config",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/config/import/borgmatic?merge_strategy=skip_duplicates&dry_run=false",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "config",
+                "import",
+                "borgmatic"
+              ],
+              "query": [
+                {
+                  "key": "merge_strategy",
+                  "value": "skip_duplicates"
+                },
+                {
+                  "key": "dry_run",
+                  "value": "false"
+                }
+              ]
+            },
+            "description": "Backend route: `POST /api/config/import/borgmatic`\n\nSource: `app/routers/config.py:120`",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "file",
+                  "type": "file",
+                  "src": []
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "21. Events",
+      "item": [
+        {
+          "name": "Stream Events",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/events/stream?token=",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "events",
+                "stream"
+              ],
+              "query": [
+                {
+                  "key": "token",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/events/stream`\n\nSource: `app/api/events.py:137`"
+          }
+        }
+      ]
+    },
+    {
+      "name": "22. Borg 2 API",
+      "item": [
+        {
+          "name": "Get Delete Job Status",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v2/archives/delete-jobs/:job_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v2",
+                "archives",
+                "delete-jobs",
+                ":job_id"
+              ],
+              "variable": [
+                {
+                  "key": "job_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/v2/archives/delete-jobs/{job_id}`\n\nSource: `app/api/v2/archives.py:535`"
+          }
+        },
+        {
+          "name": "Download File From Archive",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v2/archives/download",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v2",
+                "archives",
+                "download"
+              ]
+            },
+            "description": "Backend route: `GET /api/v2/archives/download`\n\nSource: `app/api/v2/archives.py:482`"
+          }
+        },
+        {
+          "name": "List Archives",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v2/archives/list",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v2",
+                "archives",
+                "list"
+              ]
+            },
+            "description": "Backend route: `GET /api/v2/archives/list`\n\nSource: `app/api/v2/archives.py:152`"
+          }
+        },
+        {
+          "name": "Delete Archive",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/v2/archives/:archive_id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v2",
+                "archives",
+                ":archive_id"
+              ],
+              "variable": [
+                {
+                  "key": "archive_id",
+                  "value": "archive-name"
+                }
+              ]
+            },
+            "description": "Backend route: `DELETE /api/v2/archives/{archive_id}`\n\nSource: `app/api/v2/archives.py:408`"
+          }
+        },
+        {
+          "name": "Get Archive Contents",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v2/archives/:archive_id/contents?path=",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v2",
+                "archives",
+                ":archive_id",
+                "contents"
+              ],
+              "variable": [
+                {
+                  "key": "archive_id",
+                  "value": "archive-name"
+                }
+              ],
+              "query": [
+                {
+                  "key": "path",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/v2/archives/{archive_id}/contents`\n\nSource: `app/api/v2/archives.py:299`"
+          }
+        },
+        {
+          "name": "Get Archive Info",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v2/archives/:archive_id/info?include_files=false&file_limit=1000",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v2",
+                "archives",
+                ":archive_id",
+                "info"
+              ],
+              "variable": [
+                {
+                  "key": "archive_id",
+                  "value": "archive-name"
+                }
+              ],
+              "query": [
+                {
+                  "key": "include_files",
+                  "value": "false"
+                },
+                {
+                  "key": "file_limit",
+                  "value": "1000"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/v2/archives/{archive_id}/info`\n\nSource: `app/api/v2/archives.py:187`"
+          }
+        },
+        {
+          "name": "Check Repository",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v2/backup/check",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v2",
+                "backup",
+                "check"
+              ]
+            },
+            "description": "Backend route: `POST /api/v2/backup/check`\n\nSource: `app/api/v2/backups.py:282`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Compact Repository",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v2/backup/compact",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v2",
+                "backup",
+                "compact"
+              ]
+            },
+            "description": "Backend route: `POST /api/v2/backup/compact`\n\nSource: `app/api/v2/backups.py:239`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Prune Archives",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v2/backup/prune",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v2",
+                "backup",
+                "prune"
+              ]
+            },
+            "description": "Backend route: `POST /api/v2/backup/prune`\n\nSource: `app/api/v2/backups.py:152`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Run Backup",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v2/backup/run",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v2",
+                "backup",
+                "run"
+              ]
+            },
+            "description": "Backend route: `POST /api/v2/backup/run`\n\nSource: `app/api/v2/backups.py:98`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "Create Repository",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v2/repositories",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v2",
+                "repositories"
+              ]
+            },
+            "description": "Backend route: `POST /api/v2/repositories`\n\nSource: `app/api/v2/repositories.py:203`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "List Encryption Modes",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v2/repositories/encryption-modes",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v2",
+                "repositories",
+                "encryption-modes"
+              ]
+            },
+            "description": "Backend route: `GET /api/v2/repositories/encryption-modes`\n\nSource: `app/api/v2/repositories.py:197`"
+          }
+        },
+        {
+          "name": "Import Repository",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v2/repositories/import",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v2",
+                "repositories",
+                "import"
+              ]
+            },
+            "description": "Backend route: `POST /api/v2/repositories/import`\n\nSource: `app/api/v2/repositories.py:334`",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            }
+          }
+        },
+        {
+          "name": "List Archives",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v2/repositories/:repo_id/archives",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v2",
+                "repositories",
+                ":repo_id",
+                "archives"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/v2/repositories/{repo_id}/archives`\n\nSource: `app/api/v2/repositories.py:559`"
+          }
+        },
+        {
+          "name": "Get Repository Info",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v2/repositories/:repo_id/info",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v2",
+                "repositories",
+                ":repo_id",
+                "info"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/v2/repositories/{repo_id}/info`\n\nSource: `app/api/v2/repositories.py:457`"
+          }
+        },
+        {
+          "name": "Get Repository Stats",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v2/repositories/:repo_id/stats",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v2",
+                "repositories",
+                ":repo_id",
+                "stats"
+              ],
+              "variable": [
+                {
+                  "key": "repo_id",
+                  "value": "1"
+                }
+              ]
+            },
+            "description": "Backend route: `GET /api/v2/repositories/{repo_id}/stats`\n\nSource: `app/api/v2/repositories.py:615`"
+          }
+        }
+      ]
+    },
+    {
+      "name": "23. System & Licensing",
+      "item": [
+        {
+          "name": "Get System Info",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/system/info",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "system",
+                "info"
+              ]
+            },
+            "description": "Backend route: `GET /api/system/info`\n\nSource: `app/api/system.py:54`"
+          }
+        },
+        {
+          "name": "Activate System License",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/system/licensing/activate",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "system",
+                "licensing",
+                "activate"
+              ]
+            },
+            "description": "Backend route: `POST /api/system/licensing/activate`\n\nSource: `app/api/system.py:131`"
+          }
+        },
+        {
+          "name": "Deactivate System License",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/system/licensing/deactivate",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "system",
+                "licensing",
+                "deactivate"
+              ]
+            },
+            "description": "Backend route: `POST /api/system/licensing/deactivate`\n\nSource: `app/api/system.py:148`"
+          }
+        },
+        {
+          "name": "Import System Entitlement",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/system/licensing/import",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "system",
+                "licensing",
+                "import"
+              ]
+            },
+            "description": "Backend route: `POST /api/system/licensing/import`\n\nSource: `app/api/system.py:160`"
+          }
+        },
+        {
+          "name": "Refresh System Entitlement",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/system/licensing/refresh",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "system",
+                "licensing",
+                "refresh"
+              ]
+            },
+            "description": "Backend route: `POST /api/system/licensing/refresh`\n\nSource: `app/api/system.py:118`"
+          }
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Description
- Replaced the stale Borg UI Postman collection with a route-inventory-based collection for the current FastAPI backend.
- Preserved the collection-level `base_url` / `access_token` variables and `X-Borg-Authorization: Bearer {{access_token}}` auth convention.
- Added 266 canonical backend API requests across route-domain folders and removed stale collection requests for old config, dashboard health, and events connection endpoints.
- Identified an unreachable duplicate `POST /api/repositories/{param}/break-lock` backend route and filed BOR-85 as the cleanup follow-up.

## Related Issue
- Linear: https://linear.app/nullcodeai/issue/BOR-79/refresh-borg-ui-api-collection-and-audit-backend-routes
- Follow-up cleanup: https://linear.app/nullcodeai/issue/BOR-85/remove-duplicate-repository-break-lock-route

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass

Validation run:
- `python3 -m json.tool Borg_UI_API.postman_collection.json >/dev/null`
- `git diff --check HEAD~1 HEAD`
- Static AST route/collection comparison: `backend_canonical_routes=266`, `collection_requests=266`, `missing=0`, `extra=0`

Existing unit tests were not run because this change only updates the Postman collection JSON and does not modify app or test code.

## Checklist
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; this is a Postman collection update.

## Additional Context
The route audit found one clear cleanup candidate: two repository break-lock routes differ only by path parameter name, so the first registered route shadows the second. That backend cleanup is intentionally tracked separately in BOR-85.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
