### PR TITLE
Keep Run now available for disabled schedules

### DIFF
--- a/docs/engineering/plans/2026-06-03-disabled-schedule-run-now.md
+++ b/docs/engineering/plans/2026-06-03-disabled-schedule-run-now.md
@@ -1,0 +1,33 @@
+# Disabled Schedule Run Now Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development while implementing this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep manual execution available for disabled legacy scheduled jobs.
+
+**Architecture:** Treat a disabled scheduled job as the persisted manual-run workflow described in BOR-124 rework feedback. The backend `POST /api/schedule/{id}/run-now` already accepts disabled jobs, so the implementation stays in the schedule card action state: only permissions and a pending run should disable `Run now`. Existing schedule creation, cron validation, timezone controls, and scheduled dispatcher behavior remain unchanged.
+
+**Tech Stack:** React, TypeScript, MUI, lucide-react, i18next, Vitest, Storybook.
+
+---
+
+## Files
+
+- Modify: `frontend/src/components/ScheduleJobCard.tsx`
+- Modify: `frontend/src/components/__tests__/ScheduleJobCard.test.tsx`
+- Add: `frontend/src/components/ScheduleJobCard.stories.tsx`
+
+## Implementation Tasks
+
+- [x] Verify current `main` behavior with a failing Vitest case showing disabled scheduled jobs set `primaryAction.disabled=true`.
+- [x] Change `ScheduleJobCard` so `Run now` is disabled only while `isRunNowPending` is true; `canManage` still controls whether the primary action exists.
+- [x] Keep the pending-state test to prove the action still disables while a manual run is being submitted.
+- [x] Add Storybook coverage for enabled scheduled, disabled manual-run, and pending disabled states.
+- [x] Run focused Vitest for `ScheduleJobCard`.
+- [x] Run frontend required gates: locales, typecheck, lint, build.
+- [x] Run a runtime walkthrough that creates or uses a disabled scheduled job, confirms the card displays it as disabled, and triggers `Run now`.
+
+## Self-Review
+
+- This plan deliberately does not carry forward PR #610's no-cron API/UI changes because PR #610 was closed for Rework and the owner feedback identified disabled schedules as the intended manual-run mechanism.
+- The plan does not add ad hoc cron or timezone UI; existing schedule wizard controls remain unchanged.
+- The disabled status remains visually distinct through the existing switch/badge, while the manual action remains available as an explicit button.

--- a/frontend/src/components/ScheduleJobCard.stories.tsx
+++ b/frontend/src/components/ScheduleJobCard.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box } from '@mui/material'
+import ScheduleJobCard from './ScheduleJobCard'
+
+const repositories = [
+  {
+    id: 1,
+    name: 'External Drive Repository',
+    path: '/mnt/external/borg',
+  },
+]
+
+const baseJob = {
+  id: 42,
+  name: 'External drive maintenance',
+  cron_expression: '0 21 * * *',
+  timezone: 'UTC',
+  repository: null,
+  repository_id: 1,
+  repository_ids: null,
+  enabled: true,
+  last_run: '2026-05-28T21:00:00.000Z',
+  next_run: '2026-06-03T21:00:00.000Z',
+  description: 'Back up, prune, and compact when the drive is connected.',
+  run_prune_after: true,
+  run_compact_after: true,
+  prune_keep_hourly: 0,
+  prune_keep_daily: 7,
+  prune_keep_weekly: 4,
+  prune_keep_monthly: 6,
+  prune_keep_quarterly: 0,
+  prune_keep_yearly: 1,
+  last_prune: '2026-05-28T21:12:00.000Z',
+  last_compact: '2026-05-28T21:18:00.000Z',
+}
+
+const noop = () => {}
+
+const meta = {
+  title: 'Components/ScheduleJobCard',
+  component: ScheduleJobCard,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    repositories,
+    canManage: true,
+    onEdit: noop,
+    onDelete: noop,
+    onDuplicate: noop,
+    onRunNow: noop,
+    onToggle: noop,
+  },
+  render: (args) => (
+    <Box sx={{ width: 640, maxWidth: 'calc(100vw - 32px)' }}>
+      <ScheduleJobCard {...args} />
+    </Box>
+  ),
+} satisfies Meta<typeof ScheduleJobCard>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const EnabledSchedule: Story = {
+  args: {
+    job: baseJob,
+  },
+}
+
+export const DisabledManualRun: Story = {
+  args: {
+    job: {
+      ...baseJob,
+      enabled: false,
+      next_run: null,
+    },
+  },
+}
+
+export const DisabledManualRunPending: Story = {
+  args: {
+    job: {
+      ...baseJob,
+      enabled: false,
+      next_run: null,
+    },
+    isRunNowPending: true,
+  },
+}

