### PR TITLE
Document passkey-ready HTTPS proxy deployment

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -70,7 +70,14 @@ Requirements:
 
 - the account must have a local password
 - the browser and device must support WebAuthn
-- the public Borg UI URL must be stable; passkeys are bound to the site origin
+- passkey registration and login must happen from HTTPS for non-localhost deployments
+- the public Borg UI URL must be stable; passkeys are bound to the browser origin, including scheme, host, and port
+
+For production, put Borg UI behind a reverse proxy or orchestrator that serves a
+stable HTTPS URL such as `https://backups.example.com`. `http://localhost` is
+acceptable for local development, but non-localhost HTTP origins are not
+passkey-ready. See [Reverse Proxy](reverse-proxy) for the supported deployment
+path.
 
 ## Built-in OIDC SSO
 

--- a/docs/engineering/plans/2026-06-03-passkey-ready-https-reverse-proxy-docs.md
+++ b/docs/engineering/plans/2026-06-03-passkey-ready-https-reverse-proxy-docs.md
@@ -1,0 +1,67 @@
+# Passkey-Ready HTTPS Reverse Proxy Docs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Borg UI's deployment docs explicit that production passkeys require a stable HTTPS origin and proxy-owned TLS automation.
+
+**Architecture:** Keep this as a docs-only change. Update the authentication page for the passkey requirement, and update the reverse-proxy page for the deployer stance, examples, and certificate-tooling ownership.
+
+**Tech Stack:** Markdown, VitePress docs build.
+
+---
+
+### Task 1: User-Facing Documentation
+
+**Files:**
+- Modify: `docs/authentication.md`
+- Modify: `docs/reverse-proxy.md`
+
+- [x] **Step 1: Update passkey requirements**
+
+  In `docs/authentication.md`, make the passkey requirements state that non-localhost deployments require HTTPS and that passkeys are bound to the stable public origin.
+
+- [x] **Step 2: Add passkey-ready reverse proxy guidance**
+
+  In `docs/reverse-proxy.md`, add guidance covering same-origin frontend/API access, `PUBLIC_BASE_URL`, forwarded headers, and `TRUSTED_PROXIES`.
+
+- [x] **Step 3: Clarify TLS ownership**
+
+  In `docs/reverse-proxy.md`, document reverse-proxy or orchestrator TLS termination as the supported production path. State that Borg UI does not manage TLS private keys, certificate issuance, or renewal inside the app process.
+
+- [x] **Step 4: Update proxy examples**
+
+  In `docs/reverse-proxy.md`, make Caddy and Traefik examples explicitly present automatic Let's Encrypt as the low-friction option, and make NGINX guidance explain that HTTP challenge, Cloudflare DNS challenge, and other DNS providers belong to the user's proxy/certificate tooling.
+
+### Task 2: Validation And Handoff
+
+**Files:**
+- Verify: `docs/authentication.md`
+- Verify: `docs/reverse-proxy.md`
+
+- [x] **Step 1: Run whitespace validation**
+
+  Run:
+
+  ```bash
+  git diff --check
+  ```
+
+- [x] **Step 2: Run docs rendering validation**
+
+  Run:
+
+  ```bash
+  cd docs && npm run build
+  ```
+
+- [x] **Step 3: Run targeted content review**
+
+  Run:
+
+  ```bash
+  rg -n "passkey registration and login must happen from HTTPS|Passkey registration and login require a stable HTTPS|PUBLIC_BASE_URL|TRUSTED_PROXIES|Let's Encrypt|Cloudflare DNS challenge|certificate" docs/authentication.md docs/reverse-proxy.md
+  ```
+
+- [ ] **Step 4: Publish**
+
+  Commit with the commit skill, push with the push skill, create or update the PR using the repository template, attach it to BOR-130, add the `symphony` PR label, sweep PR feedback/checks, update the Linear workpad, and move the issue to Human Review only after validation and checks pass.

--- a/docs/engineering/plans/2026-06-03-passkey-ready-https-reverse-proxy-docs.md
+++ b/docs/engineering/plans/2026-06-03-passkey-ready-https-reverse-proxy-docs.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: User-Facing Documentation
+## Task 1: User-Facing Documentation
 
 **Files:**
 - Modify: `docs/authentication.md`
@@ -32,7 +32,7 @@
 
   In `docs/reverse-proxy.md`, make Caddy and Traefik examples explicitly present automatic Let's Encrypt as the low-friction option, and make NGINX guidance explain that HTTP challenge, Cloudflare DNS challenge, and other DNS providers belong to the user's proxy/certificate tooling.
 
-### Task 2: Validation And Handoff
+## Task 2: Validation And Handoff
 
 **Files:**
 - Verify: `docs/authentication.md`

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -8,7 +8,29 @@ description: "Run Borg UI behind Nginx, Caddy, Traefik, or another reverse proxy
 
 Run Borg UI behind a reverse proxy for TLS, public hostnames, and optional external authentication.
 
