### PR TITLE
Fix missing-source backups and restore destination ownership

### DIFF
--- a/app/core/borg.py
+++ b/app/core/borg.py
@@ -611,7 +611,7 @@ class BorgInterface:
         strip_components: int = None,
     ) -> Dict:
         """Extract files from an archive"""
-        cmd = [self.borg_cmd, "extract"]
+        cmd = [self.borg_cmd, "extract", "--umask", "0022"]
 
         if remote_path:
             cmd.extend(["--remote-path", remote_path])

--- a/app/core/borg2.py
+++ b/app/core/borg2.py
@@ -475,7 +475,7 @@ class Borg2Interface:
         env: Optional[Dict] = None,
     ) -> Dict:
         """Extract files from an archive."""
-        cmd = [self.borg_cmd, "-r", repository, "extract"]
+        cmd = [self.borg_cmd, "-r", repository, "extract", "--umask", "0022"]
         if remote_path:
             cmd.extend(["--remote-path", remote_path])
         if dry_run:

--- a/app/core/borg_router.py
+++ b/app/core/borg_router.py
@@ -151,7 +151,7 @@ class BorgRouter:
                 strip_components=strip_components,
             )
 
-        cmd = ["borg", "extract", "--progress", "--log-json"]
+        cmd = ["borg", "extract", "--progress", "--log-json", "--umask", "0022"]
         if remote_path:
             cmd.extend(["--remote-path", remote_path])
         if bypass_lock:

--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -839,6 +839,34 @@ class BackupService:
             for key_file in temp_source_key_files:
                 cleanup_temp_key_file(key_file)
 
