### PR TITLE
Improve broken repository check recovery UI

### DIFF
--- a/docs/engineering/plans/2026-06-03-broken-repository-check-recovery-ui.md
+++ b/docs/engineering/plans/2026-06-03-broken-repository-check-recovery-ui.md
@@ -10,9 +10,12 @@
 
 ---
 
+## Implementation Tasks
+
 ### Task 1: Reproduce Silent Manual Check Completion
 
 **Files:**
+
 - Modify: `frontend/src/pages/__tests__/Repositories.test.tsx`
 - Read: `frontend/src/pages/Repositories.tsx`
 
@@ -22,6 +25,7 @@
 ### Task 2: Announce Terminal Check Results
 
 **Files:**
+
 - Modify: `frontend/src/pages/Repositories.tsx`
 - Test: `frontend/src/pages/__tests__/Repositories.test.tsx`
 
@@ -35,6 +39,7 @@
 ### Task 3: Add Info Recovery Commands
 
 **Files:**
+
 - Modify: `frontend/src/components/RepositoryInfoDialog.tsx`
 - Modify: `frontend/src/components/__tests__/RepositoryInfoDialog.test.tsx`
 - Modify: `frontend/src/components/RepositoryInfoDialog.stories.tsx`
@@ -52,6 +57,7 @@
 ### Task 4: Required Validation and Handoff
 
 **Files:**
+
 - Read/Update: Linear workpad comment
 - Commit/push through repo skills
 

--- a/docs/engineering/plans/2026-06-03-broken-repository-check-recovery-ui.md
+++ b/docs/engineering/plans/2026-06-03-broken-repository-check-recovery-ui.md
@@ -1,0 +1,64 @@
+# Broken Repository Check Recovery UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for app behavior changes. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make broken repository Check and Info flows produce explicit feedback and copyable recovery commands.
+
+**Architecture:** Keep the fix frontend-first. `Repositories.tsx` will announce terminal manual-check results from the existing job history endpoint, while `RepositoryInfoDialog.tsx` will render a reusable copyable recovery command panel when info loading fails.
+
+**Tech Stack:** React, TypeScript, MUI, TanStack Query, Vitest, React Testing Library, Storybook.
+
+---
+
+### Task 1: Reproduce Silent Manual Check Completion
+
+**Files:**
+- Modify: `frontend/src/pages/__tests__/Repositories.test.tsx`
+- Read: `frontend/src/pages/Repositories.tsx`
+
+- [ ] Write a failing test that renders `Repositories`, starts with a tracked check job, flips `useMaintenanceJobs` to no running jobs, mocks `repositoriesAPI.getRepositoryCheckJobs` to return a failed latest check job, and expects an error toast containing the stored error.
+- [ ] Run `cd frontend && npm test -- src/pages/__tests__/Repositories.test.tsx --runInBand` or the repo-equivalent targeted Vitest command and confirm the failure is due to missing terminal feedback.
+
+### Task 2: Announce Terminal Check Results
+
+**Files:**
+- Modify: `frontend/src/pages/Repositories.tsx`
+- Test: `frontend/src/pages/__tests__/Repositories.test.tsx`
+
+- [ ] In `handleJobCompleted`, when the tracked operation is `Check`, fetch `repositoriesAPI.getRepositoryCheckJobs(repositoryId, 1)` as it already does.
+- [ ] If the latest job status is `completed`, show `toast.success(t('repositories.toasts.checkCompleted'))`.
+- [ ] If the latest job status is `completed_with_warnings`, show `toast(t('repositories.toasts.checkCompletedWithWarnings'), { icon: '!' })`.
+- [ ] For any other terminal status, show `toast.error(t('repositories.toasts.checkFailedWithMessage', { message }))`, where `message` is `translateBackendKey(latestJob.error_message)` when present or `t('repositories.toasts.checkRunFailed')`.
+- [ ] Keep existing analytics tracking and query invalidation behavior.
+- [ ] Run the targeted test and confirm it passes.
+
+### Task 3: Add Info Recovery Commands
+
+**Files:**
+- Modify: `frontend/src/components/RepositoryInfoDialog.tsx`
+- Modify: `frontend/src/components/__tests__/RepositoryInfoDialog.test.tsx`
+- Modify: `frontend/src/components/RepositoryInfoDialog.stories.tsx`
+- Modify: `frontend/src/locales/en.json`
+- Mirror new locale keys in existing locale files.
+
+- [ ] Add a small internal copyable command block to `RepositoryInfoDialog.tsx` using `navigator.clipboard.writeText`, `toast.success`, and `toast.error`.
+- [ ] Generate commands with the repository path, Borg version, `remote_path`, and encryption. Use `generateBorgInitCommand` for initialization.
+- [ ] In the failed info state, render the existing failed alert plus recovery commands for check, repair, and initialize.
+- [ ] Write a test that renders the failed state and asserts the three commands are present.
+- [ ] Write a test that clicks a recovery command copy button and asserts `navigator.clipboard.writeText` receives that command.
+- [ ] Add or update the Storybook story showing the failed recovery state.
+- [ ] Run the targeted Info dialog test and confirm it passes.
+
+### Task 4: Required Validation and Handoff
+
+**Files:**
+- Read/Update: Linear workpad comment
+- Commit/push through repo skills
+
+- [ ] Run targeted frontend tests for `Repositories` and `RepositoryInfoDialog`.
+- [ ] Run `cd frontend && npm run check:locales`.
+- [ ] Run `cd frontend && npm run typecheck`.
+- [ ] Run `cd frontend && npm run lint`.
+- [ ] Run `cd frontend && npm run build`.
+- [ ] Run runtime validation for the Info failed-state story or app path and record the evidence.
+- [ ] Commit changes, push the BOR-127 branch, create/link PR, add `symphony` label, sweep PR feedback/checks, then move Linear to Human Review only when green.

--- a/docs/engineering/specs/2026-06-03-broken-repository-check-recovery-ui.md
+++ b/docs/engineering/specs/2026-06-03-broken-repository-check-recovery-ui.md
@@ -1,0 +1,49 @@
+# Broken Repository Check Recovery UI
+
+## Problem
+
+Broken or uninitialized Borg repositories can leave users with ambiguous maintenance feedback. A manual Check run starts a background job, the card spinner stops when the running job disappears, and the page currently only invalidates repository data and records analytics. It does not announce the terminal check status or any stored `error_message`, so a failed check can look like it simply stopped. The Info dialog also has a generic failed state without a recovery path or copyable commands.
+
+## Desired Outcome
+
+Manual repository checks should always end with visible success or failure feedback. When repository info cannot load, users should see a compact recovery panel with copyable command templates for checking, repairing, and recreating the repository using the saved repository settings. The UI should guide recovery without introducing a risky server-side reinitialization action.
+
+## Approach
+
+Use the existing job-history API rather than adding backend endpoints. `GET /repositories/{id}/check-jobs?limit=1` already returns the latest job with `status`, `completed_at`, and `error_message`. When `RepositoryCard` reports a tracked manual check has completed, `Repositories.tsx` will fetch that latest job and show a toast:
+
+- success for `completed`;
+- warning for `completed_with_warnings`;
+- error with translated/raw `error_message` for failures or other unexpected terminal states.
+
+For the Info dialog failure state, add an inline recovery section that uses saved repository data to generate copyable commands:
+
+- normal check command;
+- repair check command;
+- reinitialization command via the existing `generateBorgInitCommand` utility.
+
+This keeps the recovery UX reversible and inspectable. A future backend-backed reinitialize action can still be added if product requirements call for it.
+
+## UI Notes
+
+The recovery panel should be dense and operational, matching the existing MUI dialog style. Use balanced outlines, background tinting, icon buttons, and monospaced command blocks. Avoid heavy left accent borders and avoid expanding the Info dialog into a wizard.
+
+## Acceptance Criteria
+
+- Manual repository Check jobs surface an explicit completion toast.
+- Failed manual Check jobs display the stored job error details when present.
+- The Info dialog failed state includes copyable check, repair, and initialization command templates.
+- Recovery commands use the repository path, Borg version, encryption, and remote path from saved repository settings.
+- Existing healthy repository Info and Check flows continue to work.
+- Storybook demonstrates the failed Info recovery state.
+
+## Validation
+
+- Add a failing frontend test that proves a completed manual Check job currently produces no terminal feedback.
+- Add tests for failed Check job error feedback and Info recovery command copy buttons.
+- Run targeted frontend tests for the touched components/page.
+- Run `cd frontend && npm run check:locales`.
+- Run `cd frontend && npm run typecheck`.
+- Run `cd frontend && npm run lint`.
+- Run `cd frontend && npm run build`.
+- Run local app/runtime validation for the repository Info/Check path when feasible in the current environment.

