### PR TITLE
Add automated Borg UI configuration export

### DIFF
--- a/app/routers/config.py
+++ b/app/routers/config.py
@@ -2,7 +2,6 @@
 API endpoints for configuration export/import.
 """
 
-from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Query
 from fastapi.responses import Response
 from sqlalchemy.orm import Session
@@ -13,6 +12,7 @@ from app.database.database import get_db
 from app.services.borgmatic_service import (
     BorgmaticExportService,
     BorgmaticImportService,
+    build_borgmatic_export_artifact,
 )
 from app.core.security import get_current_user
 
@@ -42,7 +42,8 @@ async def export_borgmatic_config(
     """
     Export Borg UI configurations to borgmatic YAML format.
 
-    Returns a ZIP file containing separate config files for each repository.
+    Returns a YAML file for one repository or a ZIP file with one YAML file per
+    repository for multiple repositories.
     """
     export_service = BorgmaticExportService(db)
 
@@ -52,66 +53,18 @@ async def export_borgmatic_config(
             include_schedules=request.include_schedules,
         )
 
-        if not configs:
-            raise HTTPException(
-                status_code=404, detail="No repositories found to export"
-            )
-
-        # If only one repository, return single YAML file
-        if len(configs) == 1:
-            import yaml
-
-            repo_name, config = configs[0]
-            yaml_content = yaml.dump(config, default_flow_style=False, sort_keys=False)
-
-            # Generate timestamp prefix
-            timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-
-            # Sanitize filename
-            safe_name = "".join(
-                c for c in repo_name if c.isalnum() or c in ("-", "_")
-            ).lower()
-            base_filename = (
-                f"{safe_name}.yaml" if safe_name else "borgmatic-config.yaml"
-            )
-            filename = f"{timestamp}_{base_filename}"
-
-            return Response(
-                content=yaml_content,
-                media_type="application/x-yaml",
-                headers={"Content-Disposition": f"attachment; filename={filename}"},
-            )
-
-        # Multiple repositories: create ZIP with separate config files
-        import io
-        import zipfile
-        import yaml
-
-        # Generate timestamp prefix
-        timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-
-        zip_buffer = io.BytesIO()
-        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
-            for i, (repo_name, config) in enumerate(configs):
-                # Sanitize filename
-                safe_name = "".join(
-                    c for c in repo_name if c.isalnum() or c in ("-", "_")
-                ).lower()
-                if not safe_name:
-                    safe_name = f"repo-{i + 1}"
-
-                yaml_content = yaml.dump(
-                    config, default_flow_style=False, sort_keys=False
-                )
-                zip_file.writestr(f"{safe_name}.yaml", yaml_content)
-
-        zip_buffer.seek(0)
-        filename = f"{timestamp}_borgmatic-configs.zip"
+        artifact = build_borgmatic_export_artifact(configs)
         return Response(
-            content=zip_buffer.getvalue(),
-            media_type="application/zip",
-            headers={"Content-Disposition": f"attachment; filename={filename}"},
+            content=artifact.content,
+            media_type=artifact.media_type,
+            headers={
+                "Content-Disposition": f"attachment; filename={artifact.filename}"
+            },
         )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Export failed: {str(e)}")
 

--- a/app/scripts/export_config.py
+++ b/app/scripts/export_config.py
@@ -1,0 +1,108 @@
+"""Export Borg UI configuration from a local runtime shell.
+
+This module is intended for pre-backup scripts that run inside the Borg UI
+container or another trusted environment with access to the configured database.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+from pathlib import Path
+from typing import BinaryIO, Callable, Sequence, TextIO
+
+from sqlalchemy.orm import Session
+
+from app.database.database import SessionLocal
+from app.services.borgmatic_service import (
+    BorgmaticExportService,
+    build_borgmatic_export_artifact,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Export Borg UI repository configuration in the same format as the web UI export."
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output path for the export artifact, or '-' to write bytes to stdout.",
+    )
+    parser.add_argument(
+        "--repository-id",
+        action="append",
+        type=int,
+        dest="repository_ids",
+        help="Repository ID to export. Repeat to export multiple repositories. Defaults to all repositories.",
+    )
+    parser.add_argument(
+        "--no-schedules",
+        action="store_true",
+        help="Exclude schedule-derived retention settings from the export.",
+    )
+    return parser
+
+
+def _write_output_file(output_path: Path, content: bytes) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_file = tempfile.NamedTemporaryFile(
+        "wb",
+        delete=False,
+        dir=output_path.parent,
+        prefix=f".{output_path.name}.",
+        suffix=".tmp",
+    )
+    temp_path = Path(temp_file.name)
+    try:
+        with temp_file:
+            temp_file.write(content)
+            temp_file.flush()
+        temp_path.replace(output_path)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    session_factory: Callable[[], Session] = SessionLocal,
+    stdout: BinaryIO | None = None,
+    stderr: TextIO | None = None,
+) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    output_stream = stdout or sys.stdout.buffer
+    error_stream = stderr or sys.stderr
+
+    db = session_factory()
+    try:
+        export_service = BorgmaticExportService(db)
+        configs = export_service.export_all_repositories(
+            repository_ids=args.repository_ids,
+            include_schedules=not args.no_schedules,
+        )
+        artifact = build_borgmatic_export_artifact(configs)
+
+        if args.output == "-":
+            output_stream.write(artifact.content)
+            output_stream.flush()
+        else:
+            _write_output_file(Path(args.output), artifact.content)
+
+        return 0
+    except ValueError as exc:
+        print(str(exc), file=error_stream)
+        return 1
+    except OSError as exc:
+        print(f"Failed to write export: {exc}", file=error_stream)
+        return 1
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/services/borgmatic_service.py
+++ b/app/services/borgmatic_service.py
@@ -8,6 +8,10 @@ This service handles:
 """
 
 import json
+import io
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime
 import yaml
 from typing import List, Dict, Any, Optional, Tuple
 from sqlalchemy.orm import Session
@@ -19,6 +23,54 @@ from app.utils.schedule_time import (
     calculate_next_cron_run,
     normalize_schedule_timezone,
 )
+
+
+@dataclass(frozen=True)
+class BorgmaticExportArtifact:
+    """Packaged borgmatic export content ready for download or script output."""
+
+    content: bytes
+    filename: str
+    media_type: str
+
+
+def _safe_export_name(name: str, fallback: str) -> str:
+    safe_name = "".join(c for c in name if c.isalnum() or c in ("-", "_")).lower()
+    return safe_name or fallback
+
+
+def build_borgmatic_export_artifact(
+    configs: List[Tuple[str, Dict[str, Any]]],
+    timestamp: Optional[datetime] = None,
+) -> BorgmaticExportArtifact:
+    """Build the YAML or ZIP artifact used by UI downloads and local scripts."""
+    if not configs:
+        raise ValueError("No repositories found to export")
+
+    timestamp_text = (timestamp or datetime.now()).strftime("%Y-%m-%d_%H-%M-%S")
+
+    if len(configs) == 1:
+        repo_name, config = configs[0]
+        yaml_content = yaml.dump(config, default_flow_style=False, sort_keys=False)
+        base_filename = f"{_safe_export_name(repo_name, 'borgmatic-config')}.yaml"
+        return BorgmaticExportArtifact(
+            content=yaml_content.encode("utf-8"),
+            filename=f"{timestamp_text}_{base_filename}",
+            media_type="application/x-yaml",
+        )
+
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+        for index, (repo_name, config) in enumerate(configs):
+            yaml_content = yaml.dump(config, default_flow_style=False, sort_keys=False)
+            filename = f"{_safe_export_name(repo_name, f'repo-{index + 1}')}.yaml"
+            zip_file.writestr(filename, yaml_content)
+
+    return BorgmaticExportArtifact(
+        content=zip_buffer.getvalue(),
+        filename=f"{timestamp_text}_borgmatic-configs.zip",
+        media_type="application/zip",
+    )
 
 
 class BorgmaticExportService:

--- a/app/services/borgmatic_service.py
+++ b/app/services/borgmatic_service.py
@@ -39,6 +39,21 @@ def _safe_export_name(name: str, fallback: str) -> str:
     return safe_name or fallback
 
 
+def _unique_yaml_filename(base_name: str, used_names: set[str]) -> str:
+    filename = f"{base_name}.yaml"
+    if filename not in used_names:
+        used_names.add(filename)
+        return filename
+
+    suffix = 2
+    while True:
+        filename = f"{base_name}-{suffix}.yaml"
+        if filename not in used_names:
+            used_names.add(filename)
+            return filename
+        suffix += 1
+
+
 def build_borgmatic_export_artifact(
     configs: List[Tuple[str, Dict[str, Any]]],
     timestamp: Optional[datetime] = None,
@@ -61,9 +76,11 @@ def build_borgmatic_export_artifact(
 
     zip_buffer = io.BytesIO()
     with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+        used_names: set[str] = set()
         for index, (repo_name, config) in enumerate(configs):
             yaml_content = yaml.dump(config, default_flow_style=False, sort_keys=False)
-            filename = f"{_safe_export_name(repo_name, f'repo-{index + 1}')}.yaml"
+            base_name = _safe_export_name(repo_name, f"repo-{index + 1}")
+            filename = _unique_yaml_filename(base_name, used_names)
             zip_file.writestr(filename, yaml_content)
 
     return BorgmaticExportArtifact(

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -40,6 +40,39 @@ Keep repository passphrases outside Borg UI too. If the only copy of a passphras
 
 The generated `/data/.secret_key` is part of app state. If it changes, existing sessions are invalidated and stored encrypted app secrets, such as SSH private keys and script secrets, may no longer decrypt.
 
+## Automated Configuration Export
+
+Back up `/data` for full Borg UI recovery. In addition, keep an automated
+configuration export as a script-friendly migration and audit artifact. It uses
+the same borgmatic-compatible format as the Settings > Management >
+Export/Import page.
+
+Run the command where Borg UI can read its configured database, for example
+inside the Borg UI container:
+
+```bash
+mkdir -p /data/config-exports
+python3 -m app.scripts.export_config --output /data/config-exports/borg-ui-config.export
+```
+
+For a pre-backup script, write a timestamped export before the data volume is
+captured:
+
+```bash
+#!/bin/sh
+set -eu
+
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p /data/config-exports
+python3 -m app.scripts.export_config \
+  --output "/data/config-exports/${stamp}_borg-ui-config.export"
+```
+
+Treat these exports as sensitive because they can contain repository paths and
+stored repository passphrases. They do not include users, sessions, API tokens,
+logs, encrypted SSH key material, rclone config files, or the generated
+`/data/.secret_key`.
+
 ## Repository Checks vs Restore Checks
 
 Use both.

--- a/docs/engineering/plans/2026-05-30-automated-config-export.md
+++ b/docs/engineering/plans/2026-05-30-automated-config-export.md
@@ -1,0 +1,60 @@
+# Automated Configuration Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a script-friendly Borg UI configuration export command that reuses the web UI export format.
+
+**Architecture:** Keep `BorgmaticExportService` as the repository export source. Add a shared export artifact builder for YAML/ZIP packaging, update the FastAPI route to use it, and add `app.scripts.export_config` as the local CLI wrapper around the same service.
+
+**Tech Stack:** Python 3.11, FastAPI, SQLAlchemy, PyYAML, pytest, ruff.
+
+---
+
+## Task 1: Shared Export Artifact Builder
+
+**Files:**
+- Modify: `app/services/borgmatic_service.py`
+- Modify: `app/routers/config.py`
+- Test: `tests/unit/test_borgmatic_service.py`
+- Test: `tests/unit/test_api_config_export.py`
+
+- [ ] Add failing service tests for a single-repository artifact returning YAML bytes and a `.yaml` filename.
+- [ ] Add failing service tests for a multi-repository artifact returning ZIP bytes and a `.zip` filename.
+- [ ] Implement a `BorgmaticExportArtifact` dataclass and `build_borgmatic_export_artifact(configs, timestamp=None)` helper.
+- [ ] Refactor `app/routers/config.py` to use the helper instead of duplicating YAML/ZIP packaging.
+- [ ] Run `pytest tests/unit/test_borgmatic_service.py tests/unit/test_api_config_export.py -q`.
+
+## Task 2: Local Export Script
+
+**Files:**
+- Create: `app/scripts/export_config.py`
+- Test: `tests/unit/test_export_config_script.py`
+
+- [ ] Add failing CLI tests for `--output /tmp/borg-ui-config.yaml` writing YAML when one repository is exported.
+- [ ] Add failing CLI tests for repeated `--repository-id` writing a ZIP when multiple repositories are exported.
+- [ ] Add failing CLI tests for `--output -` writing the artifact to stdout.
+- [ ] Add failing CLI tests for no repositories returning exit code `1` and an explanatory stderr message.
+- [ ] Implement argparse options: `--output`, `--repository-id`, `--no-schedules`.
+- [ ] Open and close `SessionLocal` inside `main()`.
+- [ ] Write parent directories for file outputs and write bytes atomically enough for normal pre-backup use by using a temporary sibling file followed by `replace()`.
+- [ ] Run `pytest tests/unit/test_export_config_script.py -q`.
+
+## Task 3: Documentation
+
+**Files:**
+- Modify: `docs/export-import.md`
+- Modify: `docs/disaster-recovery.md`
+
+- [ ] Document the local command, selected-repository options, stdout mode, and sensitivity of exports.
+- [ ] Add a disaster recovery pre-backup script example that stores the automated export beside the `/data` backup.
+- [ ] Preserve the guidance that `/data` remains the full Borg UI recovery boundary.
+
+## Task 4: Final Validation and Handoff
+
+**Files:**
+- Update Linear workpad only
+
+- [ ] Run targeted tests: `pytest tests/unit/test_borgmatic_service.py tests/unit/test_api_config_export.py tests/unit/test_export_config_script.py -q`.
+- [ ] Run backend gates: `ruff check app tests` and `ruff format --check app tests`.
+- [ ] Run local smoke: create a temporary SQLite database, seed one repository, and run `python3 -m app.scripts.export_config --output /tmp/borg-ui-config.yaml`.
+- [ ] Commit with the commit skill, push with the push skill, create/link the PR, apply the `symphony` PR label, sweep PR feedback/checks, and move the Linear issue to Human Review when green.

--- a/docs/engineering/specs/2026-05-30-automated-config-export.md
+++ b/docs/engineering/specs/2026-05-30-automated-config-export.md
@@ -1,0 +1,82 @@
+# Automated Configuration Export Spec
+
+## Problem
+
+Borg UI can export repository configuration from the web UI, but disaster
+recovery routines need an unattended export path. A pre-backup script should be
+able to capture the same borgmatic-compatible configuration data without a
+browser session or manual download.
+
+The current disaster recovery guidance still correctly says that `/data` is the
+full recovery boundary. The automated export is an additional migration and
+audit artifact, not a replacement for backing up `/data`, `.secret_key`, SSH
+material, logs, and the database.
+
+## Desired Outcome
+
+Operators can run a supported command from the Borg UI runtime environment to
+write the current export/import configuration artifact to a file or stdout. The
+artifact uses the same repository export service and YAML/ZIP shape as the web
+UI export endpoint.
+
+## Scope
+
+- Add a script module callable as:
+
+  ```bash
+  python3 -m app.scripts.export_config --output /path/to/borg-ui-config.export
+  ```
+
+- Support exporting all repositories by default.
+- Support selecting repositories with repeated `--repository-id` flags.
+- Support excluding schedule-derived retention data with `--no-schedules`.
+- Support `--output -` for stdout so shell pipelines can redirect the artifact.
+- Keep single-repository exports as YAML and multi-repository exports as ZIP,
+  matching the UI endpoint behavior.
+- Refactor shared artifact generation out of the FastAPI route so the route and
+  script cannot drift.
+- Document the command in export/import and disaster recovery docs, including
+  a pre-backup script example.
+
+## Out of Scope
+
+- Importing full Borg UI `/data` state from this export.
+- Exporting users, auth tokens, logs, encrypted SSH key material, rclone config,
+  or runtime-generated secrets.
+- Adding a new frontend UI flow.
+- Scheduling Borg UI's own `/data` backup automatically.
+
+## Design
+
+The backend already has `BorgmaticExportService.export_all_repositories()` for
+the web export flow. Add a small immutable artifact value object and a
+`build_borgmatic_export_artifact()` helper near that service. The helper takes
+the exported `(repository_name, config)` tuples and returns bytes, media type,
+and default filename.
+
+`app/routers/config.py` will call the helper and translate it into a FastAPI
+`Response`. `app/scripts/export_config.py` will open a `SessionLocal`, call the
+same service/helper pair, and write the bytes to a filesystem path or
+`stdout.buffer`.
+
+The script will return a non-zero exit code when no repositories match the
+requested selection or when the output path cannot be written. It will not
+perform authentication because it is intended to run locally inside the trusted
+Borg UI process/container context against the configured database.
+
+## Validation
+
+- Add service tests proving YAML/ZIP artifact generation is stable and shared.
+- Add script tests proving the CLI writes YAML for one repository, ZIP for
+  multiple repositories, honors `--repository-id`, and fails clearly when no
+  repositories are exportable.
+- Run targeted pytest for the service/API/script tests.
+- Run backend lint and format checks.
+- Run a local smoke command against a temporary SQLite database to prove the
+  documented module invocation writes an export file.
+
+## Notes
+
+- Upstream request: https://github.com/karanhudia/borg-ui/issues/538
+- Existing UI export endpoint: `POST /api/config/export/borgmatic`
+- Existing user docs: `docs/export-import.md`, `docs/disaster-recovery.md`

--- a/docs/export-import.md
+++ b/docs/export-import.md
@@ -29,6 +29,41 @@ A single repository exports as a YAML file. Multiple repositories export as a ZI
 
 Treat exports as sensitive. They can contain repository paths and stored passphrases.
 
+### Automated Export
+
+For unattended backups, run the export command from an environment that has the
+same Borg UI database settings as the app, such as inside the Borg UI container:
+
+```bash
+python3 -m app.scripts.export_config --output /data/config-exports/borg-ui-config.export
+```
+
+By default, the command exports all repositories and includes schedule-derived
+retention settings. A single repository export is YAML. Multiple repository
+exports are ZIP files containing one YAML file per repository.
+
+Export selected repositories by repeating `--repository-id`:
+
+```bash
+python3 -m app.scripts.export_config \
+  --repository-id 1 \
+  --repository-id 2 \
+  --output /data/config-exports/selected-borg-ui-config.zip
+```
+
+Exclude schedule-derived retention settings when you only want repository
+configuration:
+
+```bash
+python3 -m app.scripts.export_config --no-schedules --output /data/config-exports/repositories.export
+```
+
+Write the artifact to stdout when a backup script should choose the destination:
+
+```bash
+python3 -m app.scripts.export_config --output - > /backup/borg-ui-config.export
+```
+
 ## Import
 
 Imports accept:

--- a/tests/unit/test_borgmatic_service.py
+++ b/tests/unit/test_borgmatic_service.py
@@ -2,11 +2,16 @@
 Tests for borgmatic export/import service.
 """
 
