### PR TITLE
Add retry actions for terminal backup jobs

### DIFF
--- a/docs/engineering/plans/2026-06-02-terminal-job-retry-actions.md
+++ b/docs/engineering/plans/2026-06-02-terminal-job-retry-actions.md
@@ -1,0 +1,84 @@
+# Terminal Job Retry Actions Implementation Plan
+
+**Goal:** Add frontend retry actions for supported terminal manual backup jobs and backup plan runs.
+
+**Architecture:** Reuse the backend retry endpoints already present in `app/api/backup.py` and `app/api/backup_plans.py`. Keep retry as an explicit recovery action: manual backup retries go through `backupAPI.retryJob`, plan-run retries go through `backupPlansAPI.retryRun`, and UI controls remain disabled or absent when the backend contract would reject the request. Use existing MUI icon-button/table patterns and locale-backed tooltips instead of introducing a new action surface.
+
+**Tech Stack:** React, TypeScript, MUI, lucide-react, TanStack Query, i18next, Vitest, Storybook.
+
+---
+
+### Task 1: API Helpers And Types
+
+**Files:**
+- Modify: `frontend/src/services/api.ts`
+- Modify: `frontend/src/services/api.test.ts`
+- Modify: `frontend/src/types/index.ts`
+- Modify: `frontend/src/types/jobs.ts`
+
+- [ ] Add `backupAPI.retryJob(jobId)` that posts to `/backup/jobs/{jobId}/retry`.
+- [ ] Add `backupPlansAPI.retryRun(runId)` that posts to `/backup-plans/runs/{runId}/retry`.
+- [ ] Add retry metadata fields to backup job and backup plan run types so responses serialize without loose access.
+- [ ] Add Vitest API helper tests that fail before the helper implementation.
+
+### Task 2: Backup Job Retry Action
+
+**Files:**
+- Modify: `frontend/src/components/BackupJobsTable.tsx`
+- Modify: `frontend/src/components/__tests__/BackupJobsTable.actions.test.tsx`
+- Modify: `frontend/src/pages/Backup.tsx`
+- Modify: `frontend/src/pages/__tests__/Backup.test.tsx`
+
+- [ ] Add an optional `actions.retry` action using `RotateCcw`, `color="info"`, and locale-backed tooltip text to stay distinct from `Run Now`'s play/success affordance.
+- [ ] Show retry for terminal `failed` and `cancelled` rows when the row is a manual backup job.
+- [ ] Disable retry with explicit tooltip text for missing repository context and insufficient backup/operator permission.
+- [ ] Show a disabled retry affordance with a destructive-job tooltip for terminal unsupported job types such as prune or delete-like activity rows.
+- [ ] Confirm before retrying, call the page-provided callback, and let page mutations invalidate backup job queries.
+
+### Task 3: Backup Plan Run Retry Action
+
+**Files:**
+- Modify: `frontend/src/components/BackupPlanRunsPanel.tsx`
+- Modify: `frontend/src/components/__tests__/BackupPlanRunsPanel.test.tsx`
+- Modify: `frontend/src/pages/backup-plans/plan-runs/PlanRunsHistoryTable.tsx`
+- Modify: `frontend/src/pages/backup-plans/plan-runs/BackupPlanHistoryDialog.tsx`
+- Modify: `frontend/src/pages/Backup.tsx`
+- Modify: `frontend/src/pages/BackupPlans.tsx`
+
+- [ ] Add retry actions to recent plan-run rows and plan history dialog rows.
+- [ ] Enable retry only for failed plan runs with at least one failed child repository and an attached backup plan.
+- [ ] Disable retry with tooltip text when the run is cancelled/non-failed, has no failed repositories, has an active run for the same plan, or the user lacks backup/operator permission on failed child repositories.
+- [ ] Confirm before retrying, call page mutation wiring, and invalidate backup plan run and backup plan queries.
+
+### Task 4: Locale And Stories
+
+**Files:**
+- Modify: `frontend/src/locales/en.json`
+- Modify: `frontend/src/locales/de.json`
+- Modify: `frontend/src/locales/es.json`
+- Modify: `frontend/src/locales/it.json`
+- Modify: `frontend/src/components/BackupJobsTable.stories.tsx`
+- Add: `frontend/src/components/BackupPlanRunsPanel.stories.tsx`
+
+- [ ] Add retry labels, confirmations, success/error toasts, disabled tooltips, and backend retry error translations in all shipped locales.
+- [ ] Add Storybook coverage for a retryable failed manual backup job.
+- [ ] Add Storybook coverage for a non-retryable destructive terminal job.
+- [ ] Add Storybook coverage for a retryable failed backup plan run.
+
+### Task 5: Validation
+
+**Commands:**
+- [ ] `cd frontend && npm run test -- src/services/api.test.ts src/components/__tests__/BackupJobsTable.actions.test.tsx src/components/__tests__/BackupPlanRunsPanel.test.tsx src/pages/__tests__/Backup.test.tsx`
+- [ ] `cd frontend && npm run check:locales`
+- [ ] `cd frontend && npm run typecheck`
+- [ ] `cd frontend && npm run lint`
+- [ ] `cd frontend && npm run build`
+- [ ] `cd frontend && npm run snapshots`
+- [ ] Runtime smoke or walkthrough for backup job and backup plan run retry controls.
+
+### Self-Review
+
+- The plan does not expose generic retry for restore, prune, compact, wipe, package, or scheduled run-now jobs.
+- Backup plan run retry follows the current backend contract: failed plan runs only, failed repositories only.
+- Disabled states use tooltips and do not rely on color alone.
+- `Run Now` remains a play/success action; retry uses a repeat icon and info color.

--- a/frontend/src/components/BackupJobsTable.stories.tsx
+++ b/frontend/src/components/BackupJobsTable.stories.tsx
@@ -43,6 +43,40 @@ const jobs: Job[] = [
   },
 ]
 