--- a/frontend/src/components/RepositoryInfoDialog.stories.tsx
+++ b/frontend/src/components/RepositoryInfoDialog.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box } from '@mui/material'
+import RepositoryInfoDialog from './RepositoryInfoDialog'
+import type { Repository } from '../types'
+
+const brokenRepository: Repository = {
+  id: 42,
+  name: 'Broken Archive',
+  path: '/mnt/borg/broken',
+  borg_version: 1,
+  encryption: 'repokey',
+  compression: 'lz4',
+  mode: 'full',
+}
+
+const meta = {
+  title: 'Components/RepositoryInfoDialog',
+  component: RepositoryInfoDialog,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    open: true,
+    repository: brokenRepository,
+    repositoryInfo: null,
+    isLoading: false,
+    onClose: () => {},
+  },
+  render: (args) => (
+    <Box sx={{ width: 760, minHeight: 520 }}>
+      <RepositoryInfoDialog {...args} />
+    </Box>
+  ),
+} satisfies Meta<typeof RepositoryInfoDialog>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const FailedInfoRecovery: Story = {}

--- a/frontend/src/components/RepositoryInfoDialog.tsx
+++ b/frontend/src/components/RepositoryInfoDialog.tsx
@@ -13,7 +13,7 @@ import {
   Paper,
 } from '@mui/material'
 import ResponsiveDialog from './shared/ResponsiveDialog'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import CalendarMonth from '@mui/icons-material/CalendarMonth'
 import CheckIcon from '@mui/icons-material/Check'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
@@ -128,6 +128,15 @@ function buildRecoveryCommands(
 function RecoveryCommandBox({ command }: { command: RecoveryCommand }) {
   const { t } = useTranslation()
   const [copied, setCopied] = useState(false)
+  const resetCopiedTimeoutRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (resetCopiedTimeoutRef.current !== null) {
+        window.clearTimeout(resetCopiedTimeoutRef.current)
+      }
+    }
+  }, [])
 
   const copyLabel = copied
     ? t('repositoryInfoDialog.recovery.copiedCommand', { label: command.label })
@@ -138,7 +147,13 @@ function RecoveryCommandBox({ command }: { command: RecoveryCommand }) {
       await navigator.clipboard.writeText(command.command)
       setCopied(true)
       toast.success(t('repositoryInfoDialog.recovery.commandCopied'))
-      window.setTimeout(() => setCopied(false), 2000)
+      if (resetCopiedTimeoutRef.current !== null) {
+        window.clearTimeout(resetCopiedTimeoutRef.current)
+      }
+      resetCopiedTimeoutRef.current = window.setTimeout(() => {
+        setCopied(false)
+        resetCopiedTimeoutRef.current = null
+      }, 2000)
     } catch {
       toast.error(t('repositoryInfoDialog.recovery.copyFailed'))
     }

--- a/frontend/src/components/RepositoryInfoDialog.tsx
+++ b/frontend/src/components/RepositoryInfoDialog.tsx
@@ -10,10 +10,13 @@ import {
   Alert,
   IconButton,
   Tooltip,
+  Paper,
 } from '@mui/material'
 import ResponsiveDialog from './shared/ResponsiveDialog'
 import { useEffect, useState } from 'react'
 import CalendarMonth from '@mui/icons-material/CalendarMonth'
+import CheckIcon from '@mui/icons-material/Check'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import FileDownload from '@mui/icons-material/FileDownload'
 import Info from '@mui/icons-material/Info'
 import Lock from '@mui/icons-material/Lock'
@@ -29,6 +32,7 @@ import PlanGate from './shared/PlanGate'
 import UpgradePrompt from './UpgradePrompt'
 import { Repository } from '../types'
 import { isV2Repo } from '../utils/repoCapabilities'
+import { generateBorgInitCommand } from '../utils/borgUtils'
 
 interface RepositoryInfo {
   encryption?: {
@@ -51,6 +55,130 @@ interface RepositoryInfoDialogProps {
   repositoryInfo: RepositoryInfo | null
   isLoading: boolean
   onClose: () => void
+}
+
+interface RecoveryCommand {
+  key: 'check' | 'repair' | 'init'
+  label: string
+  command: string
+}
+
+function buildCheckCommand(repository: Repository, repair = false): string {
+  const borgVersion = repository.borg_version === 2 ? 2 : 1
+  const binary = borgVersion === 2 ? 'borg2' : 'borg'
+  const remotePath = typeof repository.remote_path === 'string' ? repository.remote_path.trim() : ''
+  const remotePathFlag = remotePath ? ` --remote-path ${remotePath}` : ''
+
+  if (borgVersion === 2) {
+    return `${binary} -r ${repository.path} check${repair ? ' --repair' : ''}${remotePathFlag}`
+  }
+
+  return `${binary} check${repair ? ' --repair' : ''}${remotePathFlag} ${repository.path}`
+}
+
+function buildRecoveryCommands(
+  repository: Repository,
+  t: ReturnType<typeof useTranslation>['t']
+): RecoveryCommand[] {
+  const borgVersion = repository.borg_version === 2 ? 2 : 1
+  const remotePath = typeof repository.remote_path === 'string' ? repository.remote_path.trim() : ''
+  const remotePathFlag = remotePath ? `--remote-path ${remotePath} ` : ''
+  const encryption =
+    typeof repository.encryption === 'string' && repository.encryption.trim()
+      ? repository.encryption.trim()
+      : borgVersion === 2
+        ? 'repokey-aes-ocb'
+        : 'repokey'
+
+  return [
+    {
+      key: 'check',
+      label: t('repositoryInfoDialog.recovery.checkCommand'),
+      command: buildCheckCommand(repository),
+    },
+    {
+      key: 'repair',
+      label: t('repositoryInfoDialog.recovery.repairCommand'),
+      command: buildCheckCommand(repository, true),
+    },
+    {
+      key: 'init',
+      label: t('repositoryInfoDialog.recovery.initCommand'),
+      command: generateBorgInitCommand({
+        repositoryPath: repository.path,
+        borgVersion,
+        encryption,
+        remotePathFlag,
+      }),
+    },
+  ]
+}
+
+function RecoveryCommandBox({ command }: { command: RecoveryCommand }) {
+  const { t } = useTranslation()
+  const [copied, setCopied] = useState(false)
+
+  const copyLabel = copied
+    ? t('repositoryInfoDialog.recovery.copiedCommand', { label: command.label })
+    : t('repositoryInfoDialog.recovery.copyCommand', { label: command.label })
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(command.command)
+      setCopied(true)
+      toast.success(t('repositoryInfoDialog.recovery.commandCopied'))
+      window.setTimeout(() => setCopied(false), 2000)
+    } catch {
+      toast.error(t('repositoryInfoDialog.recovery.copyFailed'))
+    }
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+      <Typography variant="caption" color="text.secondary" fontWeight={700}>
+        {command.label}
+      </Typography>
+      <Box
+        sx={{
+          position: 'relative',
+          bgcolor: 'grey.900',
+          color: 'grey.100',
+          borderRadius: 1,
+          px: 1.25,
+          py: 1,
+          pr: 5,
+          fontFamily: '"JetBrains Mono","Fira Code",ui-monospace,monospace',
+          fontSize: '0.78rem',
+          lineHeight: 1.45,
+          overflowX: 'auto',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-all',
+        }}
+      >
+        {command.command}
+        <Tooltip title={copyLabel}>
+          <IconButton
+            size="small"
+            aria-label={copyLabel}
+            onClick={handleCopy}
+            sx={{
+              position: 'absolute',
+              top: 4,
+              right: 4,
+              color: 'grey.400',
+              bgcolor: 'rgba(255,255,255,0.08)',
+              '&:hover': {
+                bgcolor: 'rgba(255,255,255,0.16)',
+                color: 'grey.200',
+              },
+            }}
+          >
+            {copied ? <CheckIcon fontSize="small" /> : <ContentCopyIcon fontSize="small" />}
+          </IconButton>
+        </Tooltip>
+      </Box>
+    </Box>
+  )
 }
 
 export default function RepositoryInfoDialog({
@@ -264,7 +392,31 @@ export default function RepositoryInfoDialog({
                 )}
               </Box>
             ) : (
-              <Alert severity="error">{t('repositoryInfoDialog.failedToLoad')}</Alert>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <Alert severity="error">{t('repositoryInfoDialog.failedToLoad')}</Alert>
+                {displayRepository && (
+                  <Paper
+                    variant="outlined"
+                    sx={{
+                      p: 2,
+                      borderRadius: 1,
+                      bgcolor: 'action.hover',
+                    }}
+                  >
+                    <Typography variant="subtitle2" fontWeight={700} gutterBottom>
+                      {t('repositoryInfoDialog.recovery.title')}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+                      {t('repositoryInfoDialog.recovery.description')}
+                    </Typography>
+                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25 }}>
+                      {buildRecoveryCommands(displayRepository, t).map((command) => (
+                        <RecoveryCommandBox key={command.key} command={command} />
+                      ))}
+                    </Box>
+                  </Paper>
+                )}
+              </Box>
             )}
           </PlanGate>
         )}