+from datetime import datetime
+import io
+import zipfile
+
 import pytest
 import yaml
 from app.services.borgmatic_service import (
     BorgmaticExportService,
     BorgmaticImportService,
+    build_borgmatic_export_artifact,
 )
 from app.database.models import Repository, ScheduledJob
 
@@ -121,6 +126,56 @@ class TestBorgmaticExportService:
 
         # New flat format - path is returned as-is (already full SSH URL)
         assert config["repositories"] == [ssh_url]
+
+
+class TestBorgmaticExportArtifact:
+    """Tests for packaging exported borgmatic configs for download or CLI use."""
+
+    def test_single_repository_artifact_is_yaml_with_timestamped_filename(self):
+        artifact = build_borgmatic_export_artifact(
+            [
+                (
+                    "Test Repo",
+                    {
+                        "source_directories": ["/srv/app"],
+                        "repositories": ["/backups/test-repo"],
+                    },
+                )
+            ],
+            timestamp=datetime(2026, 5, 30, 7, 30, 0),
+        )
+
+        assert artifact.media_type == "application/x-yaml"
+        assert artifact.filename == "2026-05-30_07-30-00_testrepo.yaml"
+        assert yaml.safe_load(artifact.content) == {
+            "source_directories": ["/srv/app"],
+            "repositories": ["/backups/test-repo"],
+        }
+
+    def test_multiple_repository_artifact_is_zip_with_one_yaml_per_repository(self):
+        artifact = build_borgmatic_export_artifact(
+            [
+                ("Repo One", {"repositories": ["/backups/one"]}),
+                ("Repo Two", {"repositories": ["/backups/two"]}),
+            ],
+            timestamp=datetime(2026, 5, 30, 7, 30, 0),
+        )
+
+        assert artifact.media_type == "application/zip"
+        assert artifact.filename == "2026-05-30_07-30-00_borgmatic-configs.zip"
+
+        with zipfile.ZipFile(io.BytesIO(artifact.content)) as archive:
+            assert sorted(archive.namelist()) == ["repoone.yaml", "repotwo.yaml"]
+            assert yaml.safe_load(archive.read("repoone.yaml")) == {
+                "repositories": ["/backups/one"]
+            }
+            assert yaml.safe_load(archive.read("repotwo.yaml")) == {
+                "repositories": ["/backups/two"]
+            }
+
+    def test_empty_export_artifact_raises_value_error(self):
+        with pytest.raises(ValueError, match="No repositories found to export"):
+            build_borgmatic_export_artifact([])
 
 
 class TestBorgmaticImportService:

--- a/tests/unit/test_borgmatic_service.py
+++ b/tests/unit/test_borgmatic_service.py
@@ -173,6 +173,24 @@ class TestBorgmaticExportArtifact:
                 "repositories": ["/backups/two"]
             }
 
+    def test_multiple_repository_artifact_disambiguates_duplicate_safe_names(self):
+        artifact = build_borgmatic_export_artifact(
+            [
+                ("Repo One", {"repositories": ["/backups/one"]}),
+                ("RepoOne", {"repositories": ["/backups/two"]}),
+            ],
+            timestamp=datetime(2026, 5, 30, 7, 30, 0),
+        )
+
+        with zipfile.ZipFile(io.BytesIO(artifact.content)) as archive:
+            assert sorted(archive.namelist()) == ["repoone-2.yaml", "repoone.yaml"]
+            assert yaml.safe_load(archive.read("repoone.yaml")) == {
+                "repositories": ["/backups/one"]
+            }
+            assert yaml.safe_load(archive.read("repoone-2.yaml")) == {
+                "repositories": ["/backups/two"]
+            }
+
     def test_empty_export_artifact_raises_value_error(self):
         with pytest.raises(ValueError, match="No repositories found to export"):
             build_borgmatic_export_artifact([])

--- a/tests/unit/test_export_config_script.py
+++ b/tests/unit/test_export_config_script.py
@@ -1,0 +1,125 @@
+import io
+import zipfile
+
+import yaml
+
+from app.database.models import Repository, ScheduledJob
+from app.scripts import export_config
+
+
+def _add_repository(db_session, name: str, path: str) -> Repository:
+    repository = Repository(
+        name=name,
+        path=path,
+        repository_type="local",
+        encryption="repokey",
+        compression="lz4",
+    )
+    db_session.add(repository)
+    db_session.commit()
+    db_session.refresh(repository)
+    return repository
+
+
+def test_cli_writes_yaml_file_for_single_repository(tmp_path, db_session):
+    repository = _add_repository(db_session, "App Config", "/backups/app-config")
+    output_path = tmp_path / "borg-ui-config.yaml"
+    stderr = io.StringIO()
+
+    exit_code = export_config.main(
+        ["--output", str(output_path)],
+        session_factory=lambda: db_session,
+        stderr=stderr,
+    )
+
+    assert exit_code == 0
+    assert stderr.getvalue() == ""
+    assert yaml.safe_load(output_path.read_text(encoding="utf-8")) == {
+        "repositories": [repository.path],
+        "compression": "lz4",
+        "borg_ui_name": "App Config",
+    }
+
+
+def test_cli_writes_zip_file_for_selected_repositories(tmp_path, db_session):
+    first = _add_repository(db_session, "App One", "/backups/app-one")
+    second = _add_repository(db_session, "App Two", "/backups/app-two")
+    _add_repository(db_session, "Ignored App", "/backups/ignored")
+    output_path = tmp_path / "selected-configs.zip"
+
+    exit_code = export_config.main(
+        [
+            "--repository-id",
+            str(first.id),
+            "--repository-id",
+            str(second.id),
+            "--output",
+            str(output_path),
+        ],
+        session_factory=lambda: db_session,
+    )
+
+    assert exit_code == 0
+    with zipfile.ZipFile(output_path) as archive:
+        assert sorted(archive.namelist()) == ["appone.yaml", "apptwo.yaml"]
+        assert yaml.safe_load(archive.read("appone.yaml"))["repositories"] == [
+            "/backups/app-one"
+        ]
+        assert yaml.safe_load(archive.read("apptwo.yaml"))["repositories"] == [
+            "/backups/app-two"
+        ]
+
+
+def test_cli_can_write_single_repository_export_to_stdout(db_session):
+    repository = _add_repository(db_session, "Stdout App", "/backups/stdout")
+    stdout = io.BytesIO()
+
+    exit_code = export_config.main(
+        ["--output", "-"],
+        session_factory=lambda: db_session,
+        stdout=stdout,
+    )
+
+    assert exit_code == 0
+    assert yaml.safe_load(stdout.getvalue())["repositories"] == [repository.path]
+
+
+def test_cli_no_schedules_excludes_schedule_retention(tmp_path, db_session):
+    repository = _add_repository(db_session, "Scheduled App", "/backups/scheduled")
+    db_session.add(
+        ScheduledJob(
+            name="scheduled-app-backup",
+            cron_expression="0 2 * * *",
+            repository=repository.path,
+            enabled=True,
+            prune_keep_daily=7,
+            run_prune_after=True,
+            run_compact_after=False,
+        )
+    )
+    db_session.commit()
+    output_path = tmp_path / "no-schedules.yaml"
+
+    exit_code = export_config.main(
+        ["--no-schedules", "--output", str(output_path)],
+        session_factory=lambda: db_session,
+    )
+
+    assert exit_code == 0
+    data = yaml.safe_load(output_path.read_text(encoding="utf-8"))
+    assert "keep_daily" not in data
+
+
+def test_cli_returns_error_when_no_repositories_match(tmp_path, db_session):
+    stderr = io.StringIO()
+    output_path = tmp_path / "missing.yaml"
+
+    exit_code = export_config.main(
+        ["--repository-id", "999", "--output", str(output_path)],
+        session_factory=lambda: db_session,
+        stderr=stderr,
+    )
+
+    assert exit_code == 1
+    assert "No repositories found to export" in stderr.getvalue()
+    assert not output_path.exists()


