### PR TITLE
Always run visual reports, clean closed PRs, and filter noise

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -3,7 +3,7 @@ name: GitHub Pages Visual Regression
 on:
   pull_request:
     branches: [main, develop]
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, closed]
     paths:
       - "frontend/.storybook/**"
       - "frontend/scripts/**"
@@ -28,8 +28,8 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-visual-state
+  cancel-in-progress: false
 
 env:
   NODE_VERSION: "22"
@@ -38,7 +38,7 @@ env:
 jobs:
   visuals:
     name: Storybook Visual Report
-    if: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'run-visuals') && github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -48,19 +48,16 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v5
-        with:
-          path: source
-          persist-credentials: false
-
       - name: Resolve visual mode
         id: visual_mode
         env:
+          EVENT_ACTION: ${{ github.event.action || '' }}
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number || '' }}
         run: |
-          if [ "$EVENT_NAME" = "pull_request" ] || [ -n "$PR_NUMBER" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ] && [ "$EVENT_ACTION" = "closed" ]; then
+            mode="cleanup"
+          elif [ "$EVENT_NAME" = "pull_request" ] || [ -n "$PR_NUMBER" ]; then
             mode="pr"
           else
             mode="baseline"
@@ -69,7 +66,15 @@ jobs:
           echo "mode=$mode" >> "$GITHUB_OUTPUT"
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
+      - name: Checkout source
+        if: ${{ steps.visual_mode.outputs.mode != 'cleanup' }}
+        uses: actions/checkout@v5
+        with:
+          path: source
+          persist-credentials: false
+
       - name: Set up Node.js ${{ env.NODE_VERSION }}
+        if: ${{ steps.visual_mode.outputs.mode != 'cleanup' }}
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -77,14 +82,17 @@ jobs:
           cache-dependency-path: source/frontend/package-lock.json
 
       - name: Install frontend dependencies
+        if: ${{ steps.visual_mode.outputs.mode != 'cleanup' }}
         working-directory: source/frontend
         run: npm ci
 
       - name: Install Playwright Chromium
+        if: ${{ steps.visual_mode.outputs.mode != 'cleanup' }}
         working-directory: source/frontend
         run: PLAYWRIGHT_BROWSERS_PATH=0 npx playwright install --with-deps chromium
 
       - name: Capture Storybook snapshots
+        if: ${{ steps.visual_mode.outputs.mode != 'cleanup' }}
         working-directory: source/frontend
         run: npm run visual:screenshots
         env:
@@ -132,6 +140,11 @@ jobs:
           rm -rf visual-state/visual/baseline
           mkdir -p visual-state/visual/baseline
           cp -R visual-actual/. visual-state/visual/baseline/
+
+      - name: Remove closed pull request visual report
+        if: ${{ steps.visual_mode.outputs.mode == 'cleanup' }}
+        run: |
+          rm -rf visual-state/visual/reports/pr-${{ steps.visual_mode.outputs.pr_number }}
 
       - name: Commit visual state
         working-directory: visual-state

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -123,6 +123,15 @@ jobs:
 
           mkdir -p visual/baseline visual/reports
 
+      - name: Resolve pull request changed files
+        if: ${{ steps.visual_mode.outputs.mode == 'pr' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.visual_mode.outputs.pr_number }}
+        run: |
+          gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename' > "$GITHUB_WORKSPACE/visual-pr-files.txt"
+
       - name: Generate pull request visual report
         if: ${{ steps.visual_mode.outputs.mode == 'pr' }}
         working-directory: source/frontend
@@ -130,9 +139,11 @@ jobs:
         env:
           VISUAL_BASELINE_DIR: ${{ github.workspace }}/visual-state/visual/baseline
           VISUAL_ACTUAL_DIR: ${{ github.workspace }}/visual-actual
+          VISUAL_CHANGED_FILES_PATH: ${{ github.workspace }}/visual-pr-files.txt
           VISUAL_REPORT_DIR: ${{ github.workspace }}/visual-state/visual/reports/pr-${{ steps.visual_mode.outputs.pr_number }}
           VISUAL_REPORT_TITLE: "PR #${{ steps.visual_mode.outputs.pr_number }} visual report"
           VISUAL_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          VISUAL_UNRELATED_DIFF_THRESHOLD: "0.001"
 
       - name: Update main visual baseline
         if: ${{ steps.visual_mode.outputs.mode == 'baseline' }}