--- a/frontend/src/components/RepositoryInfoDialog.tsx
+++ b/frontend/src/components/RepositoryInfoDialog.tsx
@@ -63,17 +63,28 @@ interface RecoveryCommand {
   command: string
 }
 
+const SAFE_SHELL_ARG_PATTERN = /^[A-Za-z0-9_@%+=:,./-]+$/
+
+function shellQuote(value: string): string {
+  if (value && SAFE_SHELL_ARG_PATTERN.test(value)) {
+    return value
+  }
+
+  return `'${value.replace(/'/g, "'\\''")}'`
+}
+
 function buildCheckCommand(repository: Repository, repair = false): string {
   const borgVersion = repository.borg_version === 2 ? 2 : 1
   const binary = borgVersion === 2 ? 'borg2' : 'borg'
   const remotePath = typeof repository.remote_path === 'string' ? repository.remote_path.trim() : ''
-  const remotePathFlag = remotePath ? ` --remote-path ${remotePath}` : ''
+  const remotePathFlag = remotePath ? ` --remote-path ${shellQuote(remotePath)}` : ''
+  const repositoryPath = shellQuote(repository.path)
 
   if (borgVersion === 2) {
-    return `${binary} -r ${repository.path} check${repair ? ' --repair' : ''}${remotePathFlag}`
+    return `${binary} -r ${repositoryPath} check${repair ? ' --repair' : ''}${remotePathFlag}`
   }
 
-  return `${binary} check${repair ? ' --repair' : ''}${remotePathFlag} ${repository.path}`
+  return `${binary} check${repair ? ' --repair' : ''}${remotePathFlag} ${repositoryPath}`
 }
 
 function buildRecoveryCommands(
@@ -82,7 +93,7 @@ function buildRecoveryCommands(
 ): RecoveryCommand[] {
   const borgVersion = repository.borg_version === 2 ? 2 : 1
   const remotePath = typeof repository.remote_path === 'string' ? repository.remote_path.trim() : ''
-  const remotePathFlag = remotePath ? `--remote-path ${remotePath} ` : ''
+  const remotePathFlag = remotePath ? `--remote-path ${shellQuote(remotePath)} ` : ''
   const encryption =
     typeof repository.encryption === 'string' && repository.encryption.trim()
       ? repository.encryption.trim()
@@ -105,7 +116,7 @@ function buildRecoveryCommands(
       key: 'init',
       label: t('repositoryInfoDialog.recovery.initCommand'),
       command: generateBorgInitCommand({
-        repositoryPath: repository.path,
+        repositoryPath: shellQuote(repository.path),
         borgVersion,
         encryption,
         remotePathFlag,
@@ -261,16 +272,7 @@ export default function RepositoryInfoDialog({
       </DialogTitle>
       <DialogContent>
         {displayRepository && (
-          <PlanGate
-            feature="borg_v2"
-            when={isV2Repo(displayRepository)}
-            fallback={
-              <UpgradePrompt
-                requiredPlan="pro"
-                message={t('dialogs.repositoryInfo.v2PlanRequired')}
-              />
-            }
-          >
+          <>
             {isLoading ? (
               <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 8 }}>
                 <Typography variant="body2" color="text.secondary">
@@ -278,119 +280,134 @@ export default function RepositoryInfoDialog({
                 </Typography>
               </Box>
             ) : displayRepositoryInfo ? (
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, mt: 1 }}>
-                {/* Repository Details Cards */}
-                <Box
-                  sx={{
-                    display: 'grid',
-                    gridTemplateColumns: { xs: '1fr', md: 'repeat(2, 1fr)' },
-                    gap: 2,
-                  }}
-                >
-                  {/* Encryption */}
-                  <Card sx={{ backgroundColor: '#f3e5f5' }}>
-                    <CardContent sx={{ py: 2 }}>
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'space-between',
-                          mb: 1,
-                        }}
-                      >
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-                          <Lock sx={{ color: '#7b1fa2', fontSize: 28 }} />
+              <PlanGate
+                feature="borg_v2"
+                when={isV2Repo(displayRepository)}
+                fallback={
+                  <UpgradePrompt
+                    requiredPlan="pro"
+                    message={t('dialogs.repositoryInfo.v2PlanRequired')}
+                  />
+                }
+              >
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, mt: 1 }}>
+                  {/* Repository Details Cards */}
+                  <Box
+                    sx={{
+                      display: 'grid',
+                      gridTemplateColumns: { xs: '1fr', md: 'repeat(2, 1fr)' },
+                      gap: 2,
+                    }}
+                  >
+                    {/* Encryption */}
+                    <Card sx={{ backgroundColor: '#f3e5f5' }}>
+                      <CardContent sx={{ py: 2 }}>
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'space-between',
+                            mb: 1,
+                          }}
+                        >
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                            <Lock sx={{ color: '#7b1fa2', fontSize: 28 }} />
+                            <Typography variant="body2" color="text.secondary" fontWeight={500}>
+                              {t('dialogs.repositoryInfo.encryption')}
+                            </Typography>
+                          </Box>
+                          {displayRepository?.has_keyfile && (
+                            <Tooltip
+                              title={t('dialogs.repositoryInfo.exportKeyfileTooltip')}
+                              arrow
+                              placement="top"
+                            >
+                              <IconButton
+                                onClick={handleDownloadKeyfile}
+                                size="small"
+                                sx={{
+                                  backgroundColor: '#7b1fa2',
+                                  color: 'white',
+                                  width: 30,
+                                  height: 30,
+                                  '&:hover': {
+                                    backgroundColor: '#4a148c',
+                                    transform: 'scale(1.1)',
+                                  },
+                                  transition: 'all 0.15s ease',
+                                }}
+                              >
+                                <FileDownload sx={{ fontSize: 16 }} />
+                              </IconButton>
+                            </Tooltip>
+                          )}
+                        </Box>
+                        <Typography variant="h6" fontWeight={700} sx={{ color: '#7b1fa2', ml: 5 }}>
+                          {displayRepositoryInfo.encryption?.mode || 'N/A'}
+                        </Typography>
+                      </CardContent>
+                    </Card>
+
+                    {/* Last Modified */}
+                    <Card sx={{ backgroundColor: '#e1f5fe' }}>
+                      <CardContent sx={{ py: 2 }}>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1 }}>
+                          <CalendarMonth sx={{ color: '#0277bd', fontSize: 28 }} />
                           <Typography variant="body2" color="text.secondary" fontWeight={500}>
-                            {t('dialogs.repositoryInfo.encryption')}
+                            {t('dialogs.repositoryInfo.lastModified')}
                           </Typography>
                         </Box>
-                        {displayRepository?.has_keyfile && (
-                          <Tooltip
-                            title={t('dialogs.repositoryInfo.exportKeyfileTooltip')}
-                            arrow
-                            placement="top"
-                          >
-                            <IconButton
-                              onClick={handleDownloadKeyfile}
-                              size="small"
-                              sx={{
-                                backgroundColor: '#7b1fa2',
-                                color: 'white',
-                                width: 30,
-                                height: 30,
-                                '&:hover': {
-                                  backgroundColor: '#4a148c',
-                                  transform: 'scale(1.1)',
-                                },
-                                transition: 'all 0.15s ease',
-                              }}
-                            >
-                              <FileDownload sx={{ fontSize: 16 }} />
-                            </IconButton>
-                          </Tooltip>
-                        )}
-                      </Box>
-                      <Typography variant="h6" fontWeight={700} sx={{ color: '#7b1fa2', ml: 5 }}>
-                        {displayRepositoryInfo.encryption?.mode || 'N/A'}
-                      </Typography>
-                    </CardContent>
-                  </Card>
-
-                  {/* Last Modified */}
-                  <Card sx={{ backgroundColor: '#e1f5fe' }}>
-                    <CardContent sx={{ py: 2 }}>
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1 }}>
-                        <CalendarMonth sx={{ color: '#0277bd', fontSize: 28 }} />
-                        <Typography variant="body2" color="text.secondary" fontWeight={500}>
-                          {t('dialogs.repositoryInfo.lastModified')}
+                        <Typography
+                          variant="body2"
+                          fontWeight={600}
+                          sx={{ color: '#0277bd', ml: 5 }}
+                        >
+                          {displayRepositoryInfo.repository?.last_modified
+                            ? formatDateShort(displayRepositoryInfo.repository.last_modified)
+                            : 'N/A'}
                         </Typography>