### PR DESCRIPTION
## Description
Adds a supported local export command for unattended Borg UI configuration backups. The new `app.scripts.export_config` module reuses the same borgmatic export service and YAML/ZIP packaging as the web UI export endpoint, so pre-backup scripts can capture repository configuration without a browser session.

Also refactors the FastAPI export route to use the shared artifact builder, disambiguates colliding ZIP member names for multi-repository exports, and updates export/import plus disaster recovery docs with automated export examples and recovery-boundary caveats.

## Related Issue
Fixes #538
Linear: BOR-94

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [x] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `pytest tests/unit/test_borgmatic_service.py::TestBorgmaticExportArtifact::test_multiple_repository_artifact_disambiguates_duplicate_safe_names -q`
- `pytest tests/unit/test_borgmatic_service.py tests/unit/test_api_config_export.py tests/unit/test_export_config_script.py -q`
- `ruff check app tests`
- `ruff format --check app tests`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- Local smoke with a seeded SQLite database using the project Python interpreter and `python -m app.scripts.export_config --output .codex/tmp/bor-94-smoke/borg-ui-config.export`

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; this is a backend/script and documentation change.

## Additional Context
The automated export is a disaster recovery aid, not a replacement for backing up Borg UI's `/data` volume and `.secret_key`. The docs keep that boundary explicit.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