--- a/docs/engineering/plans/2026-06-01-github-pages-visual-regression.md
+++ b/docs/engineering/plans/2026-06-01-github-pages-visual-regression.md
@@ -1,6 +1,6 @@
 # GitHub Pages Visual Regression Implementation Plan
 
-**Goal:** Replace Argos with opt-in GitHub Pages visual reports and automatic
+**Goal:** Replace Argos with automatic GitHub Pages visual reports and automatic
 `main` baselines.
 
 **Architecture:** Reuse the existing Storybook screenshot capture script. Add a
@@ -46,14 +46,15 @@ Vitest, `pngjs`, Storybook, Playwright.
 
 - [x] Update workflow tests to expect GitHub Pages visual regression instead of
       Argos upload.
-- [x] Replace the Argos workflow with a label-gated GitHub Pages visual workflow.
+- [x] Replace the Argos workflow with an automatic GitHub Pages visual workflow.
+- [x] Remove closed pull request report directories from `/visual/reports`.
 - [x] Update `pages.yml` so docs deployments preserve `/visual`.
 - [x] Update package scripts from `argos:*` to `visual:*`.
 - [x] Run `cd frontend && npm run test -- scripts/argos-workflow-config.test.mjs --run`.
 
 ### Task 4: Docs and Verification
 
-- [x] Update `docs/testing.md` with the label/manual review flow and Pages report
+- [x] Update `docs/testing.md` with the automatic review flow and Pages report
       URL behavior.
 - [x] Run `git diff --check`.
 - [x] Run focused frontend script tests.

--- a/docs/engineering/plans/2026-06-01-github-pages-visual-regression.md
+++ b/docs/engineering/plans/2026-06-01-github-pages-visual-regression.md
@@ -34,6 +34,8 @@ Vitest, `pngjs`, Storybook, Playwright.
       changed, added, removed, and unchanged summary counts.
 - [x] Implement `visual-regression-report.mjs` with `compareVisualSnapshots()`,
       diff PNG output, `summary.json`, and static `index.html`.
+- [x] Filter tiny unrelated PR drift while preserving small diffs for touched
+      Storybook snapshots.
 - [x] Run `cd frontend && npm run test -- scripts/visual-regression-report.test.mjs --run`.
 
 ### Task 2: PR Body Section

--- a/docs/engineering/specs/2026-06-01-github-pages-visual-regression.md
+++ b/docs/engineering/specs/2026-06-01-github-pages-visual-regression.md
@@ -19,6 +19,8 @@ Replace paid Argos uploads with a GitHub-only visual regression workflow that:
 - No user should need to download a workflow artifact to review visual changes.
 - The report must show before, after, and diff images for changed screenshots,
   plus added and removed screenshots.
+- PR reports should suppress tiny unrelated pixel drift below 0.1% while keeping
+  small changes in screenshots tied to files touched by the PR.
 - The existing docs site must remain intact when visual reports are deployed.
 - The workflow should use GitHub Actions, GitHub Pages, and repository storage
   only. No Argos, Chromatic, Percy, or other paid visual SaaS.
@@ -29,7 +31,8 @@ Replace paid Argos uploads with a GitHub-only visual regression workflow that:
 
 - `frontend/scripts/visual-regression-report.mjs` compares baseline and actual
   PNG directories, emits `summary.json`, copies review images, creates diff
-  PNGs, and writes a static `index.html` report.
+  PNGs, filters low-ratio drift outside changed Storybook areas, and writes a
+  static `index.html` report.
 - `frontend/scripts/visual-pr-description.mjs` builds and replaces a marked PR
   body section using the report summary and deployed Pages URL.
 - `.github/workflows/visual-regression.yml` runs on `main`, same-repository PRs,

