### PR TITLE
Reframe schedules as executable jobs

### DIFF
--- a/docs/engineering/plans/2026-06-03-executable-jobs-schedules.md
+++ b/docs/engineering/plans/2026-06-03-executable-jobs-schedules.md
@@ -1,0 +1,321 @@
+# Executable Jobs Schedules Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reframe legacy repository schedules and Backup Plan schedules as executable Jobs while hiding non-executable repositories from legacy job creation.
+
+**Architecture:** Keep the existing backend and `/schedule` route, but change the visible navigation/copy and first-tab composition. Add a small frontend utility that classifies executable legacy repositories, use it in `Schedule.tsx`, and cover the behavior with Vitest plus Storybook.
+
+**Tech Stack:** React 18, TypeScript, MUI, lucide-react, react-i18next, React Router, TanStack Query, Vitest, Storybook, Markdown docs.
+
+---
+
+## File Structure
+
+- Modify `frontend/src/components/AppSidebar.tsx` only if navigation data needs a new visible name; otherwise locale copy is enough.
+- Modify `frontend/src/pages/Schedule.tsx` to rename first-tab behavior/copy, render the legacy jobs section as a first-class section, and pass executable legacy repositories into `ScheduleWizard`.
+- Add `frontend/src/utils/executableRepositories.ts` for `isExecutableLegacyRepository` and `getExecutableLegacyRepositories`.
+- Add `frontend/src/utils/__tests__/executableRepositories.test.ts` for source/observe filtering.
+- Modify `frontend/src/components/__tests__/AppSidebar.test.tsx` to expect Jobs navigation.
+- Modify `frontend/src/components/__tests__/ScheduledJobsTable.test.tsx` for changed default/empty copy.
+- Add `frontend/src/components/ScheduledJobsTable.stories.tsx` for the Legacy Repository Jobs state.
+- Modify locale files `frontend/src/locales/en.json`, `frontend/src/locales/es.json`, and `frontend/src/locales/it.json` with matching keys.
+- Modify `docs/navigation.md` and `docs/usage-guide.md` for the visible Jobs flow.
+
+## Task 1: Failing Tests For Navigation And Executable Repositories
+
+**Files:**
+- Add: `frontend/src/utils/__tests__/executableRepositories.test.ts`
+- Modify: `frontend/src/components/__tests__/AppSidebar.test.tsx`
+- Modify: `frontend/src/components/__tests__/ScheduledJobsTable.test.tsx`
+
+- [ ] **Step 1: Add executable repository tests**
+
+Create `frontend/src/utils/__tests__/executableRepositories.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import type { Repository } from '../../types'
+import { getExecutableLegacyRepositories, isExecutableLegacyRepository } from '../executableRepositories'
+
+const repo = (overrides: Partial<Repository>): Repository =>
+  ({
+    id: 1,
+    name: 'Repo',
+    path: '/repo',
+    mode: 'full',
+    ...overrides,
+  }) as Repository
+
+describe('executable legacy repository filtering', () => {
+  it('includes full-mode repositories with legacy source directories', () => {
+    expect(isExecutableLegacyRepository(repo({ source_directories: ['/srv/app'] }))).toBe(true)
+  })
+
+  it('includes full-mode repositories with source locations', () => {
+    expect(
+      isExecutableLegacyRepository(
+        repo({
+          source_locations: [{ source_type: 'local', paths: ['/srv/app'] }],
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('includes full-mode repositories with database backup paths', () => {
+    expect(
+      isExecutableLegacyRepository(
+        repo({
+          source_locations: [
+            {
+              source_type: 'local',
+              paths: [],
+              database: {
+                template_id: 'postgres',
+                engine: 'postgres',
+                display_name: 'Postgres',
+                backup_strategy: 'dump',
+                capture_mode: 'dump',
+                backup_paths: ['/tmp/pg.sql'],
+                script_execution_target: 'server',
+              },
+            },
+          ],
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('excludes observe-mode repositories and repositories without sources', () => {
+    const executable = repo({ id: 1, source_directories: ['/srv/app'] })
+    const observe = repo({ id: 2, mode: 'observe', source_directories: ['/srv/app'] })
+    const planOwned = repo({ id: 3, source_directories: [], source_locations: [] })
+
+    expect(getExecutableLegacyRepositories([observe, planOwned, executable]).map((r) => r.id)).toEqual([1])
+  })
+})
+```
+
+- [ ] **Step 2: Update sidebar test to expect Jobs**
+
+In `frontend/src/components/__tests__/AppSidebar.test.tsx`, extend the primary
+nav assertion:
+
+```ts
+expect(screen.getAllByRole('link', { name: /jobs/i })[0]).toHaveAttribute('href', '/schedule')
+expect(screen.queryAllByRole('link', { name: /^schedule$/i })).toHaveLength(0)
+```
+
+- [ ] **Step 3: Update scheduled jobs table copy tests**
+
+In `frontend/src/components/__tests__/ScheduledJobsTable.test.tsx`, change the
+default title and empty assertions:
+
+```ts
+expect(screen.getByText('Legacy Repository Jobs')).toBeInTheDocument()
+expect(screen.getByText('No legacy repository jobs found')).toBeInTheDocument()
+```
+
+- [ ] **Step 4: Run failing tests**
+
+Run:
+
+```bash
+cd frontend && npm run test -- --run src/utils/__tests__/executableRepositories.test.ts src/components/__tests__/AppSidebar.test.tsx src/components/__tests__/ScheduledJobsTable.test.tsx
+```
+
+Expected: FAIL because `executableRepositories.ts` does not exist and current copy still says Schedule/Scheduled Jobs.
+
+## Task 2: Implement Jobs Copy And Filtering
+
+**Files:**
+- Add: `frontend/src/utils/executableRepositories.ts`
+- Modify: `frontend/src/pages/Schedule.tsx`
+- Modify: `frontend/src/locales/en.json`
+- Modify: `frontend/src/locales/es.json`
+- Modify: `frontend/src/locales/it.json`
+
+- [ ] **Step 1: Add executable repository helper**
+
+Create `frontend/src/utils/executableRepositories.ts`:
+
+```ts
+import type { Repository, SourceLocation } from '../types'
+
+function hasSourceLocationPath(location: SourceLocation): boolean {
+  if (location.paths?.some((path) => path.trim().length > 0)) return true
+  return Boolean(location.database?.backup_paths?.some((path) => path.trim().length > 0))
+}
+
+export function isExecutableLegacyRepository(repository: Repository): boolean {
+  if (repository.mode === 'observe') return false
+  if (repository.source_directories?.some((path) => path.trim().length > 0)) return true
+  return Boolean(repository.source_locations?.some(hasSourceLocationPath))
+}
+
+export function getExecutableLegacyRepositories(repositories: Repository[]): Repository[] {
+  return repositories.filter(isExecutableLegacyRepository)
+}
+```
+
+- [ ] **Step 2: Use helper in Schedule page**
+
+In `frontend/src/pages/Schedule.tsx`, import the helper and derive:
+
+```ts
+const executableLegacyRepositories = React.useMemo(
+  () => getExecutableLegacyRepositories(manageableRepositories),
+  [manageableRepositories]
+)
+const canCreateLegacyJob = executableLegacyRepositories.length > 0
+const canCreateBackupPlan = canManageRepositoriesGlobally || manageableRepositories.length > 0
+```
+
+Use `canCreateBackupPlan` for the Backup Plan button and `canCreateLegacyJob`
+for the legacy job button. Pass `executableLegacyRepositories` to
+`ScheduleWizard`.
+
+- [ ] **Step 3: Make legacy jobs first-class**
+
+In `Schedule.tsx`, keep the Backup Plans button and legacy jobs button in the
+first tab, but change labels to:
+
+```tsx
+{t('schedule.createLegacyJob', { defaultValue: 'Create legacy job' })}
+```
+
+Render `ScheduledJobsTable` unconditionally on the first tab so the empty state
+is visible:
+
+```tsx
+legacySection={
+  <ScheduledJobsTable
+    jobs={jobs}
+    repositories={repositories}
+    isLoading={isLoading}
+    title={t('schedule.legacyRepositoryJobsTitle')}
+    description={t('schedule.legacyRepositoryJobsDescription')}
+    ...
+  />
+}
+```
+
+- [ ] **Step 4: Update locale values without adding unmatched keys**
+
+Set the visible navigation/page/tab values:
+
+```json
+"navigation": { "items": { "schedule": "Jobs" } }
+"schedule": {
+  "title": "Jobs",
+  "subtitle": "Schedule and run executable backup work, checks, and restore checks",
+  "createLegacySchedule": "Create legacy job",
+  "createLegacyJob": "Create legacy job",
+  "tabs": { "byPlan": "Executable Jobs" },
+  "legacyBackupSchedulesTitle": "Legacy Repository Jobs",
+  "legacyBackupSchedulesDescription": "Legacy repository jobs continue to run here for repositories with their own source paths. Use Backup Plans for new plan-owned backup workflows.",
+  "legacyRepositoryJobsTitle": "Legacy Repository Jobs",
+  "legacyRepositoryJobsDescription": "Legacy repository jobs continue to run here for repositories with their own source paths. Use Backup Plans for new plan-owned backup workflows."
+}
+"scheduledJobsTableSection": {
+  "title": "Legacy Repository Jobs",
+  "noJobsFound": "No legacy repository jobs found",
+  "noJobsDesc": "Create a legacy job for a repository that still owns source paths."
+}
+```
+
+Apply matching keys to Spanish and Italian locale files. Existing translated
+files may use English fallback text where no reliable translation is already
+present; parity is more important than inventing poor translations.
+
+- [ ] **Step 5: Run targeted tests**
+
+Run:
+
+```bash
+cd frontend && npm run test -- --run src/utils/__tests__/executableRepositories.test.ts src/components/__tests__/AppSidebar.test.tsx src/components/__tests__/ScheduledJobsTable.test.tsx
+```
+
+Expected: PASS.
+
+## Task 3: Storybook And Docs
+
+**Files:**
+- Add: `frontend/src/components/ScheduledJobsTable.stories.tsx`
+- Modify: `docs/navigation.md`
+- Modify: `docs/usage-guide.md`
+
+- [ ] **Step 1: Add story**
+
+Create a `ScheduledJobsTable` story with at least one enabled multi-repository
+legacy job and one empty state story. Use static handlers from Storybook
+actions or `fn` if available in this repo's Storybook setup.
+
+- [ ] **Step 2: Update navigation docs**
+
+In `docs/navigation.md`, change the Backups row from Schedule to Jobs:
+
+```md
+| Backups | Jobs | Review executable backup jobs, legacy repository jobs, scheduled checks, restore checks, and plan activity. |
+```
+
+- [ ] **Step 3: Update usage guide**
+
+In `docs/usage-guide.md`, update the Backup Plan Schedules paragraph:
+
+```md
+The Jobs area still shows executable repository work, including Legacy Repository Jobs for repositories that still own source paths. New backup schedules should usually live on Backup Plans.
+```
+
+Add a short Legacy Repository Jobs subsection explaining the GitHub #559
+workflow shape and when to use Backup Plans instead.
+
+## Task 4: Full Validation And Publish
+
+**Files:**
+- `.github/PULL_REQUEST_TEMPLATE.md` for PR body content only.
+
+- [ ] **Step 1: Run frontend validation**
+
+Run:
+
+```bash
+cd frontend && npm run check:locales && npm run typecheck && npm run lint && npm run build
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run local walkthrough**
+
+Run the app with an available local dev path and verify:
+
+- sidebar shows Jobs;
+- `/schedule` opens the Jobs page;
+- first tab is Executable Jobs;
+- Legacy Repository Jobs empty/table state is visible;
+- Create legacy job opens the shared wizard.
+
+- [ ] **Step 3: Reply on GitHub issue #559**
+
+Post a concise final reply noting that the feature remains supported and is
+being reframed as Jobs/Legacy Repository Jobs, with Backup Plans remaining the
+preferred path when the plan model fits.
+
+- [ ] **Step 4: Commit and push**
+
+Commit with:
+
+```bash
+git add docs/engineering/specs/2026-06-03-executable-jobs-schedules.md docs/engineering/plans/2026-06-03-executable-jobs-schedules.md frontend/src docs
+git commit -m "feat(frontend): reframe schedules as executable jobs"
+```
+
+Push through the repository push workflow, create/attach the PR, and add the
+`symphony` label.
+
+## Plan Self-Review
+
+- Spec coverage: The plan covers the rework feedback, visible naming, executable filtering, docs, Storybook, GitHub reply, and frontend validation.
+- Placeholder scan: No `TBD` or unresolved task placeholders remain.
+- Type consistency: Repository/source helper names match the planned imports and tests.
+- Scope check: Backend schedule behavior remains unchanged because inspection showed it already supports the legacy workflow.

--- a/docs/engineering/plans/2026-06-03-executable-jobs-schedules.md
+++ b/docs/engineering/plans/2026-06-03-executable-jobs-schedules.md
@@ -19,7 +19,7 @@
 - Modify `frontend/src/components/__tests__/AppSidebar.test.tsx` to expect Jobs navigation.
 - Modify `frontend/src/components/__tests__/ScheduledJobsTable.test.tsx` for changed default/empty copy.
 - Add `frontend/src/components/ScheduledJobsTable.stories.tsx` for the Legacy Repository Jobs state.
-- Modify locale files `frontend/src/locales/en.json`, `frontend/src/locales/es.json`, and `frontend/src/locales/it.json` with matching keys.
+- Modify locale files `frontend/src/locales/en.json`, `frontend/src/locales/es.json`, `frontend/src/locales/it.json`, and `frontend/src/locales/de.json` with matching keys.
 - Modify `docs/navigation.md` and `docs/usage-guide.md` for the visible Jobs flow.
 
 ## Task 1: Failing Tests For Navigation And Executable Repositories
@@ -134,6 +134,7 @@ Expected: FAIL because `executableRepositories.ts` does not exist and current co
 - Modify: `frontend/src/locales/en.json`
 - Modify: `frontend/src/locales/es.json`
 - Modify: `frontend/src/locales/it.json`
+- Modify: `frontend/src/locales/de.json`
 
 - [ ] **Step 1: Add executable repository helper**
 
@@ -224,7 +225,7 @@ Set the visible navigation/page/tab values:
 }
 ```
 
