### PR TITLE
Smoke custom Docker port in release workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -184,7 +184,8 @@ jobs:
 
       - name: Smoke test amd64 app image
         run: |
-          docker run -d --rm --name borg-ui-smoke -p 18081:8081 \
+          docker run -d --rm --name borg-ui-smoke -p 18088:8088 \
+            -e PORT=8088 \
             -e SECRET_KEY=test-secret-key-for-ci \
             -e ACTIVATION_SERVICE_URL= \
             borg-ui-app:smoke-test
@@ -192,7 +193,7 @@ jobs:
             docker rm -f borg-ui-smoke >/dev/null 2>&1 || true
           }
           trap cleanup EXIT
-          timeout 60 bash -c 'until curl -fsS http://127.0.0.1:18081/ >/dev/null; do sleep 2; done'
+          timeout 60 bash -c 'until curl -fsS http://127.0.0.1:18088/ >/dev/null; do sleep 2; done'
           docker exec borg-ui-smoke borg --version
           docker exec borg-ui-smoke borg2 --version
 

--- a/tests/unit/test_docker_port_runtime.py
+++ b/tests/unit/test_docker_port_runtime.py
@@ -4,6 +4,15 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 
 
+def _workflow_step_block(workflow: str, step_name: str) -> str:
+    step_header = f"      - name: {step_name}"
+    step_start = workflow.index(step_header)
+    next_step_start = workflow.find("\n      - name:", step_start + len(step_header))
+    if next_step_start == -1:
+        return workflow[step_start:]
+    return workflow[step_start:next_step_start]
+
+
 def test_entrypoint_binds_server_to_configured_port() -> None:
     entrypoint = (ROOT / "entrypoint.sh").read_text(encoding="utf-8")
 
@@ -24,8 +33,9 @@ def test_release_smoke_exercises_non_default_runtime_port() -> None:
     workflow = (ROOT / ".github" / "workflows" / "docker-publish.yml").read_text(
         encoding="utf-8"
     )
+    smoke_step = _workflow_step_block(workflow, "Smoke test amd64 app image")
 
-    assert "-p 18088:8088" in workflow
-    assert "-e PORT=8088" in workflow
-    assert "http://127.0.0.1:18088/" in workflow
-    assert "-p 18081:8081" not in workflow
+    assert "-p 18088:8088" in smoke_step
+    assert "-e PORT=8088" in smoke_step
+    assert "http://127.0.0.1:18088/" in smoke_step
+    assert "-p 18081:8081" not in smoke_step

--- a/tests/unit/test_docker_port_runtime.py
+++ b/tests/unit/test_docker_port_runtime.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_entrypoint_binds_server_to_configured_port() -> None:
+    entrypoint = (ROOT / "entrypoint.sh").read_text(encoding="utf-8")
+
+    assert "PORT=${PORT:-8081}" in entrypoint
+    assert '--port "${PORT}"' in entrypoint
+    assert "--bind 0.0.0.0:${PORT}" in entrypoint
+
+
+def test_production_compose_passes_port_to_container_and_healthcheck() -> None:
+    compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+
+    assert '"${PORT:-8081}:${PORT:-8081}"' in compose
+    assert "PORT=${PORT:-8081}" in compose
+    assert "curl -f http://localhost:$${PORT:-8081}/" in compose
+
+
+def test_release_smoke_exercises_non_default_runtime_port() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "docker-publish.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "-p 18088:8088" in workflow
+    assert "-e PORT=8088" in workflow
+    assert "http://127.0.0.1:18088/" in workflow
+    assert "-p 18081:8081" not in workflow


### PR DESCRIPTION
## Description
This updates the Docker release smoke test so published images must prove the non-default `PORT` path before release. The smoke container now runs with `PORT=8088`, maps `18088:8088`, and probes the custom host port.

It also adds unit coverage that verifies:
- `entrypoint.sh` binds uvicorn/gunicorn to the configured `PORT`.
- `docker-compose.yml` passes `PORT` through and healthchecks the configured port.
- `.github/workflows/docker-publish.yml` exercises a non-default runtime port.

## Related Issue
Fixes #600
Linear: BOR-120

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Validation run:
- `pytest tests/unit/test_docker_port_runtime.py`
- `git diff --check`
- `ruff check app tests`
- `ruff format --check app tests`
- Runtime proof: pulled `ainullcode/borg-ui:2.2.0`, ran it with `PORT=8088` mapped to host port `18088`, and confirmed `/`, the JS asset, the CSS asset, and `/api/auth/config` returned HTTP 200.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; this is a release workflow and test coverage change.

## Additional Context
The direct v2.2.0 image run honored `PORT=8088` in this workspace, so this PR focuses on the reproducible repository gap: release CI did not previously exercise non-default port behavior.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests validating Docker port configuration across entrypoint, compose, and release workflows.

* **Chores**
  * Updated smoke-test container port mapping and corresponding readiness/health-check URL to the new published port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->