--- a/docs/engineering/specs/2026-06-01-github-pages-visual-regression.md
+++ b/docs/engineering/specs/2026-06-01-github-pages-visual-regression.md
@@ -12,8 +12,10 @@ Replace paid Argos uploads with a GitHub-only visual regression workflow that:
 
 ## Requirements
 
-- PR visual checks are opt-in by label (`run-visuals`) or manual dispatch.
+- Same-repository PR visual checks run automatically for frontend changes.
 - `main` pushes update the visual baseline automatically.
+- Closed or merged PRs remove their `/visual/reports/pr-<number>/` report
+  directory from the visual state branch and GitHub Pages.
 - No user should need to download a workflow artifact to review visual changes.
 - The report must show before, after, and diff images for changed screenshots,
   plus added and removed screenshots.
@@ -30,11 +32,12 @@ Replace paid Argos uploads with a GitHub-only visual regression workflow that:
   PNGs, and writes a static `index.html` report.
 - `frontend/scripts/visual-pr-description.mjs` builds and replaces a marked PR
   body section using the report summary and deployed Pages URL.
-- `.github/workflows/visual-regression.yml` runs on `main`, labeled PRs, and
-  manual dispatch. It generates screenshots, maintains a
+- `.github/workflows/visual-regression.yml` runs on `main`, same-repository PRs,
+  PR close events, and manual dispatch. It generates screenshots, maintains a
   `visual-regression-state` branch containing `/visual/baseline` and
   `/visual/reports`, builds the docs site from `main`, overlays `/visual`, and
-  deploys the full Pages artifact.
+  deploys the full Pages artifact. On PR close events, it deletes the PR report
+  directory and redeploys Pages without recapturing screenshots.
 - `.github/workflows/pages.yml` overlays `/visual` from the state branch before
   docs deploys, so regular docs deployments do not wipe visual reports.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -32,17 +32,17 @@ npm run build
 ### Storybook Visual Regression
 
 Storybook visual snapshots are handled by the `GitHub Pages Visual Regression`
-workflow. Same-repository pull request runs are opt-in: add the `run-visuals`
-label to a PR, or rerun the workflow manually with the PR number. The workflow
-also runs on `main` pushes that touch frontend source, stories, Storybook
-config, frontend scripts, or frontend package metadata.
+workflow. Same-repository pull request runs happen automatically for frontend
+changes. The workflow also runs on `main` pushes that touch frontend source,
+stories, Storybook config, frontend scripts, or frontend package metadata.
 
 The workflow builds Storybook, captures screenshots with Playwright, compares
 them against the baseline stored on the `visual-regression-state` branch, and
 publishes a static report under `/visual/reports/pr-<number>/` on GitHub Pages.
 The PR description is updated with the report link plus changed, added, and
 removed screenshot lists. Merging to `main` refreshes the baseline under
-`/visual/baseline/` for future PRs.
+`/visual/baseline/` for future PRs. When a pull request is closed or merged, its
+`/visual/reports/pr-<number>/` report directory is removed from GitHub Pages.
 
 For local proof runs:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -39,6 +39,9 @@ stories, Storybook config, frontend scripts, or frontend package metadata.
 The workflow builds Storybook, captures screenshots with Playwright, compares
 them against the baseline stored on the `visual-regression-state` branch, and
 publishes a static report under `/visual/reports/pr-<number>/` on GitHub Pages.
+For PR reports, tiny pixel drift below 0.1% is treated as unchanged unless the
+workflow can map that screenshot to a Storybook file touched by the PR; touched
+stories still appear even when their visual diff is small.
 The PR description is updated with the report link plus changed, added, and
 removed screenshot lists. Merging to `main` refreshes the baseline under
 `/visual/baseline/` for future PRs. When a pull request is closed or merged, its

