### PR TITLE
Document hosted and NAS onboarding paths

### DIFF
--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -13,9 +13,19 @@ lives or where you want new archives to be stored.
 | Setup | Use in Borg UI |
 | --- | --- |
 | Local disk or mounted share | Mount the host path into the Borg UI container and use the container path. |
-| NAS or Linux server over SSH | Add a Remote Machine, then create or import an SSH repository. |
-| Hosted Borg service | Add the provider as a Remote Machine and keep the provider's repository path exactly as given. |
+| NAS or Linux server over SSH | Add a Remote Machine, then create or import an SSH repository. See the NAS notes below when SSH and SFTP paths differ. |
+| Hosted Borg service | Add the provider as a Remote Machine and keep the provider's repository path exactly as given. BorgBase and Hetzner need the most care. |
 | Existing Borg repository | Use Import Existing. Choose Full mode if Borg UI should run backups, or Observability-only if another tool already writes archives. |
+
+## Which Setups Need Provider Guidance?
+
+| Environment | Guidance to use |
+| --- | --- |
+| BorgBase | Use the BorgBase mapping below because the `/./repo` path segment is part of the repository URL. |
+| Hetzner Storage Box | Use the Hetzner mapping below because Borg access uses port 23, relative `./` paths, and sometimes a named remote Borg binary. |
+| Synology DSM | Use the NAS mapping below when SFTP shows a share path but Borg needs the full `/volumeN/...` path. |
+| Unraid | Use the NAS mapping below with one consistent share path, usually under `/mnt/user/<share>/...`. |
+| Other hosted Borg providers | Preserve the host, port, username, and path exactly as the provider gives them. |
 
 ## BorgBase
 
@@ -48,6 +58,35 @@ Typical flow:
 5. Create a remote repository or use Import Existing with the same repository path.
 6. Save, then verify that archives can be listed or that repository creation succeeds.
 
+## Hetzner Storage Box
+
+Hetzner Storage Box repositories need explicit mapping because Borg access uses
+the extended SSH service on port 23 and paths are usually written as relative
+Storage Box paths. A repository URL can look like this:
+
+```text
+ssh://u123456@u123456.your-storagebox.de:23/./borg-repository
+```
+
+Map it into Borg UI like this:
+
+```text
+Host: u123456.your-storagebox.de
+Port: 23
+Username: u123456
+Default path: /./borg-repository
+Repository path: /./borg-repository
+Remote Borg Path: borg-1.4, when you need Hetzner's Borg 1.4 binary
+```
+
+Keep the `./` path segment and use the sub-account username and host when the
+Storage Box uses a sub-account. Leave Remote Borg Path blank when Hetzner's
+default Borg version is correct for the repository.
+
+If Borg UI needs to install the public key for a Storage Box, enable SFTP
+deployment mode on the Remote Machine. Hetzner's port 23 key format is the
+normal one-line OpenSSH public key format.
+
 ## Other Hosted Borg Providers
 
 Hosted Borg providers often use SSH URLs with provider-specific path syntax, for
@@ -60,6 +99,39 @@ If verification fails:
 - preserve any `./` path segment from the provider URL
 - confirm the Borg UI public key is authorized by the provider
 - use Import Existing when the repository was created outside Borg UI