-Apply matching keys to Spanish and Italian locale files. Existing translated
+Apply matching keys to Spanish, Italian, and German locale files. Existing translated
 files may use English fallback text where no reliable translation is already
 present; parity is more important than inventing poor translations.
 

--- a/docs/engineering/specs/2026-06-03-executable-jobs-schedules.md
+++ b/docs/engineering/specs/2026-06-03-executable-jobs-schedules.md
@@ -1,0 +1,109 @@
+# Executable Jobs Schedules Spec
+
+## Problem
+
+GitHub issue #559 asks whether repository schedules are going away because the
+reporter relies on a multi-repository scheduled workflow: wake a backup server,
+run backup/prune/compact across repositories, then power off only after the last
+repository finishes.
+
+Backup Plans can run pre/post scripts and maintenance, but multi-repository
+Backup Plans are plan-tier gated. The current product answer is that this
+legacy repository schedule capability is not going away, but the Schedule
+surface is confusing because it mixes plan schedules, repository schedules,
+checks, restore checks, activity, and legacy backup schedules under one
+"Schedule" label.
+
+PR #608 tried to solve the ticket with documentation only. Owner feedback
+rejected that approach and requested product/UI rework: move "Legacy Schedule"
+out of the Schedule tab and use a clearer concept such as crons or batch jobs,
+showing executable legacy repositories and Backup Plans while hiding newer
+repositories that do not have repository-owned sources.
+
+## Desired Outcome
+
+The scheduling area should read as an executable jobs surface rather than a
+deprecated schedule migration page. Users should understand that:
+
+- legacy repository jobs remain supported;
+- Backup Plans are the normal scheduled backup surface when they fit;
+- legacy repository jobs are for repositories that still own executable source
+  paths;
+- newer repositories without repository-owned sources are not valid legacy job
+  targets.
+
+The GitHub issue reply can then point to the product direction accurately:
+the capability remains, but the UI is being renamed/reframed around executable
+jobs.
+
+## Design
+
+Use **Jobs** as the primary visible navigation label. It is shorter and less
+cron-specific than "Crons", while still matching the existing product language
+for backup/check/history work. Keep the existing `/schedule` route for
+compatibility and tab enablement, but make visible labels say "Jobs" and make
+the first tab "Executable Jobs".
+
+The first tab keeps the existing plan-oriented cards and legacy scheduled job
+table in one operational view:
+
+- Backup Plans appear first because they are the preferred new scheduled backup
+  workflow.
+- Legacy Repository Jobs appear as a separate section and remain visible even
+  when empty, so users can see that legacy repository jobs are still supported.
+- The Create legacy job button opens the existing schedule wizard, but the
+  repository list is filtered to executable legacy repositories only.
+
+An executable legacy repository is a full-mode repository with repository-owned
+sources:
+
+- `source_directories` has at least one path; or
+- `source_locations` has at least one path; or
+- `source_locations` has a database selection with at least one `backup_paths`
+  entry.
+
+Repositories in observe mode, repositories without sources, and plan-owned
+source repositories are excluded from legacy job creation. Backup Plans remain
+selectable through the Backup Plans section.
+
+## Scope
+
+In scope:
+
+- Rename visible navigation/page/tab/copy from Schedule/Schedules to Jobs where
+  it refers to the overall executable work surface.
+- Rename legacy backup schedule copy to Legacy Repository Jobs.
+- Filter the legacy schedule wizard's repository choices to executable legacy
+  repositories.
+- Add frontend tests for navigation naming and executable repository filtering.
+- Add or update Storybook coverage for the changed scheduled jobs table state.
+- Update user docs for the navigation change.
+
+Out of scope:
+
+- Backend schedule model changes.
+- New schedule record types.
+- Combining Backup Plan and legacy repository jobs into one backend API.
+- Removing `/schedule` compatibility routes.
+- Changing plan-tier gating for multi-repository Backup Plans.
+
+## Acceptance Criteria Mapping
+
+- Legacy repository schedules are no longer presented as the main "Schedule"
+  tab; the visible surface is Jobs with an Executable Jobs tab.
+- Backup Plans and Legacy Repository Jobs are shown together in the executable
+  jobs view.
+- Legacy job creation only receives repositories with repository-owned source
+  settings.
+- Docs explain the Jobs navigation and when to use Backup Plans versus legacy
+  repository jobs.
+- GitHub issue #559 receives a final answer grounded in the implementation.
+
+## Validation
+
+- Failing-first Vitest coverage for executable repository filtering.
+- Failing-first Vitest coverage for sidebar Jobs navigation naming.
+- Targeted component tests for changed scheduled jobs table copy.
+- Required frontend gate: `npm run check:locales`, `npm run typecheck`,
+  `npm run lint`, and `npm run build`.
+- Local app walkthrough of the Jobs page and legacy job creation path.

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -17,7 +17,7 @@ For a new setup, follow the sidebar in this order:
 1. Open Dashboard to check overall health.
 2. Add storage targets from Repositories, Cloud Storage, or Remote Machines.
 3. Create a plan from Backup Plans.