--- a/frontend/src/components/ScheduleJobCard.tsx
+++ b/frontend/src/components/ScheduleJobCard.tsx
@@ -260,7 +260,7 @@ export default function ScheduleJobCard({
               label: t('schedule.card.actions.runNow'),
               icon: <Play size={13} />,
               onClick: onRunNow,
-              disabled: !job.enabled || isRunNowPending,
+              disabled: Boolean(isRunNowPending),
             }
           : undefined
       }

--- a/frontend/src/components/__tests__/ScheduleJobCard.test.tsx
+++ b/frontend/src/components/__tests__/ScheduleJobCard.test.tsx
@@ -124,4 +124,47 @@ describe('ScheduleJobCard', () => {
     })
     expect(nextRunStat?.tooltip?.props?.display?.scheduledTimeZone).toBe(baseJob.timezone)
   })
+
+  it('keeps run now available when the schedule is disabled', () => {
+    renderWithProviders(
+      <ScheduleJobCard
+        job={{ ...baseJob, enabled: false }}
+        repositories={[{ id: 1, name: 'My Repo', path: '/backups/my-repo' }]}
+        canManage
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onDuplicate={vi.fn()}
+        onRunNow={vi.fn()}
+        onToggle={vi.fn()}
+      />
+    )
+
+    const props = entityCardMock.mock.lastCall?.[0] as
+      | { primaryAction?: { disabled?: boolean } }
+      | undefined
+
+    expect(props?.primaryAction?.disabled).toBe(false)
+  })
+
+  it('disables run now while the manual run is pending', () => {
+    renderWithProviders(
+      <ScheduleJobCard
+        job={{ ...baseJob, enabled: false }}
+        repositories={[{ id: 1, name: 'My Repo', path: '/backups/my-repo' }]}
+        canManage
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onDuplicate={vi.fn()}
+        onRunNow={vi.fn()}
+        onToggle={vi.fn()}
+        isRunNowPending
+      />
+    )
+
+    const props = entityCardMock.mock.lastCall?.[0] as
+      | { primaryAction?: { disabled?: boolean } }
+      | undefined
+
+    expect(props?.primaryAction?.disabled).toBe(true)
+  })
 })


### PR DESCRIPTION
## Description
Keep the existing `Run now` action available for disabled scheduled jobs so those jobs can serve as manual-run maintenance workflows for external drives. The action still disables while a manual run submission is pending, and no cron/timezone creation behavior changes are introduced.

## Related Issue
Fixes #368
Linear: BOR-124

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- `git diff --check`
- `cd frontend && npm test -- --run src/components/__tests__/ScheduleJobCard.test.tsx --testTimeout 30000`
- `cd frontend && npx prettier --check ../docs/engineering/plans/2026-06-03-disabled-schedule-run-now.md src/components/ScheduleJobCard.tsx src/components/__tests__/ScheduleJobCard.test.tsx src/components/ScheduleJobCard.stories.tsx`
- `cd frontend && npm run check:locales && npm run typecheck && npm run lint && npm run build`
- `cd frontend && timeout 1200s npm run snapshots` built Storybook successfully but Playwright screenshot capture could not run because host browser libraries are missing.
- Runtime walkthrough with `DEV_PORT=8083 docker-compose -p borg-ui-dev -f docker-compose.dev.yml up -d --build --force-recreate`, followed by a smoke script that created a repository, saved a disabled schedule with prune/compact enabled, triggered `POST /api/schedule/{id}/run-now`, observed one archive, and confirmed the schedule remained disabled.

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Storybook coverage added for `ScheduleJobCard` enabled, disabled/manual-run, and pending disabled states. Local screenshot capture was blocked by missing host Playwright browser libraries after the Storybook build succeeded.

## Additional Context
This rework intentionally follows the owner feedback on the previous PR: disabled scheduled jobs already model the manual-run workflow, but the card disabled the `Run now` button. The implementation keeps cron validation, timezone controls, and scheduled execution behavior unchanged.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Run now" button on disabled scheduled jobs is now only disabled while a submission is pending, enabling manual execution even for disabled schedules.

* **Tests**
  * Added test coverage for the "Run now" button behavior on disabled jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 0 changed, 6 added, 0 removed, 280 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-615/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/26866412611
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- `components-schedulejobcard--disabled-manual-run--mobile.png`
- `components-schedulejobcard--disabled-manual-run-pending--mobile.png`
- `components-schedulejobcard--disabled-manual-run-pending.png`
- `components-schedulejobcard--disabled-manual-run.png`
- `components-schedulejobcard--enabled-schedule--mobile.png`
- `components-schedulejobcard--enabled-schedule.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->