-When using built-in OIDC, the frontend and API must be served from the same public origin.
+For production, terminate HTTPS at the reverse proxy, load balancer, ingress
+controller, or orchestrator. Borg UI runs as the upstream application; it does
+not issue certificates, store TLS private keys, or renew certificates inside the
+app process.
+
+Passkey registration and login require a stable HTTPS browser origin for
+non-localhost deployments. Serve the frontend and API from the same public
+origin, for example `https://backups.example.com`, so passkeys, cookies, OIDC,
+and Cloud Storage OAuth callbacks all see the same site. Split-origin frontend
+and API deployments need custom CORS and cookie handling and are not the normal
+deployment path.
+
+For a passkey-ready deployment:
+
+- set `PUBLIC_BASE_URL` to the normal browser URL, including `BASE_PATH` for
+  sub-path deployments
+- keep `PUBLIC_BASE_URL` on HTTPS except for localhost development
+- forward `Host`, `X-Forwarded-Host`, `X-Forwarded-Proto`, and
+  `X-Forwarded-For`
+- list only the proxy IPs that may be trusted in `TRUSTED_PROXIES` when Borg UI
+  should use forwarded headers
+- keep direct container access unavailable to users so they cannot bypass the
+  public HTTPS origin or spoof trusted headers
 
 ## Root Domain
 
@@ -16,6 +38,14 @@ Example public URL:
 
 ```text
 https://backups.example.com
+```
+
+Backend environment:
+
+```yaml
+environment:
+  - PUBLIC_BASE_URL=https://backups.example.com
+  - TRUSTED_PROXIES=127.0.0.1
 ```
 
 Nginx:
@@ -40,6 +70,12 @@ server {
 }
 ```
 
+NGINX terminates TLS for Borg UI, but certificate provisioning stays outside
+Borg UI. Use your NGINX or certificate tooling to obtain and renew certificates,
+such as Certbot or acme.sh with an HTTP challenge, a Cloudflare DNS challenge,
+or another DNS provider challenge. Mount or reference those certificates in
+NGINX; do not mount TLS private keys into Borg UI for in-process HTTPS.
+
 Caddy:
 
 ```text
@@ -47,6 +83,10 @@ backups.example.com {
     reverse_proxy 127.0.0.1:8081
 }
 ```
+
+Caddy is the lowest-friction option for many single-host deployments because it
+automatically obtains and renews Let's Encrypt certificates for public hostnames
+that can complete ACME validation.
 
 ## Sub-Path Deployment
 
@@ -61,6 +101,7 @@ Set:
 ```yaml
 environment:
   - BASE_PATH=/borg-ui
+  - PUBLIC_BASE_URL=https://example.com/borg-ui
 ```
 
 Your proxy must strip the `/borg-ui` prefix before forwarding to Borg UI.
@@ -138,6 +179,26 @@ authorization remains available for unsupported providers and advanced setups.
 
 ## Traefik Example
 
+Traefik can also automate Let's Encrypt issuance and renewal. Define an ACME
+certificate resolver in Traefik's static configuration, then point the Borg UI
+router at that resolver:
+
+```yaml
+entryPoints:
+  web:
+    address: ":80"
+  websecure:
+    address: ":443"
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: ops@example.com
+      storage: /letsencrypt/acme.json
+      httpChallenge:
+        entryPoint: web
+```
+
 ```yaml
 services:
   app:
@@ -149,7 +210,13 @@ services:
       - traefik.http.routers.borg-ui.entrypoints=websecure
       - traefik.http.routers.borg-ui.tls.certresolver=letsencrypt
       - traefik.http.services.borg-ui.loadbalancer.server.port=8081
+    environment:
+      - PUBLIC_BASE_URL=https://backups.example.com
 ```
+
+If HTTP challenge is not available, configure Traefik's ACME DNS challenge with
+Cloudflare or another DNS provider. That certificate automation remains a
+Traefik/proxy responsibility, not a Borg UI app responsibility.
 
 ## Trusted-Header Auth
 


### PR DESCRIPTION
## Description
Document Borg UI's passkey-ready production HTTPS stance:

- state that passkey registration and login require HTTPS for non-localhost deployments
- add reverse-proxy guidance for stable same-origin frontend/API access, PUBLIC_BASE_URL, forwarded headers, and TRUSTED_PROXIES
- clarify that TLS termination, certificate issuance, private keys, and renewal are owned by the reverse proxy, load balancer, ingress controller, orchestrator, or certificate tooling rather than the Borg UI app process
- expand Caddy, Traefik, and NGINX guidance for automatic Let's Encrypt and external certificate provisioning

## Related Issue
Linear: https://linear.app/nullcodeai/issue/BOR-130/document-passkey-ready-https-reverse-proxy-deployment

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass

Validation run:

- `git diff --check origin/main...HEAD`
- `cd docs && npm run build`
- `rg -n "passkey registration and login must happen from HTTPS|Passkey registration and login require a stable HTTPS|PUBLIC_BASE_URL|TRUSTED_PROXIES|Let's Encrypt|Cloudflare DNS challenge|certificate" docs/authentication.md docs/reverse-proxy.md`

No app runtime tests were run because this is documentation-only.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

Unit tests were not run because no application code changed.

## Screenshots (if applicable)
Not applicable for this documentation-only change.

## Additional Context
`npm run build` initially failed before dependency installation because `docs/node_modules` was absent in this workspace. After `cd docs && npm ci`, the docs build passed. Generated docs output and installed dependencies are ignored and not committed.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that passkey registration and login require a stable HTTPS public origin in production; localhost remains allowed for development.
  * Expanded reverse-proxy guidance and concrete setup examples for NGINX, Caddy, and Traefik, emphasizing TLS termination by the proxy.
  * Added a passkey-readiness checklist covering public URL settings, proxy forwarding/trust configuration, and certificate management validation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->