-4. Configure automatic runs from the plan schedule or the Schedule page.
+4. Configure automatic runs from the plan schedule or the Jobs page.
 5. Watch work in Activity and browse results in Archives.
 6. Adjust preferences, notifications, and system options from Settings.
 
@@ -33,7 +33,7 @@ For a new setup, follow the sidebar in this order:
 | Storage | Repositories | Create, import, inspect, maintain, and restore from Borg repositories. A repository is the storage target. |
 | Backups | Backup Plans | Define what to back up, where it should go, when it should run, and what maintenance should run afterward. |
 | Backups | Backup | Run older repository-based backups or legacy backup jobs. New workflows should usually start from Backup Plans. |
-| Backups | Schedule | Review scheduled repository work, scheduled restore checks, and plan schedules from one operational view. |
+| Backups | Jobs | Review executable backup jobs, legacy repository jobs, scheduled checks, restore checks, and plan activity. |
 | Backups | Archives | Browse archives, select files or folders, restore data, and run archive-level actions. |
 
 ## Settings

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -300,9 +300,15 @@ Backup Plan schedules run backups automatically.
 
 Plans can also run prune, compact, and check after successful repository backups.
 
-The Schedules area still shows scheduled repository work. New backup schedules should usually live on Backup Plans.
+The Jobs area still shows executable repository work, including Legacy Repository Jobs for repositories that still own source paths. New backup schedules should usually live on Backup Plans.
 
 Use notifications for scheduled backup failures so failures do not go unnoticed.
+
+## Legacy Repository Jobs
+
+Legacy Repository Jobs keep older repository-owned schedule workflows available. Use them when a repository still owns its source paths and the job needs to run a batch such as wake server, back up multiple repositories, prune, compact, and run a final shutdown script after the last repository finishes.
+
+Use Backup Plans for new plan-owned workflows. Backup Plans own the source configuration, selected repositories, scripts, schedule, and maintenance settings together.
 
 ## Maintenance
 
@@ -315,7 +321,7 @@ Repository maintenance actions include:
 
 Use check and restore verification regularly. A backup that cannot be restored is not useful.
 
-Scheduled repository checks and restore checks are managed from Schedule.
+Scheduled repository checks and restore checks are managed from Jobs.
 
 See [Disaster Recovery](disaster-recovery) for restore-check modes and recovery drills.
 

--- a/frontend/src/components/ScheduledJobsTable.stories.tsx
+++ b/frontend/src/components/ScheduledJobsTable.stories.tsx
@@ -75,7 +75,7 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const LegacyRepositoryJobs: Story = {}
+export const MultiRepositoryLegacyJob: Story = {}
 
 export const EmptyLegacyRepositoryJobs: Story = {
   args: {

--- a/frontend/src/components/ScheduledJobsTable.stories.tsx
+++ b/frontend/src/components/ScheduledJobsTable.stories.tsx
@@ -1,0 +1,84 @@
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box } from '@mui/material'
+import ScheduledJobsTable from './ScheduledJobsTable'
+
+type ScheduledJobsTableProps = ComponentProps<typeof ScheduledJobsTable>
+type ScheduledJob = ScheduledJobsTableProps['jobs'][number]
+type Repository = ScheduledJobsTableProps['repositories'][number]
+
+const repositories: Repository[] = [
+  { id: 1, name: 'Media archive', path: '/backups/media' },
+  { id: 2, name: 'Photos archive', path: '/backups/photos' },
+]
+
+const jobs: ScheduledJob[] = [
+  {
+    id: 42,
+    name: 'Primary server batch',
+    cron_expression: '0 2 * * *',
+    timezone: 'America/New_York',
+    repository: null,
+    repository_id: null,
+    repository_ids: [1, 2],
+    enabled: true,
+    last_run: '2026-06-02T06:00:00Z',
+    next_run: '2026-06-03T06:00:00Z',
+    created_at: '2026-05-20T12:00:00Z',
+    updated_at: '2026-06-01T12:00:00Z',
+    description: 'Wake backup server, run repository backups, prune, compact, then power off.',
+    archive_name_template: '{job_name}-{now}',
+    run_repository_scripts: true,
+    pre_backup_script_id: 7,
+    post_backup_script_id: 8,
+    run_prune_after: true,
+    run_compact_after: true,
+    prune_keep_hourly: 0,
+    prune_keep_daily: 7,
+    prune_keep_weekly: 4,
+    prune_keep_monthly: 6,
+    prune_keep_quarterly: 0,
+    prune_keep_yearly: 1,
+    last_prune: '2026-06-02T07:00:00Z',
+    last_compact: '2026-06-02T07:10:00Z',
+  },
+]
+
+const meta = {
+  title: 'Components/ScheduledJobsTable',
+  component: ScheduledJobsTable,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    jobs,
+    repositories,
+    isLoading: false,
+    title: 'Legacy Repository Jobs',
+    description:
+      'Legacy repository jobs continue to run here for repositories with their own source paths. Use Backup Plans for new plan-owned backup workflows.',
+    canManageJob: () => true,
+    onEdit: () => {},
+    onDelete: () => {},
+    onDuplicate: () => {},
+    onRunNow: () => {},
+    onToggle: () => {},
+  },
+  render: (args) => (
+    <Box sx={{ p: 3 }}>
+      <ScheduledJobsTable {...args} />
+    </Box>
+  ),
+} satisfies Meta<typeof ScheduledJobsTable>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const LegacyRepositoryJobs: Story = {}
+
+export const EmptyLegacyRepositoryJobs: Story = {
+  args: {
+    jobs: [],
+  },
+}

