### PR TITLE
Clarify BorgBase setup documentation

### DIFF
--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -72,15 +72,24 @@ Repository path: /./repo
 ```
 
 Keep the `/./repo` path from BorgBase. Do not shorten it to `/repo`; the `./`
-segment is part of the hosted SSH path Borg uses for that repository.
+segment is part of the hosted SSH path Borg uses for that repository. The
+repository name may appear as `repo` in BorgBase, but Borg UI should receive the
+path form from the SSH URL.
+
+BorgBase **SFTP Access** is not required for this flow. Borg UI uses the Borg
+repository over SSH with the public key you authorize in BorgBase.
 
 Typical flow:
 
-1. Create or import the Borg UI system SSH key.
-2. Add the Borg UI public key to BorgBase.
-3. Create or select the repository in BorgBase.
-4. Add a Remote Machine in Borg UI using the host, username, port, and default path from the BorgBase URL.
-5. Create a remote repository or use Import Existing with the same repository path.
+1. In Borg UI, go to Remote Machines and create or import the system SSH key.
+   Copy the full public key value.
+2. In BorgBase, add that public key under SSH Keys and remember the key name.
+3. Create or select the BorgBase repository. Grant the key full access, leave
+   SFTP Access disabled, and copy the SSH repository URL.
+4. Add a manual Remote Machine in Borg UI using the host, username, port, and
+   default path from the BorgBase URL.
+5. Create a full remote repository or use Import Existing. Select Remote Client,
+   choose the SSH connection, and enter the same repository path from the URL.
 6. Save, then verify that archives can be listed or that repository creation succeeds.
 
 ## Hetzner Storage Box

--- a/docs/ssh-keys.md
+++ b/docs/ssh-keys.md
@@ -100,8 +100,11 @@ ssh://abcd@abcd.repo.borgbase.com/./repo
 ```
 
 Use `/./repo` as the Remote Machine default path and repository path. Do not
-shorten it to `/repo`. See [Provider Guides](provider-guides) for BorgBase,
-Hetzner Storage Box, Synology, Unraid, and other hosted or NAS examples.
+shorten it to `/repo`. Add Borg UI's full public key in BorgBase SSH Keys and
+grant that key access to the repository; BorgBase SFTP Access is not required
+for Borg UI's Borg-over-SSH repository setup. See
+[Provider Guides](provider-guides) for BorgBase, Hetzner Storage Box, Synology,
+Unraid, and other hosted or NAS examples.
 
 ## Remote Direct Backups
 


### PR DESCRIPTION
## Description
- Clarifies the BorgBase provider guide with the full public-key grant flow.
- Documents that BorgBase SFTP Access is not required for Borg UI Borg-over-SSH repositories.
- Keeps the existing `/./repo` path guidance and explains that Borg UI should use the path form from the BorgBase SSH URL.

## Related Issue
- Linear: BOR-91
- GitHub context: https://github.com/karanhudia/borg-ui/issues/212#issuecomment-4568711448

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Local validation run:
- `rg -n "BorgBase|/\./repo|SFTP Access|full public key|Remote Client" docs/provider-guides.md docs/ssh-keys.md`
- `git diff -- docs/provider-guides.md docs/ssh-keys.md`
- `git diff --check`
- `cd docs && npm ci && npm run build`

GitHub PR checks passed after push. Local backend, frontend, and unit-test suites were not run because this is a documentation-only change.

## Checklist
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; documentation-only change.

## Additional Context
The referenced GitHub comment included BorgBase setup details that were only partially covered by the existing docs. This PR preserves the current `/./repo` recommendation and adds the missing public-key and BorgBase SFTP Access guidance.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