+const retryableFailedBackupJobs: Job[] = [
+  {
+    id: 201,
+    repository: '/backups/accounting',
+    repository_path: '/backups/accounting',
+    repository_id: 31,
+    type: 'backup',
+    status: 'failed',
+    started_at: '2026-05-22T09:00:00Z',
+    completed_at: '2026-05-22T09:04:00Z',
+    triggered_by: 'manual',
+    execution_mode: 'local',
+    has_logs: true,
+    error_message: 'Connection closed while writing archive metadata',
+  },
+]
+
+const nonRetryableDestructiveJobs: Job[] = [
+  {
+    id: 202,
+    repository: '/backups/accounting',
+    repository_path: '/backups/accounting',
+    repository_id: 31,
+    type: 'prune',
+    status: 'failed',
+    started_at: '2026-05-22T09:20:00Z',
+    completed_at: '2026-05-22T09:22:00Z',
+    triggered_by: 'manual',
+    execution_mode: 'local',
+    has_logs: true,
+    error_message: 'Retention pass stopped after partial repository scan',
+  },
+]
+
 const meta = {
   title: 'Components/BackupJobsTable',
   component: BackupJobsTable,
@@ -59,6 +93,44 @@ export const TransportModes: Story = {
   args: {
     jobs,
     showTriggerColumn: true,
+  },
+  render: (args) => (
+    <Box sx={{ p: 3 }}>
+      <BackupJobsTable {...args} />
+    </Box>
+  ),
+}
+
+export const RetryableFailedBackupJob: Story = {
+  args: {
+    jobs: retryableFailedBackupJobs,
+    showTypeColumn: true,
+    showTriggerColumn: true,
+    actions: {
+      retry: true,
+      viewLogs: true,
+    },
+    canRetryJob: () => true,
+    onRetryJob: () => {},
+  },
+  render: (args) => (
+    <Box sx={{ p: 3 }}>
+      <BackupJobsTable {...args} />
+    </Box>
+  ),
+}
+
+export const NonRetryableDestructiveJob: Story = {
+  args: {
+    jobs: nonRetryableDestructiveJobs,
+    showTypeColumn: true,
+    showTriggerColumn: true,
+    actions: {
+      retry: true,
+      viewLogs: true,
+    },
+    canRetryJob: () => true,
+    onRetryJob: () => {},
   },
   render: (args) => (
     <Box sx={{ p: 3 }}>

--- a/frontend/src/components/BackupJobsTable.tsx
+++ b/frontend/src/components/BackupJobsTable.tsx
@@ -12,6 +12,7 @@ import {
   Calendar,
   User,
   FolderOpen,
+  RotateCcw,
 } from 'lucide-react'
 import { toast } from 'react-hot-toast'
 import { useQueryClient, useQuery } from '@tanstack/react-query'
@@ -60,6 +61,7 @@ interface BackupJobsTableProps<T extends Job = Job> {
     breakLock?: boolean
     runNow?: boolean
     delete?: boolean
+    retry?: boolean
   }
 
   // Callbacks
@@ -70,10 +72,13 @@ interface BackupJobsTableProps<T extends Job = Job> {
   onBreakLock?: (job: T) => void | Promise<void>
   onRunNow?: (job: T) => void
   onDeleteJob?: (job: T) => void | Promise<void>
+  onRetryJob?: (job: T) => void | Promise<void>
 
   // User permissions
   canBreakLocks?: boolean
   canDeleteJobs?: boolean
+  canRetryJob?: (job: T) => boolean
+  retryingJobId?: string | number | null
 
   // Table styling
   headerBgColor?: string
@@ -157,6 +162,66 @@ const getTransportLabel = (
   return t('backupJobsTable.transport.server')
 }
 
+const RETRYABLE_BACKUP_JOB_STATUSES = new Set(['failed', 'cancelled'])
+const DESTRUCTIVE_JOB_TYPES = new Set([
+  'delete_archive',
+  'archive_delete',
+  'repository_wipe',
+  'wipe',
+  'prune',
+])
+
+const isManualBackupRetrySource = (job: Job): boolean => {
+  const jobType = job.type || 'backup'
+  if (jobType !== 'backup') return false
+  if (job.backup_plan_id || job.backup_plan_run_id) return false
+  if (job.scheduled_job_id || job.schedule_id) return false
+  if (job.triggered_by === 'backup_plan' || job.triggered_by === 'schedule') return false
+  return true
+}
+
+const hasBackupRetryRepositoryContext = (job: Job): boolean =>
+  Boolean(job.repository_id || job.repository || job.repository_path)
+
+const shouldShowRetryAction = (job: Job): boolean => {
+  if (!RETRYABLE_BACKUP_JOB_STATUSES.has(job.status)) return false
+  return isManualBackupRetrySource(job) || Boolean(job.type)
+}
+
+const getBackupJobRetryDisabledReason = (
+  job: Job,
+  canRetry: boolean,
+  t: (key: string, options?: Record<string, unknown>) => string
+): string | null => {
+  if (!RETRYABLE_BACKUP_JOB_STATUSES.has(job.status)) {
+    return t('backupJobsTable.retryTooltips.onlyTerminal')
+  }
+
+  if (!isManualBackupRetrySource(job)) {
+    const typeLabel = getTypeLabel(job.type || 'backup', t)
+    if (DESTRUCTIVE_JOB_TYPES.has(job.type || '')) {
+      return t('backupJobsTable.retryTooltips.destructiveType', { type: typeLabel })
+    }
+    if (job.backup_plan_id || job.backup_plan_run_id || job.triggered_by === 'backup_plan') {
+      return t('backupJobsTable.retryTooltips.backupPlanJob')
+    }
+    if (job.scheduled_job_id || job.schedule_id || job.triggered_by === 'schedule') {
+      return t('backupJobsTable.retryTooltips.scheduledJob')
+    }
+    return t('backupJobsTable.retryTooltips.unsupportedType', { type: typeLabel })
+  }
+
+  if (!hasBackupRetryRepositoryContext(job)) {
+    return t('backupJobsTable.retryTooltips.missingRepository')
+  }
+
+  if (!canRetry) {
+    return t('backupJobsTable.retryTooltips.requiresPermission')
+  }
+
+  return null
+}
+
 export const BackupJobsTable = <T extends Job = Job>({
   jobs,
   showTypeColumn = false,
@@ -172,8 +237,11 @@ export const BackupJobsTable = <T extends Job = Job>({
   onBreakLock,
   onRunNow,
   onDeleteJob,
+  onRetryJob,
   canBreakLocks = false,
   canDeleteJobs = false,
+  canRetryJob = () => false,
+  retryingJobId = null,
   headerBgColor = 'background.default',
   enableHover = true,
   getRowKey,
@@ -349,6 +417,17 @@ export const BackupJobsTable = <T extends Job = Job>({
 
   const handleCloseDeleteDialog = () => {
     setDeleteJob(null)
+  }
+
+  const handleRetryClick = (job: T) => {
+    const disabledReason = getBackupJobRetryDisabledReason(job, canRetryJob(job), t)
+    if (disabledReason) return
+    const confirmed =
+      typeof window.confirm === 'function'
+        ? window.confirm(t('backupJobsTable.confirmations.retryJob', { id: job.id }))
+        : true
+    if (!confirmed) return
+    onRetryJob?.(job)
   }
 
   // Internal break lock handler (can be overridden by onBreakLock prop)
@@ -616,6 +695,28 @@ export const BackupJobsTable = <T extends Job = Job>({
     })
   }
 
+  if (actions.retry === true && onRetryJob) {
+    actionButtons.push({
+      icon: <RotateCcw size={18} />,
+      label: t('backupJobsTable.actions.retry'),
+      onClick: handleRetryClick,
+      color: 'info',
+      tooltip: (job) => {
+        if (retryingJobId !== null && String(retryingJobId) === String(job.id)) {
+          return t('backupJobsTable.retryTooltips.retrying')
+        }
+        return (
+          getBackupJobRetryDisabledReason(job, canRetryJob(job), t) ||
+          t('backupJobsTable.retryTooltips.ready')
+        )
+      },
+      disabled: (job) =>
+        (retryingJobId !== null && String(retryingJobId) === String(job.id)) ||
+        Boolean(getBackupJobRetryDisabledReason(job, canRetryJob(job), t)),
+      show: shouldShowRetryAction,
+    })
+  }
+
   if (actions.cancel !== false) {
     actionButtons.push({
       icon: <Trash2 size={18} />,
@@ -689,6 +790,9 @@ export const BackupJobsTable = <T extends Job = Job>({
         data={jobs}
         columns={columns}
         actions={actionButtons}
+        actionColumnWidth={
+          actionButtons.length > 0 ? `${Math.max(130, actionButtons.length * 34)}px` : undefined
+        }
         getRowKey={getRowKey || ((job: T) => String((job as Job).id))}
         loading={loading}
         headerBgColor={headerBgColor}

--- a/frontend/src/components/BackupJobsTable.tsx
+++ b/frontend/src/components/BackupJobsTable.tsx
@@ -25,6 +25,7 @@ import ErrorDetailsDialog from './ErrorDetailsDialog'
 import LogViewerDialog from './LogViewerDialog'
 import CancelJobDialog from './CancelJobDialog'
 import DeleteJobDialog from './DeleteJobDialog'
+import RetryJobDialog from './RetryJobDialog'
 import LockErrorDialog from './LockErrorDialog'
 import { activityAPI, repositoriesAPI } from '../services/api'
 import { buildDownloadUrl } from '@/utils/downloadUrl'
@@ -262,6 +263,7 @@ export const BackupJobsTable = <T extends Job = Job>({
   const [logJob, setLogJob] = useState<T | null>(null)
   const [cancelJob, setCancelJob] = useState<T | null>(null)
   const [deleteJob, setDeleteJob] = useState<T | null>(null)
+  const [retryJob, setRetryJob] = useState<T | null>(null)
   const [lockError, setLockError] = useState<{
     repositoryId: number
     repositoryName: string
@@ -422,12 +424,19 @@ export const BackupJobsTable = <T extends Job = Job>({
   const handleRetryClick = (job: T) => {
     const disabledReason = getBackupJobRetryDisabledReason(job, canRetryJob(job), t)
     if (disabledReason) return
-    const confirmed =
-      typeof window.confirm === 'function'
-        ? window.confirm(t('backupJobsTable.confirmations.retryJob', { id: job.id }))
-        : true
-    if (!confirmed) return
-    onRetryJob?.(job)
+    setRetryJob(job)
+  }
+
+  const handleConfirmRetry = async () => {
+    if (!retryJob) return
+
+    const jobToRetry = retryJob
+    setRetryJob(null)
+    await onRetryJob?.(jobToRetry)
+  }
+
+  const handleCloseRetryDialog = () => {
+    setRetryJob(null)
   }
 
   // Internal break lock handler (can be overridden by onBreakLock prop)
@@ -830,6 +839,14 @@ export const BackupJobsTable = <T extends Job = Job>({
         onConfirm={handleConfirmDelete}
         jobId={deleteJob?.id}
         jobType={deleteJob?.type}
+      />
+
+      <RetryJobDialog
+        open={Boolean(retryJob)}
+        title={retryJob ? t('backupJobsTable.confirmations.retryJob', { id: retryJob.id }) : ''}
+        confirmLabel={t('backupJobsTable.actions.retry')}
+        onClose={handleCloseRetryDialog}
+        onConfirm={handleConfirmRetry}
       />
 
       {/* Archive Contents Dialog */}

--- a/frontend/src/components/BackupPlanRunsPanel.stories.tsx
+++ b/frontend/src/components/BackupPlanRunsPanel.stories.tsx
@@ -55,6 +55,64 @@ const retryableRun: BackupPlanRun = {
   ],
 }
 
+const retryInProgressRun: BackupPlanRun = {
+  ...retryableRun,
+}
+
+const activeRunForSamePlan: BackupPlanRun = {
+  id: 341,
+  backup_plan_id: plan.id,
+  trigger: 'manual',
+  status: 'running',
+  started_at: '2026-05-22T08:10:00Z',
+  created_at: '2026-05-22T08:10:00Z',
+  repositories: [
+    {
+      id: 411,
+      repository_id: 31,
+      status: 'running',
+      repository: {
+        id: 31,
+        name: 'Accounting repository',
+        path: '/backups/accounting',
+        borg_version: 2,
+      },
+      backup_job: {
+        id: 902,
+        repository_id: 31,
+        repository: '/backups/accounting',
+        type: 'backup',
+        status: 'running',
+        started_at: '2026-05-22T08:10:00Z',
+        has_logs: true,
+        execution_mode: 'local',
+      },
+    },
+  ],
+}
+
+const noFailedRepositoriesRun: BackupPlanRun = {
+  ...retryableRun,
+  id: 342,
+  repositories: [
+    {
+      ...retryableRun.repositories[0],
+      id: 412,
+      status: 'completed',
+      backup_job: retryableRun.repositories[0].backup_job
+        ? {
+            ...retryableRun.repositories[0].backup_job,
+            id: 903,
+            status: 'completed',
+          }
+        : undefined,
+    },
+  ],
+}
+
+const allowRetry = (_run: BackupPlanRun): boolean => true
+const denyRetry = (_run: BackupPlanRun): boolean => false
+
 const meta = {
   title: 'Components/BackupPlanRunsPanel',
   component: BackupPlanRunsPanel,
@@ -67,7 +125,7 @@ const meta = {
     onCancel: () => {},
     onViewLogs: () => {},
     onRetry: () => {},
-    canRetryRun: () => true,
+    canRetryRun: allowRetry,
   },
   render: (args) => (
     <Box sx={{ p: 3 }}>
@@ -81,3 +139,28 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const RetryableBackupPlanRun: Story = {}
+
+export const RetryInProgress: Story = {
+  args: {
+    runs: [retryInProgressRun],
+    retryingRunId: retryInProgressRun.id,
+  },
+}
+
+export const DisabledDueToActiveRun: Story = {
+  args: {
+    runs: [retryableRun, activeRunForSamePlan],
+  },
+}
+
+export const DisabledNoFailedRepositories: Story = {
+  args: {
+    runs: [noFailedRepositoriesRun],
+  },
+}
+
+export const DisabledNoPermission: Story = {
+  args: {
+    canRetryRun: denyRetry,
+  },
+}

--- a/frontend/src/components/BackupPlanRunsPanel.stories.tsx
+++ b/frontend/src/components/BackupPlanRunsPanel.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box } from '@mui/material'
+import BackupPlanRunsPanel from './BackupPlanRunsPanel'
+import type { BackupPlan, BackupPlanRun } from '../types'
+
+const plan: BackupPlan = {
+  id: 44,
+  name: 'Nightly accounting backup',
+  enabled: true,
+  source_type: 'local',
+  source_directories: ['/srv/accounting'],
+  exclude_patterns: ['*.tmp'],
+  archive_name_template: '{hostname}-{now}',
+  compression: 'zstd',
+  repository_run_mode: 'series',
+  max_parallel_repositories: 1,
+  failure_behavior: 'stop',
+  schedule_enabled: true,
+  timezone: 'America/New_York',
+  repository_count: 1,
+}
+
+const retryableRun: BackupPlanRun = {
+  id: 340,
+  backup_plan_id: plan.id,
+  trigger: 'manual',
+  status: 'failed',
+  started_at: '2026-05-22T08:00:00Z',
+  completed_at: '2026-05-22T08:06:00Z',
+  created_at: '2026-05-22T08:00:00Z',
+  repositories: [
+    {
+      id: 410,
+      repository_id: 31,
+      status: 'failed',
+      error_message: 'Repository connection closed during archive finalization',
+      repository: {
+        id: 31,
+        name: 'Accounting repository',
+        path: '/backups/accounting',
+        borg_version: 2,
+      },
+      backup_job: {
+        id: 901,
+        repository_id: 31,
+        repository: '/backups/accounting',
+        type: 'backup',
+        status: 'failed',
+        started_at: '2026-05-22T08:00:00Z',
+        completed_at: '2026-05-22T08:06:00Z',
+        has_logs: true,
+        execution_mode: 'local',
+      },
+    },
+  ],
+}
+
+const meta = {
+  title: 'Components/BackupPlanRunsPanel',
+  component: BackupPlanRunsPanel,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    plans: [plan],
+    runs: [retryableRun],
+    onCancel: () => {},
+    onViewLogs: () => {},
+    onRetry: () => {},
+    canRetryRun: () => true,
+  },
+  render: (args) => (
+    <Box sx={{ p: 3 }}>
+      <BackupPlanRunsPanel {...args} />
+    </Box>
+  ),
+} satisfies Meta<typeof BackupPlanRunsPanel>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const RetryableBackupPlanRun: Story = {}

--- a/frontend/src/components/BackupPlanRunsPanel.tsx
+++ b/frontend/src/components/BackupPlanRunsPanel.tsx
@@ -13,7 +13,16 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
-import { Activity, Clock, Eye, FileText, ListChecks, RefreshCw, Square } from 'lucide-react'
+import {
+  Activity,
+  Clock,
+  Eye,
+  FileText,
+  ListChecks,
+  RefreshCw,
+  RotateCcw,
+  Square,
+} from 'lucide-react'
 import ActiveBackupPlanRunCard from './ActiveBackupPlanRunCard'
 import DataTable, { type ActionButton, type Column } from './DataTable'
 import RepositoryCell from './RepositoryCell'
@@ -31,6 +40,10 @@ import {
   formatDateTimeFull,
   formatTimeRange,
 } from '../utils/dateUtils'
+import {
+  getBackupPlanRunRetryDisabledReason,
+  shouldShowBackupPlanRunRetryAction,
+} from './backupPlanRunRetry'
 
 function isActiveRun(status?: string): boolean {
   return status === 'pending' || status === 'running'
@@ -567,15 +580,21 @@ export default function BackupPlanRunsPanel({
   plans,
   loading,
   cancellingRunId,
+  retryingRunId = null,
   onCancel,
   onViewLogs,
+  onRetry,
+  canRetryRun = () => false,
 }: {
   runs: BackupPlanRun[]
   plans: BackupPlan[]
   loading?: boolean
   cancellingRunId?: number | null
+  retryingRunId?: number | null
   onCancel: (runId: number) => void
   onViewLogs: (job: BackupPlanRunLogJob) => void
+  onRetry?: (runId: number) => void
+  canRetryRun?: (run: BackupPlanRun) => boolean
 }) {
   const { t } = useTranslation()
   const activeRuns = useMemo(() => runs.filter((run) => isActiveRun(run.status)), [runs])
@@ -583,6 +602,35 @@ export default function BackupPlanRunsPanel({
     () => runs.filter((run) => !isActiveRun(run.status)).slice(0, 4),
     [runs]
   )
+  const activePlanIds = useMemo(
+    () =>
+      new Set(
+        activeRuns
+          .map((run) => run.backup_plan_id)
+          .filter((planId): planId is number => typeof planId === 'number')
+      ),
+    [activeRuns]
+  )
+  const hasActiveRunForPlan = (run: BackupPlanRun) =>
+    Boolean(run.backup_plan_id && activePlanIds.has(run.backup_plan_id))
+  const getRetryDisabledReason = (run: BackupPlanRun) =>
+    getBackupPlanRunRetryDisabledReason(run, t, {
+      canRetry: canRetryRun(run),
+      hasActiveRunForPlan: hasActiveRunForPlan(run),
+    })
+  const getRetryTooltip = (run: BackupPlanRun) => {
+    if (retryingRunId === run.id) return t('backupPlans.runsPanel.retryTooltips.retrying')
+    return getRetryDisabledReason(run) || t('backupPlans.runsPanel.retryTooltips.ready')
+  }
+  const handleRetryRun = (run: BackupPlanRun) => {
+    if (getRetryDisabledReason(run)) return
+    const confirmed =
+      typeof window.confirm === 'function'
+        ? window.confirm(t('backupPlans.runsPanel.retryConfirm', { id: run.id }))
+        : true
+    if (!confirmed) return
+    onRetry?.(run.id)
+  }
   const getPlanName = (run: BackupPlanRun) => {
     const plan = findPlan(run, plans)
     return (
@@ -714,6 +762,20 @@ export default function BackupPlanRunsPanel({
       },
       show: (run) => Boolean(findFirstLogJob(run)),
     },
+    ...(onRetry
+      ? [
+          {
+            icon: <RotateCcw size={16} />,
+            label: t('backupPlans.runsPanel.retryRun'),
+            tooltip: getRetryTooltip,
+            color: 'info' as const,
+            onClick: handleRetryRun,
+            disabled: (run: BackupPlanRun) =>
+              retryingRunId === run.id || Boolean(getRetryDisabledReason(run)),
+            show: shouldShowBackupPlanRunRetryAction,
+          },
+        ]
+      : []),
     {
       icon: <Square size={16} />,
       label: t('backupPlans.runsPanel.cancelRun'),

--- a/frontend/src/components/BackupPlanRunsPanel.tsx
+++ b/frontend/src/components/BackupPlanRunsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Alert,
@@ -26,6 +26,7 @@ import {
 import ActiveBackupPlanRunCard from './ActiveBackupPlanRunCard'
 import DataTable, { type ActionButton, type Column } from './DataTable'
 import RepositoryCell from './RepositoryCell'
+import RetryJobDialog from './RetryJobDialog'
 import StatusBadge from './StatusBadge'
 import type {
   BackupJob,
@@ -597,6 +598,7 @@ export default function BackupPlanRunsPanel({
   canRetryRun?: (run: BackupPlanRun) => boolean
 }) {
   const { t } = useTranslation()
+  const [retryRun, setRetryRun] = useState<BackupPlanRun | null>(null)
   const activeRuns = useMemo(() => runs.filter((run) => isActiveRun(run.status)), [runs])
   const recentRuns = useMemo(
     () => runs.filter((run) => !isActiveRun(run.status)).slice(0, 4),
@@ -624,12 +626,17 @@ export default function BackupPlanRunsPanel({
   }
   const handleRetryRun = (run: BackupPlanRun) => {
     if (getRetryDisabledReason(run)) return
-    const confirmed =
-      typeof window.confirm === 'function'
-        ? window.confirm(t('backupPlans.runsPanel.retryConfirm', { id: run.id }))
-        : true
-    if (!confirmed) return
-    onRetry?.(run.id)
+    setRetryRun(run)
+  }
+  const handleConfirmRetryRun = () => {
+    if (!retryRun) return
+
+    const runId = retryRun.id
+    setRetryRun(null)
+    onRetry?.(runId)
+  }
+  const handleCloseRetryDialog = () => {
+    setRetryRun(null)
   }
   const getPlanName = (run: BackupPlanRun) => {
     const plan = findPlan(run, plans)
@@ -901,6 +908,13 @@ export default function BackupPlanRunsPanel({
           ? t('backupPlans.runsPanel.empty')
           : t('backupPlans.runsPanel.emptyRecent')
       )}
+      <RetryJobDialog
+        open={Boolean(retryRun)}
+        title={retryRun ? t('backupPlans.runsPanel.retryConfirm', { id: retryRun.id }) : ''}
+        confirmLabel={t('backupPlans.runsPanel.retryRun')}
+        onClose={handleCloseRetryDialog}
+        onConfirm={handleConfirmRetryRun}
+      />
     </Stack>
   )
 }

--- a/frontend/src/components/RetryJobDialog.stories.tsx
+++ b/frontend/src/components/RetryJobDialog.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box } from '@mui/material'
+import RetryJobDialog from './RetryJobDialog'
+
+const meta = {
+  title: 'Components/RetryJobDialog',
+  component: RetryJobDialog,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    open: true,
+    title: 'Retry backup job #201?',
+    confirmLabel: 'Retry Job',
+    onClose: () => {},
+    onConfirm: () => {},
+  },
+  render: (args) => (
+    <Box sx={{ width: 420, minHeight: 180 }}>
+      <RetryJobDialog {...args} />
+    </Box>
+  ),
+} satisfies Meta<typeof RetryJobDialog>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const BackupJobRetry: Story = {}
+
+export const BackupPlanRunRetry: Story = {
+  args: {
+    title: 'Retry backup plan run #340?',
+    confirmLabel: 'Retry Run',
+  },
+}

--- a/frontend/src/components/RetryJobDialog.tsx
+++ b/frontend/src/components/RetryJobDialog.tsx
@@ -1,0 +1,50 @@
+import { Box, Button, DialogActions, DialogContent, Typography } from '@mui/material'
+import { RotateCcw } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import ResponsiveDialog from './shared/ResponsiveDialog'
+
+interface RetryJobDialogProps {
+  open: boolean
+  title: string
+  confirmLabel: string
+  onClose: () => void
+  onConfirm: () => void | Promise<void>
+}
+
+export default function RetryJobDialog({
+  open,
+  title,
+  confirmLabel,
+  onClose,
+  onConfirm,
+}: RetryJobDialogProps) {
+  const { t } = useTranslation()
+
+  return (
+    <ResponsiveDialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogContent sx={{ pt: 3 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+          <Box sx={{ color: 'info.main', lineHeight: 0 }}>
+            <RotateCcw size={24} />
+          </Box>
+          <Typography variant="h6" fontWeight={600}>
+            {title}
+          </Typography>
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} variant="outlined">
+          {t('common.buttons.cancel')}
+        </Button>
+        <Button
+          onClick={onConfirm}
+          color="info"
+          variant="contained"
+          startIcon={<RotateCcw size={18} />}
+        >
+          {confirmLabel}
+        </Button>
+      </DialogActions>
+    </ResponsiveDialog>
+  )
+}

--- a/frontend/src/components/RetryJobDialog.tsx
+++ b/frontend/src/components/RetryJobDialog.tsx
@@ -8,7 +8,7 @@ interface RetryJobDialogProps {
   title: string
   confirmLabel: string
   onClose: () => void
-  onConfirm: () => void | Promise<void>
+  onConfirm: () => void
 }
 
 export default function RetryJobDialog({

--- a/frontend/src/components/__tests__/BackupJobsTable.actions.test.tsx
+++ b/frontend/src/components/__tests__/BackupJobsTable.actions.test.tsx
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { within } from '@testing-library/react'
 import { renderWithProviders, screen, userEvent, waitFor } from '../../test/test-utils'
 import BackupJobsTable from '../BackupJobsTable'
 import { QueryClient } from '@tanstack/react-query'
@@ -269,11 +270,6 @@ describe('BackupJobsTable action internals', () => {
 
   it('confirms and calls retry for failed manual backup jobs', async () => {
     const user = userEvent.setup()
-    const confirmSpy = vi.fn(() => true)
-    Object.defineProperty(window, 'confirm', {
-      value: confirmSpy,
-      configurable: true,
-    })
     const onRetryJob = vi.fn()
 
     renderWithProviders(
@@ -298,7 +294,10 @@ describe('BackupJobsTable action internals', () => {
 
     await user.click(screen.getByRole('button', { name: /retry backup job/i }))
 
-    expect(confirmSpy).toHaveBeenCalledWith('Retry backup job #12?')
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByText('Retry backup job #12?')).toBeInTheDocument()
+    await user.click(within(dialog).getByRole('button', { name: /retry backup job/i }))
+
     expect(onRetryJob).toHaveBeenCalledWith(expect.objectContaining({ id: 12 }))
   })
 

--- a/frontend/src/components/__tests__/BackupJobsTable.actions.test.tsx
+++ b/frontend/src/components/__tests__/BackupJobsTable.actions.test.tsx
@@ -36,6 +36,8 @@ vi.mock('../DataTable', () => ({
       label: string
       onClick: (row: Record<string, unknown>) => void
       show?: (row: Record<string, unknown>) => boolean
+      disabled?: (row: Record<string, unknown>) => boolean
+      tooltip?: string | ((row: Record<string, unknown>) => string)
     }>
   }) => (
     <div>
@@ -44,11 +46,23 @@ vi.mock('../DataTable', () => ({
           <span>{String(row.id)}</span>
           {actions
             ?.filter((action) => (action.show ? action.show(row) : true))
-            .map((action) => (
-              <button key={`${row.id}-${action.label}`} onClick={() => action.onClick(row)}>
-                {action.label}
-              </button>
-            ))}
+            .map((action) => {
+              const tooltip =
+                typeof action.tooltip === 'function'
+                  ? action.tooltip(row)
+                  : action.tooltip || action.label
+              return (
+                <button
+                  key={`${row.id}-${action.label}`}
+                  aria-label={action.label}
+                  title={tooltip}
+                  disabled={action.disabled?.(row) ?? false}
+                  onClick={() => action.onClick(row)}
+                >
+                  {action.label}
+                </button>
+              )
+            })}
         </div>
       ))}
     </div>
@@ -251,6 +265,122 @@ describe('BackupJobsTable action internals', () => {
     await user.click(await screen.findByRole('button', { name: /download file/i }))
 
     expect(borgDownloadFileMock).toHaveBeenCalledWith('archive-77', '/srv/notes.txt')
+  })
+
+  it('confirms and calls retry for failed manual backup jobs', async () => {
+    const user = userEvent.setup()
+    const confirmSpy = vi.fn(() => true)
+    Object.defineProperty(window, 'confirm', {
+      value: confirmSpy,
+      configurable: true,
+    })
+    const onRetryJob = vi.fn()
+
+    renderWithProviders(
+      <BackupJobsTable
+        jobs={[
+          {
+            id: 12,
+            repository: '/backup/retryable',
+            repository_path: '/backup/retryable',
+            repository_id: 12,
+            type: 'backup',
+            status: 'failed',
+            started_at: '2026-04-01T10:00:00Z',
+            completed_at: '2026-04-01T10:05:00Z',
+          },
+        ]}
+        actions={{ retry: true }}
+        canRetryJob={() => true}
+        onRetryJob={onRetryJob}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /retry backup job/i }))
+
+    expect(confirmSpy).toHaveBeenCalledWith('Retry backup job #12?')
+    expect(onRetryJob).toHaveBeenCalledWith(expect.objectContaining({ id: 12 }))
+  })
+
+  it('does not show retry for active backup jobs', () => {
+    renderWithProviders(
+      <BackupJobsTable
+        jobs={[
+          {
+            id: 13,
+            repository: '/backup/running',
+            repository_path: '/backup/running',
+            repository_id: 13,
+            type: 'backup',
+            status: 'running',
+            started_at: '2026-04-01T10:00:00Z',
+          },
+        ]}
+        actions={{ retry: true }}
+        canRetryJob={() => true}
+        onRetryJob={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument()
+  })
+
+  it('disables retry for destructive terminal jobs with a clear tooltip', () => {
+    renderWithProviders(
+      <BackupJobsTable
+        jobs={[
+          {
+            id: 14,
+            repository: '/backup/prune',
+            repository_path: '/backup/prune',
+            repository_id: 14,
+            type: 'prune',
+            status: 'failed',
+            started_at: '2026-04-01T10:00:00Z',
+            completed_at: '2026-04-01T10:05:00Z',
+          },
+        ]}
+        actions={{ retry: true }}
+        canRetryJob={() => true}
+        onRetryJob={vi.fn()}
+      />
+    )
+
+    const retryButton = screen.getByRole('button', { name: /retry backup job/i })
+    expect(retryButton).toBeDisabled()
+    expect(retryButton).toHaveAttribute(
+      'title',
+      'Prune jobs are not safe to retry from this table.'
+    )
+  })
+
+  it('disables retry for terminal backup jobs without operator permission', () => {
+    renderWithProviders(
+      <BackupJobsTable
+        jobs={[
+          {
+            id: 15,
+            repository: '/backup/no-permission',
+            repository_path: '/backup/no-permission',
+            repository_id: 15,
+            type: 'backup',
+            status: 'cancelled',
+            started_at: '2026-04-01T10:00:00Z',
+            completed_at: '2026-04-01T10:05:00Z',
+          },
+        ]}
+        actions={{ retry: true }}
+        canRetryJob={() => false}
+        onRetryJob={vi.fn()}
+      />
+    )
+
+    const retryButton = screen.getByRole('button', { name: /retry backup job/i })
+    expect(retryButton).toBeDisabled()
+    expect(retryButton).toHaveAttribute(
+      'title',
+      'Operator access is required to retry this backup job.'
+    )
   })
 
   it('cancels running jobs through the activity API when using the built-in handler', async () => {

--- a/frontend/src/components/__tests__/BackupPlanRunsPanel.test.tsx
+++ b/frontend/src/components/__tests__/BackupPlanRunsPanel.test.tsx
@@ -55,6 +55,173 @@ describe('BackupPlanRunsPanel', () => {
     })
   })
 
+  it('confirms and retries failed backup plan runs from recent history', async () => {
+    const user = userEvent.setup()
+    const confirmSpy = vi.fn(() => true)
+    Object.defineProperty(window, 'confirm', {
+      value: confirmSpy,
+      configurable: true,
+    })
+    const onRetry = vi.fn()
+    const run = {
+      id: 17,
+      backup_plan_id: 3,
+      trigger: 'manual',
+      status: 'failed',
+      started_at: '2026-05-11T10:00:00Z',
+      completed_at: '2026-05-11T10:01:00Z',
+      created_at: '2026-05-11T10:00:00Z',
+      repositories: [
+        {
+          id: 97,
+          repository_id: 7,
+          status: 'failed',
+          repository: {
+            id: 7,
+            name: 'Primary Repo',
+            path: '/repos/primary',
+          },
+          backup_job: {
+            id: 57,
+            repository: '/repos/primary',
+            repository_id: 7,
+            status: 'failed',
+          },
+        },
+      ],
+    } satisfies BackupPlanRun
+
+    render(
+      <BackupPlanRunsPanel
+        runs={[run]}
+        plans={[plan]}
+        onCancel={vi.fn()}
+        onViewLogs={vi.fn()}
+        onRetry={onRetry}
+        canRetryRun={() => true}
+      />
+    )
+
+    const recentSection = screen.getByRole('region', { name: /recent backup plan runs/i })
+    await user.click(within(recentSection).getByRole('button', { name: /retry backup plan run/i }))
+
+    expect(confirmSpy).toHaveBeenCalledWith('Retry backup plan run #17?')
+    expect(onRetry).toHaveBeenCalledWith(17)
+  })
+
+  it('disables retry when a failed backup plan run has no failed repositories', () => {
+    const run = {
+      id: 18,
+      backup_plan_id: 3,
+      trigger: 'manual',
+      status: 'failed',
+      started_at: '2026-05-11T10:00:00Z',
+      completed_at: '2026-05-11T10:01:00Z',
+      created_at: '2026-05-11T10:00:00Z',
+      repositories: [
+        {
+          id: 98,
+          repository_id: 7,
+          status: 'completed',
+          repository: {
+            id: 7,
+            name: 'Primary Repo',
+            path: '/repos/primary',
+          },
+          backup_job: {
+            id: 58,
+            repository: '/repos/primary',
+            repository_id: 7,
+            status: 'completed',
+          },
+        },
+      ],
+    } satisfies BackupPlanRun
+
+    render(
+      <BackupPlanRunsPanel
+        runs={[run]}
+        plans={[plan]}
+        onCancel={vi.fn()}
+        onViewLogs={vi.fn()}
+        onRetry={vi.fn()}
+        canRetryRun={() => true}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: /this run has no failed repositories to retry/i,
+      })
+    ).toBeDisabled()
+  })
+
+  it('disables retry while the same backup plan already has an active run', () => {
+    const failedRun = {
+      id: 19,
+      backup_plan_id: 3,
+      trigger: 'manual',
+      status: 'failed',
+      started_at: '2026-05-11T09:00:00Z',
+      completed_at: '2026-05-11T09:01:00Z',
+      repositories: [
+        {
+          id: 99,
+          repository_id: 7,
+          status: 'failed',
+          repository: {
+            id: 7,
+            name: 'Primary Repo',
+            path: '/repos/primary',
+          },
+          backup_job: {
+            id: 59,
+            repository: '/repos/primary',
+            repository_id: 7,
+            status: 'failed',
+          },
+        },
+      ],
+    } satisfies BackupPlanRun
+    const activeRun = {
+      id: 20,
+      backup_plan_id: 3,
+      trigger: 'manual',
+      status: 'running',
+      started_at: '2026-05-11T10:00:00Z',
+      repositories: [
+        {
+          id: 100,
+          repository_id: 7,
+          status: 'running',
+          repository: {
+            id: 7,
+            name: 'Primary Repo',
+            path: '/repos/primary',
+          },
+        },
+      ],
+    } satisfies BackupPlanRun
+
+    render(
+      <BackupPlanRunsPanel
+        runs={[failedRun, activeRun]}
+        plans={[plan]}
+        onCancel={vi.fn()}
+        onViewLogs={vi.fn()}
+        onRetry={vi.fn()}
+        canRetryRun={() => true}
+      />
+    )
+
+    const recentSection = screen.getByRole('region', { name: /recent backup plan runs/i })
+    expect(
+      within(recentSection).getByRole('button', {
+        name: /wait for the running backup plan run to finish before retrying/i,
+      })
+    ).toBeDisabled()
+  })
+
   it('keeps active plan runs separate from recent plan run history', async () => {
     const user = userEvent.setup()
     const onCancel = vi.fn()

--- a/frontend/src/components/__tests__/BackupPlanRunsPanel.test.tsx
+++ b/frontend/src/components/__tests__/BackupPlanRunsPanel.test.tsx
@@ -57,11 +57,6 @@ describe('BackupPlanRunsPanel', () => {
 
   it('confirms and retries failed backup plan runs from recent history', async () => {
     const user = userEvent.setup()
-    const confirmSpy = vi.fn(() => true)
-    Object.defineProperty(window, 'confirm', {
-      value: confirmSpy,
-      configurable: true,
-    })
     const onRetry = vi.fn()
     const run = {
       id: 17,
@@ -105,8 +100,51 @@ describe('BackupPlanRunsPanel', () => {
     const recentSection = screen.getByRole('region', { name: /recent backup plan runs/i })
     await user.click(within(recentSection).getByRole('button', { name: /retry backup plan run/i }))
 
-    expect(confirmSpy).toHaveBeenCalledWith('Retry backup plan run #17?')
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByText('Retry backup plan run #17?')).toBeInTheDocument()
+    await user.click(within(dialog).getByRole('button', { name: /retry backup plan run/i }))
+
     expect(onRetry).toHaveBeenCalledWith(17)
+  })
+
+  it('does not show retry for cancelled backup plan runs', () => {
+    const run = {
+      id: 16,
+      backup_plan_id: 3,
+      trigger: 'manual',
+      status: 'cancelled',
+      started_at: '2026-05-11T10:00:00Z',
+      completed_at: '2026-05-11T10:01:00Z',
+      created_at: '2026-05-11T10:00:00Z',
+      repositories: [
+        {
+          id: 96,
+          repository_id: 7,
+          status: 'cancelled',
+          repository: {
+            id: 7,
+            name: 'Primary Repo',
+            path: '/repos/primary',
+          },
+        },
+      ],
+    } satisfies BackupPlanRun
+
+    render(
+      <BackupPlanRunsPanel
+        runs={[run]}
+        plans={[plan]}
+        onCancel={vi.fn()}
+        onViewLogs={vi.fn()}
+        onRetry={vi.fn()}
+        canRetryRun={() => true}
+      />
+    )
+
+    const recentSection = screen.getByRole('region', { name: /recent backup plan runs/i })
+    expect(
+      within(recentSection).queryByRole('button', { name: /retry backup plan run/i })
+    ).not.toBeInTheDocument()
   })
 
   it('disables retry when a failed backup plan run has no failed repositories', () => {

--- a/frontend/src/components/backupPlanRunRetry.ts
+++ b/frontend/src/components/backupPlanRunRetry.ts
@@ -1,0 +1,41 @@
+import type { BackupPlanRun } from '../types'
+
+type RetryTranslate = (key: string, options?: Record<string, unknown>) => string
+
+export function backupPlanRunHasFailedRepositories(run: BackupPlanRun): boolean {
+  return run.repositories.some(
+    (runRepository) =>
+      Boolean(runRepository.repository_id) &&
+      (runRepository.status === 'failed' || runRepository.backup_job?.status === 'failed')
+  )
+}
+
+export function shouldShowBackupPlanRunRetryAction(run: BackupPlanRun): boolean {
+  return run.status === 'failed' || run.status === 'cancelled'
+}
+
+export function getBackupPlanRunRetryDisabledReason(
+  run: BackupPlanRun,
+  t: RetryTranslate,
+  options: {
+    canRetry: boolean
+    hasActiveRunForPlan: boolean
+  }
+): string | null {
+  if (run.status !== 'failed') {
+    return t('backupPlans.runsPanel.retryTooltips.onlyFailed')
+  }
+  if (!run.backup_plan_id) {
+    return t('backupPlans.runsPanel.retryTooltips.missingPlan')
+  }
+  if (options.hasActiveRunForPlan) {
+    return t('backupPlans.runsPanel.retryTooltips.activeRun')
+  }
+  if (!backupPlanRunHasFailedRepositories(run)) {
+    return t('backupPlans.runsPanel.retryTooltips.noFailedRepositories')
+  }
+  if (!options.canRetry) {
+    return t('backupPlans.runsPanel.retryTooltips.requiresPermission')
+  }
+  return null
+}

--- a/frontend/src/components/backupPlanRunRetry.ts
+++ b/frontend/src/components/backupPlanRunRetry.ts
@@ -1,6 +1,7 @@
 import type { BackupPlanRun } from '../types'
 
 type RetryTranslate = (key: string, options?: Record<string, unknown>) => string
+type RepositoryPermissionCheck = (repositoryId: number) => boolean
 
 export function backupPlanRunHasFailedRepositories(run: BackupPlanRun): boolean {
   return run.repositories.some(
@@ -8,6 +9,23 @@ export function backupPlanRunHasFailedRepositories(run: BackupPlanRun): boolean 
       Boolean(runRepository.repository_id) &&
       (runRepository.status === 'failed' || runRepository.backup_job?.status === 'failed')
   )
+}
+
+export function canRetryBackupPlanRunForPermissions(
+  run: BackupPlanRun,
+  canBackupRepository: RepositoryPermissionCheck
+): boolean {
+  if (!backupPlanRunHasFailedRepositories(run)) return false
+  return run.repositories
+    .filter(
+      (runRepository) =>
+        runRepository.status === 'failed' || runRepository.backup_job?.status === 'failed'
+    )
+    .every(
+      (runRepository) =>
+        typeof runRepository.repository_id === 'number' &&
+        canBackupRepository(runRepository.repository_id)
+    )
 }
 
 export function shouldShowBackupPlanRunRetryAction(run: BackupPlanRun): boolean {

--- a/frontend/src/components/backupPlanRunRetry.ts
+++ b/frontend/src/components/backupPlanRunRetry.ts
@@ -11,7 +11,7 @@ export function backupPlanRunHasFailedRepositories(run: BackupPlanRun): boolean 
 }
 
 export function shouldShowBackupPlanRunRetryAction(run: BackupPlanRun): boolean {
-  return run.status === 'failed' || run.status === 'cancelled'
+  return run.status === 'failed'
 }
 
 export function getBackupPlanRunRetryDisabledReason(

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -474,6 +474,8 @@
       "startFailed": "Sicherung konnte nicht gestartet werden",
       "cancelled": "Sicherung erfolgreich abgebrochen!",
       "cancelFailed": "Sicherung konnte nicht abgebrochen werden",
+      "retryStarted": "Sicherungswiederholung gestartet",
+      "retryFailed": "Sicherung konnte nicht erneut gestartet werden",
       "selectRepository": "Bitte zuerst ein Repository auswählen"
     }
   },
@@ -770,6 +772,8 @@
       "startFailed": "Backup-Plan konnte nicht gestartet werden",
       "cancelled": "Backup-Plan-Lauf abgebrochen",
       "cancelFailed": "Backup-Plan-Lauf konnte nicht abgebrochen werden",
+      "retryStarted": "Backup-Plan-Wiederholung gestartet",
+      "retryFailed": "Backup-Plan-Lauf konnte nicht erneut gestartet werden",
       "repositoryCreated": "Repository erstellt",
       "repositoryCreateFailed": "Repository konnte nicht erstellt werden",
       "multiRepositoryRequiresPro": "Mehrere Repositories in einem Backup-Plan erfordern Pro",
@@ -1154,6 +1158,17 @@
       },
       "repositoryProgress": "{{completed}}/{{total}} Repositories abgeschlossen",
       "cancelRun": "Lauf abbrechen",
+      "retryRun": "Backup-Plan-Lauf erneut versuchen",
+      "retryConfirm": "Backup-Plan-Lauf #{{id}} erneut versuchen?",
+      "retryTooltips": {
+        "ready": "Backup-Plan-Lauf erneut versuchen",
+        "retrying": "Backup-Plan-Lauf wird erneut gestartet...",
+        "onlyFailed": "Nur fehlgeschlagene Backup-Plan-Läufe können erneut versucht werden.",
+        "missingPlan": "Dieser Lauf ist nicht mehr mit einem Backup-Plan verknüpft.",
+        "activeRun": "Warte, bis der laufende Backup-Plan-Lauf abgeschlossen ist, bevor du es erneut versuchst.",
+        "noFailedRepositories": "Dieser Lauf enthält keine fehlgeschlagenen Repositories zum erneuten Versuch.",
+        "requiresPermission": "Operator-Zugriff ist für jedes fehlgeschlagene Repository in diesem Lauf erforderlich."
+      },
       "noRepositories": "Noch keine Repository-Läufe aufgezeichnet."
     }
   },
@@ -2230,7 +2245,22 @@
       "errorDetails": "Fehlerdetails",
       "cancel": "Abbrechen",
       "cancelJob": "Aufgabe abbrechen",
-      "breakLock": "Sperre aufheben"
+      "breakLock": "Sperre aufheben",
+      "retry": "Sicherungsauftrag erneut versuchen"
+    },
+    "confirmations": {
+      "retryJob": "Sicherungsauftrag #{{id}} erneut versuchen?"
+    },
+    "retryTooltips": {
+      "ready": "Sicherungsauftrag erneut versuchen",
+      "retrying": "Sicherungsauftrag wird erneut gestartet...",
+      "onlyTerminal": "Nur fehlgeschlagene oder abgebrochene Sicherungsaufträge können erneut versucht werden.",
+      "destructiveType": "{{type}}-Aufträge können nicht sicher aus dieser Tabelle erneut versucht werden.",
+      "unsupportedType": "{{type}}-Aufträge können aus dieser Tabelle nicht erneut versucht werden.",
+      "backupPlanJob": "Versuche diesen Auftrag über seinen Backup-Plan-Lauf erneut.",
+      "scheduledJob": "Geplante Sicherungsaufträge sollten über den Zeitplan oder Plan erneut ausgeführt werden.",
+      "missingRepository": "Dieser Auftrag kann nicht erneut versucht werden, weil sein Quell-Repository fehlt.",
+      "requiresPermission": "Operator-Zugriff ist erforderlich, um diesen Sicherungsauftrag erneut zu versuchen."
     },
     "never": "Nie",
     "empty": "Keine Sicherungsaufgaben gefunden",
@@ -4400,11 +4430,15 @@
         "failedGetBackupJobs": "Fehler beim Abrufen der Sicherungsaufträge",
         "failedGetBackupStatus": "Fehler beim Abrufen des Sicherungsstatus",
         "failedCancelBackup": "Fehler beim Abbrechen der Sicherung",
-        "cannotDownloadLogsForRunningBackup": "Protokolle einer laufenden Sicherung können nicht heruntergeladen werden"
+        "cannotDownloadLogsForRunningBackup": "Protokolle einer laufenden Sicherung können nicht heruntergeladen werden",
+        "retryOnlyTerminalFailedCancelled": "Nur fehlgeschlagene oder abgebrochene Sicherungsaufträge können erneut versucht werden.",
+        "retryUnsupportedJobType": "Dieser Sicherungsauftragstyp kann nicht erneut versucht werden.",
+        "retryRequestNotReconstructable": "Dieser Sicherungsauftrag kann für einen erneuten Versuch nicht mehr rekonstruiert werden."
       },
       "backupPlans": {
         "nameRequired": "Der Name des Backup-Plans ist erforderlich.",
-        "clearLegacyRepositoryNotSelected": "Legacy-Quelleinstellungen können nicht für ein Repository gelöscht werden, das in diesem Backup-Plan nicht ausgewählt ist."
+        "clearLegacyRepositoryNotSelected": "Legacy-Quelleinstellungen können nicht für ein Repository gelöscht werden, das in diesem Backup-Plan nicht ausgewählt ist.",
+        "retryUnsupported": "Dieser Backup-Plan-Lauf kann nicht erneut versucht werden."
       },
       "restore": {
         "cancelledByUser": "Wiederherstellung vom Benutzer abgebrochen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -474,6 +474,8 @@
       "startFailed": "Failed to start backup",
       "cancelled": "Backup cancelled successfully!",
       "cancelFailed": "Failed to cancel backup",
+      "retryStarted": "Backup retry started",
+      "retryFailed": "Failed to retry backup",
       "selectRepository": "Please select a repository first"
     }
   },
@@ -770,6 +772,8 @@
       "startFailed": "Failed to start backup plan",
       "cancelled": "Backup plan run cancelled",
       "cancelFailed": "Failed to cancel backup plan run",
+      "retryStarted": "Backup plan retry started",
+      "retryFailed": "Failed to retry backup plan run",
       "repositoryCreated": "Repository created",
       "repositoryCreateFailed": "Failed to create repository",
       "multiRepositoryRequiresPro": "Multiple repositories in one backup plan require Pro",
@@ -1154,6 +1158,17 @@
       },
       "repositoryProgress": "{{completed}}/{{total}} repositories finished",
       "cancelRun": "Cancel Run",
+      "retryRun": "Retry backup plan run",
+      "retryConfirm": "Retry backup plan run #{{id}}?",
+      "retryTooltips": {
+        "ready": "Retry backup plan run",
+        "retrying": "Retrying backup plan run...",
+        "onlyFailed": "Only failed backup plan runs can be retried.",
+        "missingPlan": "This run is no longer linked to a backup plan.",
+        "activeRun": "Wait for the running backup plan run to finish before retrying.",
+        "noFailedRepositories": "This run has no failed repositories to retry.",
+        "requiresPermission": "Operator access is required for every failed repository in this run."
+      },
       "noRepositories": "No repository runs recorded yet."
     }
   },
@@ -2230,7 +2245,22 @@
       "errorDetails": "Error Details",
       "cancel": "Cancel",
       "cancelJob": "Cancel Job",
-      "breakLock": "Break Lock"
+      "breakLock": "Break Lock",
+      "retry": "Retry backup job"
+    },
+    "confirmations": {
+      "retryJob": "Retry backup job #{{id}}?"
+    },
+    "retryTooltips": {
+      "ready": "Retry backup job",
+      "retrying": "Retrying backup job...",
+      "onlyTerminal": "Only failed or cancelled backup jobs can be retried.",
+      "destructiveType": "{{type}} jobs are not safe to retry from this table.",
+      "unsupportedType": "{{type}} jobs cannot be retried from this table.",
+      "backupPlanJob": "Retry this job from its backup plan run.",
+      "scheduledJob": "Scheduled backup jobs should be rerun from the schedule or plan.",
+      "missingRepository": "This job cannot be retried because its source repository is missing.",
+      "requiresPermission": "Operator access is required to retry this backup job."
     },
     "never": "Never",
     "empty": "No backup jobs found",
@@ -4400,11 +4430,15 @@
         "failedGetBackupJobs": "Failed to get backup jobs",
         "failedGetBackupStatus": "Failed to get backup status",
         "failedCancelBackup": "Failed to cancel backup",
-        "cannotDownloadLogsForRunningBackup": "Cannot download logs for running backup"
+        "cannotDownloadLogsForRunningBackup": "Cannot download logs for running backup",
+        "retryOnlyTerminalFailedCancelled": "Only failed or cancelled backup jobs can be retried.",
+        "retryUnsupportedJobType": "This backup job type cannot be retried.",
+        "retryRequestNotReconstructable": "This backup job can no longer be reconstructed for retry."
       },
       "backupPlans": {
         "nameRequired": "Backup plan name is required.",
-        "clearLegacyRepositoryNotSelected": "Cannot clear legacy source settings for a repository that is not selected in this backup plan."
+        "clearLegacyRepositoryNotSelected": "Cannot clear legacy source settings for a repository that is not selected in this backup plan.",
+        "retryUnsupported": "This backup plan run cannot be retried."
       },
       "restore": {
         "cancelledByUser": "Restore cancelled by user",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -474,6 +474,8 @@
       "startFailed": "Error al iniciar la copia de seguridad",
       "cancelled": "¡Copia de seguridad cancelada correctamente!",
       "cancelFailed": "Error al cancelar la copia de seguridad",
+      "retryStarted": "Reintento de copia iniciado",
+      "retryFailed": "No se pudo reintentar la copia",
       "selectRepository": "Por favor selecciona un repositorio primero"
     }
   },
@@ -770,6 +772,8 @@
       "startFailed": "No se pudo iniciar el plan de copia",
       "cancelled": "Ejecución del plan cancelada",
       "cancelFailed": "No se pudo cancelar la ejecución del plan",
+      "retryStarted": "Reintento del plan de copia iniciado",
+      "retryFailed": "No se pudo reintentar la ejecución del plan",
       "repositoryCreated": "Repositorio creado",
       "repositoryCreateFailed": "No se pudo crear el repositorio",
       "multiRepositoryRequiresPro": "Varios repositorios en un plan de copia requieren Pro",
@@ -1154,6 +1158,17 @@
       },
       "repositoryProgress": "{{completed}}/{{total}} repositorios finalizados",
       "cancelRun": "Cancelar ejecución",
+      "retryRun": "Reintentar ejecución del plan",
+      "retryConfirm": "¿Reintentar la ejecución del plan #{{id}}?",
+      "retryTooltips": {
+        "ready": "Reintentar ejecución del plan",
+        "retrying": "Reintentando la ejecución del plan...",
+        "onlyFailed": "Solo se pueden reintentar ejecuciones fallidas del plan.",
+        "missingPlan": "Esta ejecución ya no está vinculada a un plan de copia.",
+        "activeRun": "Espera a que termine la ejecución activa del plan antes de reintentar.",
+        "noFailedRepositories": "Esta ejecución no tiene repositorios fallidos para reintentar.",
+        "requiresPermission": "Se requiere acceso de operador para cada repositorio fallido de esta ejecución."
+      },
       "noRepositories": "Aún no se han registrado ejecuciones de repositorio."
     }
   },
@@ -2230,7 +2245,22 @@
       "errorDetails": "Detalles del error",
       "cancel": "Cancelar",
       "cancelJob": "Cancelar trabajo",
-      "breakLock": "Forzar desbloqueo"
+      "breakLock": "Forzar desbloqueo",
+      "retry": "Reintentar trabajo de copia"
+    },
+    "confirmations": {
+      "retryJob": "¿Reintentar el trabajo de copia #{{id}}?"
+    },
+    "retryTooltips": {
+      "ready": "Reintentar trabajo de copia",
+      "retrying": "Reintentando trabajo de copia...",
+      "onlyTerminal": "Solo se pueden reintentar trabajos de copia fallidos o cancelados.",
+      "destructiveType": "Los trabajos {{type}} no son seguros para reintentar desde esta tabla.",
+      "unsupportedType": "Los trabajos {{type}} no se pueden reintentar desde esta tabla.",
+      "backupPlanJob": "Reintenta este trabajo desde su ejecución del plan de copia.",
+      "scheduledJob": "Los trabajos programados deben volver a ejecutarse desde la programación o el plan.",
+      "missingRepository": "Este trabajo no se puede reintentar porque falta su repositorio de origen.",
+      "requiresPermission": "Se requiere acceso de operador para reintentar este trabajo de copia."
     },
     "never": "Nunca",
     "empty": "No se encontraron trabajos de copia de seguridad",
@@ -4400,11 +4430,15 @@
         "failedGetBackupJobs": "Error al obtener los trabajos de copia de seguridad",
         "failedGetBackupStatus": "Error al obtener el estado de la copia de seguridad",
         "failedCancelBackup": "Error al cancelar la copia de seguridad",
-        "cannotDownloadLogsForRunningBackup": "No se pueden descargar los registros de una copia de seguridad en ejecución"
+        "cannotDownloadLogsForRunningBackup": "No se pueden descargar los registros de una copia de seguridad en ejecución",
+        "retryOnlyTerminalFailedCancelled": "Solo se pueden reintentar trabajos de copia fallidos o cancelados.",
+        "retryUnsupportedJobType": "Este tipo de trabajo de copia no se puede reintentar.",
+        "retryRequestNotReconstructable": "Este trabajo de copia ya no se puede reconstruir para reintentarlo."
       },
       "backupPlans": {
         "nameRequired": "El nombre del plan de copia de seguridad es obligatorio.",
-        "clearLegacyRepositoryNotSelected": "No se pueden borrar los ajustes de origen heredados de un repositorio que no está seleccionado en este plan de copia."
+        "clearLegacyRepositoryNotSelected": "No se pueden borrar los ajustes de origen heredados de un repositorio que no está seleccionado en este plan de copia.",
+        "retryUnsupported": "Esta ejecución del plan de copia no se puede reintentar."
       },
       "restore": {
         "cancelledByUser": "Restauración cancelada por el usuario",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -474,6 +474,8 @@
       "startFailed": "Impossibile avviare il backup",
       "cancelled": "Backup annullato con successo!",
       "cancelFailed": "Impossibile annullare il backup",
+      "retryStarted": "Tentativo di backup riavviato",
+      "retryFailed": "Impossibile ritentare il backup",
       "selectRepository": "Seleziona prima un repository"
     }
   },
@@ -770,6 +772,8 @@
       "startFailed": "Impossibile avviare il piano di backup",
       "cancelled": "Esecuzione del piano annullata",
       "cancelFailed": "Impossibile annullare l'esecuzione del piano",
+      "retryStarted": "Tentativo del piano di backup riavviato",
+      "retryFailed": "Impossibile ritentare l'esecuzione del piano",
       "repositoryCreated": "Repository creato",
       "repositoryCreateFailed": "Impossibile creare il repository",
       "multiRepositoryRequiresPro": "Più repository in un piano di backup richiedono Pro",
@@ -1154,6 +1158,17 @@
       },
       "repositoryProgress": "{{completed}}/{{total}} repository completati",
       "cancelRun": "Annulla esecuzione",
+      "retryRun": "Ritenta esecuzione piano di backup",
+      "retryConfirm": "Ritentare l'esecuzione del piano di backup #{{id}}?",
+      "retryTooltips": {
+        "ready": "Ritenta esecuzione piano di backup",
+        "retrying": "Ritentativo dell'esecuzione del piano in corso...",
+        "onlyFailed": "Solo le esecuzioni del piano fallite possono essere ritentate.",
+        "missingPlan": "Questa esecuzione non è più collegata a un piano di backup.",
+        "activeRun": "Attendi che l'esecuzione del piano in corso termini prima di ritentare.",
+        "noFailedRepositories": "Questa esecuzione non ha repository falliti da ritentare.",
+        "requiresPermission": "È richiesto l'accesso operatore per ogni repository fallito in questa esecuzione."
+      },
       "noRepositories": "Nessuna esecuzione repository registrata."
     }
   },
@@ -2230,7 +2245,22 @@
       "errorDetails": "Dettagli Errore",
       "cancel": "Annulla",
       "cancelJob": "Annulla Job",
-      "breakLock": "Rompi Blocco"
+      "breakLock": "Rompi Blocco",
+      "retry": "Ritenta job di backup"
+    },
+    "confirmations": {
+      "retryJob": "Ritentare il job di backup #{{id}}?"
+    },
+    "retryTooltips": {
+      "ready": "Ritenta job di backup",
+      "retrying": "Ritentativo del job di backup in corso...",
+      "onlyTerminal": "Solo i job di backup falliti o annullati possono essere ritentati.",
+      "destructiveType": "I job {{type}} non sono sicuri da ritentare da questa tabella.",
+      "unsupportedType": "I job {{type}} non possono essere ritentati da questa tabella.",
+      "backupPlanJob": "Ritenta questo job dalla sua esecuzione del piano di backup.",
+      "scheduledJob": "I job di backup pianificati devono essere riavviati dalla pianificazione o dal piano.",
+      "missingRepository": "Questo job non può essere ritentato perché il repository sorgente manca.",
+      "requiresPermission": "È richiesto l'accesso operatore per ritentare questo job di backup."
     },
     "never": "Mai",
     "empty": "Nessun job di backup trovato",
@@ -4400,11 +4430,15 @@
         "failedGetBackupJobs": "Impossibile ottenere i job di backup",
         "failedGetBackupStatus": "Impossibile ottenere lo stato del backup",
         "failedCancelBackup": "Impossibile annullare il backup",
-        "cannotDownloadLogsForRunningBackup": "Impossibile scaricare i log per un backup in esecuzione"
+        "cannotDownloadLogsForRunningBackup": "Impossibile scaricare i log per un backup in esecuzione",
+        "retryOnlyTerminalFailedCancelled": "Solo i job di backup falliti o annullati possono essere ritentati.",
+        "retryUnsupportedJobType": "Questo tipo di job di backup non può essere ritentato.",
+        "retryRequestNotReconstructable": "Questo job di backup non può più essere ricostruito per il ritentativo."
       },
       "backupPlans": {
         "nameRequired": "Il nome del piano di backup è obbligatorio.",
-        "clearLegacyRepositoryNotSelected": "Impossibile cancellare le impostazioni sorgente legacy per un repository non selezionato in questo piano di backup."
+        "clearLegacyRepositoryNotSelected": "Impossibile cancellare le impostazioni sorgente legacy per un repository non selezionato in questo piano di backup.",
+        "retryUnsupported": "Questa esecuzione del piano di backup non può essere ritentata."
       },
       "restore": {
         "cancelledByUser": "Ripristino annullato dall'utente",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -474,7 +474,7 @@
       "startFailed": "Impossibile avviare il backup",
       "cancelled": "Backup annullato con successo!",
       "cancelFailed": "Impossibile annullare il backup",
-      "retryStarted": "Tentativo di backup riavviato",
+      "retryStarted": "Ritentativo di backup avviato",
       "retryFailed": "Impossibile ritentare il backup",
       "selectRepository": "Seleziona prima un repository"
     }
@@ -772,7 +772,7 @@
       "startFailed": "Impossibile avviare il piano di backup",
       "cancelled": "Esecuzione del piano annullata",
       "cancelFailed": "Impossibile annullare l'esecuzione del piano",
-      "retryStarted": "Tentativo del piano di backup riavviato",
+      "retryStarted": "Ritentativo del piano di backup avviato",
       "retryFailed": "Impossibile ritentare l'esecuzione del piano",
       "repositoryCreated": "Repository creato",
       "repositoryCreateFailed": "Impossibile creare il repository",
@@ -2255,8 +2255,8 @@
       "ready": "Ritenta job di backup",
       "retrying": "Ritentativo del job di backup in corso...",
       "onlyTerminal": "Solo i job di backup falliti o annullati possono essere ritentati.",
-      "destructiveType": "I job {{type}} non sono sicuri da ritentare da questa tabella.",
-      "unsupportedType": "I job {{type}} non possono essere ritentati da questa tabella.",
+      "destructiveType": "Questo job di tipo {{type}} non è sicuro da ritentare da questa tabella.",
+      "unsupportedType": "Questo job di tipo {{type}} non può essere ritentato da questa tabella.",
       "backupPlanJob": "Ritenta questo job dalla sua esecuzione del piano di backup.",
       "scheduledJob": "I job di backup pianificati devono essere riavviati dalla pianificazione o dal piano.",
       "missingRepository": "Questo job non può essere ritentato perché il repository sorgente manca.",

--- a/frontend/src/pages/Backup.tsx
+++ b/frontend/src/pages/Backup.tsx
@@ -29,7 +29,7 @@ import LogViewerDialog from '../components/LogViewerDialog'
 import CommandPreview from '../components/CommandPreview'
 import RunningBackupsSection from '../components/RunningBackupsSection'
 import BackupPlanRunsPanel, { type BackupPlanRunLogJob } from '../components/BackupPlanRunsPanel'
-import { backupPlanRunHasFailedRepositories } from '../components/backupPlanRunRetry'
+import { canRetryBackupPlanRunForPermissions } from '../components/backupPlanRunRetry'
 import PageTabs from '../components/PageTabs'
 import BackupPlanSelect from '../components/shared/BackupPlanSelect'
 import { useAnalytics } from '../hooks/useAnalytics'
@@ -147,19 +147,10 @@ const Backup: React.FC = () => {
     )
     return repo ? permissions.canDo(repo.id, 'backup') : false
   }
-  const canRetryBackupPlanRun = (run: BackupPlanRun) => {
-    if (!backupPlanRunHasFailedRepositories(run)) return false
-    return run.repositories
-      .filter(
-        (runRepository) =>
-          runRepository.status === 'failed' || runRepository.backup_job?.status === 'failed'
-      )
-      .every(
-        (runRepository) =>
-          typeof runRepository.repository_id === 'number' &&
-          permissions.canDo(runRepository.repository_id, 'backup')
-      )
-  }
+  const canRetryBackupPlanRun = (run: BackupPlanRun) =>
+    canRetryBackupPlanRunForPermissions(run, (repositoryId) =>
+      permissions.canDo(repositoryId, 'backup')
+    )
 
   const runBackupPlanMutation = useMutation({
     mutationFn: (planId: number) => backupPlansAPI.run(planId),

--- a/frontend/src/pages/Backup.tsx
+++ b/frontend/src/pages/Backup.tsx
@@ -143,7 +143,7 @@ const Backup: React.FC = () => {
     if (repoId !== null) return permissions.canDo(repoId, 'backup')
     const repoPath = job.repository || ''
     const repo = repositoriesData?.data?.repositories?.find(
-      (candidate: Repository) => candidate.path === repoPath || candidate.name === repoPath
+      (candidate: Repository) => candidate.path === repoPath
     )
     return repo ? permissions.canDo(repo.id, 'backup') : false
   }

--- a/frontend/src/pages/Backup.tsx
+++ b/frontend/src/pages/Backup.tsx
@@ -22,12 +22,14 @@ import { toast } from 'react-hot-toast'
 import { translateBackendKey } from '../utils/translateBackendKey'
 import { BackupJob, Repository } from '../types'
 import type { BackupPlan, BackupPlanRun } from '../types'
+import type { Job } from '../types/jobs'
 import BackupJobsTable from '../components/BackupJobsTable'
 import RepoSelect from '../components/RepoSelect'
 import LogViewerDialog from '../components/LogViewerDialog'
 import CommandPreview from '../components/CommandPreview'
 import RunningBackupsSection from '../components/RunningBackupsSection'
 import BackupPlanRunsPanel, { type BackupPlanRunLogJob } from '../components/BackupPlanRunsPanel'
+import { backupPlanRunHasFailedRepositories } from '../components/backupPlanRunRetry'
 import PageTabs from '../components/PageTabs'
 import BackupPlanSelect from '../components/shared/BackupPlanSelect'
 import { useAnalytics } from '../hooks/useAnalytics'
@@ -136,6 +138,28 @@ const Backup: React.FC = () => {
   }, [selectedRepository, repositoriesData])
 
   const canStartBackup = selectedRepoData ? permissions.canDo(selectedRepoData.id, 'backup') : false
+  const canRetryManualBackupJob = (job: Job) => {
+    const repoId = typeof job.repository_id === 'number' ? job.repository_id : null
+    if (repoId !== null) return permissions.canDo(repoId, 'backup')
+    const repoPath = job.repository || ''
+    const repo = repositoriesData?.data?.repositories?.find(
+      (candidate: Repository) => candidate.path === repoPath || candidate.name === repoPath
+    )
+    return repo ? permissions.canDo(repo.id, 'backup') : false
+  }
+  const canRetryBackupPlanRun = (run: BackupPlanRun) => {
+    if (!backupPlanRunHasFailedRepositories(run)) return false
+    return run.repositories
+      .filter(
+        (runRepository) =>
+          runRepository.status === 'failed' || runRepository.backup_job?.status === 'failed'
+      )
+      .every(
+        (runRepository) =>
+          typeof runRepository.repository_id === 'number' &&
+          permissions.canDo(runRepository.repository_id, 'backup')
+      )
+  }
 
   const runBackupPlanMutation = useMutation({
     mutationFn: (planId: number) => backupPlansAPI.run(planId),
@@ -168,6 +192,25 @@ const Backup: React.FC = () => {
     onError: (error: any) => {
       toast.error(
         translateBackendKey(error.response?.data?.detail) || t('backupPlans.toasts.cancelFailed')
+      )
+    },
+  })
+
+  const retryBackupPlanRunMutation = useMutation({
+    mutationFn: (runId: number) => backupPlansAPI.retryRun(runId),
+    onSuccess: (_response, runId) => {
+      toast.success(t('backupPlans.toasts.retryStarted'))
+      queryClient.invalidateQueries({ queryKey: ['backup-plan-runs'] })
+      queryClient.invalidateQueries({ queryKey: ['backup-plans'] })
+      trackBackup(EventAction.START, 'backup_plan', undefined, {
+        trigger: 'retry',
+        backup_plan_run_id: runId,
+      })
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onError: (error: any) => {
+      toast.error(
+        translateBackendKey(error.response?.data?.detail) || t('backupPlans.toasts.retryFailed')
       )
     },
   })
@@ -205,6 +248,26 @@ const Backup: React.FC = () => {
     onError: (error: any) => {
       toast.error(
         translateBackendKey(error.response?.data?.detail) || t('backup.toasts.cancelFailed')
+      )
+    },
+  })
+
+  const retryBackupMutation = useMutation({
+    mutationFn: (jobId: string) => backupAPI.retryJob(jobId),
+    onSuccess: (_response, jobId) => {
+      toast.success(t('backup.toasts.retryStarted'))
+      queryClient.invalidateQueries({ queryKey: ['backup-status-manual'] })
+      queryClient.invalidateQueries({ queryKey: ['backup-status'] })
+      queryClient.invalidateQueries({ queryKey: ['recent-backup-jobs'] })
+      trackBackup(EventAction.START, 'manual', selectedRepoData || undefined, {
+        trigger: 'retry',
+        retry_source_job_id: jobId,
+      })
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onError: (error: any) => {
+      toast.error(
+        translateBackendKey(error.response?.data?.detail) || t('backup.toasts.retryFailed')
       )
     },
   })
@@ -449,7 +512,14 @@ const Backup: React.FC = () => {
                 ? Number(cancelBackupPlanRunMutation.variables)
                 : null
             }
+            retryingRunId={
+              retryBackupPlanRunMutation.isPending
+                ? Number(retryBackupPlanRunMutation.variables)
+                : null
+            }
             onCancel={(runId) => cancelBackupPlanRunMutation.mutate(runId)}
+            onRetry={(runId) => retryBackupPlanRunMutation.mutate(runId)}
+            canRetryRun={canRetryBackupPlanRun}
             onViewLogs={handleViewLogs}
           />
         </Stack>
@@ -576,9 +646,13 @@ const Backup: React.FC = () => {
                   downloadLogs: true,
                   errorInfo: true,
                   delete: true,
+                  retry: true,
                 }}
                 canBreakLocks={canManageRepositoryOperations}
                 canDeleteJobs={canManageRepositoryOperations}
+                canRetryJob={canRetryManualBackupJob}
+                retryingJobId={retryBackupMutation.isPending ? retryBackupMutation.variables : null}
+                onRetryJob={(job) => retryBackupMutation.mutate(String(job.id))}
                 getRowKey={(job) => String(job.id)}
                 headerBgColor="background.default"
                 enableHover={true}

--- a/frontend/src/pages/BackupPlans.tsx
+++ b/frontend/src/pages/BackupPlans.tsx
@@ -13,7 +13,7 @@ import WizardDialog from '../components/shared/WizardDialog'
 import LogViewerDialog from '../components/LogViewerDialog'
 import FileExplorerDialog from '../components/FileExplorerDialog'
 import { type BackupPlanRunLogJob } from '../components/BackupPlanRunsPanel'
-import { backupPlanRunHasFailedRepositories } from '../components/backupPlanRunRetry'
+import { canRetryBackupPlanRunForPermissions } from '../components/backupPlanRunRetry'
 import {
   backupPlansAPI,
   managedAgentsAPI,
@@ -159,19 +159,10 @@ export default function BackupPlans() {
     refetchInterval: 2000,
   })
   const backupPlanRuns: BackupPlanRun[] = useMemo(() => runsData?.data?.runs || [], [runsData])
-  const canRetryBackupPlanRun = (run: BackupPlanRun) => {
-    if (!backupPlanRunHasFailedRepositories(run)) return false
-    return run.repositories
-      .filter(
-        (runRepository) =>
-          runRepository.status === 'failed' || runRepository.backup_job?.status === 'failed'
-      )
-      .every(
-        (runRepository) =>
-          typeof runRepository.repository_id === 'number' &&
-          permissions.canDo(runRepository.repository_id, 'backup')
-      )
-  }
+  const canRetryBackupPlanRun = (run: BackupPlanRun) =>
+    canRetryBackupPlanRunForPermissions(run, (repositoryId) =>
+      permissions.canDo(repositoryId, 'backup')
+    )
   const hasActiveRunForPlan = (run: BackupPlanRun) =>
     backupPlanRuns.some(
       (candidate) =>

--- a/frontend/src/pages/BackupPlans.tsx
+++ b/frontend/src/pages/BackupPlans.tsx
@@ -13,6 +13,7 @@ import WizardDialog from '../components/shared/WizardDialog'
 import LogViewerDialog from '../components/LogViewerDialog'
 import FileExplorerDialog from '../components/FileExplorerDialog'
 import { type BackupPlanRunLogJob } from '../components/BackupPlanRunsPanel'
+import { backupPlanRunHasFailedRepositories } from '../components/backupPlanRunRetry'
 import {
   backupPlansAPI,
   managedAgentsAPI,
@@ -24,6 +25,7 @@ import {
 } from '../services/api'
 import { BorgApiClient } from '../services/borgApi'
 import { usePlan } from '../hooks/usePlan'
+import { usePermissions } from '../hooks/usePermissions'
 import { useAnalytics } from '../hooks/useAnalytics'
 import { translateBackendKey } from '../utils/translateBackendKey'
 import { buildBackupPlanPayload } from '../utils/backupPlanPayload'
@@ -93,6 +95,7 @@ export default function BackupPlans() {
   const { t } = useTranslation()
   const { track, EventCategory, EventAction } = useAnalytics()
   const { can } = usePlan()
+  const permissions = usePermissions()
   const canUseMultiRepository = can('backup_plan_multi_repository')
   const canUseMixedSourceTypes = can('backup_plan_mixed_sources')
   const canUseManagedAgents = can('managed_agents')
@@ -156,6 +159,26 @@ export default function BackupPlans() {
     refetchInterval: 2000,
   })
   const backupPlanRuns: BackupPlanRun[] = useMemo(() => runsData?.data?.runs || [], [runsData])
+  const canRetryBackupPlanRun = (run: BackupPlanRun) => {
+    if (!backupPlanRunHasFailedRepositories(run)) return false
+    return run.repositories
+      .filter(
+        (runRepository) =>
+          runRepository.status === 'failed' || runRepository.backup_job?.status === 'failed'
+      )
+      .every(
+        (runRepository) =>
+          typeof runRepository.repository_id === 'number' &&
+          permissions.canDo(runRepository.repository_id, 'backup')
+      )
+  }
+  const hasActiveRunForPlan = (run: BackupPlanRun) =>
+    backupPlanRuns.some(
+      (candidate) =>
+        candidate.id !== run.id &&
+        candidate.backup_plan_id === run.backup_plan_id &&
+        isActiveRun(candidate.status)
+    )
   const latestRunByPlan = useMemo(() => {
     const latest = new Map<number, BackupPlanRun>()
     backupPlanRuns.forEach((run) => {
@@ -399,6 +422,25 @@ export default function BackupPlans() {
     },
     onSettled: () => {
       setCancellingRunId(null)
+    },
+  })
+
+  const retryRunMutation = useMutation({
+    mutationFn: (id: number) => backupPlansAPI.retryRun(id),
+    onSuccess: (_response, runId) => {
+      toast.success(t('backupPlans.toasts.retryStarted'))
+      if (historyPlanId !== null) setHistoryPlanId(null)
+      queryClient.invalidateQueries({ queryKey: ['backup-plan-runs'] })
+      queryClient.invalidateQueries({ queryKey: ['backup-plans'] })
+      track(EventCategory.BACKUP, EventAction.START, {
+        entity: 'backup_plan_run',
+        section: BACKUP_PLANS_ANALYTICS_SECTION,
+        operation: 'retry_run',
+        backup_plan_run_id: runId,
+      })
+    },
+    onError: (error: unknown) => {
+      toast.error(errorMessage(error, t('backupPlans.toasts.retryFailed')))
     },
   })
 
@@ -731,10 +773,12 @@ export default function BackupPlans() {
   // directly so the callbacks are actually stable.
   const runMutate = runMutation.mutate
   const cancelRunMutate = cancelRunMutation.mutate
+  const retryRunMutate = retryRunMutation.mutate
   const toggleMutate = toggleMutation.mutate
   const deleteMutate = deleteMutation.mutate
   const handleRunPlan = useCallback((planId: number) => runMutate(planId), [runMutate])
   const handleCancelRun = useCallback((runId: number) => cancelRunMutate(runId), [cancelRunMutate])
+  const handleRetryRun = useCallback((runId: number) => retryRunMutate(runId), [retryRunMutate])
   const handleTogglePlan = useCallback((planId: number) => toggleMutate(planId), [toggleMutate])
   const handleDeletePlan = useCallback((planId: number) => deleteMutate(planId), [deleteMutate])
   const handleViewRepositories = useCallback(
@@ -931,6 +975,10 @@ export default function BackupPlans() {
         onClose={() => setHistoryPlanId(null)}
         onViewLogs={(job) => setLogJob(job)}
         onCancel={(runId) => cancelRunMutation.mutate(runId)}
+        onRetry={handleRetryRun}
+        retryingRunId={retryRunMutation.isPending ? Number(retryRunMutation.variables) : null}
+        canRetryRun={canRetryBackupPlanRun}
+        hasActiveRunForPlan={hasActiveRunForPlan}
         t={t}
       />
     </Box>

--- a/frontend/src/pages/__tests__/Backup.test.tsx
+++ b/frontend/src/pages/__tests__/Backup.test.tsx
@@ -15,17 +15,21 @@ const { trackBackup, toastSuccess, toastError, navigateMock } = vi.hoisted(() =>
 const {
   getManualJobsMock,
   backupJobsTableMock,
+  backupRetryJobMock,
   backupPlansListMock,
   backupPlansListRunsMock,
   backupPlansRunMock,
   backupPlansCancelRunMock,
+  backupPlansRetryRunMock,
 } = vi.hoisted(() => ({
   getManualJobsMock: vi.fn(),
   backupJobsTableMock: vi.fn(),
+  backupRetryJobMock: vi.fn(),
   backupPlansListMock: vi.fn(),
   backupPlansListRunsMock: vi.fn(),
   backupPlansRunMock: vi.fn(),
   backupPlansCancelRunMock: vi.fn(),
+  backupPlansRetryRunMock: vi.fn(),
 }))
 
 let locationState: Record<string, unknown> | null = null
@@ -131,6 +135,7 @@ vi.mock('../../services/api', () => ({
       })
     ),
     cancelJob: vi.fn(() => Promise.resolve({ data: {} })),
+    retryJob: backupRetryJobMock.mockImplementation(() => Promise.resolve({ data: {} })),
   },
   backupPlansAPI: {
     list: backupPlansListMock.mockImplementation(() =>
@@ -159,6 +164,7 @@ vi.mock('../../services/api', () => ({
       })
     ),
     cancelRun: backupPlansCancelRunMock.mockImplementation(() => Promise.resolve({ data: {} })),
+    retryRun: backupPlansRetryRunMock.mockImplementation(() => Promise.resolve({ data: {} })),
   },
   repositoriesAPI: {
     getRepositories: vi.fn(() =>
@@ -566,6 +572,47 @@ describe('Backup page', () => {
         jobs: manualJobsPayload,
       })
     )
+  })
+
+  it('wires manual backup job retry through the backup retry API', async () => {
+    const user = userEvent.setup()
+    manualJobsPayload = [
+      {
+        id: 42,
+        repository: '/repos/primary',
+        repository_id: 1,
+        status: 'failed',
+        type: 'backup',
+      },
+    ]
+
+    renderWithProviders(<Backup />)
+
+    await openLegacyBackupTab(user)
+    await user.click(await screen.findByRole('button', { name: /choose primary repo/i }))
+
+    await waitFor(() => {
+      expect(backupJobsTableMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actions: expect.objectContaining({ retry: true }),
+          onRetryJob: expect.any(Function),
+          canRetryJob: expect.any(Function),
+        })
+      )
+    })
+
+    const lastCall = backupJobsTableMock.mock.calls[backupJobsTableMock.mock.calls.length - 1]
+    const lastProps = lastCall?.[0] as {
+      onRetryJob: (job: { id: number }) => void
+      canRetryJob: (job: { repository_id: number }) => boolean
+    }
+    expect(lastProps.canRetryJob({ repository_id: 1 })).toBe(true)
+    lastProps.onRetryJob({ id: 42 })
+
+    await waitFor(() => {
+      expect(backupRetryJobMock).toHaveBeenCalledWith('42')
+    })
+    expect(toastSuccess).toHaveBeenCalledWith('Backup retry started')
   })
 
   it('labels the history section as recent manual jobs', async () => {

--- a/frontend/src/pages/__tests__/Backup.test.tsx
+++ b/frontend/src/pages/__tests__/Backup.test.tsx
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { within } from '@testing-library/react'
+import { QueryClient } from '@tanstack/react-query'
 import { renderWithProviders, screen, userEvent, waitFor } from '../../test/test-utils'
 import Backup from '../Backup'
 
@@ -39,6 +40,7 @@ let repositoriesPayload: Array<Record<string, unknown>> = []
 let manualJobsPayload: Array<Record<string, unknown>> = []
 let backupPlansPayload: Array<Record<string, unknown>> = []
 let backupPlanRunsPayload: Array<Record<string, unknown>> = []
+let backupQueryClients: QueryClient[] = []
 
 async function openLegacyBackupTab(user: ReturnType<typeof userEvent.setup>) {
   await user.click(await screen.findByRole('tab', { name: /legacy backup/i }))
@@ -47,6 +49,26 @@ async function openLegacyBackupTab(user: ReturnType<typeof userEvent.setup>) {
 async function selectBackupPlan(user: ReturnType<typeof userEvent.setup>, name: RegExp | string) {
   await user.click(await screen.findByRole('combobox', { name: /backup plan/i }))
   await user.click(await screen.findByRole('option', { name }))
+}
+
+function createBackupTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: Infinity,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  })
+}
+
+function renderBackup() {
+  const queryClient = createBackupTestQueryClient()
+  backupQueryClients.push(queryClient)
+  return renderWithProviders(<Backup />, { queryClient })
 }
 
 vi.mock('../../hooks/useAnalytics', () => ({
@@ -186,6 +208,13 @@ vi.mock('../../services/borgApi', () => ({
 }))
 
 describe('Backup page', () => {
+  afterEach(() => {
+    for (const queryClient of backupQueryClients) {
+      queryClient.clear()
+    }
+    backupQueryClients = []
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     locationState = null
@@ -224,12 +253,36 @@ describe('Backup page', () => {
       },
     ]
     manualJobsPayload = []
+    getManualJobsMock.mockImplementation(() =>
+      Promise.resolve({
+        data: {
+          jobs: manualJobsPayload,
+        },
+      })
+    )
+    backupRetryJobMock.mockImplementation(() => Promise.resolve({ data: {} }))
+    backupPlansListMock.mockImplementation(() =>
+      Promise.resolve({
+        data: {
+          backup_plans: backupPlansPayload,
+        },
+      })
+    )
+    backupPlansListRunsMock.mockImplementation(() =>
+      Promise.resolve({
+        data: {
+          runs: backupPlanRunsPayload,
+        },
+      })
+    )
+    backupPlansCancelRunMock.mockImplementation(() => Promise.resolve({ data: {} }))
+    backupPlansRetryRunMock.mockImplementation(() => Promise.resolve({ data: {} }))
   })
 
   it('defaults to the backup plans tab and keeps legacy backup separate', async () => {
     const user = userEvent.setup()
 
-    renderWithProviders(<Backup />)
+    renderBackup()
 
     expect(await screen.findByRole('tab', { name: /backup plans/i })).toHaveAttribute(
       'aria-selected',
@@ -252,7 +305,7 @@ describe('Backup page', () => {
     const user = userEvent.setup()
     locationState = { repositoryPath: '/repos/primary' }
 
-    renderWithProviders(<Backup />)
+    renderBackup()
 
     expect(await screen.findByRole('tab', { name: /legacy backup/i })).toHaveAttribute(
       'aria-selected',
@@ -292,7 +345,7 @@ describe('Backup page', () => {
       },
     ]
 
-    renderWithProviders(<Backup />)
+    renderBackup()
 
     await user.click(await screen.findByRole('button', { name: /start backup/i }))
 
@@ -304,7 +357,7 @@ describe('Backup page', () => {
   it('filters out observe-only repositories from manual backup selection', async () => {
     const user = userEvent.setup()
 
-    renderWithProviders(<Backup />)
+    renderBackup()
     await openLegacyBackupTab(user)
 
     expect(await screen.findByText('choose Primary Repo')).toBeInTheDocument()
@@ -327,7 +380,7 @@ describe('Backup page', () => {
       },
     ]
 
-    renderWithProviders(<Backup />)
+    renderBackup()
 
     const runButton = await screen.findByRole('button', { name: /run backup plan/i })
     await selectBackupPlan(user, /nightly plan/i)
@@ -358,7 +411,7 @@ describe('Backup page', () => {
       },
     ]
 
-    renderWithProviders(<Backup />)
+    renderBackup()
 
     const runButton = await screen.findByRole('button', { name: /run backup plan/i })
 
@@ -465,7 +518,7 @@ describe('Backup page', () => {
       },
     ]
 
-    renderWithProviders(<Backup />)
+    renderBackup()
 
     await selectBackupPlan(user, /nightly plan/i)
 
@@ -529,9 +582,13 @@ describe('Backup page', () => {
       },
     ]
 
-    renderWithProviders(<Backup />)
+    renderBackup()
 
-    const activeSection = await screen.findByRole('region', { name: /running backup plan runs/i })
+    const activeSection = await screen.findByRole(
+      'region',
+      { name: /running backup plan runs/i },
+      { timeout: 10000 }
+    )
     expect(activeSection).toBeInTheDocument()
     expect(within(activeSection).getByText('Nightly Plan')).toBeInTheDocument()
     expect(within(activeSection).getByText('Primary Repo')).toBeInTheDocument()
@@ -554,7 +611,7 @@ describe('Backup page', () => {
       },
     ]
 
-    renderWithProviders(<Backup />)
+    renderBackup()
 
     await waitFor(() => {
       expect(getManualJobsMock).not.toHaveBeenCalled()
@@ -586,7 +643,7 @@ describe('Backup page', () => {
       },
     ]
 
-    renderWithProviders(<Backup />)
+    renderBackup()
 
     await openLegacyBackupTab(user)
     await user.click(await screen.findByRole('button', { name: /choose primary repo/i }))
@@ -604,9 +661,11 @@ describe('Backup page', () => {
     const lastCall = backupJobsTableMock.mock.calls[backupJobsTableMock.mock.calls.length - 1]
     const lastProps = lastCall?.[0] as {
       onRetryJob: (job: { id: number }) => void
-      canRetryJob: (job: { repository_id: number }) => boolean
+      canRetryJob: (job: { repository_id?: number; repository?: string }) => boolean
     }
     expect(lastProps.canRetryJob({ repository_id: 1 })).toBe(true)
+    expect(lastProps.canRetryJob({ repository: '/repos/primary' })).toBe(true)
+    expect(lastProps.canRetryJob({ repository: 'Primary Repo' })).toBe(false)
     lastProps.onRetryJob({ id: 42 })
 
     await waitFor(() => {
@@ -618,7 +677,7 @@ describe('Backup page', () => {
   it('labels the history section as recent manual jobs', async () => {
     const user = userEvent.setup()
 
-    renderWithProviders(<Backup />)
+    renderBackup()
     await openLegacyBackupTab(user)
 
     expect(await screen.findByText('Recent Manual Jobs')).toBeInTheDocument()
@@ -629,7 +688,7 @@ describe('Backup page', () => {
 
   it('tracks repository selection and hides manual backup choices when backup permission is missing', async () => {
     const user = userEvent.setup()
-    const { unmount } = renderWithProviders(<Backup />)
+    const { unmount } = renderBackup()
 
     await openLegacyBackupTab(user)
     await user.click(await screen.findByRole('button', { name: /choose primary repo/i }))
@@ -645,7 +704,7 @@ describe('Backup page', () => {
 
     canDoBackup = false
     unmount()
-    renderWithProviders(<Backup />)
+    renderBackup()
     await openLegacyBackupTab(user)
 
     expect(screen.queryByRole('button', { name: /choose primary repo/i })).not.toBeInTheDocument()
@@ -655,7 +714,7 @@ describe('Backup page', () => {
   it('shows the generated borg command preview for the selected repository', async () => {
     const user = userEvent.setup()
 
-    renderWithProviders(<Backup />)
+    renderBackup()
 
     await openLegacyBackupTab(user)
     await user.click(await screen.findByRole('button', { name: /choose primary repo/i }))

--- a/frontend/src/pages/backup-plans/plan-runs/BackupPlanHistoryDialog.tsx
+++ b/frontend/src/pages/backup-plans/plan-runs/BackupPlanHistoryDialog.tsx
@@ -23,6 +23,10 @@ interface BackupPlanHistoryDialogProps {
   onClose: () => void
   onViewLogs: (job: BackupPlanRunLogJob) => void
   onCancel: (runId: number) => void
+  onRetry?: (runId: number) => void
+  retryingRunId?: number | null
+  canRetryRun?: (run: BackupPlanRun) => boolean
+  hasActiveRunForPlan?: (run: BackupPlanRun) => boolean
   t: TFunction
 }
 
@@ -33,6 +37,10 @@ export function BackupPlanHistoryDialog({
   onClose,
   onViewLogs,
   onCancel,
+  onRetry,
+  retryingRunId,
+  canRetryRun,
+  hasActiveRunForPlan,
   t,
 }: BackupPlanHistoryDialogProps) {
   const theme = useTheme()
@@ -65,6 +73,10 @@ export function BackupPlanHistoryDialog({
           cancelling={cancellingRunId}
           onViewLogs={onViewLogs}
           onCancel={onCancel}
+          onRetry={onRetry}
+          retryingRunId={retryingRunId}
+          canRetryRun={canRetryRun}
+          hasActiveRunForPlan={hasActiveRunForPlan}
           t={t}
         />
       </DialogContent>

--- a/frontend/src/pages/backup-plans/plan-runs/PlanRunsHistoryTable.tsx
+++ b/frontend/src/pages/backup-plans/plan-runs/PlanRunsHistoryTable.tsx
@@ -14,8 +14,10 @@ import {
 } from '@mui/material'
 import { Ban, Eye, RotateCcw } from 'lucide-react'
 import type { TFunction } from 'i18next'
+import { useState } from 'react'
 
 import type { BackupPlanRunLogJob } from '../../../components/BackupPlanRunsPanel'
+import RetryJobDialog from '../../../components/RetryJobDialog'
 import {
   getBackupPlanRunRetryDisabledReason,
   shouldShowBackupPlanRunRetryAction,
@@ -50,6 +52,7 @@ export function PlanRunsHistoryTable({
   hasActiveRunForPlan = () => false,
   t,
 }: PlanRunsHistoryTableProps) {
+  const [retryRun, setRetryRun] = useState<BackupPlanRun | null>(null)
   const formatStatusLabel = (status?: string) =>
     status
       ? t(`backupPlans.statuses.${status}`, { defaultValue: formatRunStatus(status) })
@@ -65,139 +68,120 @@ export function PlanRunsHistoryTable({
     )
   }
 
-  return (
-    <TableContainer>
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell sx={{ width: 64, fontSize: '0.7rem' }}>
-              {t('backupPlans.runsTable.columns.run', { defaultValue: 'Run' })}
-            </TableCell>
-            <TableCell sx={{ fontSize: '0.7rem' }}>
-              {t('backupPlans.runsTable.columns.started', { defaultValue: 'Started' })}
-            </TableCell>
-            <TableCell sx={{ fontSize: '0.7rem' }}>
-              {t('backupPlans.runsTable.columns.status', { defaultValue: 'Status' })}
-            </TableCell>
-            <TableCell sx={{ fontSize: '0.7rem' }}>
-              {t('backupPlans.runsTable.columns.duration', { defaultValue: 'Duration' })}
-            </TableCell>
-            <TableCell align="right" sx={{ width: 112, fontSize: '0.7rem' }}>
-              {t('backupPlans.runsTable.columns.actions', { defaultValue: 'Actions' })}
-            </TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {runs.map((run) => {
-            const startedAt = run.started_at || run.created_at
-            const logJob = findFirstLogJobForRun(run)
-            const active = isActiveRun(run.status)
-            const retryDisabledReason = getBackupPlanRunRetryDisabledReason(run, t, {
-              canRetry: canRetryRun(run),
-              hasActiveRunForPlan: hasActiveRunForPlan(run),
-            })
-            const retryTooltip =
-              retryingRunId === run.id
-                ? t('backupPlans.runsPanel.retryTooltips.retrying')
-                : retryDisabledReason || t('backupPlans.runsPanel.retryTooltips.ready')
+  const handleConfirmRetryRun = () => {
+    if (!retryRun) return
 
-            return (
-              <TableRow key={run.id} hover>
-                <TableCell
-                  sx={{
-                    fontFamily: '"JetBrains Mono","Fira Code",ui-monospace,monospace',
-                    fontSize: '0.78rem',
-                    color: 'text.secondary',
-                  }}
-                >
-                  #{run.id}
-                </TableCell>
-                <TableCell>
-                  {startedAt ? (
-                    <Tooltip title={formatDateTimeFull(startedAt)} arrow>
-                      <Typography
-                        variant="body2"
-                        color="text.secondary"
-                        sx={{ cursor: 'help', display: 'inline-block' }}
-                      >
-                        {formatRelativeTime(startedAt)}
-                      </Typography>
-                    </Tooltip>
-                  ) : (
-                    <Typography variant="body2" color="text.disabled">
-                      —
-                    </Typography>
-                  )}
-                </TableCell>
-                <TableCell>
-                  <Stack direction="row" spacing={0.5} alignItems="center">
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        color: runStatusIconColor(run.status),
-                        lineHeight: 0,
-                      }}
-                    >
-                      <RunStatusLeadIcon status={run.status} />
-                    </Box>
-                    <Typography variant="body2">{formatStatusLabel(run.status)}</Typography>
-                  </Stack>
-                </TableCell>
-                <TableCell>
-                  <Typography
-                    variant="body2"
-                    color="text.secondary"
+    const runId = retryRun.id
+    setRetryRun(null)
+    onRetry?.(runId)
+  }
+
+  return (
+    <>
+      <TableContainer>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ width: 64, fontSize: '0.7rem' }}>
+                {t('backupPlans.runsTable.columns.run', { defaultValue: 'Run' })}
+              </TableCell>
+              <TableCell sx={{ fontSize: '0.7rem' }}>
+                {t('backupPlans.runsTable.columns.started', { defaultValue: 'Started' })}
+              </TableCell>
+              <TableCell sx={{ fontSize: '0.7rem' }}>
+                {t('backupPlans.runsTable.columns.status', { defaultValue: 'Status' })}
+              </TableCell>
+              <TableCell sx={{ fontSize: '0.7rem' }}>
+                {t('backupPlans.runsTable.columns.duration', { defaultValue: 'Duration' })}
+              </TableCell>
+              <TableCell align="right" sx={{ width: 112, fontSize: '0.7rem' }}>
+                {t('backupPlans.runsTable.columns.actions', { defaultValue: 'Actions' })}
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {runs.map((run) => {
+              const startedAt = run.started_at || run.created_at
+              const logJob = findFirstLogJobForRun(run)
+              const active = isActiveRun(run.status)
+              const retryDisabledReason = getBackupPlanRunRetryDisabledReason(run, t, {
+                canRetry: canRetryRun(run),
+                hasActiveRunForPlan: hasActiveRunForPlan(run),
+              })
+              const retryTooltip =
+                retryingRunId === run.id
+                  ? t('backupPlans.runsPanel.retryTooltips.retrying')
+                  : retryDisabledReason || t('backupPlans.runsPanel.retryTooltips.ready')
+
+              return (
+                <TableRow key={run.id} hover>
+                  <TableCell
                     sx={{
                       fontFamily: '"JetBrains Mono","Fira Code",ui-monospace,monospace',
                       fontSize: '0.78rem',
+                      color: 'text.secondary',
                     }}
                   >
-                    {formatTimeRange(run.started_at, run.completed_at, run.status)}
-                  </Typography>
-                </TableCell>
-                <TableCell align="right">
-                  <Stack direction="row" spacing={0.25} justifyContent="flex-end">
-                    {logJob && (
-                      <Tooltip
-                        title={t('backupPlans.runsDialog.viewLogs', { defaultValue: 'View logs' })}
-                        arrow
+                    #{run.id}
+                  </TableCell>
+                  <TableCell>
+                    {startedAt ? (
+                      <Tooltip title={formatDateTimeFull(startedAt)} arrow>
+                        <Typography
+                          variant="body2"
+                          color="text.secondary"
+                          sx={{ cursor: 'help', display: 'inline-block' }}
+                        >
+                          {formatRelativeTime(startedAt)}
+                        </Typography>
+                      </Tooltip>
+                    ) : (
+                      <Typography variant="body2" color="text.disabled">
+                        —
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Stack direction="row" spacing={0.5} alignItems="center">
+                      <Box
+                        sx={{
+                          display: 'flex',
+                          color: runStatusIconColor(run.status),
+                          lineHeight: 0,
+                        }}
                       >
-                        <IconButton
-                          size="small"
-                          onClick={() => onViewLogs(logJob)}
-                          aria-label={t('backupPlans.runsDialog.viewLogs', {
+                        <RunStatusLeadIcon status={run.status} />
+                      </Box>
+                      <Typography variant="body2">{formatStatusLabel(run.status)}</Typography>
+                    </Stack>
+                  </TableCell>
+                  <TableCell>
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{
+                        fontFamily: '"JetBrains Mono","Fira Code",ui-monospace,monospace',
+                        fontSize: '0.78rem',
+                      }}
+                    >
+                      {formatTimeRange(run.started_at, run.completed_at, run.status)}
+                    </Typography>
+                  </TableCell>
+                  <TableCell align="right">
+                    <Stack direction="row" spacing={0.25} justifyContent="flex-end">
+                      {logJob && (
+                        <Tooltip
+                          title={t('backupPlans.runsDialog.viewLogs', {
                             defaultValue: 'View logs',
                           })}
-                          sx={{
-                            width: 28,
-                            height: 28,
-                            color: 'info.main',
-                            '&:hover': {
-                              bgcolor: (theme) => alpha(theme.palette.info.main, 0.12),
-                            },
-                          }}
+                          arrow
                         >
-                          <Eye size={15} />
-                        </IconButton>
-                      </Tooltip>
-                    )}
-                    {onRetry && shouldShowBackupPlanRunRetryAction(run) && (
-                      <Tooltip title={retryTooltip} arrow>
-                        <span>
                           <IconButton
                             size="small"
-                            onClick={() => {
-                              if (retryDisabledReason) return
-                              const confirmed =
-                                typeof window.confirm === 'function'
-                                  ? window.confirm(
-                                      t('backupPlans.runsPanel.retryConfirm', { id: run.id })
-                                    )
-                                  : true
-                              if (confirmed) onRetry(run.id)
-                            }}
-                            disabled={retryingRunId === run.id || Boolean(retryDisabledReason)}
-                            aria-label={retryTooltip}
+                            onClick={() => onViewLogs(logJob)}
+                            aria-label={t('backupPlans.runsDialog.viewLogs', {
+                              defaultValue: 'View logs',
+                            })}
                             sx={{
                               width: 28,
                               height: 28,
@@ -205,48 +189,80 @@ export function PlanRunsHistoryTable({
                               '&:hover': {
                                 bgcolor: (theme) => alpha(theme.palette.info.main, 0.12),
                               },
-                              '&.Mui-disabled': { opacity: 0.35 },
                             }}
                           >
-                            <RotateCcw size={15} />
+                            <Eye size={15} />
                           </IconButton>
-                        </span>
-                      </Tooltip>
-                    )}
-                    {active && (
-                      <Tooltip
-                        title={t('backupPlans.runsPanel.cancelRun', {
-                          defaultValue: 'Cancel run',
-                        })}
-                        arrow
-                      >
-                        <IconButton
-                          size="small"
-                          onClick={() => onCancel(run.id)}
-                          disabled={cancelling === run.id}
-                          aria-label={t('backupPlans.runsPanel.cancelRun', {
+                        </Tooltip>
+                      )}
+                      {onRetry && shouldShowBackupPlanRunRetryAction(run) && (
+                        <Tooltip title={retryTooltip} arrow>
+                          <span>
+                            <IconButton
+                              size="small"
+                              onClick={() => {
+                                if (retryDisabledReason) return
+                                setRetryRun(run)
+                              }}
+                              disabled={retryingRunId === run.id || Boolean(retryDisabledReason)}
+                              aria-label={retryTooltip}
+                              sx={{
+                                width: 28,
+                                height: 28,
+                                color: 'info.main',
+                                '&:hover': {
+                                  bgcolor: (theme) => alpha(theme.palette.info.main, 0.12),
+                                },
+                                '&.Mui-disabled': { opacity: 0.35 },
+                              }}
+                            >
+                              <RotateCcw size={15} />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      )}
+                      {active && (
+                        <Tooltip
+                          title={t('backupPlans.runsPanel.cancelRun', {
                             defaultValue: 'Cancel run',
                           })}
-                          sx={{
-                            width: 28,
-                            height: 28,
-                            color: 'warning.main',
-                            '&:hover': {
-                              bgcolor: (theme) => alpha(theme.palette.warning.main, 0.12),
-                            },
-                          }}
+                          arrow
                         >
-                          <Ban size={15} />
-                        </IconButton>
-                      </Tooltip>
-                    )}
-                  </Stack>
-                </TableCell>
-              </TableRow>
-            )
-          })}
-        </TableBody>
-      </Table>
-    </TableContainer>
+                          <IconButton
+                            size="small"
+                            onClick={() => onCancel(run.id)}
+                            disabled={cancelling === run.id}
+                            aria-label={t('backupPlans.runsPanel.cancelRun', {
+                              defaultValue: 'Cancel run',
+                            })}
+                            sx={{
+                              width: 28,
+                              height: 28,
+                              color: 'warning.main',
+                              '&:hover': {
+                                bgcolor: (theme) => alpha(theme.palette.warning.main, 0.12),
+                              },
+                            }}
+                          >
+                            <Ban size={15} />
+                          </IconButton>
+                        </Tooltip>
+                      )}
+                    </Stack>
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <RetryJobDialog
+        open={Boolean(retryRun)}
+        title={retryRun ? t('backupPlans.runsPanel.retryConfirm', { id: retryRun.id }) : ''}
+        confirmLabel={t('backupPlans.runsPanel.retryRun')}
+        onClose={() => setRetryRun(null)}
+        onConfirm={handleConfirmRetryRun}
+      />
+    </>
   )
 }

--- a/frontend/src/pages/backup-plans/plan-runs/PlanRunsHistoryTable.tsx
+++ b/frontend/src/pages/backup-plans/plan-runs/PlanRunsHistoryTable.tsx
@@ -12,10 +12,14 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
-import { Ban, Eye } from 'lucide-react'
+import { Ban, Eye, RotateCcw } from 'lucide-react'
 import type { TFunction } from 'i18next'
 
-import { type BackupPlanRunLogJob } from '../../../components/BackupPlanRunsPanel'
+import type { BackupPlanRunLogJob } from '../../../components/BackupPlanRunsPanel'
+import {
+  getBackupPlanRunRetryDisabledReason,
+  shouldShowBackupPlanRunRetryAction,
+} from '../../../components/backupPlanRunRetry'
 import { formatDateTimeFull, formatRelativeTime, formatTimeRange } from '../../../utils/dateUtils'
 import type { BackupPlanRun } from '../../../types'
 import { formatRunStatus, isActiveRun } from '../runStatus'
@@ -28,6 +32,10 @@ interface PlanRunsHistoryTableProps {
   cancelling: number | null
   onViewLogs: (job: BackupPlanRunLogJob) => void
   onCancel: (runId: number) => void
+  onRetry?: (runId: number) => void
+  retryingRunId?: number | null
+  canRetryRun?: (run: BackupPlanRun) => boolean
+  hasActiveRunForPlan?: (run: BackupPlanRun) => boolean
   t: TFunction
 }
 
@@ -36,6 +44,10 @@ export function PlanRunsHistoryTable({
   cancelling,
   onViewLogs,
   onCancel,
+  onRetry,
+  retryingRunId = null,
+  canRetryRun = () => false,
+  hasActiveRunForPlan = () => false,
   t,
 }: PlanRunsHistoryTableProps) {
   const formatStatusLabel = (status?: string) =>
@@ -70,7 +82,7 @@ export function PlanRunsHistoryTable({
             <TableCell sx={{ fontSize: '0.7rem' }}>
               {t('backupPlans.runsTable.columns.duration', { defaultValue: 'Duration' })}
             </TableCell>
-            <TableCell align="right" sx={{ width: 80, fontSize: '0.7rem' }}>
+            <TableCell align="right" sx={{ width: 112, fontSize: '0.7rem' }}>
               {t('backupPlans.runsTable.columns.actions', { defaultValue: 'Actions' })}
             </TableCell>
           </TableRow>
@@ -80,6 +92,14 @@ export function PlanRunsHistoryTable({
             const startedAt = run.started_at || run.created_at
             const logJob = findFirstLogJobForRun(run)
             const active = isActiveRun(run.status)
+            const retryDisabledReason = getBackupPlanRunRetryDisabledReason(run, t, {
+              canRetry: canRetryRun(run),
+              hasActiveRunForPlan: hasActiveRunForPlan(run),
+            })
+            const retryTooltip =
+              retryingRunId === run.id
+                ? t('backupPlans.runsPanel.retryTooltips.retrying')
+                : retryDisabledReason || t('backupPlans.runsPanel.retryTooltips.ready')
 
             return (
               <TableRow key={run.id} hover>
@@ -159,6 +179,38 @@ export function PlanRunsHistoryTable({
                         >
                           <Eye size={15} />
                         </IconButton>
+                      </Tooltip>
+                    )}
+                    {onRetry && shouldShowBackupPlanRunRetryAction(run) && (
+                      <Tooltip title={retryTooltip} arrow>
+                        <span>
+                          <IconButton
+                            size="small"
+                            onClick={() => {
+                              if (retryDisabledReason) return
+                              const confirmed =
+                                typeof window.confirm === 'function'
+                                  ? window.confirm(
+                                      t('backupPlans.runsPanel.retryConfirm', { id: run.id })
+                                    )
+                                  : true
+                              if (confirmed) onRetry(run.id)
+                            }}
+                            disabled={retryingRunId === run.id || Boolean(retryDisabledReason)}
+                            aria-label={retryTooltip}
+                            sx={{
+                              width: 28,
+                              height: 28,
+                              color: 'info.main',
+                              '&:hover': {
+                                bgcolor: (theme) => alpha(theme.palette.info.main, 0.12),
+                              },
+                              '&.Mui-disabled': { opacity: 0.35 },
+                            }}
+                          >
+                            <RotateCcw size={15} />
+                          </IconButton>
+                        </span>
                       </Tooltip>
                     )}
                     {active && (

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest'
 import MockAdapter from 'axios-mock-adapter'
-import api, { repositoriesAPI } from './api'
+import api, { backupAPI, backupPlansAPI, repositoriesAPI } from './api'
 
 describe('API Request Interceptor', () => {
   let localStorageMock: { [key: string]: string }
@@ -408,6 +408,46 @@ describe('Repositories API - Repository wipe', () => {
 
     expect(status.data).toEqual({ id: 11, status: 'running' })
     expect(cancelled.data).toEqual({ id: 11, status: 'cancelled' })
+    mock.restore()
+  })
+})
+
+describe('Retry API helpers', () => {
+  it('retries backup jobs through the backend retry endpoint', async () => {
+    const mock = new MockAdapter(api)
+    mock.onPost('/backup/jobs/42/retry').reply(202, {
+      job_id: 108,
+      status: 'pending',
+      retry_source_job_id: 42,
+    })
+
+    const response = await backupAPI.retryJob(42)
+
+    expect(response.data).toEqual({
+      job_id: 108,
+      status: 'pending',
+      retry_source_job_id: 42,
+    })
+    mock.restore()
+  })
+
+  it('retries backup plan runs through the backend retry endpoint', async () => {
+    const mock = new MockAdapter(api)
+    mock.onPost('/backup-plans/runs/77/retry').reply(202, {
+      id: 93,
+      status: 'pending',
+      trigger: 'retry',
+      retry_source_run_id: 77,
+    })
+
+    const response = await backupPlansAPI.retryRun(77)
+
+    expect(response.data).toEqual({
+      id: 93,
+      status: 'pending',
+      trigger: 'retry',
+      retry_source_run_id: 77,
+    })
     mock.restore()
   })
 })

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -557,6 +557,7 @@ export const backupAPI = {
     }),
   getScheduledJobs: () => api.get('/backup/jobs?scheduled_only=true'),
   cancelJob: (jobId: string) => api.post(`/backup/cancel/${jobId}`),
+  retryJob: (jobId: string | number) => api.post(`/backup/jobs/${jobId}/retry`),
   // Download logs as file (only for failed/cancelled backups)
   downloadLogs: (jobId: string) =>
     window.open(buildDownloadUrl(`/backup/logs/${jobId}/download`), '_blank'),
@@ -870,6 +871,7 @@ export const backupPlansAPI = {
   listRuns: () => api.get('/backup-plans/runs'),
   getRun: (id: number) => api.get(`/backup-plans/runs/${id}`),
   cancelRun: (id: number) => api.post(`/backup-plans/runs/${id}/cancel`),
+  retryRun: (id: number) => api.post(`/backup-plans/runs/${id}/retry`),
   listRunsForPlan: (id: number) => api.get(`/backup-plans/${id}/runs`),
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -157,6 +157,11 @@ export interface BackupJob {
   archive_name?: string | null
   execution_mode?: 'local' | 'remote_ssh' | 'agent' | string
   route_strategy?: string | null
+  retry_attempt?: number | null
+  retry_original_job_id?: number | null
+  retry_source_job_id?: number | null
+  retry_requested_by_user_id?: number | null
+  retry_requested_at?: string | null
   progress_details?: {
     original_size: number
     compressed_size?: number
@@ -345,6 +350,11 @@ export interface BackupPlanRun {
   completed_at?: string | null
   error_message?: string | null
   created_at?: string | null
+  retry_attempt?: number | null
+  retry_original_run_id?: number | null
+  retry_source_run_id?: number | null
+  retry_requested_by_user_id?: number | null
+  retry_requested_at?: string | null
   repositories: BackupPlanRunRepository[]
   script_executions?: BackupPlanScriptExecution[]
 }

--- a/frontend/src/types/jobs.ts
+++ b/frontend/src/types/jobs.ts
@@ -36,6 +36,11 @@ export interface Job {
   scheduled_job_id?: number | null
   execution_mode?: string | null
   route_strategy?: string | null
+  retry_attempt?: number | null
+  retry_original_job_id?: number | null
+  retry_source_job_id?: number | null
+  retry_requested_by_user_id?: number | null
+  retry_requested_at?: string | null
   progress_details?: unknown
 }
 


### PR DESCRIPTION
## Description
Adds frontend retry support for supported terminal backup jobs and backup plan runs. Manual failed or cancelled backup jobs now call the backend retry endpoint, failed backup-plan runs are retryable through the plan-run surfaces, and unsupported cases expose disabled or absent retry states with explanatory tooltips.

The retry affordance uses the info-colored rotate icon so it is visually distinct from scheduled Run Now. This also adds a shared retry confirmation dialog, retry metadata types, locale/backend error strings, targeted regression tests, a durable engineering plan, and Storybook coverage for retryable and unsafe states.

## Related Issue
Linear: https://linear.app/nullcodeai/issue/BOR-118/support-retry-actions-for-terminal-backup-jobs

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] UI/UX improvement
- [x] Test addition/improvement
- [ ] Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `cd frontend && npm run test -- --run src/services/api.test.ts src/components/__tests__/BackupJobsTable.actions.test.tsx src/components/__tests__/BackupPlanRunsPanel.test.tsx src/pages/__tests__/Backup.test.tsx --testTimeout 60000`
- `cd frontend && npm run format:check`
- `cd frontend && npm run check:locales`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `cd frontend && npm run snapshots`
- `git diff --check`

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Storybook snapshots were generated locally for the retry states on desktop and mobile:
- `components-backupjobstable--retryable-failed-backup-job`
- `components-backupjobstable--non-retryable-destructive-job`
- `components-backupplanrunspanel--retryable-backup-plan-run`
- `components-backupplanrunspanel--retry-in-progress`
- `components-backupplanrunspanel--disabled-due-to-active-run`
- `components-backupplanrunspanel--disabled-no-failed-repositories`
- `components-backupplanrunspanel--disabled-no-permission`
- `components-retryjobdialog--backup-job-retry`
- `components-retryjobdialog--backup-plan-run-retry`

## Additional Context
`npm run snapshots` required local Playwright browser and host library artifacts in ignored paths on this ARM dev host. These were installed under `frontend/node_modules/playwright-core/.local-browsers` and `frontend/.playwright-host-libs` and were not committed.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
