### PR TITLE
Remove duplicate repository break-lock route

### DIFF
--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -4634,12 +4634,7 @@ async def break_repository_lock(
 ):
     """Break a stale lock on a repository (user-initiated)"""
     try:
-        repository = db.query(Repository).filter(Repository.id == repo_id).first()
-        if not repository:
-            raise HTTPException(
-                status_code=404,
-                detail={"key": "backend.errors.repo.repositoryNotFound"},
-            )
+        repository = _load_repository_with_access(repo_id, current_user, db, "operator")
 
         logger.warning(
             "User requested lock break", repo_id=repo_id, user=current_user.username
@@ -4738,93 +4733,6 @@ async def get_repository_stats(
                 os.unlink(temp_key_file)
             except Exception:
                 pass
-
-
-@router.post("/{repository_id}/break-lock")
-async def break_repository_lock(
-    repository_id: int,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
-):
-    """
-    Break a stale lock on a repository
-
-    Use this when a backup has crashed or been killed, leaving behind a lock file
-    that prevents new backups from starting.
-
-    WARNING: Only use this if you're CERTAIN no backup is currently running!
-    """
-    try:
-        # Get repository from database
-        repository = db.query(Repository).filter(Repository.id == repository_id).first()
-        if not repository:
-            raise HTTPException(
-                status_code=404,
-                detail={"key": "backend.errors.repo.repositoryNotFound"},
-            )
-        _require_repository_access(db, current_user, repository, "operator")
-
-        logger.info(
-            "Breaking repository lock",
-            repository=repository.path,
-            user=current_user.username,
-            repository_id=repository_id,
-        )
-
-        cmd = BorgRouter(repository).build_break_lock_command(
-            repository_path=repository.path,
-            remote_path=repository.remote_path,
-        )
-
-        returncode, stdout, stderr = await _run_repository_command(
-            repository,
-            db,
-            cmd,
-            30,
-            log_message="Using SSH key for break-lock",
-            log_fields={"repository_id": repository_id},
-        )
-
-        stdout_str = stdout.decode("utf-8", errors="replace") if stdout else ""
-        stderr_str = stderr.decode("utf-8", errors="replace") if stderr else ""
-
-        if returncode == 0:
-            logger.info(
-                "Successfully broke repository lock",
-                repository=repository.path,
-                user=current_user.username,
-            )
-            return {
-                "success": True,
-                "message": "backend.success.repo.lockRemoved",
-                "repository": repository.path,
-                "output": stdout_str,
-            }
-        else:
-            logger.error(
-                "Failed to break repository lock",
-                repository=repository.path,
-                returncode=returncode,
-                stderr=stderr_str,
-            )
-            raise HTTPException(
-                status_code=500, detail={"key": "backend.errors.repo.failedToBreakLock"}
-            )
-
-    except asyncio.TimeoutError:
-        logger.error("Timeout breaking repository lock", repository_id=repository_id)
-        raise HTTPException(
-            status_code=500, detail={"key": "backend.errors.repo.breakLockTimeout"}
-        )
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(
-            "Error breaking repository lock", repository_id=repository_id, error=str(e)
-        )
-        raise HTTPException(
-            status_code=500, detail={"key": "backend.errors.repo.failedToBreakLock"}
-        )
 
 
 # Check job endpoints

--- a/tests/unit/test_api_repositories_dispatch.py
+++ b/tests/unit/test_api_repositories_dispatch.py
@@ -219,3 +219,30 @@ class TestRepositoryApiDispatch:
         assert response.json()["message"] == "backend.success.repo.lockBroken"
         mock_router.assert_called_once()
         fake_router.break_lock.assert_awaited_once()
+
+    def test_break_lock_route_requires_operator_access(
+        self, test_client: TestClient, auth_headers, test_db
+    ):
+        repo = Repository(
+            name="Repo",
+            path="/tmp/repo",
+            encryption="none",
+            repository_type="local",
+            borg_version=2,
+        )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+
+        fake_router = Mock(break_lock=AsyncMock(return_value={"success": True}))
+        with patch(
+            "app.api.repositories.BorgRouter", return_value=fake_router
+        ) as mock_router:
+            response = test_client.post(
+                f"/api/repositories/{repo.id}/break-lock",
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 403
+        mock_router.assert_not_called()
+        fake_router.break_lock.assert_not_awaited()

--- a/tests/unit/test_api_repositories_routes.py
+++ b/tests/unit/test_api_repositories_routes.py
@@ -1,4 +1,6 @@
 import asyncio
+import re
+from collections import Counter
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
@@ -33,6 +35,20 @@ def _create_repo(test_db, name: str, path: str, **kwargs) -> Repository:
 
 @pytest.mark.unit
 class TestRepositoryRouteContracts:
+    def test_repositories_register_single_canonical_break_lock_route(self):
+        break_lock_routes = [
+            route
+            for route in repositories_api.router.routes
+            if getattr(route, "path", "").endswith("/break-lock")
+            and "POST" in getattr(route, "methods", set())
+        ]
+        canonical_counts = Counter(
+            re.sub(r"\{[^}]+\}", "{param}", route.path) for route in break_lock_routes
+        )
+
+        assert canonical_counts["/{param}/break-lock"] == 1
+        assert [route.path for route in break_lock_routes] == ["/{repo_id}/break-lock"]
+
     def test_get_repositories_filters_to_explicit_permissions(
         self, test_client: TestClient, auth_headers, test_db, test_user
     ):


### PR DESCRIPTION
## Description
Removes the unreachable duplicate repository break-lock route and keeps `POST /api/repositories/{repo_id}/break-lock` as the single canonical backend endpoint. The retained route now loads the repository through the operator access helper before invoking `BorgRouter.break_lock`, preserving the existing caller path and command dispatch behavior.

## Related Issue
Linear: https://linear.app/nullcodeai/issue/BOR-85/remove-duplicate-repository-break-lock-route

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [x] Test addition/improvement
- [x] Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All relevant existing tests pass

Commands run:
- `.venv/bin/python -m pytest tests/unit/test_api_repositories_routes.py::TestRepositoryRouteContracts::test_repositories_register_single_canonical_break_lock_route tests/unit/test_api_repositories_dispatch.py::TestRepositoryApiDispatch::test_break_lock_route_requires_operator_access tests/unit/test_api_repositories_dispatch.py::TestRepositoryApiDispatch::test_break_lock_route_dispatches_through_borg_router tests/unit/test_borg_router.py::test_build_break_lock_command_uses_v1_shape tests/unit/test_borg_router.py::test_build_break_lock_command_uses_v2_shape tests/unit/test_borg_router.py::test_break_lock_delegates_to_v2_core tests/unit/test_borg_router.py::test_break_lock_delegates_to_v1_core tests/unit/test_process_utils.py::test_break_repository_lock_uses_v1_command_shape tests/unit/test_process_utils.py::test_break_repository_lock_uses_v2_command_shape tests/unit/test_utils.py::TestProcessUtils::test_break_repository_lock_local_success tests/unit/test_utils.py::TestProcessUtils::test_break_repository_lock_ssh_success -q`
- `DATA_DIR=/tmp/borg-ui-route-inventory SECRET_KEY=test-secret-key-for-testing-only ENVIRONMENT=test ACTIVATION_SERVICE_URL= ENABLE_STARTUP_LICENSE_SYNC=false .venv/bin/python - <<'PY' ... PY`
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m ruff format --check app tests`
- `git diff --check`

## Checklist
- [x] I have read the CONTRIBUTING guidelines relevant to this backend change
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where useful; no new comments were needed for this scoped cleanup
- [x] Documentation changes were not needed for this internal route registration cleanup
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; this is a backend route cleanup.

## Additional Context
The route inventory now reports a single `POST /api/repositories/{repo_id}/break-lock` route, canonicalized as `/api/repositories/{param}/break-lock` with count `1`. Local route inventory logs still show existing startup warnings unrelated to this change.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