-                      </Box>
-                      <Typography variant="body2" fontWeight={600} sx={{ color: '#0277bd', ml: 5 }}>
-                        {displayRepositoryInfo.repository?.last_modified
-                          ? formatDateShort(displayRepositoryInfo.repository.last_modified)
-                          : 'N/A'}
+                      </CardContent>
+                    </Card>
+                  </Box>
+
+                  {/* Location */}
+                  <Card variant="outlined">
+                    <CardContent sx={{ py: 2 }}>
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        display="block"
+                        sx={{ mb: 0.5 }}
+                      >
+                        {t('dialogs.repositoryInfo.repositoryLocation')}
+                      </Typography>
+                      <Typography
+                        variant="body2"
+                        sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}
+                      >
+                        {displayRepositoryInfo.repository?.location || 'N/A'}
                       </Typography>
                     </CardContent>
                   </Card>
+
+                  {/* Storage Statistics */}
+                  {isV2Repo(displayRepository) ? (
+                    <RepositoryStatsV2 archives={displayRepositoryInfo.archives || []} />
+                  ) : displayRepositoryInfo.cache?.stats &&
+                    (displayRepositoryInfo.cache.stats.total_size ?? 0) > 0 ? (
+                    <RepositoryStatsV1 stats={displayRepositoryInfo.cache.stats} />
+                  ) : (
+                    <Alert severity="info" icon={<Info />}>
+                      <Typography variant="body2" fontWeight={600} gutterBottom>
+                        {t('dialogs.repositoryInfo.noBackupsYet')}
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {t('repositoryInfoDialog.noArchivesDescription')}
+                      </Typography>
+                    </Alert>
+                  )}
                 </Box>
-
-                {/* Location */}
-                <Card variant="outlined">
-                  <CardContent sx={{ py: 2 }}>
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      display="block"
-                      sx={{ mb: 0.5 }}
-                    >
-                      {t('dialogs.repositoryInfo.repositoryLocation')}
-                    </Typography>
-                    <Typography
-                      variant="body2"
-                      sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}
-                    >
-                      {displayRepositoryInfo.repository?.location || 'N/A'}
-                    </Typography>
-                  </CardContent>
-                </Card>
-
-                {/* Storage Statistics */}
-                {isV2Repo(displayRepository) ? (
-                  <RepositoryStatsV2 archives={displayRepositoryInfo.archives || []} />
-                ) : displayRepositoryInfo.cache?.stats &&
-                  (displayRepositoryInfo.cache.stats.total_size ?? 0) > 0 ? (
-                  <RepositoryStatsV1 stats={displayRepositoryInfo.cache.stats} />
-                ) : (
-                  <Alert severity="info" icon={<Info />}>
-                    <Typography variant="body2" fontWeight={600} gutterBottom>
-                      {t('dialogs.repositoryInfo.noBackupsYet')}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      {t('repositoryInfoDialog.noArchivesDescription')}
-                    </Typography>
-                  </Alert>
-                )}
-              </Box>
+              </PlanGate>
             ) : (
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                 <Alert severity="error">{t('repositoryInfoDialog.failedToLoad')}</Alert>
@@ -418,7 +435,7 @@ export default function RepositoryInfoDialog({
                 )}
               </Box>
             )}
-          </PlanGate>
+          </>
         )}
       </DialogContent>
       <DialogActions sx={{ display: { xs: 'none', md: 'flex' } }}>

--- a/frontend/src/components/__tests__/RepositoryInfoDialog.test.tsx
+++ b/frontend/src/components/__tests__/RepositoryInfoDialog.test.tsx
@@ -381,6 +381,40 @@ describe('RepositoryInfoDialog', () => {
 
       expect(writeText).toHaveBeenCalledWith('borg check /repo/test')
     })
