### PR TITLE
Persist SSH host verification for backup hooks

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,6 +64,33 @@ if ! chmod 700 "$BORG_CACHE_DIR" 2>/dev/null; then
 fi
 echo "[$(date)] Borg cache directory setup complete"
 
+# Setup SSH home directory to persist across container updates.
+# Plain ssh commands in pre/post-backup hooks use ~/.ssh/known_hosts by default.
+SSH_HOME_DIR=/home/borg/.ssh
+PERSISTENT_SSH_DIR=/data/ssh_keys
+echo "[$(date)] Setting up persistent SSH directory at ${PERSISTENT_SSH_DIR}..."
+mkdir -p "$PERSISTENT_SSH_DIR"
+
+if [ -d "$SSH_HOME_DIR" ] && [ ! -L "$SSH_HOME_DIR" ]; then
+    if [ "$(ls -A "$SSH_HOME_DIR" 2>/dev/null)" ]; then
+        echo "[$(date)] Migrating existing SSH files to persistent storage..."
+        cp -a "$SSH_HOME_DIR"/. "$PERSISTENT_SSH_DIR"/
+    fi
+    rm -rf "$SSH_HOME_DIR"
+fi
+
+ln -sfn "$PERSISTENT_SSH_DIR" "$SSH_HOME_DIR"
+
+if ! chown -R borg:borg "$PERSISTENT_SSH_DIR" 2>/dev/null; then
+    echo "[$(date)] Warning: Could not change ownership of persistent SSH directory; continuing with existing permissions"
+fi
+if ! chmod 700 "$PERSISTENT_SSH_DIR" 2>/dev/null; then
+    echo "[$(date)] Warning: Could not chmod persistent SSH directory; continuing with existing permissions"
+fi
+chmod 600 "$PERSISTENT_SSH_DIR"/id_* 2>/dev/null || true
+chmod 644 "$PERSISTENT_SSH_DIR"/*.pub "$PERSISTENT_SSH_DIR"/known_hosts 2>/dev/null || true
+echo "[$(date)] Persistent SSH directory setup complete"
+
 # Setup SSH key symlink for root user (when PUID=0)
 # When borg user runs as root (UID 0), SSH looks for keys in /root/.ssh
 # but we deploy them to /home/borg/.ssh. Create symlink to handle this.

--- a/tests/unit/test_borg_cache_runtime.py
+++ b/tests/unit/test_borg_cache_runtime.py
@@ -26,3 +26,16 @@ def test_runtime_base_precreates_documented_borg_cache_dir() -> None:
     assert f"/home/borg/.ssh {EXPECTED_CACHE_DIR} /etc/cron.d" in dockerfile
     assert "/home/borg/.cache /etc/cron.d" in dockerfile
     assert f"chmod 700 /home/borg/.ssh {EXPECTED_CACHE_DIR}" in dockerfile
+
+
+def test_entrypoint_persists_borg_ssh_home() -> None:
+    entrypoint = (ROOT / "entrypoint.sh").read_text(encoding="utf-8")
+
+    assert "SSH_HOME_DIR=/home/borg/.ssh" in entrypoint
+    assert "PERSISTENT_SSH_DIR=/data/ssh_keys" in entrypoint
+    assert 'mkdir -p "$PERSISTENT_SSH_DIR"' in entrypoint
+    assert 'cp -a "$SSH_HOME_DIR"/. "$PERSISTENT_SSH_DIR"/' in entrypoint
+    assert 'rm -rf "$SSH_HOME_DIR"' in entrypoint
+    assert 'ln -sfn "$PERSISTENT_SSH_DIR" "$SSH_HOME_DIR"' in entrypoint
+    assert 'chown -R borg:borg "$PERSISTENT_SSH_DIR"' in entrypoint
+    assert 'chmod 700 "$PERSISTENT_SSH_DIR"' in entrypoint

--- a/tests/unit/test_borg_cache_runtime.py
+++ b/tests/unit/test_borg_cache_runtime.py
@@ -29,6 +29,7 @@ def test_runtime_base_precreates_documented_borg_cache_dir() -> None:
 
 
 def test_entrypoint_persists_borg_ssh_home() -> None:
+    """Require hook SSH client state to live on Borg UI's persistent data volume."""
     entrypoint = (ROOT / "entrypoint.sh").read_text(encoding="utf-8")
 
     assert "SSH_HOME_DIR=/home/borg/.ssh" in entrypoint


### PR DESCRIPTION
## Description
Persist Borg UI's SSH home directory across container updates by migrating `/home/borg/.ssh` into `/data/ssh_keys` at startup and replacing it with a symlink. This keeps ordinary user hook commands such as `ssh user@host ...` pointed at persistent `known_hosts` state without injecting `StrictHostKeyChecking=no` into hooks.

The existing root-mode behavior is preserved because `/root/.ssh` still points through `/home/borg/.ssh` when `PUID=0`.

## Related Issue
Fixes #82
Linear: BOR-129

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `pytest tests/unit/test_borg_cache_runtime.py::test_entrypoint_persists_borg_ssh_home -q` failed before implementation and passed after implementation
- `pytest tests/unit/test_borg_cache_runtime.py tests/unit/test_script_library_executor.py -q`
- `bash -n entrypoint.sh`
- `git diff --check`
- `ruff check app tests`
- `ruff format --check app tests`
- Local shell simulation of the SSH migration/symlink block passed

## Checklist
- [x] Checked for `CONTRIBUTING.md`; this repository copy does not include one
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Documentation impact reviewed; `docker-compose.yml` already documents `/data` as application data including SSH keys
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; this is a container startup/runtime fix with no UI surface.

## Additional Context
The bug was caused by hook scripts using plain OpenSSH defaults. Without a persistent Borg SSH home, accepted host keys in `~/.ssh/known_hosts` could be lost when the container was replaced. The fix keeps verification intact and persists the SSH client state through the existing `/data` volume.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSH home directory for the borg user is now persisted to a dedicated storage location, migrated when present, and replaced with a secure link; ownership and file permissions are applied to protect keys.

* **Tests**
  * Added a unit test verifying the SSH persistence, migration, symlink, and permission behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->