--- a/frontend/src/components/__tests__/AppSidebar.test.tsx
+++ b/frontend/src/components/__tests__/AppSidebar.test.tsx
@@ -139,6 +139,8 @@ describe('AppSidebar', () => {
         'href',
         '/cloud-storage'
       )
+      expect(screen.getAllByRole('link', { name: /jobs/i })[0]).toHaveAttribute('href', '/schedule')
+      expect(screen.queryAllByRole('link', { name: /^schedule$/i })).toHaveLength(0)
       expect(screen.getAllByRole('link', { name: /manual backup/i }).length).toBeGreaterThan(0)
       expect(screen.getAllByRole('link', { name: /managed agents/i }).length).toBeGreaterThan(0)
     })

--- a/frontend/src/components/__tests__/ScheduledJobsTable.test.tsx
+++ b/frontend/src/components/__tests__/ScheduledJobsTable.test.tsx
@@ -52,7 +52,7 @@ const defaultProps = {
 describe('ScheduledJobsTable', () => {
   it('renders the section title', () => {
     render(<ScheduledJobsTable {...defaultProps} />)
-    expect(screen.getByText('All Scheduled Jobs')).toBeInTheDocument()
+    expect(screen.getByText('Legacy Repository Jobs')).toBeInTheDocument()
   })
 
   it('renders a card for each job', () => {
@@ -78,7 +78,7 @@ describe('ScheduledJobsTable', () => {
 
   it('shows empty state when jobs array is empty', () => {
     render(<ScheduledJobsTable {...defaultProps} jobs={[]} />)
-    expect(screen.getByText('No scheduled jobs found')).toBeInTheDocument()
+    expect(screen.getByText('No legacy repository jobs found')).toBeInTheDocument()
   })
 
   it('renders the jobs list without an outer card wrapper', () => {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -118,7 +118,7 @@
       "archives": "Archive",
       "restore": "Wiederherstellen",
       "integrity": "Integrität",
-      "schedule": "Zeitplan"
+      "schedule": "Jobs"
     },
     "badges": {
       "new": "Neu"
@@ -537,16 +537,17 @@
     }
   },
   "schedule": {
-    "title": "Zeitplan",
-    "subtitle": "Verwalte automatische Sicherungen und Repository-Überprüfungen",
+    "title": "Jobs",
+    "subtitle": "Plane und starte ausführbare Backup-, Prüf- und Restore-Jobs",
     "createBackup": "Sicherungszeitplan erstellen",
     "createBackupPlan": "Backup-Plan erstellen",
     "createSchedule": "Zeitplan erstellen",
-    "createLegacySchedule": "Legacy-Zeitplan erstellen",
+    "createLegacySchedule": "Legacy-Job erstellen",
+    "createLegacyJob": "Legacy-Job erstellen",
     "addCheck": "Überprüfungszeitplan hinzufügen",
     "addRestoreCheck": "Restore-Prüfung hinzufügen",
     "tabs": {
-      "byPlan": "Zeitpläne",
+      "byPlan": "Ausführbare Jobs",
       "backupJobs": "Aktivität",
       "repositoryChecks": "Repository-Überprüfungen",
       "restoreChecks": "Restore-Prüfungen"
@@ -577,8 +578,10 @@
       "runCheckTip": "Integritätsprüfung läuft nach jedem Backup (zusätzlich zu geplanten Prüfungen unten)"
     },
     "noRepositories": "Du musst mindestens ein Repository erstellen, bevor du Sicherungen planst.",
-    "legacyBackupSchedulesTitle": "Legacy-Sicherungszeitpläne",
-    "legacyBackupSchedulesDescription": "Bestehende Repository-basierte Zeitpläne laufen hier weiter. Neue geplante Sicherungen sollten als Backup-Pläne erstellt werden.",
+    "legacyBackupSchedulesTitle": "Legacy-Repository-Jobs",
+    "legacyBackupSchedulesDescription": "Legacy-Repository-Jobs laufen hier für Repositories mit eigenen Quellpfaden weiter. Nutze Backup-Pläne für neue planbasierte Backup-Abläufe.",
+    "legacyRepositoryJobsTitle": "Legacy-Repository-Jobs",
+    "legacyRepositoryJobsDescription": "Legacy-Repository-Jobs laufen hier für Repositories mit eigenen Quellpfaden weiter. Nutze Backup-Pläne für neue planbasierte Backup-Abläufe.",
     "confirmRunNow": "\"{{name}}\" jetzt ausführen?",
     "maintenance": {
       "pruning": "Archive werden bereinigt...",
@@ -3731,9 +3734,9 @@
     }
   },
   "scheduledJobsTableSection": {
-    "title": "Alle geplanten Aufgaben",
-    "noJobsFound": "Keine geplanten Aufgaben gefunden",
-    "noJobsDesc": "Erstelle deine erste geplante Sicherungsaufgabe"
+    "title": "Legacy-Repository-Jobs",
+    "noJobsFound": "Keine Legacy-Repository-Jobs gefunden",
+    "noJobsDesc": "Erstelle einen Legacy-Job für ein Repository, das noch eigene Quellpfade besitzt."
   },
   "advancedRepositoryOptions": {
     "title": "Erweiterte Optionen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -118,7 +118,7 @@
       "archives": "Archives",
       "restore": "Restore",
       "integrity": "Integrity",
-      "schedule": "Schedule"
+      "schedule": "Jobs"
     },
     "badges": {
       "new": "New"
@@ -537,16 +537,17 @@
     }
   },
   "schedule": {
-    "title": "Schedule",
-    "subtitle": "Manage automated backups and repository checks",
+    "title": "Jobs",
+    "subtitle": "Schedule and run executable backup work, checks, and restore checks",
     "createBackup": "Create Backup Schedule",
     "createBackupPlan": "Create Backup Plan",
     "createSchedule": "Create Schedule",
-    "createLegacySchedule": "Create legacy schedule",
+    "createLegacySchedule": "Create legacy job",
+    "createLegacyJob": "Create legacy job",
     "addCheck": "Add Check Schedule",
     "addRestoreCheck": "Add Restore Check",
     "tabs": {
-      "byPlan": "Schedules",
+      "byPlan": "Executable Jobs",
       "backupJobs": "Activity",
       "repositoryChecks": "Repository Checks",
       "restoreChecks": "Restore Checks"
@@ -577,8 +578,10 @@
       "runCheckTip": "Integrity check runs after each backup (in addition to any scheduled check below)"
     },
     "noRepositories": "You need to create at least one repository before scheduling backups.",
-    "legacyBackupSchedulesTitle": "Legacy Backup Schedules",
-    "legacyBackupSchedulesDescription": "Existing repository-based schedules continue to run here. New scheduled backups should be created as Backup Plans.",
+    "legacyBackupSchedulesTitle": "Legacy Repository Jobs",
+    "legacyBackupSchedulesDescription": "Legacy repository jobs continue to run here for repositories with their own source paths. Use Backup Plans for new plan-owned backup workflows.",
+    "legacyRepositoryJobsTitle": "Legacy Repository Jobs",
+    "legacyRepositoryJobsDescription": "Legacy repository jobs continue to run here for repositories with their own source paths. Use Backup Plans for new plan-owned backup workflows.",
     "confirmRunNow": "Run \"{{name}}\" now?",
     "maintenance": {
       "pruning": "Pruning archives...",
@@ -3731,9 +3734,9 @@
     }
   },
   "scheduledJobsTableSection": {
-    "title": "All Scheduled Jobs",
-    "noJobsFound": "No scheduled jobs found",
-    "noJobsDesc": "Create your first scheduled backup job"
+    "title": "Legacy Repository Jobs",
+    "noJobsFound": "No legacy repository jobs found",
+    "noJobsDesc": "Create a legacy job for a repository that still owns source paths."
   },
   "advancedRepositoryOptions": {
     "title": "Advanced Options",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -118,7 +118,7 @@
       "archives": "Archivos",
       "restore": "Restaurar",
       "integrity": "Integridad",
-      "schedule": "Programación"
+      "schedule": "Trabajos"
     },
     "badges": {
       "new": "Nuevo"
@@ -537,16 +537,17 @@
     }
   },
   "schedule": {
-    "title": "Programación",
-    "subtitle": "Gestiona copias de seguridad automatizadas y comprobaciones de repositorio",
+    "title": "Trabajos",
+    "subtitle": "Programa y ejecuta trabajos de copia, comprobación y restauración",
     "createBackup": "Crear programación de copia de seguridad",
     "createBackupPlan": "Crear plan de copia",
     "createSchedule": "Crear programación",
-    "createLegacySchedule": "Crear programación heredada",
+    "createLegacySchedule": "Crear trabajo heredado",
+    "createLegacyJob": "Crear trabajo heredado",
     "addCheck": "Agregar comprobación programada",
     "addRestoreCheck": "Agregar comprobación de restauración",
     "tabs": {
-      "byPlan": "Programaciones",
+      "byPlan": "Trabajos ejecutables",
       "backupJobs": "Actividad",
       "repositoryChecks": "Comprobaciones de repositorio",
       "restoreChecks": "Comprobaciones de restauración"
@@ -577,8 +578,10 @@
       "runCheckTip": "La comprobación de integridad se ejecuta después de cada copia (además de cualquier comprobación programada abajo)"
     },
     "noRepositories": "Necesitas crear al menos un repositorio antes de programar copias de seguridad.",
-    "legacyBackupSchedulesTitle": "Programaciones de copia heredadas",
-    "legacyBackupSchedulesDescription": "Las programaciones existentes basadas en repositorio siguen ejecutándose aquí. Las nuevas copias programadas deberían crearse como planes de copia.",
+    "legacyBackupSchedulesTitle": "Trabajos de repositorio heredados",
+    "legacyBackupSchedulesDescription": "Los trabajos de repositorio heredados siguen ejecutándose aquí para repositorios con sus propias rutas de origen. Usa planes de copia para nuevos flujos de copia gestionados por planes.",
+    "legacyRepositoryJobsTitle": "Trabajos de repositorio heredados",
+    "legacyRepositoryJobsDescription": "Los trabajos de repositorio heredados siguen ejecutándose aquí para repositorios con sus propias rutas de origen. Usa planes de copia para nuevos flujos de copia gestionados por planes.",
     "confirmRunNow": "¿Ejecutar \"{{name}}\" ahora?",
     "maintenance": {
       "pruning": "Podando archivos...",
@@ -3731,9 +3734,9 @@
     }
   },
   "scheduledJobsTableSection": {
-    "title": "Todos los trabajos programados",
-    "noJobsFound": "No se encontraron trabajos programados",
-    "noJobsDesc": "Crea tu primer trabajo de copia de seguridad programado"
+    "title": "Trabajos de repositorio heredados",
+    "noJobsFound": "No se encontraron trabajos de repositorio heredados",
+    "noJobsDesc": "Crea un trabajo heredado para un repositorio que todavía tenga rutas de origen propias."
   },
   "advancedRepositoryOptions": {
     "title": "Opciones avanzadas",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -118,7 +118,7 @@
       "archives": "Archivi",
       "restore": "Ripristino",
       "integrity": "Integrità",
-      "schedule": "Pianificazione"
+      "schedule": "Lavori"
     },
     "badges": {
       "new": "Nuovo"
@@ -537,16 +537,17 @@
     }
   },
   "schedule": {
-    "title": "Pianificazione",
-    "subtitle": "Gestisci backup automatizzati e controlli del repository",
+    "title": "Lavori",
+    "subtitle": "Pianifica ed esegui lavori di backup, controllo e ripristino",
     "createBackup": "Crea Pianificazione Backup",
     "createBackupPlan": "Crea piano di backup",
     "createSchedule": "Crea pianificazione",
-    "createLegacySchedule": "Crea pianificazione legacy",
+    "createLegacySchedule": "Crea lavoro legacy",
+    "createLegacyJob": "Crea lavoro legacy",
     "addCheck": "Aggiungi Pianificazione Controllo",
     "addRestoreCheck": "Aggiungi controllo di ripristino",
     "tabs": {
-      "byPlan": "Pianificazioni",
+      "byPlan": "Lavori eseguibili",
       "backupJobs": "Attività",
       "repositoryChecks": "Controlli Repository",
       "restoreChecks": "Controlli di ripristino"
@@ -577,8 +578,10 @@
       "runCheckTip": "Il controllo di integrità viene eseguito dopo ogni backup (oltre a qualsiasi controllo pianificato qui sotto)"
     },
     "noRepositories": "Devi creare almeno un repository prima di pianificare i backup.",
-    "legacyBackupSchedulesTitle": "Pianificazioni backup legacy",
-    "legacyBackupSchedulesDescription": "Le pianificazioni esistenti basate su repository continuano a essere eseguite qui. I nuovi backup pianificati dovrebbero essere creati come piani di backup.",
+    "legacyBackupSchedulesTitle": "Lavori repository legacy",
+    "legacyBackupSchedulesDescription": "I lavori repository legacy continuano a essere eseguiti qui per repository con percorsi sorgente propri. Usa i piani di backup per nuovi flussi gestiti dai piani.",
+    "legacyRepositoryJobsTitle": "Lavori repository legacy",
+    "legacyRepositoryJobsDescription": "I lavori repository legacy continuano a essere eseguiti qui per repository con percorsi sorgente propri. Usa i piani di backup per nuovi flussi gestiti dai piani.",
     "confirmRunNow": "Eseguire \"{{name}}\" ora?",
     "maintenance": {
       "pruning": "Pulizia archivi in corso...",
@@ -3731,9 +3734,9 @@
     }
   },
   "scheduledJobsTableSection": {
-    "title": "Tutti i Job Pianificati",
-    "noJobsFound": "Nessun job pianificato trovato",
-    "noJobsDesc": "Crea il tuo primo job di backup pianificato"
+    "title": "Lavori repository legacy",
+    "noJobsFound": "Nessun lavoro repository legacy trovato",
+    "noJobsDesc": "Crea un lavoro legacy per un repository che possiede ancora percorsi sorgente."
   },
   "advancedRepositoryOptions": {
     "title": "Opzioni Avanzate",

--- a/frontend/src/pages/Schedule.tsx
+++ b/frontend/src/pages/Schedule.tsx
@@ -37,6 +37,7 @@ import { type BackupPlan, type BackupPlanRun, Repository } from '../types'
 import { useTrackedJobOutcomes } from '../hooks/useTrackedJobOutcomes'
 import { getJobDurationSeconds } from '../utils/analyticsProperties'
 import { buildScheduleDeepLink, parseScheduleDeepLink } from '../utils/scheduleDeepLink'
+import { getExecutableLegacyRepositories } from '../utils/executableRepositories'
 
 interface ScheduledJob {
   id: number
@@ -213,6 +214,10 @@ const Schedule: React.FC = () => {
   )
   const manageableRepositories = repositories.filter((repo: Repository) =>
     canDo(repo.id, 'maintenance')
+  )
+  const executableLegacyRepositories = React.useMemo(
+    () => getExecutableLegacyRepositories(manageableRepositories),
+    [manageableRepositories]
   )
 
   // Backup job history — fetch all jobs (not just scheduled) so orphaned/manual
@@ -509,7 +514,9 @@ const Schedule: React.FC = () => {
     [canDo, canManageRepositoriesGlobally, repositories]
   )
 
-  const canCreateSchedule = canManageRepositoriesGlobally || manageableRepositories.length > 0
+  const canManageAnyRepository = canManageRepositoriesGlobally || manageableRepositories.length > 0
+  const canCreateBackupPlan = canManageAnyRepository
+  const canCreateLegacyJob = executableLegacyRepositories.length > 0
 
   const jobs = jobsData?.data?.jobs || []
   const allBackupJobs = backupJobsData?.data?.jobs || []
@@ -543,42 +550,44 @@ const Schedule: React.FC = () => {
         </Box>
 
         {/* Action Button — hidden for viewers */}
-        {canCreateSchedule && currentTab === TAB_BY_PLAN && (
+        {(canCreateBackupPlan || canCreateLegacyJob) && currentTab === TAB_BY_PLAN && (
           <Stack
             direction={{ xs: 'column', sm: 'row' }}
             spacing={1}
             sx={{ width: { xs: '100%', sm: 'auto' } }}
           >
-            <Button
-              variant="outlined"
-              startIcon={<Plus size={18} />}
-              onClick={openCreateWizard}
-              disabled={!canCreateSchedule}
-              fullWidth
-              sx={{ width: { xs: '100%', sm: 'auto' } }}
-            >
-              {t('schedule.createLegacySchedule', {
-                defaultValue: 'Create legacy schedule',
-              })}
-            </Button>
-            <Button
-              variant="contained"
-              startIcon={<Plus size={18} />}
-              onClick={() => navigate('/backup-plans')}
-              disabled={!canCreateSchedule}
-              fullWidth
-              sx={{ width: { xs: '100%', sm: 'auto' } }}
-            >
-              {t('schedule.createBackupPlan')}
-            </Button>
+            {canCreateLegacyJob && (
+              <Button
+                variant="outlined"
+                startIcon={<Plus size={18} />}
+                onClick={openCreateWizard}
+                fullWidth
+                sx={{ width: { xs: '100%', sm: 'auto' } }}
+              >
+                {t('schedule.createLegacyJob', {
+                  defaultValue: 'Create legacy job',
+                })}
+              </Button>
+            )}
+            {canCreateBackupPlan && (
+              <Button
+                variant="contained"
+                startIcon={<Plus size={18} />}
+                onClick={() => navigate('/backup-plans')}
+                fullWidth
+                sx={{ width: { xs: '100%', sm: 'auto' } }}
+              >
+                {t('schedule.createBackupPlan')}
+              </Button>
+            )}
           </Stack>
         )}
-        {canCreateSchedule && currentTab === TAB_REPO_CHECKS && (
+        {canManageAnyRepository && currentTab === TAB_REPO_CHECKS && (
           <Button
             variant="contained"
             startIcon={<Plus size={18} />}
             onClick={() => scheduledChecksSectionRef.current?.openAddDialog()}
-            disabled={!canCreateSchedule}
+            disabled={!canManageAnyRepository}
             fullWidth
             sx={{
               width: { xs: '100%', sm: 'auto' },
@@ -588,12 +597,12 @@ const Schedule: React.FC = () => {
             {t('schedule.addCheck')}
           </Button>
         )}
-        {canCreateSchedule && currentTab === TAB_RESTORE_CHECKS && (
+        {canManageAnyRepository && currentTab === TAB_RESTORE_CHECKS && (
           <Button
             variant="contained"
             startIcon={<Plus size={18} />}
             onClick={() => scheduledRestoreChecksSectionRef.current?.openAddDialog()}
-            disabled={!canCreateSchedule}
+            disabled={!canManageAnyRepository}
             fullWidth
             sx={{
               width: { xs: '100%', sm: 'auto' },
@@ -640,23 +649,21 @@ const Schedule: React.FC = () => {
           canManageRepo={(repoId) => canDo(repoId, 'maintenance')}
           canManagePlan={() => canManageRepositoriesGlobally}
           legacySection={
-            (isLoading || jobs.length > 0) && (
-              <ScheduledJobsTable
-                jobs={jobs}
-                repositories={repositories}
-                isLoading={isLoading}
-                title={t('schedule.legacyBackupSchedulesTitle')}
-                description={t('schedule.legacyBackupSchedulesDescription')}
-                canManageJob={canManageJob}
-                onEdit={openEditWizard}
-                onDelete={setDeleteConfirmJob}
-                onDuplicate={handleDuplicateJob}
-                onRunNow={handleRunJobNow}
-                onToggle={handleToggleJob}
-                isRunNowPending={runJobNowMutation.isPending}
-                isDuplicatePending={duplicateJobMutation.isPending}
-              />
-            )
+            <ScheduledJobsTable
+              jobs={jobs}
+              repositories={repositories}
+              isLoading={isLoading}
+              title={t('schedule.legacyRepositoryJobsTitle')}
+              description={t('schedule.legacyRepositoryJobsDescription')}
+              canManageJob={canManageJob}
+              onEdit={openEditWizard}
+              onDelete={setDeleteConfirmJob}
+              onDuplicate={handleDuplicateJob}
+              onRunNow={handleRunJobNow}
+              onToggle={handleToggleJob}
+              isRunNowPending={runJobNowMutation.isPending}
+              isDuplicatePending={duplicateJobMutation.isPending}
+            />
           }
         />
       )}
@@ -741,7 +748,7 @@ const Schedule: React.FC = () => {
         onClose={() => setShowScheduleWizard(false)}
         mode={wizardMode}
         scheduledJob={editingJobForWizard}
-        repositories={manageableRepositories || []}
+        repositories={executableLegacyRepositories}
         scripts={scriptsData?.data || []}
         onSubmit={handleWizardSubmit}
       />

--- a/frontend/src/pages/Schedule.tsx
+++ b/frontend/src/pages/Schedule.tsx
@@ -205,7 +205,8 @@ const Schedule: React.FC = () => {
 
     const currentRepositoryIds = new Set<number>()
     editingJobForWizard.repository_ids?.forEach((repoId) => currentRepositoryIds.add(repoId))
-    if (editingJobForWizard.repository_id) currentRepositoryIds.add(editingJobForWizard.repository_id)
+    if (editingJobForWizard.repository_id)
+      currentRepositoryIds.add(editingJobForWizard.repository_id)
 
     const currentRepositories = repositories.filter(
       (repo) =>

--- a/frontend/src/pages/Schedule.tsx
+++ b/frontend/src/pages/Schedule.tsx
@@ -200,6 +200,25 @@ const Schedule: React.FC = () => {
   const { canBreakLock: canBreakLockForBackupJob, lockBreakingEnabled } = useLockBreakPermissions({
     repositories,
   })
+  const scheduleWizardRepositories = React.useMemo(() => {
+    if (wizardMode !== 'edit' || !editingJobForWizard) return executableLegacyRepositories
+
+    const currentRepositoryIds = new Set<number>()
+    editingJobForWizard.repository_ids?.forEach((repoId) => currentRepositoryIds.add(repoId))
+    if (editingJobForWizard.repository_id) currentRepositoryIds.add(editingJobForWizard.repository_id)
+
+    const currentRepositories = repositories.filter(
+      (repo) =>
+        currentRepositoryIds.has(repo.id) ||
+        (Boolean(editingJobForWizard.repository) && repo.path === editingJobForWizard.repository)
+    )
+    if (currentRepositories.length === 0) return executableLegacyRepositories
+
+    const repositoriesById = new Map<number, Repository>()
+    executableLegacyRepositories.forEach((repo) => repositoriesById.set(repo.id, repo))
+    currentRepositories.forEach((repo) => repositoriesById.set(repo.id, repo))
+    return Array.from(repositoriesById.values())
+  }, [editingJobForWizard, executableLegacyRepositories, repositories, wizardMode])
 
   // Backup job history — fetch all jobs (not just scheduled) so orphaned/manual
   // history remains visible after a legacy schedule is deleted.
@@ -730,7 +749,7 @@ const Schedule: React.FC = () => {
         onClose={() => setShowScheduleWizard(false)}
         mode={wizardMode}
         scheduledJob={editingJobForWizard}
-        repositories={executableLegacyRepositories}
+        repositories={scheduleWizardRepositories}
         scripts={scriptsData?.data || []}
         onSubmit={handleWizardSubmit}
       />

--- a/frontend/src/pages/__tests__/Schedule.jobs.test.tsx
+++ b/frontend/src/pages/__tests__/Schedule.jobs.test.tsx
@@ -31,7 +31,7 @@ const { track, mockState } = vi.hoisted(() => ({
         timezone: 'UTC',
         repository: null,
         repository_id: null,
-        repository_ids: [1],
+        repository_ids: [1, 2],
         enabled: true,
         last_run: null,
         next_run: '2026-06-04T02:00:00Z',
@@ -172,5 +172,19 @@ describe('Schedule Jobs page', () => {
       expect(within(dialog).getByText('Legacy source repo')).toBeInTheDocument()
     })
     expect(within(dialog).queryByText('Plan-owned repo')).not.toBeInTheDocument()
+  })
+
+  it('keeps existing source-less repository targets available when editing a legacy job', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<Schedule />, { initialRoute: '/schedule' })
+
+    expect(await screen.findByText('Legacy server batch')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+
+    const dialog = await screen.findByRole('dialog', { name: 'Legacy job wizard' })
+    expect(within(dialog).getByText('Legacy source repo')).toBeInTheDocument()
+    expect(within(dialog).getByText('Plan-owned repo')).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/__tests__/Schedule.jobs.test.tsx
+++ b/frontend/src/pages/__tests__/Schedule.jobs.test.tsx
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderWithProviders, screen, userEvent, waitFor, within } from '../../test/test-utils'
+import type { Repository } from '../../types'
+import Schedule from '../Schedule'
+
+const { track, mockState } = vi.hoisted(() => ({
+  track: vi.fn(),
+  mockState: {
+    repositories: [
+      {
+        id: 1,
+        name: 'Legacy source repo',
+        path: '/backup/legacy-source',
+        mode: 'full',
+        source_directories: ['/srv/data'],
+      },
+      {
+        id: 2,
+        name: 'Plan-owned repo',
+        path: '/backup/plan-owned',
+        mode: 'full',
+        source_directories: [],
+        source_locations: [],
+      },
+    ] as Repository[],
+    jobs: [
+      {
+        id: 11,
+        name: 'Legacy server batch',
+        cron_expression: '0 2 * * *',
+        timezone: 'UTC',
+        repository: null,
+        repository_id: null,
+        repository_ids: [1],
+        enabled: true,
+        last_run: null,
+        next_run: '2026-06-04T02:00:00Z',
+        created_at: '2026-06-03T00:00:00Z',
+        updated_at: null,
+        description: 'Wake server, back up repositories, then power off.',
+        archive_name_template: null,
+        run_repository_scripts: false,
+        pre_backup_script_id: null,
+        post_backup_script_id: null,
+        run_prune_after: true,
+        run_compact_after: true,
+        prune_keep_hourly: 0,
+        prune_keep_daily: 7,
+        prune_keep_weekly: 4,
+        prune_keep_monthly: 6,
+        prune_keep_quarterly: 0,
+        prune_keep_yearly: 1,
+        last_prune: null,
+        last_compact: null,
+      },
+    ],
+  },
+}))
+
+vi.mock('../../hooks/useAnalytics', () => ({
+  useAnalytics: () => ({
+    track,
+    EventCategory: { BACKUP: 'backup' },
+    EventAction: {
+      COMPLETE: 'complete',
+      CREATE: 'create',
+      DELETE: 'delete',
+      EDIT: 'edit',
+      FAIL: 'fail',
+      START: 'start',
+    },
+  }),
+}))
+
+vi.mock('../../hooks/useAuth', () => ({
+  useAuth: () => ({
+    hasGlobalPermission: (permission: string) => permission === 'repositories.manage_all',
+  }),
+}))
+
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    canDo: () => true,
+  }),
+}))
+
+vi.mock('../../hooks/useTrackedJobOutcomes', () => ({
+  useTrackedJobOutcomes: () => undefined,
+}))
+
+vi.mock('../../components/ScheduleWizard', () => ({
+  default: ({ open, repositories }: { open: boolean; repositories: Repository[] }) =>
+    open ? (
+      <div role="dialog" aria-label="Legacy job wizard">
+        {repositories.map((repository) => (
+          <span key={repository.id}>{repository.name}</span>
+        ))}
+      </div>
+    ) : null,
+}))
+
+vi.mock('../../services/api', () => ({
+  scheduleAPI: {
+    createScheduledJob: vi.fn(() => Promise.resolve({ data: {} })),
+    deleteScheduledJob: vi.fn(() => Promise.resolve({ data: {} })),
+    duplicateScheduledJob: vi.fn(() => Promise.resolve({ data: {} })),
+    getScheduledJobs: vi.fn(() => Promise.resolve({ data: { jobs: mockState.jobs } })),
+    getUpcomingJobs: vi.fn(() => Promise.resolve({ data: { upcoming_jobs: [] } })),
+    runScheduledJobNow: vi.fn(() => Promise.resolve({ data: {} })),
+    toggleScheduledJob: vi.fn(() => Promise.resolve({ data: {} })),
+    updateScheduledJob: vi.fn(() => Promise.resolve({ data: {} })),
+  },
+  repositoriesAPI: {
+    getCheckSchedule: vi.fn(() =>
+      Promise.resolve({
+        data: {
+          check_cron_expression: null,
+          check_schedule_enabled: false,
+          check_timezone: null,
+        },
+      })
+    ),
+    getRepositories: vi.fn(() =>
+      Promise.resolve({ data: { repositories: mockState.repositories } })
+    ),
+    getRestoreCheckSchedule: vi.fn(() =>
+      Promise.resolve({
+        data: {
+          restore_check_cron_expression: null,
+          restore_check_schedule_enabled: false,
+          restore_check_timezone: null,
+        },
+      })
+    ),
+  },
+  backupAPI: {
+    cancelJob: vi.fn(() => Promise.resolve({ data: {} })),
+    getAllJobs: vi.fn(() => Promise.resolve({ data: { jobs: [] } })),
+  },
+  scriptsAPI: {
+    list: vi.fn(() => Promise.resolve({ data: [] })),
+  },
+  backupPlansAPI: {
+    cancelRun: vi.fn(() => Promise.resolve({ data: {} })),
+    get: vi.fn(() => Promise.resolve({ data: {} })),
+    list: vi.fn(() => Promise.resolve({ data: { backup_plans: [] } })),
+    listRuns: vi.fn(() => Promise.resolve({ data: { runs: [] } })),
+  },
+}))
+
+describe('Schedule Jobs page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.localStorage.clear()
+  })
+
+  it('shows executable jobs and limits legacy job creation to source-backed repositories', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<Schedule />, { initialRoute: '/schedule' })
+
+    expect(await screen.findByRole('heading', { name: 'Jobs' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Executable Jobs' })).toBeInTheDocument()
+
+    expect(await screen.findByText('Legacy Repository Jobs')).toBeInTheDocument()
+    expect(screen.getByText('Legacy server batch')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Create legacy job' }))
+
+    const dialog = await screen.findByRole('dialog', { name: 'Legacy job wizard' })
+    await waitFor(() => {
+      expect(within(dialog).getByText('Legacy source repo')).toBeInTheDocument()
+    })
+    expect(within(dialog).queryByText('Plan-owned repo')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/utils/__tests__/executableRepositories.test.ts
+++ b/frontend/src/utils/__tests__/executableRepositories.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import type { Repository } from '../../types'
+import {
+  getExecutableLegacyRepositories,
+  isExecutableLegacyRepository,
+} from '../executableRepositories'
+
+const repo = (overrides: Partial<Repository>): Repository =>
+  ({
+    id: 1,
+    name: 'Repo',
+    path: '/repo',
+    mode: 'full',
+    ...overrides,
+  }) as Repository
+
+describe('executable legacy repository filtering', () => {
+  it('includes full-mode repositories with legacy source directories', () => {
+    expect(isExecutableLegacyRepository(repo({ source_directories: ['/srv/app'] }))).toBe(true)
+  })
+
+  it('includes full-mode repositories with source locations', () => {
+    expect(
+      isExecutableLegacyRepository(
+        repo({
+          source_locations: [{ source_type: 'local', paths: ['/srv/app'] }],
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('includes full-mode repositories with database backup paths', () => {
+    expect(
+      isExecutableLegacyRepository(
+        repo({
+          source_locations: [
+            {
+              source_type: 'local',
+              paths: [],
+              database: {
+                template_id: 'postgres',
+                engine: 'postgres',
+                display_name: 'Postgres',
+                backup_strategy: 'dump',
+                capture_mode: 'dump',
+                backup_paths: ['/tmp/pg.sql'],
+                script_execution_target: 'server',
+              },
+            },
+          ],
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('excludes observe-mode repositories and repositories without sources', () => {
+    const executable = repo({ id: 1, source_directories: ['/srv/app'] })
+    const observe = repo({ id: 2, mode: 'observe', source_directories: ['/srv/app'] })
+    const planOwned = repo({ id: 3, source_directories: [], source_locations: [] })
+
+    expect(getExecutableLegacyRepositories([observe, planOwned, executable]).map((r) => r.id)).toEqual(
+      [1]
+    )
+  })
+})

--- a/frontend/src/utils/__tests__/executableRepositories.test.ts
+++ b/frontend/src/utils/__tests__/executableRepositories.test.ts
@@ -58,8 +58,8 @@ describe('executable legacy repository filtering', () => {
     const observe = repo({ id: 2, mode: 'observe', source_directories: ['/srv/app'] })
     const planOwned = repo({ id: 3, source_directories: [], source_locations: [] })
 
-    expect(getExecutableLegacyRepositories([observe, planOwned, executable]).map((r) => r.id)).toEqual(
-      [1]
-    )
+    expect(
+      getExecutableLegacyRepositories([observe, planOwned, executable]).map((r) => r.id)
+    ).toEqual([1])
   })
 })

--- a/frontend/src/utils/executableRepositories.ts
+++ b/frontend/src/utils/executableRepositories.ts
@@ -1,0 +1,16 @@
+import type { Repository, SourceLocation } from '../types'
+
+function hasSourceLocationPath(location: SourceLocation): boolean {
+  if (location.paths?.some((path) => path.trim().length > 0)) return true
+  return Boolean(location.database?.backup_paths?.some((path) => path.trim().length > 0))
+}
+
+export function isExecutableLegacyRepository(repository: Repository): boolean {
+  if (repository.mode === 'observe') return false
+  if (repository.source_directories?.some((path) => path.trim().length > 0)) return true
+  return Boolean(repository.source_locations?.some(hasSourceLocationPath))
+}
+
+export function getExecutableLegacyRepositories(repositories: Repository[]): Repository[] {
+  return repositories.filter(isExecutableLegacyRepository)
+}


### PR DESCRIPTION
## Description
Reframes the visible scheduling surface as Jobs while keeping the existing `/schedule` route for compatibility. Backup Plans stay in the first operational view, and legacy repository schedules are presented as Legacy Repository Jobs instead of looking like deprecated schedules.

The legacy job creation path now filters repository choices to full-mode repositories that still own executable sources through `source_directories`, `source_locations.paths`, or database `backup_paths`. Observe-mode and source-less plan-owned repositories are not offered as new legacy job targets. Edit mode still preserves an existing legacy job's current repository targets, including source-less targets, so opening an old job does not silently drop repositories.

This also updates navigation/user docs, localized copy, Storybook coverage, and durable engineering spec/plan documents for BOR-123.

## Related Issue
Linear: BOR-123
Related GitHub issue: #559

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] UI/UX improvement
- [x] Test addition/improvement
- [ ] Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Validation run after merging latest `origin/main`:
- `git diff --check`
- `cd frontend && npm run format:check`
- `cd frontend && npm run test -- --run src/utils/__tests__/executableRepositories.test.ts src/components/__tests__/AppSidebar.test.tsx src/components/__tests__/ScheduledJobsTable.test.tsx src/pages/__tests__/Schedule.jobs.test.tsx`
- `cd frontend && npm run check:locales && npm run typecheck && npm run lint && npm run build`
- `curl -I --max-time 5 http://127.0.0.1:5175/schedule`

The build still reports the existing `webauthn.ts` mixed dynamic/static import warning and the existing large chunk warning.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
No screenshots captured. The local `/schedule` route served successfully through Vite, and the added Schedule page test covers the Jobs/Executable Jobs labels, Legacy Repository Jobs rendering, legacy wizard repository filtering, and edit-mode target preservation.

## Additional Context
PR #608 was closed because the docs-only approach was rejected in rework. This PR implements the requested product/UI direction: keep legacy repository schedules supported, present them as executable jobs alongside Backup Plans, and avoid offering non-executable newer repositories as new legacy job targets.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rebranded "Schedule" → "Jobs" with an "Executable Jobs" tab and a persistent "Legacy Repository Jobs" section; split create actions for Backup Plans vs. Legacy Jobs and only offer legacy-job creation for executable legacy repositories.

* **Documentation**
  * Added implementation/spec plan and updated navigation and usage guides to reflect the Jobs flow and legacy-job behavior.

* **Localization**
  * Updated en/es/it/de UI strings for Jobs and legacy job copy.

* **Tests**
  * Added unit, page, and Storybook tests covering executable-repo filtering and Jobs/legacy-job flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 0 changed, 4 added, 0 removed, 280 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-614/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/26869151880
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- `components-scheduledjobstable--empty-legacy-repository-jobs--mobile.png`
- `components-scheduledjobstable--empty-legacy-repository-jobs.png`
- `components-scheduledjobstable--multi-repository-legacy-job--mobile.png`
- `components-scheduledjobstable--multi-repository-legacy-job.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->