--- a/frontend/scripts/argos-workflow-config.test.mjs
+++ b/frontend/scripts/argos-workflow-config.test.mjs
@@ -15,7 +15,7 @@ async function readText(relativePath) {
 }
 
 describe('GitHub Pages visual regression workflow', () => {
-  it('wires frontend scripts and CI to publish opt-in visual reports on GitHub Pages', async () => {
+  it('wires frontend scripts and CI to publish automatic visual reports on GitHub Pages', async () => {
     const packageJson = JSON.parse(await readFile(path.join(frontendRoot, 'package.json'), 'utf8'))
     const workflow = await readText('.github/workflows/visual-regression.yml')
     const pagesWorkflow = await readText('.github/workflows/pages.yml')
@@ -34,8 +34,10 @@ describe('GitHub Pages visual regression workflow', () => {
 
     expect(workflow).toContain('name: GitHub Pages Visual Regression')
     expect(workflow).toContain('pull_request:')
-    expect(workflow).toContain('types: [opened, synchronize, reopened, labeled]')
-    expect(workflow).toContain('run-visuals')
+    expect(workflow).toContain('types: [opened, synchronize, reopened, closed]')
+    expect(workflow).not.toContain('run-visuals')
+    expect(workflow).toContain('group: ${{ github.workflow }}-visual-state')
+    expect(workflow).toContain('cancel-in-progress: false')
     expect(workflow).toContain('push:')
     expect(workflow).toContain('frontend/src/**')
     expect(workflow).toContain('frontend/.storybook/**')
@@ -46,6 +48,10 @@ describe('GitHub Pages visual regression workflow', () => {
     expect(workflow).toContain('npm run visual:screenshots')
     expect(workflow).toContain('npm run visual:report')
     expect(workflow).toContain('node scripts/visual-pr-description.mjs')
+    expect(workflow).toContain('mode="cleanup"')
+    expect(workflow).toContain(
+      'rm -rf visual-state/visual/reports/pr-${{ steps.visual_mode.outputs.pr_number }}'
+    )
     expect(workflow).toContain('actions/deploy-pages@v4')
     expect(workflow).toContain('GITHUB_TOKEN: ${{ github.token }}')
     expect(workflow).toContain('pull-requests: write')

--- a/frontend/scripts/argos-workflow-config.test.mjs
+++ b/frontend/scripts/argos-workflow-config.test.mjs
@@ -47,6 +47,9 @@ describe('GitHub Pages visual regression workflow', () => {
     expect(workflow).toContain('npx playwright install --with-deps chromium')
     expect(workflow).toContain('npm run visual:screenshots')
     expect(workflow).toContain('npm run visual:report')
+    expect(workflow).toContain('Resolve pull request changed files')
+    expect(workflow).toContain('VISUAL_CHANGED_FILES_PATH')
+    expect(workflow).toContain('VISUAL_UNRELATED_DIFF_THRESHOLD: "0.001"')
     expect(workflow).toContain('node scripts/visual-pr-description.mjs')
     expect(workflow).toContain('mode="cleanup"')
     expect(workflow).toContain(

--- a/frontend/scripts/visual-regression-report.mjs
+++ b/frontend/scripts/visual-regression-report.mjs
@@ -12,9 +12,40 @@ const { PNG } = pngjs
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const frontendRoot = path.resolve(__dirname, '..')
+const repoRoot = path.resolve(frontendRoot, '..')
 
 function normalizeFileName(fileName) {
   return fileName.split(path.sep).join('/')
+}
+
+function normalizeRelativePath(fileName) {
+  return normalizeFileName(fileName).replace(/^\.\//, '')
+}
+
+function storyTitleToSnapshotPrefix(title) {
+  return title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function snapshotMatchesPrefix(fileName, prefix) {
+  const snapshotName = fileName.endsWith('.png') ? fileName.slice(0, -4) : fileName
+  return snapshotName === prefix || snapshotName.startsWith(`${prefix}--`)
+}
+
+function parseThreshold(value, fallback = 0) {
+  if (value === undefined || value === '') {
+    return fallback
+  }
+
+  const parsed = Number.parseFloat(value)
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback
+  }
+
+  return parsed
 }
 
 function escapeHtml(value) {
@@ -74,6 +105,73 @@ async function listPngFiles(rootDir, currentDir = rootDir) {
 
 async function readPng(filePath) {
   return PNG.sync.read(await readFile(filePath))
+}
+
+async function readLines(filePath) {
+  if (!filePath) {
+    return []
+  }
+
+  const content = await readFile(filePath, 'utf8')
+  return content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+async function readStoryTitle(storyPath) {
+  try {
+    const storySource = await readFile(storyPath, 'utf8')
+    return storySource.match(/title:\s*['"`]([^'"`]+)['"`]/)?.[1] || ''
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return ''
+    }
+
+    throw error
+  }
+}
+
+async function snapshotPrefixForChangedFile(fileName, sourceRoot) {
+  const relativeFileName = normalizeRelativePath(fileName)
+
+  if (!relativeFileName.startsWith('frontend/src/')) {
+    return ''
+  }
+
+  const sourcePath = path.join(sourceRoot, relativeFileName)
+  const extension = path.extname(relativeFileName)
+  const basename = path.basename(relativeFileName, extension)
+  const candidateStoryPaths = relativeFileName.includes('.stories.')
+    ? [sourcePath]
+    : ['.tsx', '.ts', '.jsx', '.js'].map((storyExtension) =>
+        path.join(path.dirname(sourcePath), `${basename}.stories${storyExtension}`)
+      )
+
+  for (const storyPath of candidateStoryPaths) {
+    const title = await readStoryTitle(storyPath)
+
+    if (title) {
+      return storyTitleToSnapshotPrefix(title)
+    }
+  }
+
+  return ''
+}
+
+async function resolveRelevantSnapshotPrefixes({ changedFiles, changedFilesPath, sourceRoot }) {
+  const fileNames = [...(changedFiles || []), ...(await readLines(changedFilesPath))]
+  const prefixes = new Set()
+
+  for (const fileName of fileNames) {
+    const prefix = await snapshotPrefixForChangedFile(fileName, sourceRoot)
+
+    if (prefix) {
+      prefixes.add(prefix)
+    }
+  }
+
+  return prefixes
 }
 
 async function copySnapshot(sourceRoot, outputDir, kind, fileName) {
@@ -483,6 +581,10 @@ export async function compareVisualSnapshots({
   outputDir,
   reportUrl = '',
   metadata = {},
+  sourceRoot = repoRoot,
+  changedFiles = [],
+  changedFilesPath = '',
+  unrelatedDiffThreshold = 0,
 } = {}) {
   if (!baselineDir) {
     throw new Error('compareVisualSnapshots requires a baselineDir.')
@@ -504,6 +606,12 @@ export async function compareVisualSnapshots({
   const changed = []
   const removed = []
   const unchanged = []
+  const relevantSnapshotPrefixes = await resolveRelevantSnapshotPrefixes({
+    changedFiles,
+    changedFilesPath,
+    sourceRoot,
+  })
+  const relevantSnapshotPrefixList = Array.from(relevantSnapshotPrefixes)
 
   await rm(outputDir, { force: true, recursive: true })
   await mkdir(outputDir, { recursive: true })
@@ -532,8 +640,18 @@ export async function compareVisualSnapshots({
     const baseline = await readPng(baselinePath)
     const actual = await readPng(actualPath)
     const { diff, diffPixels, dimensionsChanged, totalPixels } = makeDiffPng(baseline, actual)
+    const diffRatio = totalPixels === 0 ? 0 : diffPixels / totalPixels
+    const isRelevantSnapshot = relevantSnapshotPrefixList.some((prefix) =>
+      snapshotMatchesPrefix(fileName, prefix)
+    )
+    const isTinyUnrelatedDiff =
+      unrelatedDiffThreshold > 0 &&
+      !isRelevantSnapshot &&
+      !dimensionsChanged &&
+      diffPixels > 0 &&
+      diffRatio <= unrelatedDiffThreshold
 
-    if (diffPixels === 0 && !dimensionsChanged) {
+    if ((diffPixels === 0 && !dimensionsChanged) || isTinyUnrelatedDiff) {
       unchanged.push({ fileName })
       continue
     }
@@ -551,7 +669,7 @@ export async function compareVisualSnapshots({
       diffPath,
       diffPixels,
       totalPixels,
-      diffRatio: totalPixels === 0 ? 0 : diffPixels / totalPixels,
+      diffRatio,
       dimensionsChanged,
       baseline: {
         width: baseline.width,
@@ -604,6 +722,13 @@ function cliOptions(args = process.argv.slice(2), env = process.env) {
       readCliValue(args, '--output-dir') ||
       env.VISUAL_REPORT_DIR ||
       path.resolve(frontendRoot, 'visual-report'),
+    sourceRoot: readCliValue(args, '--source-root') || env.VISUAL_SOURCE_ROOT || repoRoot,
+    changedFilesPath:
+      readCliValue(args, '--changed-files-path') || env.VISUAL_CHANGED_FILES_PATH || '',
+    unrelatedDiffThreshold: parseThreshold(
+      readCliValue(args, '--unrelated-diff-threshold') || env.VISUAL_UNRELATED_DIFF_THRESHOLD,
+      0
+    ),
     reportUrl: readCliValue(args, '--report-url') || env.VISUAL_REPORT_URL || '',
     metadata: {
       title: readCliValue(args, '--title') || env.VISUAL_REPORT_TITLE || 'Visual regression report',

--- a/frontend/scripts/visual-regression-report.test.mjs
+++ b/frontend/scripts/visual-regression-report.test.mjs
@@ -1,5 +1,5 @@
 import { createWriteStream } from 'node:fs'
-import { mkdir, mkdtemp, readFile, stat } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
@@ -27,6 +27,20 @@ const white = [255, 255, 255, 255]
 const black = [0, 0, 0, 255]
 const red = [255, 0, 0, 255]
 const blue = [0, 0, 255, 255]
+
+function filledPixels(color, width, height) {
+  return Array.from({ length: width * height }, () => color)
+}
+
+function pixelsWithChanges(baseColor, changedColor, changedPixels, width, height) {
+  const pixels = filledPixels(baseColor, width, height)
+
+  for (let index = 0; index < changedPixels; index += 1) {
+    pixels[index] = changedColor
+  }
+
+  return pixels
+}
 
 describe('compareVisualSnapshots', () => {
   it('classifies changed, added, removed, and unchanged screenshots', async () => {
@@ -97,5 +111,121 @@ describe('compareVisualSnapshots', () => {
       fileName: 'resized.png',
       dimensionsChanged: true,
     })
+  })
+
+  it('ignores tiny unrelated drift while keeping screenshots linked to changed stories', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'borg-visual-relevance-'))
+    const baselineDir = path.join(root, 'baseline')
+    const actualDir = path.join(root, 'actual')
+    const outputDir = path.join(root, 'report')
+    const sourceRoot = path.join(root, 'source')
+    const storyPath = path.join(sourceRoot, 'frontend/src/components/Thing.stories.tsx')
+
+    await mkdir(path.dirname(storyPath), { recursive: true })
+    await writeFile(storyPath, "export default { title: 'Components/Thing' }\n")
+
+    await writePng(
+      path.join(baselineDir, 'components-thing--minor-icon.png'),
+      filledPixels(white, 100, 100),
+      100,
+      100
+    )
+    await writePng(
+      path.join(actualDir, 'components-thing--minor-icon.png'),
+      pixelsWithChanges(white, red, 1, 100, 100),
+      100,
+      100
+    )
+
+    await writePng(
+      path.join(baselineDir, 'components-other--tiny-drift.png'),
+      filledPixels(white, 100, 100),
+      100,
+      100
+    )
+    await writePng(
+      path.join(actualDir, 'components-other--tiny-drift.png'),
+      pixelsWithChanges(white, blue, 1, 100, 100),
+      100,
+      100
+    )
+
+    await writePng(
+      path.join(baselineDir, 'components-other--large-change.png'),
+      filledPixels(white, 100, 100),
+      100,
+      100
+    )
+    await writePng(
+      path.join(actualDir, 'components-other--large-change.png'),
+      pixelsWithChanges(white, red, 20, 100, 100),
+      100,
+      100
+    )
+
+    const summary = await compareVisualSnapshots({
+      baselineDir,
+      actualDir,
+      outputDir,
+      sourceRoot,
+      changedFiles: ['frontend/src/components/Thing.stories.tsx'],
+      unrelatedDiffThreshold: 0.001,
+    })
+
+    expect(summary.changed.map((item) => item.fileName)).toEqual([
+      'components-other--large-change.png',
+      'components-thing--minor-icon.png',
+    ])
+    expect(summary.unchanged).toContainEqual({ fileName: 'components-other--tiny-drift.png' })
+    expect(summary.totals.changed).toBe(2)
+    expect(summary.totals.unchanged).toBe(1)
+  })
+
+  it('uses the tiny drift threshold when no changed story can be mapped', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'borg-visual-unmapped-'))
+    const baselineDir = path.join(root, 'baseline')
+    const actualDir = path.join(root, 'actual')
+    const outputDir = path.join(root, 'report')
+
+    await writePng(
+      path.join(baselineDir, 'components-one--tiny-drift.png'),
+      filledPixels(white, 100, 100),
+      100,
+      100
+    )
+    await writePng(
+      path.join(actualDir, 'components-one--tiny-drift.png'),
+      pixelsWithChanges(white, blue, 1, 100, 100),
+      100,
+      100
+    )
+
+    await writePng(
+      path.join(baselineDir, 'components-two--large-change.png'),
+      filledPixels(white, 100, 100),
+      100,
+      100
+    )
+    await writePng(
+      path.join(actualDir, 'components-two--large-change.png'),
+      pixelsWithChanges(white, red, 20, 100, 100),
+      100,
+      100
+    )
+
+    const summary = await compareVisualSnapshots({
+      baselineDir,
+      actualDir,
+      outputDir,
+      changedFiles: ['frontend/scripts/visual-regression-report.mjs'],
+      unrelatedDiffThreshold: 0.001,
+    })
+
+    expect(summary.changed.map((item) => item.fileName)).toEqual([
+      'components-two--large-change.png',
+    ])
+    expect(summary.unchanged).toContainEqual({ fileName: 'components-one--tiny-drift.png' })
+    expect(summary.totals.changed).toBe(1)
+    expect(summary.totals.unchanged).toBe(1)
   })
 })


### PR DESCRIPTION
## Description
Remove the `run-visuals` label gate from the GitHub Pages visual regression workflow so same-repository pull requests run visual snapshots automatically for frontend changes.

Add cleanup behavior for closed or merged PRs: the workflow removes `/visual/reports/pr-<number>/` from `visual-regression-state` and redeploys GitHub Pages without recapturing screenshots. The visual workflow is serialized so close cleanup and `main` baseline updates cannot race and re-publish stale report assets.

Filter low-value screenshot noise in PR reports. The workflow passes the PR changed-file list into the report generator, ignores sub-0.1% pixel drift by default, and still keeps tiny diffs when they map to a Storybook file touched by the PR. This addresses reports like PR #587, where only the two ScriptsStep screenshots were genuine changes.

## Related Issue
None.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `cd frontend && npm run test -- scripts/visual-regression-report.test.mjs scripts/argos-workflow-config.test.mjs --run`
- `npx prettier --check .github/workflows/visual-regression.yml docs/testing.md docs/engineering/specs/2026-06-01-github-pages-visual-regression.md docs/engineering/plans/2026-06-01-github-pages-visual-regression.md frontend/scripts/visual-regression-report.mjs frontend/scripts/visual-regression-report.test.mjs frontend/scripts/argos-workflow-config.test.mjs`
- `git diff --check`
- `cd docs && npm run build`
- Replayed PR #587 and PR #589 report assets through the new filter locally.
- Pre-push hooks passed: frontend format, locale, typecheck, and lint.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable. This changes workflow/report behavior.

## Additional Context
The visual report section is managed by the GitHub Actions workflow after each PR run.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Visual regression runs automatically for same-repo pull requests; main updates baselines.
  * PR-close cleanup removes per‑PR visual report directories.
  * Reports now filter tiny unrelated pixel drift and honor PR-changed-file mappings.

* **Documentation**
  * Docs and plans updated to describe automatic workflow, cleanup behavior, and drift rules.

* **Tests**
  * Test suites updated to validate triggers, cleanup behavior, and tiny-diff handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- visual-regression:start -->
## Visual regression report
No visual changes detected: 0 changed, 0 added, 0 removed, 238 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-589/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/26766118730
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- None
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->