+
+## Synology, Unraid, and Other NAS Targets
+
+Synology, Unraid, and similar NAS setups usually do not need separate provider
+pages. They do need careful path mapping when the path shown by browsing is not
+the exact path Borg needs over SSH.
+
+Use this general mapping:
+
+```text
+Host: nas.example.com
+Port: 22, or your custom SSH port
+Username: the NAS user that can run Borg and access the repository path
+Default path: the path Borg UI should browse first
+Repository path: the Borg repository path in that same browsing namespace
+```
+
+For Synology, SFTP browsing may show a share path such as `/backups/repo` while
+Borg needs `/volume1/backups/repo` over SSH. Configure the Remote Machine SSH
+path prefix, for example `/volume1`, and keep the repository path as
+`/backups/repo`. See [Remote Machines](ssh-keys#synology-and-nas-path-prefixes)
+for the path-prefix model.
+
+For Unraid, choose one path style and keep it consistent. User shares commonly
+live under `/mnt/user`, for example:
+
+```text
+Repository path: /mnt/user/backups/borg-repository
+```
+
+Avoid mixing `/mnt/user/...` paths with `/mnt/diskN/...` paths for the same
+repository. Also confirm the SSH account can run Borg; share-only NAS users may
+not have shell access.
 
 ## Existing Scripts or Cron Backups
 

--- a/docs/ssh-keys.md
+++ b/docs/ssh-keys.md
@@ -100,7 +100,8 @@ ssh://abcd@abcd.repo.borgbase.com/./repo
 ```
 
 Use `/./repo` as the Remote Machine default path and repository path. Do not
-shorten it to `/repo`. See [Provider Guides](provider-guides).
+shorten it to `/repo`. See [Provider Guides](provider-guides) for BorgBase,
+Hetzner Storage Box, Synology, Unraid, and other hosted or NAS examples.
 
 ## Remote Direct Backups
 
@@ -118,7 +119,8 @@ passed to Borg as the repository-side remote Borg path.
 ## Synology and NAS Path Prefixes
 
 Some NAS devices expose different paths over SFTP and SSH. Synology DSM is a
-common example:
+common example. For provider-level mapping notes, see
+[Provider Guides](provider-guides#synology-unraid-and-other-nas-targets).
 
 ```text
 SFTP path shown while browsing: /playbackup/borguitest

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -84,7 +84,8 @@ Remote repositories use a Remote Machine connection.
 
 Use remote repositories when the Borg archive should live on another server or off-site storage.
 
-For BorgBase and other hosted Borg providers, see [Provider Guides](provider-guides).
+For BorgBase, Hetzner Storage Box, other hosted Borg providers, and NAS path
+mapping notes, see [Provider Guides](provider-guides).
 
 ## Import an Existing Repository
 
@@ -98,7 +99,9 @@ Use Import Existing when a Borg repository already exists and you want Borg UI t
 
 Full mode lets Borg UI run backups for the repository. Observability-only mode is for repositories backed up by something else; Borg UI can browse archives, restore files, run checks, and show health, but it will not run backups or scheduled backups for that repository.
 
-If the repository comes from BorgBase or another hosted Borg service, keep the provider's repository path exactly as given. See [Provider Guides](provider-guides).
+If the repository comes from BorgBase, Hetzner Storage Box, another hosted Borg
+service, or a NAS with special path mapping, keep the provider's repository path
+exactly as given. See [Provider Guides](provider-guides).
 
 ## Repository vs Backup Plan
 


### PR DESCRIPTION
## Description
Adds concise Provider Guides coverage for hosted Borg and NAS-backed repositories:

- identifies BorgBase, Hetzner Storage Box, Synology, Unraid, and other hosted providers in a mapping table
- documents Hetzner host, port, username, repository path, default path, and Remote Borg Path mapping
- adds lightweight Synology and Unraid NAS path guidance
- links the expanded guidance from Usage Guide and Remote Machines

## Related Issue
Linear: BOR-84

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] UI/UX improvement
- [ ] Test addition/improvement
- [ ] Refactoring

## Testing
Validation run for this docs-only change:

- `cd docs && npm run build`
- `git diff --check`
- Generated HTML inspection for `provider-guides.html`, `usage-guide.html`, and `ssh-keys.html`

- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works; not applicable because this is documentation-only
- [ ] All existing tests pass; not run because this change only touches documentation and the docs build passed

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas; not applicable because no code changed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes; not applicable because no runtime code changed

## Screenshots (if applicable)
Not applicable. Rendered documentation output was reviewed through the VitePress build output.

## Additional Context
`npm ci` in `docs/` was required because local docs dependencies were not installed before running the VitePress build. It reported existing dependency audit findings; no dependency or generated artifacts are included in this PR.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
