### PR TITLE
Clarify Backup Plan schedule migration workflow

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -300,7 +300,39 @@ Backup Plan schedules run backups automatically.
 
 Plans can also run prune, compact, and check after successful repository backups.
 
-The Schedules area still shows scheduled repository work. New backup schedules should usually live on Backup Plans.
+The Schedule area still shows scheduled repository work. Existing
+repository-based schedules continue to run there. New backup schedules should
+usually live on Backup Plans.
+
+### Move a Schedule Workflow to a Backup Plan
+
+For a workflow that wakes a backup server, backs up several repositories, prunes
+and compacts them, then powers the server off after the last repository
+finishes, use one scheduled Backup Plan:
+
+1. Create or edit a Backup Plan.
+2. Select the repositories that should run in the plan. Use series mode when the
+   repositories should run one after another. Use parallel mode only when it is
+   safe for the selected repositories and scripts.
+3. In the Scripts step, add the wake script as a plan pre-backup script.
+4. Add the power-off script as a plan post-backup script. Set its run condition
+   to Always, On success, On failure, or On warning depending on when the server
+   should shut down.
+5. In Maintenance, enable prune and compact and set the retention policy.
+6. In Schedule, enable the cron schedule and timezone.
+7. Save the plan.
+
+Plan pre-backup scripts run once before repository backups begin. Repository
+backups then run in the selected order or parallel mode, with prune and compact
+running after each successful repository backup when enabled. Plan post-backup
+scripts run once after the whole plan run finishes, so they are the right place
+for cleanup or power-off actions that should wait for the last repository.
+
+When you create a Backup Plan from an existing repository, Borg UI can copy that
+repository's preferred schedule, schedule-level scripts, prune/compact settings,
+and retention policy into the new plan. Review the plan afterward if the old
+schedule targeted multiple repositories, then add the remaining repositories and
+confirm the run mode.
 
 Use notifications for scheduled backup failures so failures do not go unnoticed.
 


### PR DESCRIPTION
## Description
Adds usage-guide documentation for moving legacy repository schedule workflows to scheduled Backup Plans, including wake scripts, repository run mode, prune/compact maintenance, and power-off post scripts that wait for the full plan run to finish.

## Related Issue
Addresses #559

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A: documentation-only change)
- [ ] All existing tests pass (not run: documentation-only change)

Validation run:
- `git diff --check`
- `cd docs && npm ci && npm run build`

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (N/A: documentation-only change)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes (N/A: documentation-only change)

## Screenshots (if applicable)
Not applicable: documentation-only change.

## Additional Context
The current implementation already supports the workflow described in issue #559: Backup Plans run plan-level pre-scripts once, repository backups with maintenance in series or parallel, then plan-level post-scripts once after the whole run finishes. This PR documents that path for users migrating from repository schedules.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Backup Plan Schedules guidance clarifying when to use the Schedule area versus creating new Backup Plans
  * Added step-by-step instructions for converting existing Schedule workflows into Backup Plans
  * Expanded guidance on creating Backup Plans from existing repositories, including which settings to copy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->