### PR TITLE
Support manual-only scheduled jobs

### DIFF
--- a/app/api/schedule.py
+++ b/app/api/schedule.py
@@ -160,6 +160,12 @@ def _serialize_schedule_timezone(job: ScheduledJob) -> Optional[str]:
     return job.timezone or DEFAULT_SCHEDULE_TIMEZONE
 
 
+def _serialize_schedule_next_run(job: ScheduledJob) -> Optional[str]:
+    if not _schedule_enabled_from_cron(job.cron_expression):
+        return None
+    return serialize_datetime(job.next_run)
+
+
 def _raise_invalid_schedule_timezone(exc: InvalidScheduleTimezone) -> NoReturn:
     raise HTTPException(
         status_code=400,
@@ -440,7 +446,7 @@ async def get_scheduled_jobs(
                     "repository_ids": repository_ids,
                     "enabled": job.enabled,
                     "last_run": serialize_datetime(job.last_run),
-                    "next_run": serialize_datetime(job.next_run),
+                    "next_run": _serialize_schedule_next_run(job),
                     "created_at": serialize_datetime(job.created_at),
                     "updated_at": serialize_datetime(job.updated_at),
                     "description": job.description,
@@ -799,7 +805,7 @@ async def create_scheduled_job(
                 "timezone": _serialize_schedule_timezone(scheduled_job),
                 "repository": scheduled_job.repository,
                 "enabled": scheduled_job.enabled,
-                "next_run": serialize_datetime(scheduled_job.next_run),
+                "next_run": _serialize_schedule_next_run(scheduled_job),
             },
         }
     except HTTPException:
@@ -1069,7 +1075,7 @@ async def get_scheduled_job(
                 "repository": job.repository,
                 "enabled": job.enabled,
                 "last_run": serialize_datetime(job.last_run),
-                "next_run": serialize_datetime(job.next_run),
+                "next_run": _serialize_schedule_next_run(job),
                 "next_runs": next_runs,
                 "created_at": serialize_datetime(job.created_at),
                 "updated_at": serialize_datetime(job.updated_at),

--- a/app/api/schedule.py
+++ b/app/api/schedule.py
@@ -58,7 +58,7 @@ from pydantic import BaseModel
 
 class ScheduledJobCreate(BaseModel):
     name: str
-    cron_expression: str
+    cron_expression: Optional[str] = None
     timezone: Optional[str] = None
     repository: Optional[str] = None  # Legacy single-repo (by path)
     repository_id: Optional[int] = None  # Single-repo (by ID)
@@ -139,6 +139,25 @@ def _calculate_next_schedule_run(
     schedule_timezone: Optional[str] = None,
 ) -> datetime:
     return calculate_next_cron_run(cron_expression, base_time, schedule_timezone)
+
+
+def _normalize_schedule_cron(cron_expression: Optional[str]) -> str:
+    return (cron_expression or "").strip()
+
+
+def _schedule_enabled_from_cron(cron_expression: Optional[str]) -> bool:
+    return bool(_normalize_schedule_cron(cron_expression))
+
+
+def _serialize_schedule_cron(cron_expression: Optional[str]) -> Optional[str]:
+    cron = _normalize_schedule_cron(cron_expression)
+    return cron or None
+
+
+def _serialize_schedule_timezone(job: ScheduledJob) -> Optional[str]:
+    if not _schedule_enabled_from_cron(job.cron_expression):
+        return None
+    return job.timezone or DEFAULT_SCHEDULE_TIMEZONE
 
 
 def _raise_invalid_schedule_timezone(exc: InvalidScheduleTimezone) -> NoReturn:
@@ -408,12 +427,14 @@ async def get_scheduled_jobs(
             else:
                 repository_ids = None
 
+            schedule_enabled = _schedule_enabled_from_cron(job.cron_expression)
             result_jobs.append(
                 {
                     "id": job.id,
                     "name": job.name,
-                    "cron_expression": job.cron_expression,
-                    "timezone": job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
+                    "schedule_enabled": schedule_enabled,
+                    "cron_expression": _serialize_schedule_cron(job.cron_expression),
+                    "timezone": _serialize_schedule_timezone(job),
                     "repository": job.repository,
                     "repository_id": job.repository_id,
                     "repository_ids": repository_ids,
@@ -571,23 +592,27 @@ async def create_scheduled_job(
             )
             # Continue anyway - the atomic transaction + rollback will protect us
 
-        # Validate timezone and cron expression
-        try:
-            schedule_timezone = normalize_schedule_timezone(job_data.timezone)
-            next_run = _calculate_next_schedule_run(
-                job_data.cron_expression,
-                schedule_timezone=schedule_timezone,
-            )
-        except InvalidScheduleTimezone as e:
-            _raise_invalid_schedule_timezone(e)
-        except Exception as e:
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "key": "backend.errors.schedule.invalidCronExpression",
-                    "params": {"error": str(e)},
-                },
-            )
+        cron_expression = _normalize_schedule_cron(job_data.cron_expression)
+        if cron_expression:
+            try:
+                schedule_timezone = normalize_schedule_timezone(job_data.timezone)
+                next_run = _calculate_next_schedule_run(
+                    cron_expression,
+                    schedule_timezone=schedule_timezone,
+                )
+            except InvalidScheduleTimezone as e:
+                _raise_invalid_schedule_timezone(e)
+            except Exception as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "key": "backend.errors.schedule.invalidCronExpression",
+                        "params": {"error": str(e)},
+                    },
+                )
+        else:
+            schedule_timezone = DEFAULT_SCHEDULE_TIMEZONE
+            next_run = None
 
         # Check if job name already exists
         existing_job = (
@@ -623,7 +648,7 @@ async def create_scheduled_job(
         # Create scheduled job
         scheduled_job = ScheduledJob(
             name=job_data.name,
-            cron_expression=job_data.cron_expression,
+            cron_expression=cron_expression,
             timezone=schedule_timezone,
             repository=job_data.repository,  # Legacy
             repository_id=job_data.repository_id,  # Single-repo by ID
@@ -765,8 +790,13 @@ async def create_scheduled_job(
             "job": {
                 "id": scheduled_job.id,
                 "name": scheduled_job.name,
-                "cron_expression": scheduled_job.cron_expression,
-                "timezone": scheduled_job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
+                "schedule_enabled": _schedule_enabled_from_cron(
+                    scheduled_job.cron_expression
+                ),
+                "cron_expression": _serialize_schedule_cron(
+                    scheduled_job.cron_expression
+                ),
+                "timezone": _serialize_schedule_timezone(scheduled_job),
                 "repository": scheduled_job.repository,
                 "enabled": scheduled_job.enabled,
                 "next_run": serialize_datetime(scheduled_job.next_run),
@@ -911,6 +941,8 @@ async def get_upcoming_jobs(
         for job in jobs:
             try:
                 _require_schedule_access(db, current_user, job, "viewer")
+                if not _schedule_enabled_from_cron(job.cron_expression):
+                    continue
                 next_run = _calculate_next_schedule_run(
                     job.cron_expression,
                     now,
@@ -1011,16 +1043,19 @@ async def get_scheduled_job(
         _require_schedule_access(db, current_user, job, "viewer")
 
         # Calculate next run times
-        try:
-            next_runs = [
-                serialize_datetime(next_dt)
-                for next_dt in calculate_next_cron_runs(
-                    job.cron_expression,
-                    count=5,
-                    schedule_timezone=job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
-                )
-            ]
-        except:
+        if _schedule_enabled_from_cron(job.cron_expression):
+            try:
+                next_runs = [
+                    serialize_datetime(next_dt)
+                    for next_dt in calculate_next_cron_runs(
+                        job.cron_expression,
+                        count=5,
+                        schedule_timezone=job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
+                    )
+                ]
+            except:
+                next_runs = []
+        else:
             next_runs = []
 
         return {
@@ -1028,8 +1063,9 @@ async def get_scheduled_job(
             "job": {
                 "id": job.id,
                 "name": job.name,
-                "cron_expression": job.cron_expression,
-                "timezone": job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
+                "schedule_enabled": _schedule_enabled_from_cron(job.cron_expression),
+                "cron_expression": _serialize_schedule_cron(job.cron_expression),
+                "timezone": _serialize_schedule_timezone(job),
                 "repository": job.repository,
                 "enabled": job.enabled,
                 "last_run": serialize_datetime(job.last_run),
@@ -1107,35 +1143,39 @@ async def update_scheduled_job(
             job.name = job_data.name
 
         schedule_definition_changed = (
-            job_data.cron_expression is not None
+            "cron_expression" in job_data.model_fields_set
             or "timezone" in job_data.model_fields_set
         )
         if schedule_definition_changed:
-            next_cron_expression = (
+            next_cron_expression = _normalize_schedule_cron(
                 job_data.cron_expression
-                if job_data.cron_expression is not None
+                if "cron_expression" in job_data.model_fields_set
                 else job.cron_expression
             )
-            try:
-                next_schedule_timezone = normalize_schedule_timezone(
-                    job_data.timezone
-                    if "timezone" in job_data.model_fields_set
-                    else job.timezone
-                )
-                next_run = _calculate_next_schedule_run(
-                    next_cron_expression,
-                    schedule_timezone=next_schedule_timezone,
-                )
-            except InvalidScheduleTimezone as e:
-                _raise_invalid_schedule_timezone(e)
-            except Exception as e:
-                raise HTTPException(
-                    status_code=400,
-                    detail={
-                        "key": "backend.errors.schedule.invalidCronExpression",
-                        "params": {"error": str(e)},
-                    },
-                )
+            if next_cron_expression:
+                try:
+                    next_schedule_timezone = normalize_schedule_timezone(
+                        job_data.timezone
+                        if "timezone" in job_data.model_fields_set
+                        else job.timezone
+                    )
+                    next_run = _calculate_next_schedule_run(
+                        next_cron_expression,
+                        schedule_timezone=next_schedule_timezone,
+                    )
+                except InvalidScheduleTimezone as e:
+                    _raise_invalid_schedule_timezone(e)
+                except Exception as e:
+                    raise HTTPException(
+                        status_code=400,
+                        detail={
+                            "key": "backend.errors.schedule.invalidCronExpression",
+                            "params": {"error": str(e)},
+                        },
+                    )
+            else:
+                next_schedule_timezone = DEFAULT_SCHEDULE_TIMEZONE
+                next_run = None
 
             job.cron_expression = next_cron_expression
             job.timezone = next_schedule_timezone
@@ -1149,21 +1189,24 @@ async def update_scheduled_job(
         if job_data.enabled is not None:
             job.enabled = job_data.enabled
             if job.enabled and not was_enabled and not schedule_definition_changed:
-                try:
-                    job.next_run = _calculate_next_schedule_run(
-                        job.cron_expression,
-                        schedule_timezone=job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
-                    )
-                except InvalidScheduleTimezone as e:
-                    _raise_invalid_schedule_timezone(e)
-                except Exception as e:
-                    raise HTTPException(
-                        status_code=400,
-                        detail={
-                            "key": "backend.errors.schedule.invalidCronExpression",
-                            "params": {"error": str(e)},
-                        },
-                    )
+                if _schedule_enabled_from_cron(job.cron_expression):
+                    try:
+                        job.next_run = _calculate_next_schedule_run(
+                            job.cron_expression,
+                            schedule_timezone=job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
+                        )
+                    except InvalidScheduleTimezone as e:
+                        _raise_invalid_schedule_timezone(e)
+                    except Exception as e:
+                        raise HTTPException(
+                            status_code=400,
+                            detail={
+                                "key": "backend.errors.schedule.invalidCronExpression",
+                                "params": {"error": str(e)},
+                            },
+                        )
+                else:
+                    job.next_run = None
 
         if job_data.description is not None:
             job.description = job_data.description
@@ -1340,21 +1383,24 @@ async def toggle_scheduled_job(
 
         job.enabled = not job.enabled
         if job.enabled:
-            try:
-                job.next_run = _calculate_next_schedule_run(
-                    job.cron_expression,
-                    schedule_timezone=job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
-                )
-            except InvalidScheduleTimezone as e:
-                _raise_invalid_schedule_timezone(e)
-            except Exception as e:
-                raise HTTPException(
-                    status_code=400,
-                    detail={
-                        "key": "backend.errors.schedule.invalidCronExpression",
-                        "params": {"error": str(e)},
-                    },
-                )
+            if _schedule_enabled_from_cron(job.cron_expression):
+                try:
+                    job.next_run = _calculate_next_schedule_run(
+                        job.cron_expression,
+                        schedule_timezone=job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
+                    )
+                except InvalidScheduleTimezone as e:
+                    _raise_invalid_schedule_timezone(e)
+                except Exception as e:
+                    raise HTTPException(
+                        status_code=400,
+                        detail={
+                            "key": "backend.errors.schedule.invalidCronExpression",
+                            "params": {"error": str(e)},
+                        },
+                    )
+            else:
+                job.next_run = None
         job.updated_at = datetime.now(timezone.utc)
         db.commit()
 
@@ -1411,21 +1457,25 @@ async def duplicate_scheduled_job(
             new_name = f"{base_name} ({counter})"
 
         # Calculate next run time from cron expression
-        try:
-            next_run = _calculate_next_schedule_run(
-                original_job.cron_expression,
-                schedule_timezone=original_job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
-            )
-        except InvalidScheduleTimezone as e:
-            _raise_invalid_schedule_timezone(e)
-        except Exception as e:
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "key": "backend.errors.schedule.invalidCronExpression",
-                    "params": {"error": str(e)},
-                },
-            )
+        if _schedule_enabled_from_cron(original_job.cron_expression):
+            try:
+                next_run = _calculate_next_schedule_run(
+                    original_job.cron_expression,
+                    schedule_timezone=original_job.timezone
+                    or DEFAULT_SCHEDULE_TIMEZONE,
+                )
+            except InvalidScheduleTimezone as e:
+                _raise_invalid_schedule_timezone(e)
+            except Exception as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "key": "backend.errors.schedule.invalidCronExpression",
+                        "params": {"error": str(e)},
+                    },
+                )
+        else:
+            next_run = None
 
         # Create the duplicate job
         duplicated_job = ScheduledJob(
@@ -1518,8 +1568,13 @@ async def duplicate_scheduled_job(
                 "id": duplicated_job.id,
                 "name": duplicated_job.name,
                 "enabled": duplicated_job.enabled,
-                "cron_expression": duplicated_job.cron_expression,
-                "timezone": duplicated_job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
+                "schedule_enabled": _schedule_enabled_from_cron(
+                    duplicated_job.cron_expression
+                ),
+                "cron_expression": _serialize_schedule_cron(
+                    duplicated_job.cron_expression
+                ),
+                "timezone": _serialize_schedule_timezone(duplicated_job),
             },
         }
     except HTTPException:
@@ -2611,6 +2666,11 @@ def _dispatch_due_scheduled_job(
     from app.database.models import Repository
 
     now = to_utc_naive(now)
+    if not _schedule_enabled_from_cron(job.cron_expression):
+        job.next_run = None
+        db.commit()
+        logger.warning("Skipped manual-only job in scheduled dispatcher", job_id=job.id)
+        return None
 
     repo_links = (
         db.query(ScheduledJobRepository).filter_by(scheduled_job_id=job.id).all()

--- a/docs/engineering/plans/2026-06-02-manual-only-scheduled-jobs.md
+++ b/docs/engineering/plans/2026-06-02-manual-only-scheduled-jobs.md
@@ -1,0 +1,21 @@
+# Manual-Only Scheduled Jobs Implementation Plan
+
+## Goal
+
+Allow legacy backup schedules to be saved as manual-only jobs with no cron expression while preserving existing scheduled cron behavior.
+
+## Design
+
+- Treat `ScheduledJob.cron_expression` as the existing persistence signal: a non-empty cron means scheduled, an empty string means manual-only.
+- Keep `enabled` as the job availability toggle. Manual-only enabled jobs can be run with Run now but never receive `next_run`.
+- Return `schedule_enabled`, nullable `cron_expression`, nullable `timezone`, and `next_run=null` in API responses for manual-only jobs.
+- Add a manual-only switch to the existing schedule wizard step. The shared `SchedulePicker` remains the only cron/timezone UI and is rendered only when scheduling is enabled.
+
+## Tasks
+
+- [x] Add failing backend route tests for create, list, update, duplicate, and toggle behavior.
+- [x] Add failing frontend tests for the schedule step and manual-only job card state.
+- [x] Update `app/api/schedule.py` request models, cron normalization, serialization, create/update/toggle/duplicate paths, and scheduler dispatch safeguards.
+- [x] Update legacy schedule wizard state, payload mapping, review UI, schedule config UI, cards, and TypeScript types.
+- [x] Update locale files and Storybook coverage for the new manual-only state.
+- [x] Run targeted backend/frontend tests, required validation gates, and runtime walkthrough evidence.

--- a/frontend/src/components/BackupHistorySection.tsx
+++ b/frontend/src/components/BackupHistorySection.tsx
@@ -9,7 +9,7 @@ import { useAnalytics } from '../hooks/useAnalytics'
 interface ScheduledJob {
   id: number
   name: string
-  cron_expression: string
+  cron_expression: string | null
   repository: string | null
   repository_id: number | null
   repository_ids: number[] | null

--- a/frontend/src/components/DeleteScheduleDialog.tsx
+++ b/frontend/src/components/DeleteScheduleDialog.tsx
@@ -16,7 +16,7 @@ import { AlertCircle, Trash2 } from 'lucide-react'
 interface ScheduledJob {
   id: number
   name: string
-  cron_expression: string
+  cron_expression: string | null
   repository: string | null
   repository_id: number | null
   repository_ids: number[] | null

--- a/frontend/src/components/ScheduleJobCard.tsx
+++ b/frontend/src/components/ScheduleJobCard.tsx
@@ -28,7 +28,8 @@ interface Repository {
 interface ScheduledJob {
   id: number
   name: string
-  cron_expression: string
+  schedule_enabled?: boolean
+  cron_expression: string | null
   timezone?: string | null
   repository: string | null
   repository_id: number | null
@@ -96,8 +97,10 @@ export default function ScheduleJobCard({
   const { t } = useTranslation()
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
+  const isScheduled = job.schedule_enabled ?? Boolean(job.cron_expression)
   const scheduleTimezone = job.timezone || 'UTC'
-  const scheduleDisplay = formatCronHuman(job.cron_expression)
+  const manualOnlyLabel = t('schedule.card.stats.manualOnly', { defaultValue: 'Manual only' })
+  const scheduleDisplay = isScheduled ? formatCronHuman(job.cron_expression || '') : manualOnlyLabel
   const nextRunDisplay = job.next_run
     ? formatScheduledInstantDisplay(job.next_run, scheduleTimezone)
     : null
@@ -107,7 +110,7 @@ export default function ScheduleJobCard({
       icon: <CalendarClock size={11} />,
       label: t('schedule.card.stats.schedule'),
       value: scheduleDisplay,
-      tooltip: `${job.cron_expression} (${scheduleTimezone})`,
+      tooltip: isScheduled ? `${job.cron_expression} (${scheduleTimezone})` : '',
       color: 'info',
     },
     {
@@ -126,17 +129,20 @@ export default function ScheduleJobCard({
     {
       icon: <CalendarCheck size={11} />,
       label: t('schedule.card.stats.nextRun'),
-      value: nextRunDisplay?.value ?? t('common.never'),
-      tooltip: nextRunDisplay ? <ScheduledInstantTooltip display={nextRunDisplay} /> : '',
+      value: isScheduled ? (nextRunDisplay?.value ?? t('common.never')) : manualOnlyLabel,
+      tooltip:
+        isScheduled && nextRunDisplay ? <ScheduledInstantTooltip display={nextRunDisplay} /> : '',
       color: 'success',
     },
   ]
 
   const meta: MetaItem[] = []
-  meta.push({
-    label: t('common.timezone', { defaultValue: 'Timezone' }),
-    value: scheduleTimezone,
-  })
+  if (isScheduled) {
+    meta.push({
+      label: t('common.timezone', { defaultValue: 'Timezone' }),
+      value: scheduleTimezone,
+    })
+  }
   if (job.description) meta.push({ label: t('schedule.card.meta.note'), value: job.description })
   if (job.run_prune_after)
     meta.push({

--- a/frontend/src/components/ScheduleWizard.tsx
+++ b/frontend/src/components/ScheduleWizard.tsx
@@ -18,7 +18,8 @@ import { Repository } from '../types'
 export interface ScheduledJob {
   id: number
   name: string
-  cron_expression: string
+  schedule_enabled?: boolean
+  cron_expression: string | null
   timezone?: string | null
   repository: string | null
   repository_id: number | null
@@ -62,8 +63,8 @@ export interface ScheduleData {
   description: string | null
   repository_ids: number[]
   enabled: boolean
-  cron_expression: string
-  timezone: string
+  cron_expression: string | null
+  timezone: string | null
   archive_name_template: string
   pre_backup_script_id: number | null
   post_backup_script_id: number | null
@@ -88,6 +89,7 @@ interface WizardState {
   repositoryIds: number[]
 
   // Step 2: Schedule
+  scheduleEnabled: boolean
   cronExpression: string
   timezone: string
   archiveNameTemplate: string
@@ -114,6 +116,7 @@ const createInitialState = (): WizardState => ({
   name: '',
   description: '',
   repositoryIds: [],
+  scheduleEnabled: true,
   cronExpression: '0 2 * * *',
   timezone: getBrowserTimeZone(),
   archiveNameTemplate: '{job_name}-{now}',
@@ -180,12 +183,15 @@ const ScheduleWizard: React.FC<ScheduleWizardProps> = ({
       }
     }
 
+    const scheduleEnabled = scheduledJob.schedule_enabled ?? Boolean(scheduledJob.cron_expression)
+
     setWizardState({
       name: scheduledJob.name,
       description: scheduledJob.description || '',
       repositoryIds: Array.from(new Set(repository_ids)),
-      cronExpression: scheduledJob.cron_expression,
-      timezone: scheduledJob.timezone || 'UTC',
+      scheduleEnabled,
+      cronExpression: scheduledJob.cron_expression || '0 2 * * *',
+      timezone: scheduledJob.timezone || getBrowserTimeZone(),
       archiveNameTemplate: scheduledJob.archive_name_template || '{job_name}-{now}',
       preBackupScriptId: scheduledJob.pre_backup_script_id || null,
       postBackupScriptId: scheduledJob.post_backup_script_id || null,
@@ -240,8 +246,10 @@ const ScheduleWizard: React.FC<ScheduleWizardProps> = ({
         return true
 
       case 'schedule':
-        if (!wizardState.cronExpression.trim()) return false
-        if (!wizardState.timezone.trim()) return false
+        if (wizardState.scheduleEnabled) {
+          if (!wizardState.cronExpression.trim()) return false
+          if (!wizardState.timezone.trim()) return false
+        }
         if (!wizardState.archiveNameTemplate.trim()) return false
         return true
 
@@ -269,8 +277,8 @@ const ScheduleWizard: React.FC<ScheduleWizardProps> = ({
       description: wizardState.description || null,
       repository_ids: Array.from(new Set(wizardState.repositoryIds)),
       enabled: mode === 'edit' && scheduledJob ? scheduledJob.enabled : true,
-      cron_expression: wizardState.cronExpression,
-      timezone: wizardState.timezone,
+      cron_expression: wizardState.scheduleEnabled ? wizardState.cronExpression : null,
+      timezone: wizardState.scheduleEnabled ? wizardState.timezone : null,
       archive_name_template: wizardState.archiveNameTemplate,
       pre_backup_script_id: wizardState.preBackupScriptId,
       post_backup_script_id: wizardState.postBackupScriptId,
@@ -292,6 +300,7 @@ const ScheduleWizard: React.FC<ScheduleWizardProps> = ({
       source: 'wizard',
       mode,
       repository_count: wizardState.repositoryIds.length,
+      schedule_enabled: wizardState.scheduleEnabled,
     })
 
     onSubmit(data)
@@ -320,6 +329,7 @@ const ScheduleWizard: React.FC<ScheduleWizardProps> = ({
         return (
           <WizardStepScheduleConfig
             data={{
+              scheduleEnabled: wizardState.scheduleEnabled,
               cronExpression: wizardState.cronExpression,
               timezone: wizardState.timezone,
               archiveNameTemplate: wizardState.archiveNameTemplate,

--- a/frontend/src/components/ScheduledJobsTable.tsx
+++ b/frontend/src/components/ScheduledJobsTable.tsx
@@ -6,7 +6,8 @@ import ScheduleJobCard from './ScheduleJobCard'
 interface ScheduledJob {
   id: number
   name: string
-  cron_expression: string
+  schedule_enabled?: boolean
+  cron_expression: string | null
   timezone?: string | null
   repository: string | null
   repository_id: number | null

--- a/frontend/src/components/__tests__/ScheduleJobCard.test.tsx
+++ b/frontend/src/components/__tests__/ScheduleJobCard.test.tsx
@@ -124,4 +124,42 @@ describe('ScheduleJobCard', () => {
     })
     expect(nextRunStat?.tooltip?.props?.display?.scheduledTimeZone).toBe(baseJob.timezone)
   })
+
+  it('shows manual-only jobs without cron or timezone metadata', () => {
+    renderWithProviders(
+      <ScheduleJobCard
+        job={{
+          ...baseJob,
+          cron_expression: null,
+          timezone: null,
+          next_run: null,
+          name: 'External Drive Manual',
+        }}
+        repositories={[{ id: 1, name: 'External Drive Repo', path: '/backups/external' }]}
+        canManage
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onDuplicate={vi.fn()}
+        onRunNow={vi.fn()}
+        onToggle={vi.fn()}
+      />
+    )
+
+    const props = entityCardMock.mock.lastCall?.[0] as
+      | {
+          stats: Array<{ label: string; value: string; tooltip?: string; color?: string }>
+          meta?: Array<{ label: string; value: string }>
+          primaryAction?: { disabled?: boolean }
+        }
+      | undefined
+    const scheduleStat = props?.stats.find((stat) => stat.label === 'Schedule')
+    const nextRunStat = props?.stats.find((stat) => stat.color === 'success')
+
+    expect(scheduleStat).toMatchObject({ value: 'Manual only', tooltip: '' })
+    expect(nextRunStat).toMatchObject({ value: 'Manual only', tooltip: '' })
+    expect(props?.meta ?? []).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ label: 'Timezone' })])
+    )
+    expect(props?.primaryAction?.disabled).not.toBe(true)
+  })
 })

--- a/frontend/src/components/__tests__/ScheduleWizard.test.tsx
+++ b/frontend/src/components/__tests__/ScheduleWizard.test.tsx
@@ -1,0 +1,158 @@
+import { screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import ScheduleWizard, { type ScheduledJob } from '../ScheduleWizard'
+import { renderWithProviders } from '../../test/test-utils'
+import { type Repository } from '../../types'
+
+vi.mock('../../hooks/useAnalytics', () => ({
+  useAnalytics: () => ({
+    track: vi.fn(),
+    EventCategory: { BACKUP: 'backup' },
+    EventAction: { CREATE: 'create', EDIT: 'edit' },
+  }),
+}))
+
+vi.mock('../MultiRepositorySelector', () => ({
+  default: ({
+    repositories,
+    selectedIds,
+    onChange,
+  }: {
+    repositories: Array<{ id: number; name: string }>
+    selectedIds: number[]
+    onChange: (ids: number[]) => void
+  }) => (
+    <div>
+      {repositories.map((repo) => {
+        const selected = selectedIds.includes(repo.id)
+        return (
+          <button
+            key={repo.id}
+            type="button"
+            aria-pressed={selected}
+            onClick={() =>
+              onChange(
+                selected ? selectedIds.filter((id) => id !== repo.id) : [...selectedIds, repo.id]
+              )
+            }
+          >
+            {repo.name}
+          </button>
+        )
+      })}
+    </div>
+  ),
+}))
+
+const repositories: Repository[] = [
+  {
+    id: 7,
+    name: 'Archive drive',
+    path: '/repos/archive-drive',
+    mode: 'full',
+  },
+]
+
+const manualOnlyJob: ScheduledJob = {
+  id: 42,
+  name: 'External drive maintenance',
+  schedule_enabled: false,
+  cron_expression: null,
+  timezone: null,
+  repository: null,
+  repository_id: null,
+  repository_ids: [7],
+  enabled: true,
+  description: 'Runs when the drive is connected',
+  archive_name_template: '{job_name}-{now}',
+  run_repository_scripts: false,
+  pre_backup_script_id: null,
+  post_backup_script_id: null,
+  pre_backup_script_parameters: {},
+  post_backup_script_parameters: {},
+  run_prune_after: true,
+  run_compact_after: true,
+  prune_keep_hourly: 0,
+  prune_keep_daily: 7,
+  prune_keep_weekly: 4,
+  prune_keep_monthly: 6,
+  prune_keep_quarterly: 0,
+  prune_keep_yearly: 1,
+}
+
+describe('ScheduleWizard', () => {
+  it('creates manual-only jobs without cron or timezone data', () => {
+    const onClose = vi.fn()
+    const onSubmit = vi.fn()
+
+    renderWithProviders(
+      <ScheduleWizard
+        open
+        mode="create"
+        repositories={repositories}
+        scripts={[]}
+        onClose={onClose}
+        onSubmit={onSubmit}
+      />
+    )
+
+    fireEvent.change(screen.getByLabelText(/Job Name/i), {
+      target: { value: 'External drive maintenance' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Archive drive' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    fireEvent.click(screen.getByLabelText(/Run manually only/i))
+
+    for (let step = 0; step < 3; step += 1) {
+      fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    }
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Schedule' }))
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'External drive maintenance',
+        repository_ids: [7],
+        cron_expression: null,
+        timezone: null,
+      })
+    )
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('submits manual-only jobs without cron or timezone data', () => {
+    const onClose = vi.fn()
+    const onSubmit = vi.fn()
+
+    renderWithProviders(
+      <ScheduleWizard
+        open
+        mode="edit"
+        scheduledJob={manualOnlyJob}
+        repositories={repositories}
+        scripts={[]}
+        onClose={onClose}
+        onSubmit={onSubmit}
+      />
+    )
+
+    for (let step = 0; step < 4; step += 1) {
+      fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    }
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }))
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'External drive maintenance',
+        repository_ids: [7],
+        cron_expression: null,
+        timezone: null,
+        run_prune_after: true,
+        run_compact_after: true,
+      })
+    )
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/wizard/schedule/WizardStepScheduleConfig.stories.tsx
+++ b/frontend/src/components/wizard/schedule/WizardStepScheduleConfig.stories.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box, Stack } from '@mui/material'
+
+import WizardStepScheduleConfig from './WizardStepScheduleConfig'
+
+const meta = {
+  title: 'Schedule/WizardStepScheduleConfig',
+  component: WizardStepScheduleConfig,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof WizardStepScheduleConfig>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+function ScheduleConfigPreview({ initialScheduleEnabled }: { initialScheduleEnabled: boolean }) {
+  const [data, setData] = useState({
+    scheduleEnabled: initialScheduleEnabled,
+    cronExpression: '0 2 * * *',
+    timezone: 'UTC',
+    archiveNameTemplate: '{job_name}-{now}',
+  })
+
+  return (
+    <Box sx={{ width: 560, maxWidth: 'calc(100vw - 32px)' }}>
+      <WizardStepScheduleConfig
+        data={data}
+        jobName="external-drive-maintenance"
+        onChange={(updates) => setData((current) => ({ ...current, ...updates }))}
+      />
+    </Box>
+  )
+}
+
+export const Scheduled: Story = {
+  args: {
+    data: {
+      scheduleEnabled: true,
+      cronExpression: '0 2 * * *',
+      timezone: 'UTC',
+      archiveNameTemplate: '{job_name}-{now}',
+    },
+    jobName: 'external-drive-maintenance',
+    onChange: () => {},
+  },
+  render: () => <ScheduleConfigPreview initialScheduleEnabled />,
+}
+
+export const ManualOnly: Story = {
+  args: {
+    data: {
+      scheduleEnabled: false,
+      cronExpression: '0 2 * * *',
+      timezone: 'UTC',
+      archiveNameTemplate: '{job_name}-{now}',
+    },
+    jobName: 'external-drive-maintenance',
+    onChange: () => {},
+  },
+  render: () => (
+    <Stack spacing={2}>
+      <ScheduleConfigPreview initialScheduleEnabled={false} />
+    </Stack>
+  ),
+}

--- a/frontend/src/components/wizard/schedule/WizardStepScheduleConfig.tsx
+++ b/frontend/src/components/wizard/schedule/WizardStepScheduleConfig.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Stack } from '@mui/material'
+import { Alert, FormControlLabel, Stack, Switch } from '@mui/material'
 import SchedulePicker from '../../shared/SchedulePicker'
 import ArchiveNameTemplateInput from '../../ArchiveNameTemplateInput'
 
 interface WizardStepScheduleConfigData {
+  scheduleEnabled: boolean
   cronExpression: string
   timezone?: string
   archiveNameTemplate: string
@@ -25,15 +26,37 @@ const WizardStepScheduleConfig: React.FC<WizardStepScheduleConfigProps> = ({
 
   return (
     <Stack spacing={2}>
-      <SchedulePicker
-        cronExpression={data.cronExpression}
-        timezone={data.timezone || 'UTC'}
-        onChange={(updates) => onChange(updates)}
-        required
-        size="medium"
-        cronLabel={t('wizard.scheduleWizard.config.scheduleLabel')}
-        cronHelperText={t('wizard.scheduleWizard.config.scheduleHelper')}
+      <FormControlLabel
+        sx={{
+          m: 0,
+          alignItems: 'center',
+          gap: 1,
+          '& .MuiFormControlLabel-label': { lineHeight: 1.35 },
+        }}
+        control={
+          <Switch
+            checked={!data.scheduleEnabled}
+            onChange={(event) => onChange({ scheduleEnabled: !event.target.checked })}
+          />
+        }
+        label={t('wizard.scheduleWizard.config.manualOnlyLabel')}
       />
+
+      {data.scheduleEnabled ? (
+        <SchedulePicker
+          cronExpression={data.cronExpression}
+          timezone={data.timezone || 'UTC'}
+          onChange={(updates) => onChange(updates)}
+          required
+          size="medium"
+          cronLabel={t('wizard.scheduleWizard.config.scheduleLabel')}
+          cronHelperText={t('wizard.scheduleWizard.config.scheduleHelper')}
+        />
+      ) : (
+        <Alert severity="info" sx={{ alignItems: 'center' }}>
+          {t('wizard.scheduleWizard.config.manualOnlyHelper')}
+        </Alert>
+      )}
 
       <ArchiveNameTemplateInput
         value={data.archiveNameTemplate}

--- a/frontend/src/components/wizard/schedule/WizardStepScheduleReview.tsx
+++ b/frontend/src/components/wizard/schedule/WizardStepScheduleReview.tsx
@@ -10,6 +10,7 @@ interface WizardStepScheduleReviewProps {
     name: string
     description: string
     repositoryIds: number[]
+    scheduleEnabled: boolean
     cronExpression: string
     timezone?: string
     archiveNameTemplate: string
@@ -264,11 +265,24 @@ const WizardStepScheduleReview: React.FC<WizardStepScheduleReviewProps> = ({
             </AttrRow>
           )}
           <AttrRow label={t('wizard.scheduleWizard.review.schedule')}>
-            <CodePill>{data.cronExpression}</CodePill>
+            {data.scheduleEnabled ? (
+              <CodePill>{data.cronExpression}</CodePill>
+            ) : (
+              <Chip
+                label={t('wizard.scheduleWizard.review.manualOnly')}
+                color="default"
+                size="small"
+                sx={{ height: 17, fontSize: '0.62rem', fontWeight: 600 }}
+              />
+            )}
           </AttrRow>
-          <AttrRow label={t('wizard.scheduleWizard.review.timezone', { defaultValue: 'Timezone' })}>
-            <CodePill>{data.timezone || 'UTC'}</CodePill>
-          </AttrRow>
+          {data.scheduleEnabled && (
+            <AttrRow
+              label={t('wizard.scheduleWizard.review.timezone', { defaultValue: 'Timezone' })}
+            >
+              <CodePill>{data.timezone || 'UTC'}</CodePill>
+            </AttrRow>
+          )}
           <AttrRow label={t('wizard.scheduleWizard.review.archiveNameTemplate')}>
             <CodePill>{data.archiveNameTemplate}</CodePill>
           </AttrRow>

--- a/frontend/src/components/wizard/schedule/__tests__/WizardStepScheduleConfig.test.tsx
+++ b/frontend/src/components/wizard/schedule/__tests__/WizardStepScheduleConfig.test.tsx
@@ -21,6 +21,7 @@ vi.mock('cron-parser', () => ({
 
 describe('WizardStepScheduleConfig', () => {
   const defaultData = {
+    scheduleEnabled: true,
     cronExpression: '0 2 * * *',
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
     archiveNameTemplate: '{job_name}-{now}',
@@ -235,6 +236,35 @@ describe('WizardStepScheduleConfig', () => {
 
     const cronInput = screen.getByLabelText(/Schedule \(Cron Expression\)/i)
     expect(cronInput).toBeRequired()
+  })
+
+  it('hides cron and timezone controls for manual-only jobs', () => {
+    render(
+      <WizardStepScheduleConfig
+        {...defaultProps}
+        data={{ ...defaultData, scheduleEnabled: false }}
+      />
+    )
+
+    expect(screen.getByLabelText(/Run manually only/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/Schedule \(Cron Expression\)/i)).not.toBeInTheDocument()
+    expect(screen.getByLabelText(/Archive Name Template/i)).toBeInTheDocument()
+    expect(screen.getByText(/No cron expression or timezone is required/i)).toBeInTheDocument()
+  })
+
+  it('emits schedule mode changes', () => {
+    const onChange = vi.fn()
+    render(
+      <WizardStepScheduleConfig
+        {...defaultProps}
+        data={{ ...defaultData, scheduleEnabled: false }}
+        onChange={onChange}
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText(/Run manually only/i))
+
+    expect(onChange).toHaveBeenCalledWith({ scheduleEnabled: true })
   })
 
   it('displays next run times inline with info tooltip', () => {

--- a/frontend/src/components/wizard/schedule/__tests__/WizardStepScheduleReview.test.tsx
+++ b/frontend/src/components/wizard/schedule/__tests__/WizardStepScheduleReview.test.tsx
@@ -19,6 +19,7 @@ describe('WizardStepScheduleReview', () => {
     name: 'Daily Backup Job',
     description: 'Backup all servers daily',
     repositoryIds: [1, 2],
+    scheduleEnabled: true,
     cronExpression: '0 2 * * *',
     archiveNameTemplate: '{job_name}-{now}',
     preBackupScriptId: 1,

--- a/frontend/src/components/wizard/schedule/__tests__/WizardStepScheduleReview.test.tsx
+++ b/frontend/src/components/wizard/schedule/__tests__/WizardStepScheduleReview.test.tsx
@@ -104,6 +104,19 @@ describe('WizardStepScheduleReview', () => {
     expect(screen.getByText('0 2 * * *')).toBeInTheDocument()
   })
 
+  it('displays manual-only review state without timezone row', () => {
+    render(
+      <WizardStepScheduleReview
+        {...defaultProps}
+        data={{ ...defaultData, scheduleEnabled: false }}
+      />
+    )
+
+    expect(screen.getByText('Manual only')).toBeInTheDocument()
+    expect(screen.queryByText('0 2 * * *')).not.toBeInTheDocument()
+    expect(screen.queryByText('Timezone')).not.toBeInTheDocument()
+  })
+
   it('displays archive name template', () => {
     render(<WizardStepScheduleReview {...defaultProps} />)
 

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -590,6 +590,7 @@
     "card": {
       "stats": {
         "schedule": "Schedule",
+        "manualOnly": "Nur manuell",
         "repository": "Repository",
         "lastRun": "Last Run",
         "nextRun": "Next Run"
@@ -3650,6 +3651,8 @@
         "compactInfo": "Komprimierung gibt nach der Bereinigung Speicherplatz frei. Kann bei großen Repositories Zeit in Anspruch nehmen."
       },
       "config": {
+        "manualOnlyLabel": "Nur manuell ausführen",
+        "manualOnlyHelper": "Kein Cron-Ausdruck und keine Zeitzone erforderlich. Verwende Jetzt ausführen, wenn das Repository verfügbar ist.",
         "scheduleLabel": "Zeitplan (Cron-Ausdruck)",
         "scheduleHelper": "Klicke auf das Uhr-Symbol, um den visuellen Builder zu verwenden.",
         "timezoneLabel": "Zeitzone",
@@ -3662,6 +3665,7 @@
         "name": "Name",
         "repositories": "Repositories ({{count}})",
         "schedule": "Zeitplan",
+        "manualOnly": "Nur manuell",
         "timezone": "Zeitzone",
         "archiveNameTemplate": "Archivnamen-Vorlage",
         "scriptsConfiguration": "Skriptkonfiguration",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -604,6 +604,7 @@
     "card": {
       "stats": {
         "schedule": "Schedule",
+        "manualOnly": "Manual only",
         "repository": "Repository",
         "lastRun": "Last Run",
         "nextRun": "Next Run"
@@ -3650,6 +3651,8 @@
         "compactInfo": "Compact reclaims disk space after prune. May take time on large repositories."
       },
       "config": {
+        "manualOnlyLabel": "Run manually only",
+        "manualOnlyHelper": "No cron expression or timezone is required. Use Run Now when the repository is available.",
         "scheduleLabel": "Schedule (Cron Expression)",
         "scheduleHelper": "Click the clock icon to use the visual builder.",
         "timezoneLabel": "Timezone",
@@ -3662,6 +3665,7 @@
         "name": "Name",
         "repositories": "Repositories ({{count}})",
         "schedule": "Schedule",
+        "manualOnly": "Manual only",
         "timezone": "Timezone",
         "archiveNameTemplate": "Archive Name Template",
         "scriptsConfiguration": "Scripts Configuration",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -590,6 +590,7 @@
     "card": {
       "stats": {
         "schedule": "Schedule",
+        "manualOnly": "Solo manual",
         "repository": "Repository",
         "lastRun": "Last Run",
         "nextRun": "Next Run"
@@ -3650,6 +3651,8 @@
         "compactInfo": "La compactación recupera espacio en disco tras la poda. Puede llevar tiempo en repositorios grandes."
       },
       "config": {
+        "manualOnlyLabel": "Ejecutar solo manualmente",
+        "manualOnlyHelper": "No se requiere expresión cron ni zona horaria. Usa Ejecutar ahora cuando el repositorio esté disponible.",
         "scheduleLabel": "Programación (Expresión Cron)",
         "scheduleHelper": "Haz clic en el icono del reloj para usar el constructor visual.",
         "timezoneLabel": "Zona horaria",
@@ -3662,6 +3665,7 @@
         "name": "Nombre",
         "repositories": "Repositorios ({{count}})",
         "schedule": "Programación",
+        "manualOnly": "Solo manual",
         "timezone": "Zona horaria",
         "archiveNameTemplate": "Plantilla de nombre de archivo",
         "scriptsConfiguration": "Configuración de scripts",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -590,6 +590,7 @@
     "card": {
       "stats": {
         "schedule": "Schedule",
+        "manualOnly": "Solo manuale",
         "repository": "Repository",
         "lastRun": "Last Run",
         "nextRun": "Next Run"
@@ -3650,6 +3651,8 @@
         "compactInfo": "La compattazione recupera spazio su disco dopo la pulizia. Potrebbe richiedere tempo su repository di grandi dimensioni."
       },
       "config": {
+        "manualOnlyLabel": "Esegui solo manualmente",
+        "manualOnlyHelper": "Non sono necessari espressione cron o fuso orario. Usa Esegui ora quando il repository è disponibile.",
         "scheduleLabel": "Pianificazione (Espressione Cron)",
         "scheduleHelper": "Clicca l'icona dell'orologio per usare il costruttore visivo.",
         "timezoneLabel": "Fuso orario",
@@ -3662,6 +3665,7 @@
         "name": "Nome",
         "repositories": "Repository ({{count}})",
         "schedule": "Pianificazione",
+        "manualOnly": "Solo manuale",
         "timezone": "Fuso orario",
         "archiveNameTemplate": "Template Nome Archivio",
         "scriptsConfiguration": "Configurazione Script",

--- a/frontend/src/pages/Schedule.tsx
+++ b/frontend/src/pages/Schedule.tsx
@@ -41,7 +41,8 @@ import { buildScheduleDeepLink, parseScheduleDeepLink } from '../utils/scheduleD
 interface ScheduledJob {
   id: number
   name: string
-  cron_expression: string
+  schedule_enabled?: boolean
+  cron_expression: string | null
   timezone?: string | null
   repository: string | null // Legacy single-repo
   repository_id: number | null // Single-repo by ID

--- a/tests/smoke/test_manual_only_schedule_smoke.py
+++ b/tests/smoke/test_manual_only_schedule_smoke.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Black-box smoke coverage for manual-only legacy schedule run-now flows."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tests.smoke.live_helpers import SmokeClient, SmokeFailure
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run manual-only schedule smoke test")
+    parser.add_argument("--url", default="http://localhost:8082")
+    args = parser.parse_args()
+
+    client = SmokeClient(args.url)
+    try:
+        client.authenticate()
+        run_id = str(int(time.time()))
+        schedule_name = f"Manual Only Schedule Smoke {run_id}"
+
+        source_root = client.prepare_source_tree(
+            "manual-only-schedule-source",
+            {"manual.txt": "manual-only schedule smoke\n"},
+        )
+        repo_id, repo_path = client.create_repository(
+            name=f"Manual Only Schedule Smoke Repo {run_id}",
+            repo_path=client.temp_dir / "manual-only-schedule-repo",
+            source_dirs=[source_root],
+        )
+
+        create_response = client.request_ok(
+            "POST",
+            "/api/schedule/",
+            headers=client._headers(json_body=True),
+            json={
+                "name": schedule_name,
+                "repository_ids": [repo_id],
+                "enabled": True,
+                "run_prune_after": True,
+                "run_compact_after": True,
+            },
+            expected=(200, 201),
+        )
+        schedule = create_response.json().get("job") or create_response.json()
+        schedule_id = schedule["id"]
+        if schedule.get("schedule_enabled") is not False:
+            raise SmokeFailure(
+                f"Manual-only create did not return schedule_enabled=false: {schedule}"
+            )
+        if schedule.get("cron_expression") is not None:
+            raise SmokeFailure(f"Manual-only create returned cron data: {schedule}")
+        if schedule.get("timezone") is not None:
+            raise SmokeFailure(f"Manual-only create returned timezone data: {schedule}")
+
+        list_response = client.request_ok("GET", "/api/schedule/")
+        listed_schedule = next(
+            item for item in list_response.json()["jobs"] if item["id"] == schedule_id
+        )
+        if listed_schedule.get("schedule_enabled") is not False:
+            raise SmokeFailure(
+                f"Manual-only list did not mark job clearly: {listed_schedule}"
+            )
+        if listed_schedule.get("cron_expression") is not None:
+            raise SmokeFailure(
+                f"Manual-only list returned cron data: {listed_schedule}"
+            )
+        if listed_schedule.get("timezone") is not None:
+            raise SmokeFailure(
+                f"Manual-only list returned timezone data: {listed_schedule}"
+            )
+        if listed_schedule.get("next_run") is not None:
+            raise SmokeFailure(f"Manual-only list returned next_run: {listed_schedule}")
+
+        client.run_schedule_now(schedule_id)
+
+        deadline = time.time() + 90
+        while time.time() < deadline:
+            archives = client.list_archives(repo_path)
+            if len(archives) == 1:
+                break
+            time.sleep(0.5)
+
+        archives = client.list_archives(repo_path)
+        if len(archives) != 1:
+            raise SmokeFailure(
+                f"Expected exactly one archive after manual-only run-now for {repo_path}, got {archives}"
+            )
+
+        client.log("Manual-only schedule smoke passed")
+        return 0
+    finally:
+        client.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_api_schedule_routes.py
+++ b/tests/unit/test_api_schedule_routes.py
@@ -90,7 +90,7 @@ class TestScheduleRouteContracts:
             "External Drive Manual",
             cron_expression="",
             repository="/repos/external",
-            next_run=None,
+            next_run=datetime.now(timezone.utc) + timedelta(hours=1),
         )
 
         response = test_client.get("/api/schedule/", headers=admin_headers)
@@ -102,6 +102,34 @@ class TestScheduleRouteContracts:
         assert job["cron_expression"] is None
         assert job["timezone"] is None
         assert job["next_run"] is None
+        test_db.refresh(schedule)
+        assert schedule.next_run is not None
+
+    def test_get_schedule_returns_manual_only_fields(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        schedule = _create_schedule(
+            test_db,
+            "External Drive Manual Detail",
+            cron_expression="",
+            repository="/repos/external-detail",
+            next_run=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+
+        response = test_client.get(
+            f"/api/schedule/{schedule.id}", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        job = body["job"]
+        assert job["schedule_enabled"] is False
+        assert job["cron_expression"] is None
+        assert job["timezone"] is None
+        assert job["next_run"] is None
+        test_db.refresh(schedule)
+        assert schedule.cron_expression == ""
+        assert schedule.next_run is not None
 
     def test_upcoming_jobs_returns_enabled_jobs_sorted_and_filtered(
         self,

--- a/tests/unit/test_api_schedule_routes.py
+++ b/tests/unit/test_api_schedule_routes.py
@@ -82,6 +82,27 @@ class TestScheduleRouteContracts:
         job = next(item for item in body["jobs"] if item["id"] == schedule.id)
         assert job["repository_ids"] == [repo_b.id, repo_a.id]
 
+    def test_list_schedules_marks_manual_only_jobs(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        schedule = _create_schedule(
+            test_db,
+            "External Drive Manual",
+            cron_expression="",
+            repository="/repos/external",
+            next_run=None,
+        )
+
+        response = test_client.get("/api/schedule/", headers=admin_headers)
+
+        assert response.status_code == 200
+        body = response.json()
+        job = next(item for item in body["jobs"] if item["id"] == schedule.id)
+        assert job["schedule_enabled"] is False
+        assert job["cron_expression"] is None
+        assert job["timezone"] is None
+        assert job["next_run"] is None
+
     def test_upcoming_jobs_returns_enabled_jobs_sorted_and_filtered(
         self,
         test_client: TestClient,
@@ -123,6 +144,46 @@ class TestScheduleRouteContracts:
             job["id"] == soon.id and job["type"] == "schedule"
             for job in body["upcoming_jobs"]
         )
+
+    def test_create_manual_only_schedule_without_cron(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        repo = _create_repo(test_db, "External Drive", "/repos/external-drive")
+
+        response = test_client.post(
+            "/api/schedule/",
+            json={
+                "name": "External Drive Manual",
+                "repository_ids": [repo.id],
+                "enabled": True,
+                "run_prune_after": True,
+                "run_compact_after": True,
+            },
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["job"]["schedule_enabled"] is False
+        assert body["job"]["cron_expression"] is None
+        assert body["job"]["timezone"] is None
+        assert body["job"]["next_run"] is None
+
+        schedule = (
+            test_db.query(ScheduledJob).filter_by(name="External Drive Manual").one()
+        )
+        assert schedule.cron_expression == ""
+        assert schedule.next_run is None
+        assert schedule.enabled is True
+        assert schedule.run_prune_after is True
+        assert schedule.run_compact_after is True
+
+        links = (
+            test_db.query(ScheduledJobRepository)
+            .filter_by(scheduled_job_id=schedule.id)
+            .all()
+        )
+        assert [link.repository_id for link in links] == [repo.id]
 
     def test_upcoming_jobs_includes_scheduled_backup_plans(
         self, test_client: TestClient, admin_headers, test_db
@@ -252,6 +313,27 @@ class TestScheduleRouteContracts:
         )
         assert schedule.id not in {job.id for job in due_jobs}
 
+    def test_update_schedule_can_clear_cron_for_manual_only(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        schedule = _create_schedule(
+            test_db,
+            "Convert To Manual",
+            repository="/repos/manual",
+            next_run=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+
+        response = test_client.put(
+            f"/api/schedule/{schedule.id}",
+            json={"cron_expression": "", "timezone": None},
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        test_db.refresh(schedule)
+        assert schedule.cron_expression == ""
+        assert schedule.next_run is None
+
     def test_delete_schedule_nulls_backup_job_links(
         self, test_client: TestClient, admin_headers, test_db
     ):
@@ -326,6 +408,51 @@ class TestScheduleRouteContracts:
             .all()
         )
         assert [link.repository_id for link in links] == [repo_b.id, repo_a.id]
+
+    def test_duplicate_manual_only_schedule_keeps_no_next_run(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        original = _create_schedule(
+            test_db,
+            "Manual Original",
+            cron_expression="",
+            repository="/repos/manual",
+            next_run=None,
+        )
+
+        response = test_client.post(
+            f"/api/schedule/{original.id}/duplicate", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        duplicated_id = response.json()["job"]["id"]
+        duplicated = test_db.query(ScheduledJob).filter_by(id=duplicated_id).one()
+        assert duplicated.enabled is False
+        assert duplicated.cron_expression == ""
+        assert duplicated.next_run is None
+        assert response.json()["job"]["schedule_enabled"] is False
+
+    def test_toggle_manual_only_schedule_does_not_compute_next_run(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        schedule = _create_schedule(
+            test_db,
+            "Manual Toggle",
+            cron_expression="",
+            repository="/repos/manual",
+            next_run=None,
+        )
+        schedule.enabled = False
+        test_db.commit()
+
+        response = test_client.post(
+            f"/api/schedule/{schedule.id}/toggle", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        test_db.refresh(schedule)
+        assert schedule.enabled is True
+        assert schedule.next_run is None
 
     def test_run_now_requires_configured_repositories(
         self, test_client: TestClient, admin_headers, test_db


### PR DESCRIPTION
## Description
Adds manual-only support to the legacy scheduled-job flow. Jobs can now be saved without cron or timezone data, remain available for Run Now, and are clearly marked as manual-only in cards, review UI, and API responses.

The backend treats an empty cron expression as manual-only, keeps `next_run` unset, skips scheduler dispatch for those jobs, and preserves existing cron validation for scheduled jobs. The frontend adds a manual-only switch while keeping `SchedulePicker` as the only cron/timezone UI for scheduled jobs.

## Related Issue
Fixes #368
Linear: https://linear.app/nullcodeai/issue/BOR-124/support-manually-triggered-jobs-without-schedules

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m ruff format --check app tests`
- `.venv/bin/python -m pytest tests/unit/test_api_schedule_routes.py -q`
- `git diff --check`
- `cd frontend && npm run check:locales`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `cd frontend && npm test -- --run src/components/wizard/schedule/__tests__/WizardStepScheduleConfig.test.tsx src/components/wizard/schedule/__tests__/WizardStepScheduleReview.test.tsx src/components/__tests__/ScheduleJobCard.test.tsx src/components/__tests__/ScheduleWizard.test.tsx --testTimeout 30000`
- `DEV_PORT=8083 docker-compose -p borg-ui-dev -f docker-compose.dev.yml up -d --build --force-recreate`
- `.venv/bin/python tests/smoke/test_manual_only_schedule_smoke.py --url http://localhost:8083`
- `docker-compose -p borg-ui-dev -f docker-compose.dev.yml down`

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Local Storybook snapshot generation built Storybook successfully, but Playwright screenshot capture could not run in this host because required browser libraries such as `libnspr4`, `libnss3`, `libatk1.0-0`, and `libxkbcommon0` are missing. Runtime smoke coverage verified the manual-only save, list, and Run Now path against the dev backend.

## Additional Context
Manual-only jobs use `schedule_enabled=false`, `cron_expression=null`, `timezone=null`, and `next_run=null` in API responses. Existing scheduled jobs continue to use non-empty cron expressions and normalized schedule timezones.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual-only jobs supported (no cron/timezone) and a schedule toggle in the wizard; UI sends/receives scheduling state.

* **Bug Fixes**
  * API/listings now include schedule_enabled, omit timezone/next-run for manual-only jobs, and skip dispatching disabled schedules.

* **Localization**
  * Added "manual only" strings for English, German, Spanish, and Italian.

* **Tests**
  * Added unit and smoke tests covering manual-only schedule flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 0 changed, 4 added, 0 removed, 254 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-610/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/26854811351
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- `schedule-wizardstepscheduleconfig--manual-only--mobile.png`
- `schedule-wizardstepscheduleconfig--manual-only.png`
- `schedule-wizardstepscheduleconfig--scheduled--mobile.png`
- `schedule-wizardstepscheduleconfig--scheduled.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->