+
+    it('clears the copied feedback timeout when unmounted', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      const setTimeoutSpy = vi.spyOn(window, 'setTimeout')
+      const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout')
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+      })
+
+      const { unmount } = render(
+        <RepositoryInfoDialog
+          open={true}
+          repository={{ ...mockRepository, encryption: 'repokey', borg_version: 1 }}
+          repositoryInfo={null}
+          isLoading={false}
+          onClose={vi.fn()}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Copy Check repository command' }))
+      await waitFor(() => expect(writeText).toHaveBeenCalledWith('borg check /repo/test'))
+      const copyTimeoutResult = setTimeoutSpy.mock.results.find(
+        (_, index) => setTimeoutSpy.mock.calls[index]?.[1] === 2000
+      )
+
+      expect(copyTimeoutResult?.value).toBeDefined()
+
+      unmount()
+
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(copyTimeoutResult?.value)
+      setTimeoutSpy.mockRestore()
+      clearTimeoutSpy.mockRestore()
+    })
   })
 
   describe('Close Button', () => {

--- a/frontend/src/components/__tests__/RepositoryInfoDialog.test.tsx
+++ b/frontend/src/components/__tests__/RepositoryInfoDialog.test.tsx
@@ -3,10 +3,22 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import RepositoryInfoDialog from '../RepositoryInfoDialog'
 
+const { mockCanUseFeature } = vi.hoisted(() => ({
+  mockCanUseFeature: vi.fn(() => true),
+}))
+
 vi.mock('../../services/api', () => ({
   repositoriesAPI: {
     downloadKeyfile: vi.fn(),
   },
+}))
+
+vi.mock('../../hooks/usePlan', () => ({
+  usePlan: () => ({
+    plan: 'community',
+    isLoading: false,
+    can: mockCanUseFeature,
+  }),
 }))
 
 import { repositoriesAPI } from '../../services/api'
@@ -37,6 +49,11 @@ const mockRepositoryInfo = {
 }
 
 describe('RepositoryInfoDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCanUseFeature.mockReturnValue(true)
+  })
+
   describe('Rendering', () => {
     it('renders dialog when open', () => {
       render(
@@ -294,6 +311,54 @@ describe('RepositoryInfoDialog', () => {
       expect(screen.getByText('borg init --encryption repokey /repo/test')).toBeInTheDocument()
     })
 
+    it('shell-escapes recovery command paths and remote path values', () => {
+      render(
+        <RepositoryInfoDialog
+          open={true}
+          repository={{
+            ...mockRepository,
+            encryption: 'repokey',
+            borg_version: 1,
+            path: '/repo/test path;rm',
+            remote_path: '/usr/bin/borg 2',
+          }}
+          repositoryInfo={null}
+          isLoading={false}
+          onClose={vi.fn()}
+        />
+      )
+
+      expect(
+        screen.getByText("borg check --remote-path '/usr/bin/borg 2' '/repo/test path;rm'")
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText("borg check --repair --remote-path '/usr/bin/borg 2' '/repo/test path;rm'")
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          "borg init --encryption repokey --remote-path '/usr/bin/borg 2' '/repo/test path;rm'"
+        )
+      ).toBeInTheDocument()
+    })
+
+    it('shows recovery commands for Borg 2 repositories even when Borg 2 details are gated', () => {
+      mockCanUseFeature.mockReturnValue(false)
+
+      render(
+        <RepositoryInfoDialog
+          open={true}
+          repository={{ ...mockRepository, encryption: 'repokey-aes-ocb', borg_version: 2 }}
+          repositoryInfo={null}
+          isLoading={false}
+          onClose={vi.fn()}
+        />
+      )
+
+      expect(screen.getByText(/Failed to load repository information/i)).toBeInTheDocument()
+      expect(screen.getByText('Recovery commands')).toBeInTheDocument()
+      expect(screen.getByText('borg2 -r /repo/test check')).toBeInTheDocument()
+    })
+
     it('copies a recovery command to the clipboard', async () => {
       const user = userEvent.setup()
       const writeText = vi.fn().mockResolvedValue(undefined)
@@ -312,9 +377,7 @@ describe('RepositoryInfoDialog', () => {
         />
       )
 
-      await user.click(
-        screen.getByRole('button', { name: 'Copy Check repository command' })
-      )
+      await user.click(screen.getByRole('button', { name: 'Copy Check repository command' }))
 
       expect(writeText).toHaveBeenCalledWith('borg check /repo/test')
     })
@@ -356,7 +419,6 @@ describe('RepositoryInfoDialog', () => {
   })
 
   describe('beforeEach cleanup', () => {
-    beforeEach(() => vi.clearAllMocks())
     it('placeholder to attach beforeEach', () => {})
   })
 

--- a/frontend/src/components/__tests__/RepositoryInfoDialog.test.tsx
+++ b/frontend/src/components/__tests__/RepositoryInfoDialog.test.tsx
@@ -276,6 +276,48 @@ describe('RepositoryInfoDialog', () => {
 
       expect(screen.getByText(/Failed to load repository information/i)).toBeInTheDocument()
     })
+
+    it('shows copyable recovery commands when repository info cannot load', () => {
+      render(
+        <RepositoryInfoDialog
+          open={true}
+          repository={{ ...mockRepository, encryption: 'repokey', borg_version: 1 }}
+          repositoryInfo={null}
+          isLoading={false}
+          onClose={vi.fn()}
+        />
+      )
+
+      expect(screen.getByText('Recovery commands')).toBeInTheDocument()
+      expect(screen.getByText('borg check /repo/test')).toBeInTheDocument()
+      expect(screen.getByText('borg check --repair /repo/test')).toBeInTheDocument()
+      expect(screen.getByText('borg init --encryption repokey /repo/test')).toBeInTheDocument()
+    })
+
+    it('copies a recovery command to the clipboard', async () => {
+      const user = userEvent.setup()
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+      })
+
+      render(
+        <RepositoryInfoDialog
+          open={true}
+          repository={{ ...mockRepository, encryption: 'repokey', borg_version: 1 }}
+          repositoryInfo={null}
+          isLoading={false}
+          onClose={vi.fn()}
+        />
+      )
+
+      await user.click(
+        screen.getByRole('button', { name: 'Copy Check repository command' })
+      )
+
+      expect(writeText).toHaveBeenCalledWith('borg check /repo/test')
+    })
   })
 
   describe('Close Button', () => {

--- a/frontend/src/components/__tests__/RepositoryInfoDialog.test.tsx
+++ b/frontend/src/components/__tests__/RepositoryInfoDialog.test.tsx
@@ -452,10 +452,6 @@ describe('RepositoryInfoDialog', () => {
     })
   })
 
-  describe('beforeEach cleanup', () => {
-    it('placeholder to attach beforeEach', () => {})
-  })
-
   describe('Borg 2 repository stats', () => {
     const v2Repo = { id: 2, name: 'V2 Repo', path: '/repo/test', borg_version: 2 }
     const v2Info = {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1236,6 +1236,10 @@
       "deleted": "Repository erfolgreich gelöscht",
       "deleteFailed": "Repository konnte nicht gelöscht werden",
       "checkStarted": "Überprüfung gestartet",
+      "checkCompleted": "Überprüfung abgeschlossen",
+      "checkCompletedWithWarnings": "Überprüfung mit Warnungen abgeschlossen",
+      "checkRunFailed": "Überprüfung fehlgeschlagen",
+      "checkFailedWithMessage": "Überprüfung fehlgeschlagen: {{message}}",
       "checkFailed": "Überprüfung konnte nicht gestartet werden",
       "compactStarted": "Komprimierung gestartet",
       "compactFailed": "Komprimierung konnte nicht gestartet werden",
@@ -4121,7 +4125,18 @@
   "repositoryInfoDialog": {
     "failedToDownloadKeyfile": "Schlüsseldatei konnte nicht heruntergeladen werden",
     "noArchivesDescription": "Dieses Repository wurde initialisiert, enthält aber keine Archive. Speicherstatistiken erscheinen hier nach der ersten Sicherung.",
-    "failedToLoad": "Repository-Informationen konnten nicht geladen werden. Stelle sicher, dass das Repository zugänglich und ordnungsgemäß initialisiert ist."
+    "failedToLoad": "Repository-Informationen konnten nicht geladen werden. Stelle sicher, dass das Repository zugänglich und ordnungsgemäß initialisiert ist.",
+    "recovery": {
+      "title": "Wiederherstellungsbefehle",
+      "description": "Nutze diese Befehlsvorlagen, um dieses Repository außerhalb von Borg UI zu diagnostizieren, zu reparieren oder neu zu erstellen.",
+      "checkCommand": "Repository prüfen",
+      "repairCommand": "Reparaturprüfung",
+      "initCommand": "Repository initialisieren",
+      "copyCommand": "Befehl {{label}} kopieren",
+      "copiedCommand": "Befehl {{label}} kopiert",
+      "commandCopied": "Befehl kopiert",
+      "copyFailed": "Befehl konnte nicht kopiert werden"
+    }
   },
   "analyticsBanner": {
     "viewDashboardLink": "Unser öffentliches Analyse-Dashboard anzeigen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1236,6 +1236,10 @@
       "deleted": "Repository deleted successfully",
       "deleteFailed": "Failed to delete repository",
       "checkStarted": "Check operation started",
+      "checkCompleted": "Check completed",
+      "checkCompletedWithWarnings": "Check completed with warnings",
+      "checkRunFailed": "Check failed",
+      "checkFailedWithMessage": "Check failed: {{message}}",
       "checkFailed": "Failed to start check",
       "compactStarted": "Compact operation started",
       "compactFailed": "Failed to start compact",
@@ -4121,7 +4125,18 @@
   "repositoryInfoDialog": {
     "failedToDownloadKeyfile": "Failed to download keyfile",
     "noArchivesDescription": "This repository has been initialized but contains no archives. Storage statistics will appear here after you create your first backup.",
-    "failedToLoad": "Failed to load repository information. Make sure the repository is accessible and properly initialized."
+    "failedToLoad": "Failed to load repository information. Make sure the repository is accessible and properly initialized.",
+    "recovery": {
+      "title": "Recovery commands",
+      "description": "Use these command templates when you need to diagnose, repair, or recreate this repository outside Borg UI.",
+      "checkCommand": "Check repository",
+      "repairCommand": "Repair check",
+      "initCommand": "Initialize repository",
+      "copyCommand": "Copy {{label}} command",
+      "copiedCommand": "Copied {{label}} command",
+      "commandCopied": "Command copied",
+      "copyFailed": "Failed to copy command"
+    }
   },
   "analyticsBanner": {
     "viewDashboardLink": "View our public analytics dashboard",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -4130,7 +4130,7 @@
       "title": "Comandos de recuperación",
       "description": "Usa estas plantillas de comandos cuando necesites diagnosticar, reparar o recrear este repositorio fuera de Borg UI.",
       "checkCommand": "Comprobar repositorio",
-      "repairCommand": "Comprobación de reparación",
+      "repairCommand": "Reparar repositorio",
       "initCommand": "Inicializar repositorio",
       "copyCommand": "Copiar comando {{label}}",
       "copiedCommand": "Comando {{label}} copiado",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -1236,6 +1236,10 @@
       "deleted": "Repositorio eliminado correctamente",
       "deleteFailed": "Error al eliminar el repositorio",
       "checkStarted": "Verificación iniciada",
+      "checkCompleted": "Verificación completada",
+      "checkCompletedWithWarnings": "Verificación completada con advertencias",
+      "checkRunFailed": "Verificación fallida",
+      "checkFailedWithMessage": "Verificación fallida: {{message}}",
       "checkFailed": "Error al iniciar la verificación",
       "compactStarted": "Compactación iniciada",
       "compactFailed": "Error al iniciar la compactación",
@@ -4121,7 +4125,18 @@
   "repositoryInfoDialog": {
     "failedToDownloadKeyfile": "Error al descargar el archivo de clave",
     "noArchivesDescription": "Este repositorio ha sido inicializado pero no contiene archivos. Las estadísticas de almacenamiento aparecerán aquí después de crear tu primera copia de seguridad.",
-    "failedToLoad": "Error al cargar la información del repositorio. Asegúrate de que el repositorio sea accesible y esté correctamente inicializado."
+    "failedToLoad": "Error al cargar la información del repositorio. Asegúrate de que el repositorio sea accesible y esté correctamente inicializado.",
+    "recovery": {
+      "title": "Comandos de recuperación",
+      "description": "Usa estas plantillas de comandos cuando necesites diagnosticar, reparar o recrear este repositorio fuera de Borg UI.",
+      "checkCommand": "Comprobar repositorio",
+      "repairCommand": "Comprobación de reparación",
+      "initCommand": "Inicializar repositorio",
+      "copyCommand": "Copiar comando {{label}}",
+      "copiedCommand": "Comando {{label}} copiado",
+      "commandCopied": "Comando copiado",
+      "copyFailed": "Error al copiar el comando"
+    }
   },
   "analyticsBanner": {
     "viewDashboardLink": "Ver nuestro panel de análisis público",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -1236,6 +1236,10 @@
       "deleted": "Repository eliminato con successo",
       "deleteFailed": "Impossibile eliminare il repository",
       "checkStarted": "Operazione di controllo avviata",
+      "checkCompleted": "Controllo completato",
+      "checkCompletedWithWarnings": "Controllo completato con avvisi",
+      "checkRunFailed": "Controllo non riuscito",
+      "checkFailedWithMessage": "Controllo non riuscito: {{message}}",
       "checkFailed": "Impossibile avviare il controllo",
       "compactStarted": "Operazione di compattazione avviata",
       "compactFailed": "Impossibile avviare la compattazione",
@@ -4121,7 +4125,18 @@
   "repositoryInfoDialog": {
     "failedToDownloadKeyfile": "Impossibile scaricare il file chiave",
     "noArchivesDescription": "Questo repository è stato inizializzato ma non contiene archivi. Le statistiche di archiviazione appariranno qui dopo aver creato il primo backup.",
-    "failedToLoad": "Impossibile caricare le informazioni del repository. Assicurati che il repository sia accessibile e inizializzato correttamente."
+    "failedToLoad": "Impossibile caricare le informazioni del repository. Assicurati che il repository sia accessibile e inizializzato correttamente.",
+    "recovery": {
+      "title": "Comandi di recupero",
+      "description": "Usa questi modelli di comando quando devi diagnosticare, riparare o ricreare questo repository fuori da Borg UI.",
+      "checkCommand": "Controlla repository",
+      "repairCommand": "Controllo con riparazione",
+      "initCommand": "Inizializza repository",
+      "copyCommand": "Copia comando {{label}}",
+      "copiedCommand": "Comando {{label}} copiato",
+      "commandCopied": "Comando copiato",
+      "copyFailed": "Impossibile copiare il comando"
+    }
   },
   "analyticsBanner": {
     "viewDashboardLink": "Visualizza la nostra dashboard di analisi pubblica",

--- a/frontend/src/pages/Repositories.tsx
+++ b/frontend/src/pages/Repositories.tsx
@@ -514,6 +514,7 @@ export default function Repositories() {
     const tracked = maintenanceTrackingRef.current.get(repositoryId)
     if (tracked) {
       const repository = repositories.find((repo: Repository) => repo.id === repositoryId)
+      let toastShown = false
       try {
         const response =
           tracked.operation === 'Check'
@@ -527,13 +528,16 @@ export default function Repositories() {
           if (tracked.operation === 'Check') {
             if (latestJob.status === 'completed') {
               toast.success(t('repositories.toasts.checkCompleted'))
+              toastShown = true
             } else if (latestJob.status === 'completed_with_warnings') {
               toast(t('repositories.toasts.checkCompletedWithWarnings'), { icon: '!' })
+              toastShown = true
             } else {
               const message = latestJob.error_message
-                ? translateBackendKey(latestJob.error_message)
+                ? translateBackendKey(latestJob.error_message) || latestJob.error_message
                 : t('repositories.toasts.checkRunFailed')
               toast.error(t('repositories.toasts.checkFailedWithMessage', { message }))
+              toastShown = true
             }
           }
 
@@ -547,8 +551,14 @@ export default function Repositories() {
             duration_seconds: getJobDurationSeconds(latestJob.started_at, latestJob.completed_at),
             error_present: !!latestJob.error_message,
           })
+        } else if (tracked.operation === 'Check') {
+          toast.success(t('repositories.toasts.checkCompleted'))
+          toastShown = true
         }
       } catch {
+        if (tracked.operation === 'Check' && !toastShown) {
+          toast.success(t('repositories.toasts.checkCompleted'))
+        }
         // Best-effort analytics should not affect maintenance UX.
       }
       maintenanceTrackingRef.current.delete(repositoryId)

--- a/frontend/src/pages/Repositories.tsx
+++ b/frontend/src/pages/Repositories.tsx
@@ -48,6 +48,14 @@ const TERMINAL_WIPE_STATUSES = new Set([
 ])
 type RcloneRepositoryAction = 'sync' | 'hydrate'
 
+interface MaintenanceJobSummary {
+  id: number
+  status?: string | null
+  started_at?: string | null
+  completed_at?: string | null
+  error_message?: string | null
+}
+
 function parseBackupPlanFilterId(value: string | null): number | null {
   if (!value) return null
   const id = Number(value)
@@ -513,9 +521,22 @@ export default function Repositories() {
             : tracked.operation === 'Compact'
               ? await repositoriesAPI.getRepositoryCompactJobs(repositoryId, 1)
               : await repositoriesAPI.getRepositoryPruneJobs(repositoryId, 1)
-        const latestJob = response.data?.jobs?.[0]
+        const latestJob = response.data?.jobs?.[0] as MaintenanceJobSummary | undefined
 
         if (latestJob?.status) {
+          if (tracked.operation === 'Check') {
+            if (latestJob.status === 'completed') {
+              toast.success(t('repositories.toasts.checkCompleted'))
+            } else if (latestJob.status === 'completed_with_warnings') {
+              toast(t('repositories.toasts.checkCompletedWithWarnings'), { icon: '!' })
+            } else {
+              const message = latestJob.error_message
+                ? translateBackendKey(latestJob.error_message)
+                : t('repositories.toasts.checkRunFailed')
+              toast.error(t('repositories.toasts.checkFailedWithMessage', { message }))
+            }
+          }
+
           const action =
             latestJob.status === 'completed' || latestJob.status === 'completed_with_warnings'
               ? EventAction.COMPLETE

--- a/frontend/src/pages/__tests__/Repositories.test.tsx
+++ b/frontend/src/pages/__tests__/Repositories.test.tsx
@@ -27,6 +27,37 @@ const mockRepository = {
   mode: 'full',
 }
 
+const buildCheckJob = (
+  overrides: Partial<{
+    id: number
+    repository_id: number
+    status: string
+    started_at: string
+    completed_at: string
+    error_message: string | null
+    progress: number
+    progress_message: string
+    scheduled_check: boolean
+  }> = {}
+) => ({
+  id: 23,
+  repository_id: 1,
+  status: 'failed',
+  started_at: '2026-01-01T00:00:00Z',
+  completed_at: '2026-01-01T00:00:05Z',
+  error_message: 'Repository is not initialized',
+  progress: 100,
+  progress_message: 'Check failed',
+  scheduled_check: false,
+  ...overrides,
+})
+
+const mockLatestCheckJob = (job: ReturnType<typeof buildCheckJob>) => {
+  vi.mocked(repositoriesAPI.getRepositoryCheckJobs).mockResolvedValue({
+    data: { jobs: [job] },
+  } as Awaited<ReturnType<typeof repositoriesAPI.getRepositoryCheckJobs>>)
+}
+
 vi.mock('react-hot-toast', () => {
   const toastMock = Object.assign(vi.fn(), {
     success: vi.fn(),
@@ -176,27 +207,11 @@ describe('Repositories', () => {
     vi.mocked(backupPlansAPI.list).mockResolvedValue({
       data: { backup_plans: [] },
     } as Awaited<ReturnType<typeof backupPlansAPI.list>>)
-    vi.mocked(repositoriesAPI.getRepositoryCheckJobs).mockResolvedValue({
-      data: {
-        jobs: [
-          {
-            id: 23,
-            repository_id: 1,
-            status: 'failed',
-            started_at: '2026-01-01T00:00:00Z',
-            completed_at: '2026-01-01T00:00:05Z',
-            error_message: 'Repository is not initialized',
-            progress: 100,
-            progress_message: 'Check failed',
-            scheduled_check: false,
-          },
-        ],
-      },
-    } as Awaited<ReturnType<typeof repositoriesAPI.getRepositoryCheckJobs>>)
+    mockLatestCheckJob(buildCheckJob())
     mockCheckRepository.mockResolvedValue({ data: { job_id: 23 } })
   })
 
-  it('announces stored error details when a manual check job fails after the spinner stops', async () => {
+  async function runManualCheckToCompletion() {
     renderWithProviders(<Repositories />)
 
     fireEvent.click(await screen.findByRole('button', { name: 'start check' }))
@@ -210,11 +225,55 @@ describe('Repositories', () => {
     })
 
     fireEvent.click(screen.getByRole('button', { name: 'complete check' }))
+  }
+
+  it('announces stored error details when a manual check job fails after the spinner stops', async () => {
+    await runManualCheckToCompletion()
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
         expect.stringContaining('Repository is not initialized')
       )
+    })
+  })
+
+  it('announces success when a manual check job completes cleanly', async () => {
+    mockLatestCheckJob(buildCheckJob({ status: 'completed', error_message: null }))
+
+    await runManualCheckToCompletion()
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Check completed')
+    })
+  })
+
+  it('announces warnings when a manual check job completes with warnings', async () => {
+    mockLatestCheckJob(buildCheckJob({ status: 'completed_with_warnings', error_message: null }))
+
+    await runManualCheckToCompletion()
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith('Check completed with warnings', { icon: '!' })
+    })
+  })
+
+  it('announces a fallback error when a failed manual check has no stored message', async () => {
+    mockLatestCheckJob(buildCheckJob({ error_message: null }))
+
+    await runManualCheckToCompletion()
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Check failed: Check failed')
+    })
+  })
+
+  it('still announces completion when the check job summary lookup fails', async () => {
+    vi.mocked(repositoriesAPI.getRepositoryCheckJobs).mockRejectedValue(new Error('lookup failed'))
+
+    await runManualCheckToCompletion()
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Check completed')
     })
   })
 })

--- a/frontend/src/pages/__tests__/Repositories.test.tsx
+++ b/frontend/src/pages/__tests__/Repositories.test.tsx
@@ -1,0 +1,220 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { renderWithProviders } from '../../test/test-utils'
+import Repositories from '../Repositories'
+import { backupPlansAPI, repositoriesAPI } from '../../services/api'
+import { toast } from 'react-hot-toast'
+
+const { mockCheckRepository } = vi.hoisted(() => ({
+  mockCheckRepository: vi.fn(),
+}))
+
+const mockRepository = {
+  id: 1,
+  name: 'Broken Repo',
+  path: '/repo/broken',
+  encryption: 'repokey',
+  compression: 'lz4',
+  source_directories: [],
+  exclude_patterns: [],
+  last_backup: null,
+  last_check: null,
+  last_compact: null,
+  total_size: null,
+  archive_count: 0,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: null,
+  mode: 'full',
+}
+
+vi.mock('react-hot-toast', () => {
+  const toastMock = Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+  })
+
+  return {
+    toast: toastMock,
+    Toaster: () => null,
+  }
+})
+
+vi.mock('../../hooks/useAuth', () => ({
+  useAuth: () => ({
+    hasGlobalPermission: () => true,
+  }),
+}))
+
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    canDo: () => true,
+  }),
+}))
+
+vi.mock('../../context/AppContext', () => ({
+  useAppState: () => ({
+    refetch: vi.fn(),
+  }),
+}))
+
+vi.mock('../../hooks/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackMaintenance: vi.fn(),
+    trackRepository: vi.fn(),
+    EventAction: {
+      START: 'Start',
+      COMPLETE: 'Complete',
+      FAIL: 'Fail',
+      SEARCH: 'Search',
+      FILTER: 'Filter',
+      DELETE: 'Delete',
+    },
+  }),
+}))
+
+vi.mock('../../services/api', () => ({
+  repositoriesAPI: {
+    getRepositories: vi.fn(),
+    getRepositoryCheckJobs: vi.fn(),
+  },
+  backupPlansAPI: {
+    list: vi.fn(),
+    get: vi.fn(),
+    createFromRepository: vi.fn(),
+  },
+}))
+
+vi.mock('../../services/borgApi', () => ({
+  BorgApiClient: vi.fn(function BorgApiClientMock() {
+    return {
+      checkRepository: mockCheckRepository,
+      getInfo: vi.fn(),
+    }
+  }),
+}))
+
+vi.mock('../../components/CheckWarningDialog', () => ({
+  default: ({
+    open,
+    onConfirm,
+  }: {
+    open: boolean
+    onConfirm: (options: { maxDuration: number; checkExtraFlags: string }) => void
+  }) =>
+    open ? (
+      <button type="button" onClick={() => onConfirm({ maxDuration: 3600, checkExtraFlags: '' })}>
+        confirm check
+      </button>
+    ) : null,
+}))
+
+vi.mock('../../components/CompactWarningDialog', () => ({
+  default: () => null,
+}))
+
+vi.mock('../../components/RepositoryWizard', () => ({
+  default: () => null,
+}))
+
+vi.mock('../../components/PruneRepositoryDialog', () => ({
+  default: () => null,
+}))
+
+vi.mock('../../components/RepositoryWipeDialog', () => ({
+  default: () => null,
+}))
+
+vi.mock('../../components/RepositoryInfoDialog', () => ({
+  default: () => null,
+}))
+
+vi.mock('../repositories-page/CreateBackupPlanDialog', () => ({
+  CreateBackupPlanDialog: () => null,
+}))
+
+vi.mock('../repositories-page/RepositoriesHeader', () => ({
+  RepositoriesHeader: () => null,
+}))
+
+vi.mock('../repositories-page/RepositoriesToolbar', () => ({
+  RepositoriesToolbar: () => null,
+}))
+
+vi.mock('../repositories-page/RepositoryGroups', () => ({
+  RepositoryGroups: ({
+    repositories,
+    onCheck,
+    onJobCompleted,
+  }: {
+    repositories: Array<typeof mockRepository>
+    onCheck: (repository: typeof mockRepository) => void
+    onJobCompleted: (repositoryId: number) => void
+  }) => {
+    if (repositories.length === 0) {
+      return <div>loading repositories</div>
+    }
+
+    return (
+      <>
+        <button type="button" onClick={() => onCheck(repositories[0])}>
+          start check
+        </button>
+        <button type="button" onClick={() => onJobCompleted(1)}>
+          complete check
+        </button>
+      </>
+    )
+  },
+}))
+
+describe('Repositories', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(repositoriesAPI.getRepositories).mockResolvedValue({
+      data: { repositories: [mockRepository] },
+    } as Awaited<ReturnType<typeof repositoriesAPI.getRepositories>>)
+    vi.mocked(backupPlansAPI.list).mockResolvedValue({
+      data: { backup_plans: [] },
+    } as Awaited<ReturnType<typeof backupPlansAPI.list>>)
+    vi.mocked(repositoriesAPI.getRepositoryCheckJobs).mockResolvedValue({
+      data: {
+        jobs: [
+          {
+            id: 23,
+            repository_id: 1,
+            status: 'failed',
+            started_at: '2026-01-01T00:00:00Z',
+            completed_at: '2026-01-01T00:00:05Z',
+            error_message: 'Repository is not initialized',
+            progress: 100,
+            progress_message: 'Check failed',
+            scheduled_check: false,
+          },
+        ],
+      },
+    } as Awaited<ReturnType<typeof repositoriesAPI.getRepositoryCheckJobs>>)
+    mockCheckRepository.mockResolvedValue({ data: { job_id: 23 } })
+  })
+
+  it('announces stored error details when a manual check job fails after the spinner stops', async () => {
+    renderWithProviders(<Repositories />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'start check' }))
+    fireEvent.click(screen.getByRole('button', { name: 'confirm check' }))
+
+    await waitFor(() => {
+      expect(mockCheckRepository).toHaveBeenCalledWith({
+        maxDuration: 3600,
+        checkExtraFlags: '',
+      })
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'complete check' }))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringContaining('Repository is not initialized')
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Description
Adds explicit terminal feedback for manual repository Check jobs and improves the broken repository Info failure state with copyable recovery command templates. Failed checks preserve stored error details, check completion cannot go silent when the follow-up job lookup is unavailable, recovery commands are shell-escaped before display/copy, and recovery command copy feedback now clears its reset timer on dialog unmount.