+    def _validate_local_source_paths_exist(
+        self, source_paths: list[str], skip_paths: set[str] | None = None
+    ) -> None:
+        skip_paths = skip_paths or set()
+        missing_paths = [
+            source_path
+            for source_path in source_paths
+            if source_path not in skip_paths
+            and not source_path.startswith("ssh://")
+            and not Path(source_path).exists()
+        ]
+        if not missing_paths:
+            return
+
+        logger.error(
+            "Backup source path does not exist",
+            missing_paths=missing_paths,
+            missing_count=len(missing_paths),
+        )
+        raise ValueError(
+            json.dumps(
+                {
+                    "key": "backend.errors.filesystem.pathNotFound",
+                    "params": {"path": missing_paths[0]},
+                }
+            )
+        )
+
     def _parse_ssh_url(self, ssh_url: str) -> dict:
         """
         Parse SSH URL to extract connection details
@@ -2016,6 +2044,14 @@ class BackupService:
                         canary_path=str(canary_path),
                     )
 
+            snapshot_source_paths = {
+                path
+                for location in normalized_locations or []
+                if location.get("snapshot")
+                for path in location.get("paths") or []
+            }
+            source_paths_for_existence_check = list(source_paths)
+
             if normalized_locations is not None:
                 (
                     source_paths,
@@ -2160,6 +2196,10 @@ class BackupService:
                             job_id=job_id,
                             continue_on_failure=True,
                         )
+
+            self._validate_local_source_paths_exist(
+                source_paths_for_existence_check, skip_paths=snapshot_source_paths
+            )
 
             # Calculate total expected size of source directories in background
             # This runs asynchronously without blocking backup start

--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -848,7 +848,7 @@ class BackupService:
             for source_path in source_paths
             if source_path not in skip_paths
             and not source_path.startswith("ssh://")
-            and not Path(source_path).exists()
+            and not os.path.lexists(source_path)
         ]
         if not missing_paths:
             return

--- a/app/services/restore_service.py
+++ b/app/services/restore_service.py
@@ -26,6 +26,38 @@ class RestoreService:
     def __init__(self):
         self.running_processes = {}  # Track running restore processes by job_id
 
+    def _ensure_local_destination(self, destination: str) -> None:
+        dest_path = Path(destination)
+        if dest_path.exists():
+            return
+
+        missing_paths = []
+        owner_source = dest_path
+        while not owner_source.exists():
+            missing_paths.append(owner_source)
+            parent = owner_source.parent
+            if parent == owner_source:
+                break
+            owner_source = parent
+
+        owner_stat = owner_source.stat() if owner_source.exists() else None
+        dest_path.mkdir(parents=True, exist_ok=True)
+
+        if owner_stat is None or getattr(os, "geteuid", lambda: -1)() != 0:
+            return
+
+        for created_path in reversed(missing_paths):
+            try:
+                os.chown(str(created_path), owner_stat.st_uid, owner_stat.st_gid)
+            except OSError as e:
+                logger.warning(
+                    "Failed to adjust restore destination owner",
+                    path=str(created_path),
+                    uid=owner_stat.st_uid,
+                    gid=owner_stat.st_gid,
+                    error=str(e),
+                )
+
     async def execute_restore(
         self,
         job_id: int,
@@ -184,7 +216,7 @@ class RestoreService:
             dest_path = Path(destination)
             if not dest_path.exists():
                 try:
-                    dest_path.mkdir(parents=True, exist_ok=True)
+                    self._ensure_local_destination(destination)
                     logger.info("Created destination directory", path=destination)
                 except Exception as e:
                     logger.error("Failed to create destination directory", error=str(e))

--- a/app/services/v2/restore_service.py
+++ b/app/services/v2/restore_service.py
@@ -26,6 +26,8 @@ class RestoreV2Service:
             repository_path,
             "extract",
             "--log-json",
+            "--umask",
+            "0022",
         ]
         if remote_path:
             cmd.extend(["--remote-path", remote_path])

--- a/tests/unit/test_backup_service.py
+++ b/tests/unit/test_backup_service.py
@@ -440,12 +440,14 @@ class TestBackupService:
         repo_path.mkdir()
         (repo_path / "data").mkdir()
         (repo_path / "config").write_text("[repository]\nversion = 1\n")
+        source_path = tmp_path / "source"
+        source_path.mkdir()
         repo = Repository(
             name="Repo",
             path=str(repo_path),
             encryption="none",
             repository_type="local",
-            source_directories='["/data"]',
+            source_directories=f'["{source_path}"]',
             compression="lz4",
         )
         settings_row = SystemSettings(log_save_policy="all_jobs")
@@ -484,7 +486,7 @@ class TestBackupService:
             patch.object(
                 backup_service,
                 "_prepare_source_paths",
-                AsyncMock(return_value=(["/data"], [])),
+                AsyncMock(return_value=([str(source_path)], [])),
             ),
             patch.object(
                 backup_service, "_calculate_and_update_size_background", AsyncMock()
@@ -598,6 +600,14 @@ class TestBackupService:
         calculate_size.assert_not_called()
         notifications.send_backup_start.assert_not_awaited()
         notifications.send_backup_failure.assert_awaited_once()
+
+    def test_validate_local_source_paths_allows_dangling_symlink_source(
+        self, backup_service, tmp_path
+    ):
+        source_link = tmp_path / "dangling-source"
+        source_link.symlink_to(tmp_path / "missing-target")
+
+        backup_service._validate_local_source_paths_exist([str(source_link)])
 
     @pytest.mark.parametrize(
         ("returncode", "expected_status"),
@@ -995,12 +1005,14 @@ class TestBackupService:
         repo_path.mkdir()
         (repo_path / "data").mkdir()
         (repo_path / "config").write_text("[repository]\nversion = 1\n")
+        source_path = tmp_path / "source"
+        source_path.mkdir()
         repo = Repository(
             name="Repo",
             path=str(repo_path),
             encryption="none",
             repository_type="local",
-            source_directories='["/data"]',
+            source_directories=f'["{source_path}"]',
             compression="lz4",
         )
         settings_row = SystemSettings(log_save_policy="all_jobs")
@@ -1043,7 +1055,7 @@ class TestBackupService:
             patch.object(
                 backup_service,
                 "_prepare_source_paths",
-                AsyncMock(return_value=(["/data"], [])),
+                AsyncMock(return_value=([str(source_path)], [])),
             ),
             patch.object(
                 backup_service, "_calculate_and_update_size_background", AsyncMock()
@@ -1086,12 +1098,14 @@ class TestBackupService:
         repo_path.mkdir()
         (repo_path / "data").mkdir()
         (repo_path / "config").write_text("[repository]\nversion = 1\n")
+        source_path = tmp_path / "source"
+        source_path.mkdir()
         repo = Repository(
             name="Repo",
             path=str(repo_path),
             encryption="none",
             repository_type="local",
-            source_directories='["/data"]',
+            source_directories=f'["{source_path}"]',
             compression="lz4",
         )
         settings_row = SystemSettings(log_save_policy="all_jobs")
@@ -1135,7 +1149,7 @@ class TestBackupService:
             patch.object(
                 backup_service,
                 "_prepare_source_paths",
-                AsyncMock(return_value=(["/data"], [])),
+                AsyncMock(return_value=([str(source_path)], [])),
             ),
             patch.object(
                 backup_service, "_calculate_and_update_size_background", AsyncMock()
@@ -1177,12 +1191,14 @@ class TestBackupService:
         repo_path.mkdir()
         (repo_path / "data").mkdir()
         (repo_path / "config").write_text("[repository]\nversion = 1\n")
+        source_path = tmp_path / "source"
+        source_path.mkdir()
         repo = Repository(
             name="Repo",
             path=str(repo_path),
             encryption="none",
             repository_type="local",
-            source_directories='["/data"]',
+            source_directories=f'["{source_path}"]',
             compression="lz4",
         )
         settings_row = SystemSettings(log_save_policy="all_jobs")
@@ -1220,7 +1236,7 @@ class TestBackupService:
             patch.object(
                 backup_service,
                 "_prepare_source_paths",
-                AsyncMock(return_value=(["/data"], [])),
+                AsyncMock(return_value=([str(source_path)], [])),
             ),
             patch.object(
                 backup_service, "_calculate_and_update_size_background", AsyncMock()
@@ -1261,12 +1277,14 @@ class TestBackupService:
         repo_path.mkdir()
         (repo_path / "data").mkdir()
         (repo_path / "config").write_text("[repository]\nversion = 1\n")
+        source_path = tmp_path / "source"
+        source_path.mkdir()
         repo = Repository(
             name="Repo",
             path=str(repo_path),
             encryption="none",
             repository_type="local",
-            source_directories='["/data"]',
+            source_directories=f'["{source_path}"]',
             compression="lz4",
         )
         settings_row = SystemSettings(log_save_policy="all_jobs")
@@ -1305,7 +1323,7 @@ class TestBackupService:
             patch.object(
                 backup_service,
                 "_prepare_source_paths",
-                AsyncMock(return_value=(["/data"], [])),
+                AsyncMock(return_value=([str(source_path)], [])),
             ),
             patch.object(
                 backup_service, "_calculate_and_update_size_background", AsyncMock()
@@ -1346,12 +1364,14 @@ class TestBackupService:
         repo_path.mkdir()
         (repo_path / "data").mkdir()
         (repo_path / "config").write_text("[repository]\nversion = 1\n")
+        source_path = tmp_path / "source"
+        source_path.mkdir()
         repo = Repository(
             name="Repo",
             path=str(repo_path),
             encryption="none",
             repository_type="local",
-            source_directories='["/data"]',
+            source_directories=f'["{source_path}"]',
             compression="lz4",
         )
         settings_row = SystemSettings(log_save_policy="all_jobs")
@@ -1390,7 +1410,7 @@ class TestBackupService:
             patch.object(
                 backup_service,
                 "_prepare_source_paths",
-                AsyncMock(return_value=(["/data"], [])),
+                AsyncMock(return_value=([str(source_path)], [])),
             ),
             patch.object(
                 backup_service, "_calculate_and_update_size_background", AsyncMock()

--- a/tests/unit/test_backup_service.py
+++ b/tests/unit/test_backup_service.py
@@ -518,6 +518,87 @@ class TestBackupService:
         notifications.send_backup_success.assert_awaited_once()
         notifications.send_backup_failure.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_execute_backup_fails_missing_local_source_before_borg_create(
+        self, backup_service, test_db, tmp_path
+    ):
+        repo_path = tmp_path / "repo"
+        repo_path.mkdir()
+        (repo_path / "config").write_text("[repository]\nversion = 1\n")
+        missing_source = tmp_path / "missing-source"
+        repo = Repository(
+            name="Repo",
+            path=str(repo_path),
+            encryption="none",
+            repository_type="local",
+            source_directories=f'["{missing_source}"]',
+            compression="lz4",
+        )
+        settings_row = SystemSettings(log_save_policy="all_jobs")
+        job = BackupJob(repository=repo.path, status="pending")
+        test_db.add_all([repo, settings_row, job])
+        test_db.commit()
+        test_db.refresh(job)
+
+        fake_process = FakeProcess(
+            returncode=107,
+            stdout_lines=[
+                '{"type":"log_message","levelname":"WARNING","msgid":"BackupFileNotFoundError","message":"source missing"}',
+                '{"type":"log_message","levelname":"WARNING","message":"terminating with warning status, rc 107"}',
+            ],
+        )
+        notifications = MagicMock()
+        notifications.send_backup_start = AsyncMock()
+        notifications.send_backup_success = AsyncMock()
+        notifications.send_backup_warning = AsyncMock()
+        notifications.send_backup_failure = AsyncMock()
+
+        with (
+            patch.object(
+                backup_service,
+                "_execute_hooks",
+                AsyncMock(
+                    return_value={
+                        "success": True,
+                        "execution_logs": [],
+                        "scripts_executed": 0,
+                        "scripts_failed": 0,
+                        "using_library": False,
+                    }
+                ),
+            ),
+            patch.object(
+                backup_service, "_calculate_and_update_size_background", AsyncMock()
+            ) as calculate_size,
+            patch.object(backup_service, "_update_archive_stats", AsyncMock()),
+            patch.object(backup_service, "_update_repository_stats", AsyncMock()),
+            patch(
+                "app.services.backup_service.resolve_repo_ssh_key_file",
+                return_value=None,
+            ),
+            patch(
+                "app.services.backup_service.asyncio.create_subprocess_exec",
+                return_value=fake_process,
+            ) as create_subprocess,
+            patch(
+                "app.services.backup_service.asyncio.create_task",
+                side_effect=_discard_background_task,
+            ),
+            patch("app.services.backup_service.notification_service", notifications),
+            patch("app.services.backup_service.mqtt_service") as mqtt,
+        ):
+            mqtt.sync_state_with_db = Mock()
+            await backup_service.execute_backup(job.id, repo.path, db=test_db)
+
+        test_db.refresh(job)
+        assert job.status == "failed"
+        assert "backend.errors.filesystem.pathNotFound" in job.error_message
+        assert str(missing_source) in job.error_message
+        create_subprocess.assert_not_called()
+        calculate_size.assert_not_called()
+        notifications.send_backup_start.assert_not_awaited()
+        notifications.send_backup_failure.assert_awaited_once()
+
     @pytest.mark.parametrize(
         ("returncode", "expected_status"),
         [
@@ -1421,13 +1502,15 @@ class TestBackupService:
     ):
         repo_path = tmp_path / "borg2-repo"
         repo_path.mkdir()
+        source_file = tmp_path / "source.txt"
+        source_file.write_text("borg2 source")
 
         repo = Repository(
             name="Borg 2 Repo",
             path=str(repo_path),
             encryption="none",
             repository_type="local",
-            source_directories='["/data/source.txt"]',
+            source_directories=f'["{source_file}"]',
             compression="lz4",
             borg_version=2,
         )
@@ -1463,7 +1546,7 @@ class TestBackupService:
             patch.object(
                 backup_service,
                 "_prepare_source_paths",
-                AsyncMock(return_value=(["/data/source.txt"], [])),
+                AsyncMock(return_value=([str(source_file)], [])),
             ),
             patch.object(
                 backup_service, "_calculate_and_update_size_background", AsyncMock()
@@ -1499,7 +1582,7 @@ class TestBackupService:
         assert "create" in create_cmd
         assert f"{repo.path}::" not in " ".join(create_cmd)
         assert create_cmd[-2] == "manual-backup"
-        assert "/data/source.txt" in create_cmd
+        assert str(source_file) in create_cmd
         notifications.send_backup_success.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -1508,13 +1591,15 @@ class TestBackupService:
     ):
         repo_path = tmp_path / "borg2-progress-repo"
         repo_path.mkdir()
+        source_file = tmp_path / "source.txt"
+        source_file.write_text("borg2 source")
 
         repo = Repository(
             name="Borg 2 Repo",
             path=str(repo_path),
             encryption="none",
             repository_type="local",
-            source_directories='["/data/source.txt"]',
+            source_directories=f'["{source_file}"]',
             compression="none",
             borg_version=2,
         )
@@ -1558,7 +1643,7 @@ class TestBackupService:
             patch.object(
                 backup_service,
                 "_prepare_source_paths",
-                AsyncMock(return_value=(["/data/source.txt"], [])),
+                AsyncMock(return_value=([str(source_file)], [])),
             ),
             patch.object(
                 backup_service, "_calculate_and_update_size_background", AsyncMock()

--- a/tests/unit/test_backup_service_mocks.py
+++ b/tests/unit/test_backup_service_mocks.py
@@ -132,15 +132,19 @@ async def test_prepare_source_paths_reuses_first_sshfs_temp_root_for_multiple_co
 
 
 @pytest.mark.asyncio
-async def test_execute_backup_command(backup_service_fixture, mock_db_session):
+async def test_execute_backup_command(
+    backup_service_fixture, mock_db_session, tmp_path
+):
     """Test 'borg create' command construction"""
     # Setup Data
     job_id = 999
+    source_path = tmp_path / "data"
+    source_path.mkdir()
     repo = Repository(
         id=1,
         path="/backups/repo",
         compression="zstd,3",
-        source_directories='["/home/user/data"]',
+        source_directories=f'["{source_path}"]',
         exclude_patterns='["*.tmp"]',
         passphrase="secret",
         mode="full",
@@ -219,7 +223,7 @@ async def test_execute_backup_command(backup_service_fixture, mock_db_session):
                     assert "zstd,3" in create_call_args
                     assert "--exclude" in create_call_args
                     assert "*.tmp" in create_call_args
-                    assert "/home/user/data" in create_call_args  # Source path
+                    assert str(source_path) in create_call_args  # Source path
 
                     # Verify content of the archive argument
                     archive_arg = [a for a in create_call_args if "::" in a][0]
@@ -227,14 +231,16 @@ async def test_execute_backup_command(backup_service_fixture, mock_db_session):
 
 
 @pytest.mark.asyncio
-async def test_execute_backup_hooks(backup_service_fixture, mock_db_session):
+async def test_execute_backup_hooks(backup_service_fixture, mock_db_session, tmp_path):
     """Test pre/post backup hook execution"""
     # Setup Data
     job_id = 999
+    source_path = tmp_path / "data"
+    source_path.mkdir()
     repo = Repository(
         id=1,
         path="/backups/repo",
-        source_directories='["/data"]',
+        source_directories=f'["{source_path}"]',
         pre_backup_script="echo pre",
         post_backup_script="echo post",
     )
@@ -313,14 +319,16 @@ async def test_execute_backup_hooks(backup_service_fixture, mock_db_session):
 
 @pytest.mark.asyncio
 async def test_execute_backup_runs_post_hook_on_cancel_as_failure(
-    backup_service_fixture, mock_db_session
+    backup_service_fixture, mock_db_session, tmp_path
 ):
     """Cancelled backups should still execute post-backup hooks with failure semantics."""
     job_id = 1001
+    source_path = tmp_path / "data"
+    source_path.mkdir()
     repo = Repository(
         id=1,
         path="/backups/repo",
-        source_directories='["/data"]',
+        source_directories=f'["{source_path}"]',
         post_backup_script="echo post",
     )
     job = BackupJob(id=job_id, status="cancelled")
@@ -785,13 +793,15 @@ async def test_sync_rclone_after_borg_preserves_existing_borg_warning(
 
 @pytest.mark.asyncio
 async def test_execute_backup_uses_rclone_sync_failure_for_hooks_and_notifications(
-    backup_service_fixture, mock_db_session
+    backup_service_fixture, mock_db_session, tmp_path
 ):
     job_id = 46
+    source_path = tmp_path / "data"
+    source_path.mkdir()
     repo = Repository(
         id=1,
         path="/backups/repo",
-        source_directories='["/data"]',
+        source_directories=f'["{source_path}"]',
         compression="lz4",
     )
     job = BackupJob(id=job_id, status="pending")
@@ -832,7 +842,7 @@ async def test_execute_backup_uses_rclone_sync_failure_for_hooks_and_notificatio
         patch.object(
             backup_service_fixture,
             "_prepare_source_paths",
-            new=AsyncMock(return_value=(["/data"], [])),
+            new=AsyncMock(return_value=([str(source_path)], [])),
         ),
         patch.object(
             backup_service_fixture,
@@ -1169,9 +1179,11 @@ async def test_execute_backup_delegates_remote_ssh_job(
 
 @pytest.mark.asyncio
 async def test_execute_backup_resolves_grouped_source_locations(
-    backup_service_fixture, mock_db_session
+    backup_service_fixture, mock_db_session, tmp_path
 ):
     job_id = 501
+    local_source = tmp_path / "srv-app"
+    local_source.mkdir()
     repo = Repository(
         id=1,
         path="/backups/repo",
@@ -1201,7 +1213,7 @@ async def test_execute_backup_resolves_grouped_source_locations(
         {
             "source_type": "local",
             "source_ssh_connection_id": None,
-            "paths": ["/srv/app"],
+            "paths": [str(local_source)],
         },
         {
             "source_type": "remote",
@@ -1259,7 +1271,7 @@ async def test_execute_backup_resolves_grouped_source_locations(
             "_prepare_source_paths",
             new=AsyncMock(
                 return_value=(
-                    ["/srv/app", "data", "var/lib/service"],
+                    [str(local_source), "data", "var/lib/service"],
                     [
                         ("/tmp/sshfs-a", "data"),
                         ("/tmp/sshfs-b", "var/lib/service"),
@@ -1282,13 +1294,13 @@ async def test_execute_backup_resolves_grouped_source_locations(
             job_id,
             repo.path,
             db=mock_db_session,
-            source_directories=["/srv/app", "data", "/var/lib/service"],
+            source_directories=[str(local_source), "data", "/var/lib/service"],
             source_locations=source_locations,
         )
 
     prepare_source_paths.assert_awaited_once_with(
         [
-            "/srv/app",
+            str(local_source),
             "ssh://backup-a@server-a.example:22/home/backup-a/data",
             "ssh://backup-b@server-b.example:2222/var/lib/service",
         ],

--- a/tests/unit/test_borg2.py
+++ b/tests/unit/test_borg2.py
@@ -56,3 +56,35 @@ async def test_list_archive_contents_omits_depth_when_not_requested():
         max_lines=1_000_000,
         env=None,
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_extract_archive_uses_restore_umask():
+    with patch.object(
+        borg2,
+        "_run",
+        new=AsyncMock(return_value={"success": True, "stdout": ""}),
+    ) as mock_run:
+        await borg2.extract_archive(
+            repository="/repo",
+            archive="archive-1",
+            paths=["home/user/file.txt"],
+            destination="/restore",
+        )
+
+    mock_run.assert_awaited_once_with(
+        [
+            "borg2",
+            "-r",
+            "/repo",
+            "extract",
+            "--umask",
+            "0022",
+            "archive-1",
+            "home/user/file.txt",
+        ],
+        timeout=3600,
+        cwd="/restore",
+        env=None,
+    )

--- a/tests/unit/test_borg_router.py
+++ b/tests/unit/test_borg_router.py
@@ -639,6 +639,8 @@ def test_build_restore_extract_command_adds_strip_components_for_v1():
         "extract",
         "--progress",
         "--log-json",
+        "--umask",
+        "0022",
         "--remote-path",
         "/usr/bin/borg",
         "--bypass-lock",

--- a/tests/unit/test_borg_wrapper.py
+++ b/tests/unit/test_borg_wrapper.py
@@ -61,6 +61,8 @@ class TestBorgWrapper:
         assert args[0] == [
             "borg",
             "extract",
+            "--umask",
+            "0022",
             "--noacls",
             "--noxattrs",
             "--noflags",
@@ -89,6 +91,8 @@ class TestBorgWrapper:
         assert args[0] == [
             "borg",
             "extract",
+            "--umask",
+            "0022",
             "--strip-components",
             "2",
             "--noacls",

--- a/tests/unit/test_restore_service.py
+++ b/tests/unit/test_restore_service.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import pytest
 from sqlalchemy.orm import sessionmaker
@@ -306,6 +306,59 @@ class TestRestoreServiceExecution:
         assert refreshed.progress == 100
         assert refreshed.progress_percent == 100.0
         assert "STDOUT:" in refreshed.logs
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_local_restore_root_created_destination_inherits_existing_parent_owner(
+        self, testing_session_local, restore_job, tmp_path
+    ):
+        parent = tmp_path / "parent"
+        parent.mkdir()
+        destination = parent / "new" / "child"
+        parent_stat = parent.stat()
+        service = RestoreService()
+        process = FakeRestoreProcess(
+            returncode=0,
+            stderr_chunks=[
+                b'{"type":"progress_percent","current":1,"total":1,"finished":true}\n'
+            ],
+            stdout_lines=[b"restored\n"],
+        )
+
+        notification_mock = SimpleNamespace(
+            send_restore_success=AsyncMock(return_value=None),
+            send_restore_failure=AsyncMock(return_value=None),
+        )
+
+        with (
+            patch("app.services.restore_service.SessionLocal", testing_session_local),
+            patch("app.services.restore_service.os.geteuid", return_value=0),
+            patch("app.services.restore_service.os.chown") as chown_mock,
+            patch(
+                "app.services.restore_service.asyncio.create_subprocess_exec",
+                return_value=process,
+            ),
+            patch(
+                "app.services.restore_service.notification_service",
+                notification_mock,
+            ),
+        ):
+            await service._execute_local_to_local(
+                restore_job.id,
+                restore_job.repository,
+                restore_job.archive,
+                str(destination),
+                None,
+            )
+
+        assert destination.exists()
+        chown_mock.assert_has_calls(
+            [
+                call(str(parent / "new"), parent_stat.st_uid, parent_stat.st_gid),
+                call(str(destination), parent_stat.st_uid, parent_stat.st_gid),
+            ],
+            any_order=False,
+        )
 
     @pytest.mark.unit
     @pytest.mark.asyncio

--- a/tests/unit/test_v2_restore_service.py
+++ b/tests/unit/test_v2_restore_service.py
@@ -24,6 +24,8 @@ def test_build_extract_command_uses_borg2_archive_identifier():
         "/repos/v2",
         "extract",
         "--log-json",
+        "--umask",
+        "0022",
         "--remote-path",
         "/usr/local/bin/borg2",
         "--bypass-lock",


### PR DESCRIPTION
## Description
Fixes two backup/restore regressions reported in #96.

- Direct local backup sources are checked after pre-backup hooks and before Borg `create`, so a missing source fails the job without creating an empty archive.
- Local restores that create a missing destination chain assign those directories to the nearest existing parent owner when Borg UI runs as root.
- Borg 1 and Borg 2 extract command builders pass `--umask 0022` so selected-path restore parent directories are traversable instead of being created with Borg's restrictive default umask.
- Local source preflight treats dangling symlink sources as present, matching Borg's symlink backup behavior while still failing truly missing source paths.
- Backup service mock tests now create real temporary local sources where they exercise the local-source preflight path.

## Related Issue
Fixes #96

Linear: BOR-126

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [x] Test addition/improvement
- [ ] Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Targeted backend unit tests pass

Validation run locally:

- `pytest tests/unit/test_backup_service.py::TestBackupService::test_validate_local_source_paths_allows_dangling_symlink_source` failed before the follow-up fix with `pathNotFound` for the dangling symlink source.
- `pytest tests/unit/test_backup_service.py::TestBackupService::test_validate_local_source_paths_allows_dangling_symlink_source tests/unit/test_backup_service.py::TestBackupService::test_execute_backup_fails_missing_local_source_before_borg_create` passed: 2 passed, 35 warnings.
- `pytest tests/unit/test_backup_service.py::TestBackupService::test_execute_backup_success_saves_logs_and_notifies_success tests/unit/test_backup_service.py::TestBackupService::test_execute_backup_parses_v1_json_progress tests/unit/test_backup_service.py::TestBackupService::test_execute_backup_publishes_terminal_status_before_stats_refresh tests/unit/test_backup_service.py::TestBackupService::test_execute_backup_completes_when_returncode_is_only_available_via_wait tests/unit/test_backup_service.py::TestBackupService::test_execute_backup_warning_marks_warning_and_notifies_warning tests/unit/test_backup_service.py::TestBackupService::test_execute_backup_lock_error_marks_failed_and_keeps_error_hint tests/unit/test_backup_service.py::TestBackupService::test_execute_backup_fails_missing_local_source_before_borg_create tests/unit/test_backup_service.py::TestBackupService::test_validate_local_source_paths_allows_dangling_symlink_source` passed: 8 passed, 35 warnings.
- `pytest tests/unit/test_backup_service.py::TestBackupService::test_execute_backup_fails_missing_local_source_before_borg_create tests/unit/test_restore_service.py::TestRestoreServiceExecution::test_local_restore_root_created_destination_inherits_existing_parent_owner tests/unit/test_borg_router.py::test_build_restore_extract_command_adds_strip_components_for_v1 tests/unit/test_v2_restore_service.py::test_build_extract_command_uses_borg2_archive_identifier tests/unit/test_borg_wrapper.py::TestBorgWrapper::test_extract_archive_builds_command_without_strip_components tests/unit/test_borg_wrapper.py::TestBorgWrapper::test_extract_archive_builds_command_with_strip_components tests/unit/test_borg2.py::test_extract_archive_uses_restore_umask` failed before the initial fix with 7 failures, then passed after the initial fix with 7 passed.
- `pytest tests/unit/test_backup_service_mocks.py::test_execute_backup_command tests/unit/test_backup_service_mocks.py::test_execute_backup_hooks tests/unit/test_backup_service_mocks.py::test_execute_backup_runs_post_hook_on_cancel_as_failure tests/unit/test_backup_service_mocks.py::test_execute_backup_uses_rclone_sync_failure_for_hooks_and_notifications tests/unit/test_backup_service_mocks.py::test_execute_backup_resolves_grouped_source_locations` passed: 5 passed, 3 warnings.
- `pytest tests/unit/test_backup_service_mocks.py tests/unit/test_backup_service.py tests/unit/test_restore_service.py tests/unit/test_borg_router.py tests/unit/test_v2_restore_service.py tests/unit/test_borg_wrapper.py tests/unit/test_borg2.py` passed: 146 passed, 6 skipped, 36 warnings.
- `ruff check app tests` passed.
- `ruff format --check app tests` passed.
- `git diff --check` passed.
- `DEV_PORT=8083 docker-compose -p borg-ui-dev -f docker-compose.dev.yml up -d --build --force-recreate` plus targeted live API proof against `http://localhost:8083`: missing-source backup failed with zero archives; selected restore into a missing destination completed with destination owner `1000:1000`; `docker-compose -p borg-ui-dev -f docker-compose.dev.yml down`.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas where comments were needed
- [x] I have made corresponding changes to the documentation where needed; no user docs changed because this is backend bug behavior
- [x] My changes generate no new warnings beyond existing test-environment deprecation warnings
- [x] New and existing targeted unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; backend-only backup and restore behavior.

## Additional Context
The original reproduction showed Borg 1.4.4 returning warning rc 107 for a missing source while still creating an archive, and selected restore creating root-owned/non-traversable parent directories when the app ran as root. The live API proof now covers both paths through the running dev backend.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