## Related Issue
Fixes #201
Linear: BOR-127
Follow-up: BOR-131 tracks evaluating guided in-app recovery command actions.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `cd frontend && npm test -- --run src/components/__tests__/RepositoryInfoDialog.test.tsx`
- `cd frontend && npm test -- --run src/pages/__tests__/Repositories.test.tsx src/components/__tests__/RepositoryInfoDialog.test.tsx`
- `cd frontend && npm run format:check`
- `cd frontend && npm run check:locales`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `cd frontend && npm run build-storybook`
- Served `frontend/storybook-static` locally and confirmed `iframe.html?id=components-repositoryinfodialog--failed-info-recovery&viewMode=story` returned `HTTP/1.0 200 OK`.

## Checklist
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines; `CONTRIBUTING.md` is not present in this checkout
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
No screenshot captured: local Chromium cannot launch in this environment because `libnspr4.so` is missing and no system Chrome/Chromium install is available. The failed-state Storybook iframe was served locally and returned `HTTP/1.0 200 OK`.

## Additional Context
Recovery is intentionally command-template based in this PR. That gives users copyable diagnostic and repair commands without adding destructive server-side reinitialize or repair actions. Guided in-app recovery execution is product-fit but needs backend job orchestration, confirmations, logs, and failure handling, so it is tracked separately in BOR-131.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show status toasts for manual repository checks (success, warning, error) and add a recovery panel in the repo info dialog with copyable check/repair/init commands.

* **Documentation**
  * Added engineering plan and spec describing UI behavior, acceptance criteria, and validation steps.

* **Storybook**
  * Added a story demonstrating the failed-recovery state of the repo info dialog.

* **Tests**
  * Added tests for toast outcomes, recovery command formatting, clipboard copy behavior, and lifecycle cleanup.

* **Localization**
  * Added EN/DE/ES/IT translations for check statuses and recovery UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 0 changed, 2 added, 0 removed, 278 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-609/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/26864327180
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- `components-repositoryinfodialog--failed-info-recovery--mobile.png`
- `components-repositoryinfodialog--failed-info-recovery.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->