### PR TITLE
Add managed agent connection diagnostics

### DIFF
--- a/agent/borg_ui_agent/runtime.py
+++ b/agent/borg_ui_agent/runtime.py
@@ -23,6 +23,7 @@ DEFAULT_CAPABILITIES = [
     "logs.stream",
     "backup.create",
     "backup.cancel",
+    "diagnostics.run",
     "filesystem.browse",
     "repository.init",
     "repository.info",

--- a/agent/borg_ui_agent/session.py
+++ b/agent/borg_ui_agent/session.py
@@ -54,10 +54,7 @@ def _normalize_tcp_error(exc: Exception) -> tuple[str, str]:
 
 def _open_tcp_connection(host: str, port: int, timeout_seconds: float) -> None:
     connection = socket_module.create_connection((host, port), timeout=timeout_seconds)
-    try:
-        return None
-    finally:
-        connection.close()
+    connection.close()
 
 
 class SessionCommandClient:

--- a/agent/borg_ui_agent/session.py
+++ b/agent/borg_ui_agent/session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import socket as socket_module
 import time
 from collections.abc import Callable
 from typing import Any, Optional
@@ -35,6 +36,28 @@ def _session_url(server_url: str) -> str:
     return urlunparse(
         parsed._replace(scheme=scheme, path=path, params="", query="", fragment="")
     )
+
+
+def _elapsed_ms(started_at: float) -> int:
+    return int(round((time.monotonic() - started_at) * 1000))
+
+
+def _normalize_tcp_error(exc: Exception) -> tuple[str, str]:
+    if isinstance(exc, TimeoutError):
+        return "timeout", "Connection timed out"
+    if isinstance(exc, ConnectionRefusedError):
+        return "connection_refused", "Connection refused"
+    if isinstance(exc, OSError):
+        return "network_error", str(exc) or exc.__class__.__name__
+    return "tcp_check_failed", str(exc) or exc.__class__.__name__
+
+
+def _open_tcp_connection(host: str, port: int, timeout_seconds: float) -> None:
+    connection = socket_module.create_connection((host, port), timeout=timeout_seconds)
+    try:
+        return None
+    finally:
+        connection.close()
 
 
 class SessionCommandClient:
@@ -243,6 +266,10 @@ class AgentSessionRuntime:
             self._handle_filesystem_browse(client, payload)
             return
 
+        if command == "diagnostics.run":
+            self._handle_diagnostics(client, payload)
+            return
+
         if command == "cancel":
             if job_id is None:
                 client.send_result({"success": True})
@@ -307,4 +334,49 @@ class AgentSessionRuntime:
                 "items": items[:max_items],
                 "items_truncated": True,
             }
+        client.send_result(result)
+
+    def _handle_diagnostics(
+        self, client: SessionCommandClient, payload: dict[str, Any]
+    ) -> None:
+        started_at = time.monotonic()
+        result: dict[str, Any] = {"success": True}
+        target = (
+            payload.get("target") if isinstance(payload.get("target"), dict) else None
+        )
+
+        if target is not None:
+            host = str(target.get("host") or "")
+            port = int(target.get("port") or 0)
+            timeout_seconds = float(target.get("timeout_seconds") or 3.0)
+            tcp_started_at = time.monotonic()
+            tcp_result: dict[str, Any] = {
+                "target": {
+                    "host": host,
+                    "port": port,
+                    "timeout_seconds": timeout_seconds,
+                }
+            }
+            try:
+                _open_tcp_connection(host, port, timeout_seconds)
+            except Exception as exc:
+                error_code, message = _normalize_tcp_error(exc)
+                tcp_result.update(
+                    {
+                        "status": "failed",
+                        "elapsed_ms": _elapsed_ms(tcp_started_at),
+                        "error": error_code,
+                        "message": message,
+                    }
+                )
+            else:
+                tcp_result.update(
+                    {
+                        "status": "success",
+                        "elapsed_ms": _elapsed_ms(tcp_started_at),
+                    }
+                )
+            result["tcp"] = tcp_result
+
+        result["session"] = {"status": "success", "elapsed_ms": _elapsed_ms(started_at)}
         client.send_result(result)

--- a/app/api/managed_machines.py
+++ b/app/api/managed_machines.py
@@ -1,3 +1,5 @@
+import ipaddress
+import re
 import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
@@ -25,10 +27,22 @@ from app.services.agent_job_dispatcher import (
 )
 from app.services.agent_filesystem_service import browse_agent_filesystem
 from app.services.agent_connection_manager import agent_connection_manager
+from app.services.agent_connection_manager import (
+    AgentCommandError,
+    AgentCommandTimeout,
+    AgentConnectionUnavailable,
+)
 from app.utils.datetime_utils import serialize_datetime
 
 logger = structlog.get_logger()
 router = APIRouter(prefix="/api/managed-machines", tags=["managed-machines"])
+
+AGENT_DIAGNOSTICS_TIMEOUT_SECONDS = 5.0
+_DIAGNOSTIC_HOST_RE = re.compile(
+    r"^(?=.{1,253}\.?$)"
+    r"(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)*"
+    r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.?$"
+)
 
 
 def require_managed_agents_admin_user(
@@ -152,6 +166,16 @@ class AgentSessionLogEntryResponse(BaseModel):
     created_at: str
 
 
+class AgentDiagnosticTarget(BaseModel):
+    host: str
+    port: int = Field(ge=1, le=65535)
+    timeout_seconds: float = Field(default=3.0, ge=0.5, le=10.0)
+
+
+class AgentDiagnosticsRequest(BaseModel):
+    target: Optional[AgentDiagnosticTarget] = None
+
+
 class AgentBackupJobCreate(BaseModel):
     repository_path: str
     archive_name: str
@@ -181,6 +205,90 @@ def _optional_trimmed(value: Optional[str]) -> Optional[str]:
         return None
     stripped = value.strip()
     return stripped or None
+
+
+def _validate_diagnostic_host(host: str) -> str:
+    stripped = host.strip()
+    if not stripped:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"key": "backend.errors.agents.diagnosticsTargetHostRequired"},
+        )
+
+    try:
+        ipaddress.ip_address(stripped)
+        return stripped
+    except ValueError:
+        pass
+
+    if not _DIAGNOSTIC_HOST_RE.fullmatch(stripped):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"key": "backend.errors.agents.diagnosticsTargetHostInvalid"},
+        )
+    return stripped
+
+
+def _diagnostic_agent_metadata(agent: AgentMachine) -> dict[str, Any]:
+    return {
+        "id": agent.id,
+        "name": agent.name,
+        "agent_id": agent.agent_id,
+        "hostname": agent.hostname,
+        "status": agent.status,
+        "last_seen_at": (
+            serialize_datetime(agent.last_seen_at) if agent.last_seen_at else None
+        ),
+        "agent_version": agent.agent_version,
+        "borg_versions": agent.borg_versions or [],
+        "capabilities": agent.capabilities or [],
+        "last_error": agent.last_error,
+    }
+
+
+def _diagnostics_error_response(
+    agent: AgentMachine,
+    *,
+    session_status: str,
+    error: str,
+    message: str,
+) -> dict[str, Any]:
+    return {
+        "agent": _diagnostic_agent_metadata(agent),
+        "session": {
+            "status": session_status,
+            "elapsed_ms": None,
+            "error": error,
+            "message": message,
+        },
+        "tcp": None,
+    }
+
+
+def _normalize_diagnostics_result(
+    agent: AgentMachine,
+    result: dict[str, Any],
+) -> dict[str, Any]:
+    session_result = (
+        result.get("session") if isinstance(result.get("session"), dict) else {}
+    )
+    normalized: dict[str, Any] = {
+        "agent": _diagnostic_agent_metadata(agent),
+        "session": {
+            "status": str(session_result.get("status") or "success"),
+        },
+        "tcp": None,
+    }
+    if "elapsed_ms" in session_result:
+        normalized["session"]["elapsed_ms"] = session_result.get("elapsed_ms")
+    for key in ("error", "message"):
+        if session_result.get(key):
+            normalized["session"][key] = session_result[key]
+
+    tcp_result = result.get("tcp")
+    if isinstance(tcp_result, dict):
+        normalized["tcp"] = tcp_result
+    return normalized
 
 
 def _build_backup_job_payload(payload: AgentBackupJobCreate) -> dict[str, Any]:
@@ -433,6 +541,61 @@ async def browse_agent_machine_filesystem(
         include_hidden=include_hidden,
         timeout_seconds=AGENT_FILESYSTEM_BROWSE_TIMEOUT_SECONDS,
     )
+
+
+@router.post("/agents/{agent_machine_id}/diagnostics")
+async def run_agent_machine_diagnostics(
+    agent_machine_id: int,
+    payload: AgentDiagnosticsRequest,
+    _: User = Depends(require_managed_agents_admin_user),
+    db: Session = Depends(get_db),
+):
+    agent = db.query(AgentMachine).filter(AgentMachine.id == agent_machine_id).first()
+    if not agent:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"key": "backend.errors.agents.agentNotFound"},
+        )
+
+    command_payload: dict[str, Any] = {}
+    if payload.target is not None:
+        command_payload["target"] = {
+            "host": _validate_diagnostic_host(payload.target.host),
+            "port": payload.target.port,
+            "timeout_seconds": float(payload.target.timeout_seconds),
+        }
+
+    try:
+        result = await agent_connection_manager.send_command(
+            agent.id,
+            command="diagnostics.run",
+            payload=command_payload,
+            timeout_seconds=AGENT_DIAGNOSTICS_TIMEOUT_SECONDS,
+            wait_for_result=True,
+        )
+    except AgentConnectionUnavailable as exc:
+        return _diagnostics_error_response(
+            agent,
+            session_status="offline",
+            error="agent_offline",
+            message=str(exc),
+        )
+    except AgentCommandTimeout:
+        return _diagnostics_error_response(
+            agent,
+            session_status="timeout",
+            error="agent_timeout",
+            message="Agent did not return diagnostics before the timeout",
+        )
+    except AgentCommandError as exc:
+        return _diagnostics_error_response(
+            agent,
+            session_status="failed",
+            error=str(exc.payload.get("code") or "agent_command_failed"),
+            message=str(exc),
+        )
+
+    return _normalize_diagnostics_result(agent, result)
 
 
 @router.get(

--- a/docs/engineering/plans/2026-06-03-managed-agent-diagnostics.md
+++ b/docs/engineering/plans/2026-06-03-managed-agent-diagnostics.md
@@ -1,0 +1,224 @@
+# Managed Agent Diagnostics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a managed-agent diagnostics action that verifies live session health and optional TCP reachability through the outbound agent session.
+
+**Architecture:** Add an ephemeral `diagnostics.run` session command and a managed-machine API endpoint that validates input, snapshots agent metadata, sends the command over `agent_connection_manager`, and returns normalized result states. Add a focused React dialog opened from each Managed Agents card, reusing the existing page/test/story structure and `ResponsiveDialog`.
+
+**Tech Stack:** FastAPI, Pydantic, pytest, WebSocket session command manager, Python socket APIs, React, TypeScript, MUI, Lucide, TanStack Query, Vitest, Storybook.
+
+---
+
+### Task 1: Backend Diagnostics Endpoint
+
+**Files:**
+- Modify: `tests/unit/test_api_managed_machines.py`
+- Modify: `app/api/managed_machines.py`
+
+- [ ] **Step 1: Write failing backend tests**
+
+  Add tests that post to `/api/managed-machines/agents/{agent.id}/diagnostics`
+  and cover:
+
+  - live-session success with no target and no `AgentJob` row;
+  - live-session success with a TCP target result returned from the agent;
+  - offline agent response with `session.status == "offline"`;
+  - session command timeout response with `session.status == "timeout"`;
+  - invalid target host/port/timeout returns 422;
+  - agent-returned TCP failure stays HTTP 200 with `tcp.status == "failed"`.
+
+- [ ] **Step 2: Run backend tests and confirm red**
+
+  Run:
+
+  ```bash
+  pytest tests/unit/test_api_managed_machines.py -q -k diagnostic
+  ```
+
+  Expected before implementation: tests fail because the diagnostics endpoint
+  and response contract do not exist.
+
+- [ ] **Step 3: Implement the endpoint**
+
+  Add Pydantic request/response models in `app/api/managed_machines.py`.
+  Validate target host, port, and timeout before dispatch. Use
+  `agent_connection_manager.send_command(agent.id, command="diagnostics.run",
+  payload={...}, timeout_seconds=..., wait_for_result=True)` and map:
+
+  - `AgentConnectionUnavailable` -> HTTP 200 with `session.status = "offline"`;
+  - `AgentCommandTimeout` -> HTTP 200 with `session.status = "timeout"`;
+  - `AgentCommandError` -> HTTP 200 with `session.status = "failed"`;
+  - returned payload -> HTTP 200 with normalized session/TCP result objects.
+
+- [ ] **Step 4: Re-run backend tests**
+
+  Run:
+
+  ```bash
+  pytest tests/unit/test_api_managed_machines.py -q -k diagnostic
+  ```
+
+  Expected after implementation: targeted diagnostics tests pass.
+
+### Task 2: Agent Diagnostics Command Handler
+
+**Files:**
+- Modify: `tests/unit/test_agent_runtime.py`
+- Modify: `agent/borg_ui_agent/runtime.py`
+- Modify: `agent/borg_ui_agent/session.py`
+
+- [ ] **Step 1: Write failing agent tests**
+
+  Add tests that:
+
+  - assert `diagnostics.run` is advertised in `get_capabilities()`;
+  - run a session command with no target and assert a success result with
+    elapsed milliseconds;
+  - run a session command with a TCP target and a mocked socket connection that
+    succeeds;
+  - run a session command with a mocked socket failure and assert normalized
+    failed TCP result.
+
+- [ ] **Step 2: Run agent tests and confirm red**
+
+  Run:
+
+  ```bash
+  pytest tests/unit/test_agent_runtime.py -q -k diagnostic
+  ```
+
+  Expected before implementation: tests fail because the capability and handler
+  do not exist.
+
+- [ ] **Step 3: Implement agent handler**
+
+  Add `diagnostics.run` to `DEFAULT_CAPABILITIES`. In
+  `AgentSessionRuntime._handle_command`, route `diagnostics.run` to a helper
+  that measures elapsed time with `time.monotonic()`, optionally calls
+  `socket.create_connection((host, port), timeout=timeout_seconds)`, closes the
+  socket, and returns normalized results. Keep all network calls mockable by
+  referencing the imported socket module.
+
+- [ ] **Step 4: Re-run agent tests**
+
+  Run:
+
+  ```bash
+  pytest tests/unit/test_agent_runtime.py -q -k diagnostic
+  ```
+
+  Expected after implementation: targeted agent tests pass.
+
+### Task 3: Frontend API Types and Diagnostics Dialog
+
+**Files:**
+- Modify: `frontend/src/services/api.ts`
+- Modify: `frontend/src/pages/ManagedAgents.tsx`
+- Modify: `frontend/src/pages/__tests__/ManagedAgents.test.tsx`
+
+- [ ] **Step 1: Write failing frontend tests**
+
+  Extend the Managed Agents API mock with `runDiagnostics`. Add tests for:
+
+  - agent card exposes "Run diagnostics";
+  - clicking it opens the dialog and runs session-only diagnostics;
+  - loading state disables only the dialog run button;
+  - success state displays metadata and elapsed session timing;
+  - partial failure displays successful session plus failed TCP result;
+  - offline and timeout results display clear status copy.
+
+- [ ] **Step 2: Run frontend tests and confirm red**
+
+  Run:
+
+  ```bash
+  cd frontend && npm run test -- src/pages/__tests__/ManagedAgents.test.tsx --run -t "diagnostic"
+  ```
+
+  Expected before implementation: tests fail because the API method, action, and
+  dialog do not exist.
+
+- [ ] **Step 3: Implement frontend behavior**
+
+  Add request/response TypeScript types and
+  `managedAgentsAPI.runDiagnostics(agentId, payload)`. Add
+  `AgentDiagnosticsDialog` using `ResponsiveDialog`, text fields for optional
+  host/port/timeout, status rows, role-aware error/success feedback, and a
+  retry-capable run button. Add a compact card icon action with Lucide icon and
+  tooltip, leaving logs, reinstall, revoke, and delete independent.
+
+- [ ] **Step 4: Re-run frontend tests**
+
+  Run:
+
+  ```bash
+  cd frontend && npm run test -- src/pages/__tests__/ManagedAgents.test.tsx --run -t "diagnostic"
+  ```
+
+  Expected after implementation: targeted diagnostics frontend tests pass.
+
+### Task 4: Storybook and User Docs
+
+**Files:**
+- Modify: `frontend/src/pages/ManagedAgents.stories.tsx`
+- Modify: `docs/managed-agents.md`
+
+- [ ] **Step 1: Add Storybook states**
+
+  Add stories that show diagnostics success, partial TCP failure, and offline or
+  timeout dialog states. Do not commit generated Argos screenshots.
+
+- [ ] **Step 2: Update docs**
+
+  Add a concise Managed Agents diagnostics section explaining where the action
+  lives, what the session check proves, what optional TCP target checks prove,
+  and that the feature uses outbound agent sessions only.
+
+### Task 5: Required Validation and Publish
+
+**Files:**
+- Inspect: `.github/PULL_REQUEST_TEMPLATE.md`
+
+- [ ] **Step 1: Run targeted validation**
+
+  Run:
+
+  ```bash
+  pytest tests/unit/test_api_managed_machines.py -q -k diagnostic
+  pytest tests/unit/test_agent_runtime.py -q -k diagnostic
+  cd frontend && npm run test -- src/pages/__tests__/ManagedAgents.test.tsx --run -t "diagnostic"
+  ```
+
+- [ ] **Step 2: Run required backend checks**
+
+  Run:
+
+  ```bash
+  ruff check app tests
+  ruff format --check app tests
+  ```
+
+- [ ] **Step 3: Run required frontend checks**
+
+  Run:
+
+  ```bash
+  cd frontend && npm run check:locales
+  cd frontend && npm run typecheck
+  cd frontend && npm run lint
+  cd frontend && npm run build
+  ```
+
+- [ ] **Step 4: Capture runtime evidence**
+
+  Launch Borg UI locally with an available smoke/dev path and verify the
+  Managed Agents page can open the diagnostics dialog, submit a session check,
+  and show a result without blocking other card actions.
+
+- [ ] **Step 5: Commit, push, PR, and Linear handoff**
+
+  Commit the focused diff, push the branch, create/update a PR using
+  `.github/PULL_REQUEST_TEMPLATE.md`, attach it to Linear, sweep PR feedback and
+  checks, update this ticket workpad with validation evidence and handoff note,
+  then move the issue to Human Review only when the completion bar is met.

--- a/docs/engineering/specs/2026-06-03-managed-agent-diagnostics.md
+++ b/docs/engineering/specs/2026-06-03-managed-agent-diagnostics.md
@@ -1,0 +1,127 @@
+# Managed Agent Diagnostics Spec
+
+## Problem
+
+Managed Agents show online/offline state, last seen time, logs, and job
+history, but operators do not have a focused action for proving that an
+enrolled agent has a healthy outbound session or can reach a specific service
+from the agent host. When an agent is flaky or a repository/service endpoint is
+suspect, the current UI forces operators to infer state from logs and job
+history.
+
+## Desired Outcome
+
+Each managed-agent card exposes a diagnostics action. The action opens a
+focused dialog that can run a live outbound session health check and optionally
+ask the agent to try a TCP connection to a user-provided host and port. Results
+include clear pass/fail state, elapsed timing, normalized error details, and
+the metadata operators need for troubleshooting.
+
+## Design
+
+Use the existing authenticated `/api/agents/session` WebSocket command path.
+The backend adds a managed-machine endpoint that validates the optional target
+payload, snapshots the selected agent metadata, and sends an ephemeral
+`diagnostics.run` command through `agent_connection_manager.send_command`.
+Diagnostics do not create `AgentJob` rows and do not require inbound access to
+the agent host.
+
+The request accepts an optional TCP target:
+
+```json
+{
+  "target": {
+    "host": "postgres.internal",
+    "port": 5432,
+    "timeout_seconds": 3
+  }
+}
+```
+
+If no target is provided, the agent performs only the session round trip. Host
+input is trimmed, bounded, and rejected when empty or containing characters that
+cannot be a hostname, IPv4 address, or IPv6 literal. Port is an integer from 1
+through 65535. Timeout is bounded to a short range so a diagnostic cannot hold a
+server request indefinitely.
+
+The agent handles `diagnostics.run` directly in the session runtime. It uses
+Python socket APIs with caller-supplied host, port, and timeout values. It does
+not run shell commands. TCP failures are normalized into stable error codes and
+short messages.
+
+The response shape is:
+
+```json
+{
+  "agent": {
+    "id": 7,
+    "name": "Production NAS",
+    "agent_id": "agt_prod_nas_01",
+    "status": "online",
+    "last_seen_at": "2026-06-03T14:00:00+00:00",
+    "agent_version": "0.4.0",
+    "borg_versions": [],
+    "capabilities": ["session.commands", "diagnostics.run"],
+    "last_error": null
+  },
+  "session": {
+    "status": "success",
+    "elapsed_ms": 12
+  },
+  "tcp": {
+    "target": { "host": "postgres.internal", "port": 5432, "timeout_seconds": 3 },
+    "status": "failed",
+    "elapsed_ms": 81,
+    "error": "connection_refused",
+    "message": "Connection refused"
+  }
+}
+```
+
+Offline agents return a diagnostic payload with `session.status` set to
+`offline` rather than forcing the UI to decode a generic error. Session command
+timeouts return `session.status` set to `timeout`. Agent command errors return
+`session.status` set to `failed` with a normalized message.
+
+The Managed Agents UI adds a compact "Run diagnostics" icon action on each
+agent card. The dialog uses the shared `ResponsiveDialog`, a simple optional
+host/port/timeout form, and status rows for metadata, session health, and TCP
+target health. It shows loading, success, partial failure, offline, and timeout
+states without disabling the existing logs, reinstall, revoke, or delete card
+actions.
+
+## Acceptance Criteria
+
+- Managed Agents cards expose a diagnostics action for enrolled agents.
+- Diagnostics include session round-trip health and metadata: online/offline
+  state, last seen time, agent version, Borg versions, capabilities, and last
+  error.
+- Diagnostics support an optional TCP target check from the selected agent to a
+  host and port with timeout, success/failure, elapsed time, and normalized
+  error text.
+- Backend validation rejects invalid host, port, and timeout input.
+- Backend and agent implementation use structured socket/session APIs and do
+  not run shell commands from user-provided strings.
+- The flow reuses existing Managed Agents API/session infrastructure and avoids
+  inbound agent connectivity.
+- The UI represents loading, success, partial failure, offline, and timeout
+  states without blocking existing card actions.
+- Storybook and targeted tests cover diagnostics action and result states.
+
+## Validation
+
+- Backend targeted tests cover diagnostic success, offline agent, timeout,
+  invalid target, and failed TCP connection result.
+- Agent targeted tests cover the diagnostic command handler without performing
+  network calls outside mocked sockets.
+- Frontend targeted tests cover the diagnostics dialog/action states.
+- Required frontend checks pass: `npm run check:locales`,
+  `npm run typecheck`, `npm run lint`, and `npm run build`.
+- Required backend checks pass: `ruff check app tests`,
+  `ruff format --check app tests`, and relevant `pytest` tests.
+
+## Notes
+
+A broad synthetic bandwidth speed test stays out of scope. Borg UI already
+reports real backup and restore transfer speeds, and a synthetic speed target
+needs a clearer product contract.

--- a/docs/managed-agents.md
+++ b/docs/managed-agents.md
@@ -91,6 +91,16 @@ you revoke access, delete it from the fleet list, or unregister it on the client
 
 ## Revoke and Delete
 
+- **Run diagnostics** opens a focused check for the selected agent. A
+  session-only run verifies that Borg UI can reach the agent over the existing
+  outbound WebSocket session and shows troubleshooting metadata such as online
+  state, last seen time, agent version, Borg versions, capabilities, and last
+  error.
+- To check whether the agent host can reach another service, enter a target
+  host and port before running diagnostics. The agent attempts a TCP connection
+  from the client machine and reports success or failure, elapsed time, timeout,
+  and normalized error text. Borg UI validates the target input and the agent
+  uses socket APIs, not shell commands.
 - **Revoke access** blocks the agent credential but keeps the machine visible for
   history and troubleshooting.
 - **Delete agent** removes the machine from active fleet lists. Existing job and

--- a/frontend/src/pages/ManagedAgents.stories.tsx
+++ b/frontend/src/pages/ManagedAgents.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Box, Chip, Divider, Paper, Stack, Typography } from '@mui/material'
 import { Laptop, Play, Server } from 'lucide-react'
 import type {
+  AgentDiagnosticsResponse,
   AgentEnrollmentTokenSummary,
   AgentJobResponse,
   AgentMachineResponse,
@@ -11,6 +12,7 @@ import AddAgentDialog from './managed-agents/AddAgentDialog'
 import AgentInstallCommand from './managed-agents/AgentInstallCommand'
 import { buildAgentInstallCommand } from './managed-agents/agentInstallCommandText'
 import {
+  AgentDiagnosticsDialog,
   AgentDeleteConfirmationDialog,
   AgentJobLogsDialog,
   AgentList,
@@ -162,6 +164,46 @@ const jobLogs = [
     received_at: '2026-05-16T11:52:01.000Z',
   },
 ]
+
+const diagnosticsSuccess: AgentDiagnosticsResponse = {
+  agent: {
+    id: agents[0].id,
+    name: agents[0].name,
+    agent_id: agents[0].agent_id,
+    hostname: agents[0].hostname,
+    status: agents[0].status,
+    last_seen_at: agents[0].last_seen_at,
+    agent_version: agents[0].agent_version,
+    borg_versions: agents[0].borg_versions,
+    capabilities: ['session.commands', 'diagnostics.run', 'backup.create'],
+    last_error: null,
+  },
+  session: { status: 'success', elapsed_ms: 12 },
+  tcp: null,
+}
+
+const diagnosticsPartialFailure: AgentDiagnosticsResponse = {
+  agent: diagnosticsSuccess.agent,
+  session: { status: 'success', elapsed_ms: 10 },
+  tcp: {
+    target: { host: 'postgres.internal', port: 5432, timeout_seconds: 3 },
+    status: 'failed',
+    elapsed_ms: 4,
+    error: 'connection_refused',
+    message: 'Connection refused',
+  },
+}
+
+const diagnosticsTimeout: AgentDiagnosticsResponse = {
+  agent: { ...diagnosticsSuccess.agent, status: 'offline' },
+  session: {
+    status: 'timeout',
+    elapsed_ms: null,
+    error: 'agent_timeout',
+    message: 'Agent did not return diagnostics before the timeout',
+  },
+  tcp: null,
+}
 
 const agentsById = new Map(agents.map((agent) => [agent.id, agent]))
 const exampleCommand = buildAgentInstallCommand(
@@ -454,6 +496,48 @@ export const AgentReinstallDialogOpen: Story = {
         serverUrl="https://borg-ui.example.com"
         onCancel={() => {}}
         onCopy={() => {}}
+      />
+    </Box>
+  ),
+}
+
+export const AgentDiagnosticsSuccess: Story = {
+  render: () => (
+    <Box sx={{ p: 3, bgcolor: 'background.default', minHeight: '100vh' }}>
+      <AgentDiagnosticsDialog
+        open
+        agent={agents[0]}
+        initialResult={diagnosticsSuccess}
+        onClose={() => {}}
+        onRunDiagnostics={async () => diagnosticsSuccess}
+      />
+    </Box>
+  ),
+}
+
+export const AgentDiagnosticsPartialFailure: Story = {
+  render: () => (
+    <Box sx={{ p: 3, bgcolor: 'background.default', minHeight: '100vh' }}>
+      <AgentDiagnosticsDialog
+        open
+        agent={agents[0]}
+        initialResult={diagnosticsPartialFailure}
+        onClose={() => {}}
+        onRunDiagnostics={async () => diagnosticsPartialFailure}
+      />
+    </Box>
+  ),
+}
+
+export const AgentDiagnosticsTimeout: Story = {
+  render: () => (
+    <Box sx={{ p: 3, bgcolor: 'background.default', minHeight: '100vh' }}>
+      <AgentDiagnosticsDialog
+        open
+        agent={agents[1]}
+        initialResult={diagnosticsTimeout}
+        onClose={() => {}}
+        onRunDiagnostics={async () => diagnosticsTimeout}
       />
     </Box>
   ),

--- a/frontend/src/pages/ManagedAgents.tsx
+++ b/frontend/src/pages/ManagedAgents.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Navigate } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'react-hot-toast'
@@ -8,6 +8,7 @@ import {
   Box,
   Button,
   Chip,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -24,11 +25,13 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  TextField,
   Tooltip,
   Typography,
   useTheme,
 } from '@mui/material'
 import {
+  Activity,
   AlertTriangle,
   Ban,
   CheckCircle,
@@ -43,6 +46,8 @@ import {
 } from 'lucide-react'
 import {
   AgentEnrollmentTokenSummary,
+  AgentDiagnosticsRequest,
+  AgentDiagnosticsResponse,
   AgentJobLogEntryResponse,
   AgentJobResponse,
   AgentMachineResponse,
@@ -57,6 +62,7 @@ import PageTabs from '../components/PageTabs'
 import PageHeader from '../components/PageHeader'
 import PlanGate from '../components/shared/PlanGate'
 import LogViewerDialog, { type LogViewerFetchLogs } from '../components/shared/LogViewerDialog'
+import ResponsiveDialog from '../components/shared/ResponsiveDialog'
 import AddAgentDialog from './managed-agents/AddAgentDialog'
 import { resolveAgentServerUrl } from './managed-agents/agentServerUrl'
 import {
@@ -131,6 +137,45 @@ function formatBorgBinary(binary: Record<string, unknown>): string {
   const label = version || path || 'borg'
 
   return installSource ? `${label} (${installSource})` : label
+}
+
+function formatElapsedMs(value?: number | null): string {
+  if (typeof value !== 'number') return 'Not reported'
+  return `${Math.round(value)} ms`
+}
+
+function buildDiagnosticsPayload(
+  hostValue: string,
+  portValue: string,
+  timeoutValue: string
+): AgentDiagnosticsRequest {
+  const host = hostValue.trim()
+  if (!host) return {}
+
+  return {
+    target: {
+      host,
+      port: Number(portValue),
+      timeout_seconds: Number(timeoutValue),
+    },
+  }
+}
+
+function sessionStatusLabel(status: string): string {
+  switch (status) {
+    case 'success':
+      return 'Session healthy'
+    case 'offline':
+      return 'Agent offline'
+    case 'timeout':
+      return 'Timed out'
+    default:
+      return 'Session failed'
+  }
+}
+
+function tcpStatusLabel(status: string): string {
+  return status === 'success' ? 'TCP reachable' : 'TCP failed'
 }
 
 export default function ManagedAgents() {
@@ -388,6 +433,16 @@ export default function ManagedAgents() {
               status: agent.status,
             })
             setLogsAgent(agent)
+          }}
+          onRunDiagnostics={async (agent, payload) => {
+            trackSystem(EventAction.START, {
+              section: MANAGED_AGENTS_ANALYTICS_SECTION,
+              operation: 'run_agent_diagnostics',
+              status: agent.status,
+              has_target: Boolean(payload.target),
+            })
+            const response = await managedAgentsAPI.runDiagnostics(agent.id, payload)
+            return response.data
           }}
           isRevoking={revokeAgentMutation.isPending}
           isDeleting={deleteAgentMutation.isPending}
@@ -675,6 +730,288 @@ const getAgentStatusIcon = (status: string) => {
   }
 }
 
+export function AgentDiagnosticsDialog({
+  agent,
+  open,
+  initialResult = null,
+  onClose,
+  onRunDiagnostics,
+}: {
+  agent: AgentMachineResponse | null
+  open: boolean
+  initialResult?: AgentDiagnosticsResponse | null
+  onClose: () => void
+  onRunDiagnostics?: (
+    agent: AgentMachineResponse,
+    payload: AgentDiagnosticsRequest
+  ) => Promise<AgentDiagnosticsResponse>
+}) {
+  const [targetHost, setTargetHost] = useState('')
+  const [targetPort, setTargetPort] = useState('')
+  const [targetTimeout, setTargetTimeout] = useState('3')
+  const [result, setResult] = useState<AgentDiagnosticsResponse | null>(initialResult)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [running, setRunning] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    setResult(initialResult)
+    setErrorMessage(null)
+    setRunning(false)
+  }, [initialResult, open])
+
+  const runDiagnostics = async () => {
+    if (!agent || !onRunDiagnostics) return
+    setRunning(true)
+    setErrorMessage(null)
+    try {
+      const nextResult = await onRunDiagnostics(
+        agent,
+        buildDiagnosticsPayload(targetHost, targetPort, targetTimeout)
+      )
+      setResult(nextResult)
+    } catch (error) {
+      setErrorMessage(extractBackendMessage(error, 'Failed to run diagnostics'))
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  const diagnosticAgent = result?.agent
+  const borgVersions = diagnosticAgent?.borg_versions ?? agent?.borg_versions ?? []
+  const capabilities = diagnosticAgent?.capabilities ?? agent?.capabilities ?? []
+  const lastError = diagnosticAgent?.last_error ?? agent?.last_error ?? null
+
+  const footer = (
+    <DialogActions sx={{ px: 3, py: 2 }}>
+      <Button onClick={onClose}>Close</Button>
+      <Button
+        variant="contained"
+        onClick={() => void runDiagnostics()}
+        disabled={!agent || running || !onRunDiagnostics}
+        startIcon={running ? <CircularProgress color="inherit" size={16} /> : <Activity size={16} />}
+      >
+        {running ? 'Running diagnostics' : 'Run check'}
+      </Button>
+    </DialogActions>
+  )
+
+  return (
+    <ResponsiveDialog open={open} onClose={onClose} fullWidth maxWidth="md" footer={footer}>
+      <DialogTitle>Agent diagnostics</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2.25} sx={{ pt: 0.5, pb: 1 }}>
+          <Box>
+            <Typography fontWeight={700}>{getAgentLabel(agent || undefined)}</Typography>
+            <Typography color="text.secondary" variant="body2" sx={{ mt: 0.25 }}>
+              Verify the outbound agent session and optionally test a TCP target from the agent
+              host.
+            </Typography>
+          </Box>
+
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr', sm: 'minmax(0, 1fr) 120px 140px' },
+              gap: 1.25,
+            }}
+          >
+            <TextField
+              label="Target host"
+              value={targetHost}
+              onChange={(event) => setTargetHost(event.target.value)}
+              placeholder="postgres.internal"
+              size="small"
+              helperText="Optional TCP target"
+            />
+            <TextField
+              label="Port"
+              value={targetPort}
+              onChange={(event) => setTargetPort(event.target.value)}
+              placeholder="5432"
+              size="small"
+              type="number"
+              inputProps={{ min: 1, max: 65535 }}
+            />
+            <TextField
+              label="Timeout"
+              value={targetTimeout}
+              onChange={(event) => setTargetTimeout(event.target.value)}
+              size="small"
+              type="number"
+              inputProps={{ min: 0.5, max: 10, step: 0.5 }}
+              helperText="Seconds"
+            />
+          </Box>
+
+          {errorMessage && (
+            <Alert severity="error" role="alert" sx={{ borderRadius: 1.5 }}>
+              {errorMessage}
+            </Alert>
+          )}
+
+          <Box
+            sx={{
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: 1.5,
+              overflow: 'hidden',
+            }}
+          >
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' },
+              }}
+            >
+              {[
+                ['Status', diagnosticAgent?.status ?? agent?.status ?? 'unknown'],
+                ['Last seen', formatDate(diagnosticAgent?.last_seen_at ?? agent?.last_seen_at)],
+                ['Agent version', diagnosticAgent?.agent_version ?? agent?.agent_version ?? '—'],
+                [
+                  'Borg',
+                  borgVersions.length ? borgVersions.map(formatBorgBinary).join(', ') : 'None',
+                ],
+              ].map(([label, value], index) => (
+                <Box
+                  key={label}
+                  sx={{
+                    px: 1.5,
+                    py: 1.25,
+                    borderRight: { xs: 0, sm: index % 2 === 0 ? '1px solid' : 0 },
+                    borderBottom: index < 2 ? '1px solid' : 0,
+                    borderColor: 'divider',
+                    minWidth: 0,
+                  }}
+                >
+                  <Typography variant="caption" color="text.secondary" fontWeight={700}>
+                    {label}
+                  </Typography>
+                  <Typography noWrap title={String(value)} fontWeight={600}>
+                    {value}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          </Box>
+
+          <Stack spacing={1}>
+            <Typography variant="caption" color="text.secondary" fontWeight={700}>
+              Capabilities
+            </Typography>
+            <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap">
+              {capabilities.length ? (
+                capabilities.map((capability) => (
+                  <Chip key={capability} label={capability} size="small" variant="outlined" />
+                ))
+              ) : (
+                <Chip label="None reported" size="small" variant="outlined" />
+              )}
+            </Stack>
+          </Stack>
+
+          {lastError && (
+            <Alert
+              severity="warning"
+              icon={<AlertTriangle size={16} />}
+              sx={{ borderRadius: 1.5 }}
+            >
+              {lastError}
+            </Alert>
+          )}
+
+          {result ? (
+            <Stack spacing={1.25} aria-live="polite">
+              <DiagnosticResultRow
+                title={sessionStatusLabel(result.session.status)}
+                elapsed={result.session.elapsed_ms}
+                error={result.session.error}
+                message={result.session.message}
+                severity={result.session.status === 'success' ? 'success' : 'warning'}
+              />
+              {result.tcp ? (
+                <DiagnosticResultRow
+                  title={tcpStatusLabel(result.tcp.status)}
+                  elapsed={result.tcp.elapsed_ms}
+                  target={`${result.tcp.target.host}:${result.tcp.target.port}`}
+                  error={result.tcp.error}
+                  message={result.tcp.message}
+                  severity={result.tcp.status === 'success' ? 'success' : 'error'}
+                />
+              ) : null}
+            </Stack>
+          ) : (
+            <Alert severity="info" sx={{ borderRadius: 1.5 }}>
+              Run a check to verify the active agent session. Add a host and port to test TCP
+              reachability from the agent host.
+            </Alert>
+          )}
+        </Stack>
+      </DialogContent>
+    </ResponsiveDialog>
+  )
+}
+
+function DiagnosticResultRow({
+  title,
+  elapsed,
+  error,
+  message,
+  target,
+  severity,
+}: {
+  title: string
+  elapsed?: number | null
+  error?: string | null
+  message?: string | null
+  target?: string
+  severity: 'success' | 'warning' | 'error'
+}) {
+  return (
+    <Box
+      sx={{
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1.5,
+        px: 1.5,
+        py: 1.25,
+      }}
+    >
+      <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
+        <Stack direction="row" spacing={0.75} alignItems="center" minWidth={0}>
+          {severity === 'success' ? (
+            <CheckCircle size={16} />
+          ) : severity === 'error' ? (
+            <XCircle size={16} />
+          ) : (
+            <AlertTriangle size={16} />
+          )}
+          <Typography fontWeight={700}>{title}</Typography>
+        </Stack>
+        <Chip label={formatElapsedMs(elapsed)} size="small" variant="outlined" />
+      </Stack>
+      {target && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.75 }}>
+          {target}
+        </Typography>
+      )}
+      {error && (
+        <Typography
+          variant="body2"
+          sx={{ mt: 0.75, fontFamily: '"JetBrains Mono","Fira Code",ui-monospace,monospace' }}
+        >
+          {error}
+        </Typography>
+      )}
+      {message && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {message}
+        </Typography>
+      )}
+    </Box>
+  )
+}
+
 export function AgentDeleteConfirmationDialog({
   agent,
   open,
@@ -770,6 +1107,7 @@ export function AgentList({
   onRevoke,
   onDelete,
   onViewLogs,
+  onRunDiagnostics,
   isRevoking,
   isDeleting,
 }: {
@@ -779,6 +1117,10 @@ export function AgentList({
   onRevoke: (agent: AgentMachineResponse) => void
   onDelete: (agent: AgentMachineResponse) => void
   onViewLogs: (agent: AgentMachineResponse) => void
+  onRunDiagnostics?: (
+    agent: AgentMachineResponse,
+    payload: AgentDiagnosticsRequest
+  ) => Promise<AgentDiagnosticsResponse>
   isRevoking: boolean
   isDeleting: boolean
 }) {
@@ -787,6 +1129,30 @@ export function AgentList({
   const isDark = theme.palette.mode === 'dark'
   const [deleteTarget, setDeleteTarget] = useState<AgentMachineResponse | null>(null)
   const [reinstallTarget, setReinstallTarget] = useState<AgentMachineResponse | null>(null)
+  const [diagnosticsTarget, setDiagnosticsTarget] = useState<AgentMachineResponse | null>(null)
+  const handleRunDiagnostics =
+    onRunDiagnostics ??
+    (async (agent: AgentMachineResponse): Promise<AgentDiagnosticsResponse> => ({
+      agent: {
+        id: agent.id,
+        name: agent.name,
+        agent_id: agent.agent_id,
+        hostname: agent.hostname,
+        status: agent.status,
+        last_seen_at: agent.last_seen_at,
+        agent_version: agent.agent_version,
+        borg_versions: agent.borg_versions,
+        capabilities: agent.capabilities,
+        last_error: agent.last_error,
+      },
+      session: {
+        status: 'failed',
+        elapsed_ms: null,
+        error: 'diagnostics_unavailable',
+        message: 'Diagnostics are unavailable in this story or test surface.',
+      },
+      tcp: null,
+    }))
 
   if (!agents.length) {
     return <Alert severity="info">No agents enrolled.</Alert>
@@ -1021,6 +1387,32 @@ export function AgentList({
                     borderColor: isDark ? alpha('#fff', 0.06) : alpha('#000', 0.07),
                   }}
                 >
+                  <Tooltip title="Run diagnostics" arrow>
+                    <IconButton
+                      size="small"
+                      aria-label="Run diagnostics"
+                      onClick={() => {
+                        trackSystem(EventAction.START, {
+                          section: MANAGED_AGENTS_ANALYTICS_SECTION,
+                          operation: 'open_diagnostics_dialog',
+                          status: agent.status,
+                        })
+                        setDiagnosticsTarget(agent)
+                      }}
+                      sx={{
+                        width: { xs: 40, sm: 34 },
+                        height: { xs: 40, sm: 34 },
+                        borderRadius: 1.5,
+                        color: alpha(theme.palette.success.main, 0.75),
+                        '&:hover': {
+                          color: theme.palette.success.main,
+                          bgcolor: alpha(theme.palette.success.main, isDark ? 0.15 : 0.1),
+                        },
+                      }}
+                    >
+                      <Activity size={16} />
+                    </IconButton>
+                  </Tooltip>
                   <Tooltip title="View agent logs" arrow>
                     <IconButton
                       size="small"
@@ -1135,6 +1527,12 @@ export function AgentList({
         serverUrl={serverUrl}
         onCopy={onCopy}
         onCancel={() => setReinstallTarget(null)}
+      />
+      <AgentDiagnosticsDialog
+        open={!!diagnosticsTarget}
+        agent={diagnosticsTarget}
+        onClose={() => setDiagnosticsTarget(null)}
+        onRunDiagnostics={handleRunDiagnostics}
       />
     </>
   )

--- a/frontend/src/pages/ManagedAgents.tsx
+++ b/frontend/src/pages/ManagedAgents.tsx
@@ -144,6 +144,33 @@ function formatElapsedMs(value?: number | null): string {
   return `${Math.round(value)} ms`
 }
 
+function parseDiagnosticsPort(value: string): number | null {
+  const trimmed = value.trim()
+  if (!/^\d+$/.test(trimmed)) return null
+  const port = Number.parseInt(trimmed, 10)
+  return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : null
+}
+
+function parseDiagnosticsTimeout(value: string): number | null {
+  const timeout = Number.parseFloat(value.trim())
+  return Number.isFinite(timeout) && timeout >= 0.5 && timeout <= 10 ? timeout : null
+}
+
+function getDiagnosticsTargetError(
+  hostValue: string,
+  portValue: string,
+  timeoutValue: string
+): string | null {
+  if (!hostValue.trim()) return null
+  if (parseDiagnosticsPort(portValue) === null) {
+    return 'Enter a TCP port between 1 and 65535.'
+  }
+  if (parseDiagnosticsTimeout(timeoutValue) === null) {
+    return 'Enter a timeout between 0.5 and 10 seconds.'
+  }
+  return null
+}
+
 function buildDiagnosticsPayload(
   hostValue: string,
   portValue: string,
@@ -151,12 +178,15 @@ function buildDiagnosticsPayload(
 ): AgentDiagnosticsRequest {
   const host = hostValue.trim()
   if (!host) return {}
+  const port = parseDiagnosticsPort(portValue)
+  const timeout = parseDiagnosticsTimeout(timeoutValue)
+  if (port === null || timeout === null) return {}
 
   return {
     target: {
       host,
-      port: Number(portValue),
-      timeout_seconds: Number(timeoutValue),
+      port,
+      timeout_seconds: timeout,
     },
   }
 }
@@ -752,6 +782,10 @@ export function AgentDiagnosticsDialog({
   const [result, setResult] = useState<AgentDiagnosticsResponse | null>(initialResult)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [running, setRunning] = useState(false)
+  const targetError = getDiagnosticsTargetError(targetHost, targetPort, targetTimeout)
+  const hasTarget = Boolean(targetHost.trim())
+  const portInvalid = hasTarget && parseDiagnosticsPort(targetPort) === null
+  const timeoutInvalid = hasTarget && parseDiagnosticsTimeout(targetTimeout) === null
 
   useEffect(() => {
     if (!open) return
@@ -762,6 +796,11 @@ export function AgentDiagnosticsDialog({
 
   const runDiagnostics = async () => {
     if (!agent || !onRunDiagnostics) return
+    const validationError = getDiagnosticsTargetError(targetHost, targetPort, targetTimeout)
+    if (validationError) {
+      setErrorMessage(validationError)
+      return
+    }
     setRunning(true)
     setErrorMessage(null)
     try {
@@ -788,7 +827,7 @@ export function AgentDiagnosticsDialog({
       <Button
         variant="contained"
         onClick={() => void runDiagnostics()}
-        disabled={!agent || running || !onRunDiagnostics}
+        disabled={!agent || running || !onRunDiagnostics || !!targetError}
         startIcon={
           running ? <CircularProgress color="inherit" size={16} /> : <Activity size={16} />
         }
@@ -834,6 +873,9 @@ export function AgentDiagnosticsDialog({
               size="small"
               type="number"
               inputProps={{ min: 1, max: 65535 }}
+              required={hasTarget}
+              error={portInvalid}
+              helperText={portInvalid ? '1-65535' : undefined}
             />
             <TextField
               label="Timeout"
@@ -842,9 +884,17 @@ export function AgentDiagnosticsDialog({
               size="small"
               type="number"
               inputProps={{ min: 0.5, max: 10, step: 0.5 }}
-              helperText="Seconds"
+              required={hasTarget}
+              error={timeoutInvalid}
+              helperText={timeoutInvalid ? '0.5-10 seconds' : 'Seconds'}
             />
           </Box>
+
+          {targetError && (
+            <Alert severity="warning" role="alert" sx={{ borderRadius: 1.5 }}>
+              {targetError}
+            </Alert>
+          )}
 
           {errorMessage && (
             <Alert severity="error" role="alert" sx={{ borderRadius: 1.5 }}>

--- a/frontend/src/pages/ManagedAgents.tsx
+++ b/frontend/src/pages/ManagedAgents.tsx
@@ -789,7 +789,9 @@ export function AgentDiagnosticsDialog({
         variant="contained"
         onClick={() => void runDiagnostics()}
         disabled={!agent || running || !onRunDiagnostics}
-        startIcon={running ? <CircularProgress color="inherit" size={16} /> : <Activity size={16} />}
+        startIcon={
+          running ? <CircularProgress color="inherit" size={16} /> : <Activity size={16} />
+        }
       >
         {running ? 'Running diagnostics' : 'Run check'}
       </Button>
@@ -911,11 +913,7 @@ export function AgentDiagnosticsDialog({
           </Stack>
 
           {lastError && (
-            <Alert
-              severity="warning"
-              icon={<AlertTriangle size={16} />}
-              sx={{ borderRadius: 1.5 }}
-            >
+            <Alert severity="warning" icon={<AlertTriangle size={16} />} sx={{ borderRadius: 1.5 }}>
               {lastError}
             </Alert>
           )}

--- a/frontend/src/pages/__tests__/ManagedAgents.test.tsx
+++ b/frontend/src/pages/__tests__/ManagedAgents.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen, waitFor, within } from '@testing-library/react'
 import { QueryClient } from '@tanstack/react-query'
 import ManagedAgents, {
+  AgentDiagnosticsDialog,
   AgentList,
   AgentSetupGuide,
   AgentSetupHelpContent,
@@ -12,7 +13,12 @@ import AgentInstallCommand from '../managed-agents/AgentInstallCommand'
 import { buildAgentInstallCommand } from '../managed-agents/agentInstallCommandText'
 import { isLocalAgentServerUrl, resolveAgentServerUrl } from '../managed-agents/agentServerUrl'
 import { renderWithProviders, userEvent } from '../../test/test-utils'
-import { AgentJobResponse, AgentMachineResponse, managedAgentsAPI } from '../../services/api'
+import {
+  AgentDiagnosticsResponse,
+  AgentJobResponse,
+  AgentMachineResponse,
+  managedAgentsAPI,
+} from '../../services/api'
 import type { AxiosResponse } from 'axios'
 import { buildAgentReinstallCommand } from '../managed-agents/agentInstallCommandText'
 
@@ -33,6 +39,7 @@ vi.mock('../../services/api', () => ({
     deleteAgent: vi.fn(),
     createBackupJob: vi.fn(),
     cancelJob: vi.fn(),
+    runDiagnostics: vi.fn(),
   },
 }))
 
@@ -68,6 +75,49 @@ vi.mock('react-hot-toast', async () => {
   }
 })
 
+function buildAgent(overrides: Partial<AgentMachineResponse> = {}): AgentMachineResponse {
+  return {
+    id: 7,
+    agent_id: 'agent-client-7',
+    name: 'client',
+    hostname: 'client-01',
+    status: 'online',
+    os: 'linux',
+    arch: 'arm64',
+    agent_version: '0.4.0',
+    last_seen_at: '2026-05-18T10:00:00.000Z',
+    borg_versions: [{ major: 1, version: '1.2.8', path: '/usr/bin/borg' }],
+    capabilities: ['session.commands', 'diagnostics.run'],
+    last_error: null,
+    created_at: '2026-05-18T09:00:00.000Z',
+    updated_at: '2026-05-18T10:00:00.000Z',
+    ...overrides,
+  } as AgentMachineResponse
+}
+
+function buildDiagnosticsResult(
+  agent: AgentMachineResponse,
+  overrides: Partial<AgentDiagnosticsResponse> = {}
+): AgentDiagnosticsResponse {
+  return {
+    agent: {
+      id: agent.id,
+      name: agent.name,
+      agent_id: agent.agent_id,
+      hostname: agent.hostname ?? null,
+      status: agent.status,
+      last_seen_at: agent.last_seen_at ?? null,
+      agent_version: agent.agent_version ?? null,
+      borg_versions: agent.borg_versions ?? [],
+      capabilities: agent.capabilities ?? [],
+      last_error: agent.last_error ?? null,
+    },
+    session: { status: 'success', elapsed_ms: 12 },
+    tcp: null,
+    ...overrides,
+  }
+}
+
 describe('ManagedAgents', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -78,6 +128,9 @@ describe('ManagedAgents', () => {
     vi.mocked(managedAgentsAPI.listJobs).mockResolvedValue({ data: [] } as AxiosResponse)
     vi.mocked(managedAgentsAPI.listJobLogs).mockResolvedValue({ data: [] } as AxiosResponse)
     vi.mocked(managedAgentsAPI.listAgentLogs).mockResolvedValue({ data: [] } as AxiosResponse)
+    vi.mocked(managedAgentsAPI.runDiagnostics).mockResolvedValue({
+      data: buildDiagnosticsResult(buildAgent()),
+    } as AxiosResponse<AgentDiagnosticsResponse>)
   })
 
   it('shows concrete remote setup instructions before any agents are enrolled', async () => {
@@ -462,6 +515,7 @@ describe('ManagedAgents', () => {
         onRevoke={onRevoke}
         onDelete={onDelete}
         onViewLogs={vi.fn()}
+        onRunDiagnostics={vi.fn()}
         isRevoking={false}
         isDeleting={false}
       />
@@ -475,6 +529,138 @@ describe('ManagedAgents', () => {
 
     await user.click(screen.getByRole('button', { name: /revoke agent/i }))
     expect(onRevoke).toHaveBeenCalledWith(agent)
+  })
+
+  it('opens managed-agent diagnostics from an agent card and runs a session check', async () => {
+    const user = userEvent.setup()
+    const agent = buildAgent({
+      id: 7,
+      hostname: 'client-01',
+      agent_id: 'agent-client-7',
+      status: 'online',
+      last_seen_at: '2026-05-18T10:00:00.000Z',
+      agent_version: '0.4.0',
+      borg_versions: [{ major: 1, version: '1.2.8', path: '/usr/bin/borg' }],
+      capabilities: ['session.commands', 'diagnostics.run'],
+    })
+    vi.mocked(managedAgentsAPI.listAgents).mockResolvedValue({ data: [agent] } as AxiosResponse)
+    vi.mocked(managedAgentsAPI.runDiagnostics).mockResolvedValue({
+      data: buildDiagnosticsResult(agent, { session: { status: 'success', elapsed_ms: 12 } }),
+    } as AxiosResponse<AgentDiagnosticsResponse>)
+
+    renderWithProviders(<ManagedAgents />, { initialRoute: '/managed-agents' })
+
+    await screen.findByText('client-01', undefined, { timeout: 10000 })
+    await user.click(screen.getByRole('button', { name: /run diagnostics/i }))
+
+    const dialog = await screen.findByRole('dialog', { name: /agent diagnostics/i })
+    expect(within(dialog).getByText(/client-01/i)).toBeInTheDocument()
+
+    await user.click(within(dialog).getByRole('button', { name: /run check/i }))
+
+    await waitFor(() => {
+      expect(managedAgentsAPI.runDiagnostics).toHaveBeenCalledWith(7, {})
+    })
+    expect(await within(dialog).findByText(/Session healthy/i)).toBeInTheDocument()
+    expect(within(dialog).getByText('12 ms')).toBeInTheDocument()
+    expect(within(dialog).getByText(/diagnostics.run/i)).toBeInTheDocument()
+  }, 60000)
+
+  it('keeps existing agent card actions enabled while diagnostics are loading', async () => {
+    const user = userEvent.setup()
+    let resolveDiagnostics:
+      | ((value: AxiosResponse<AgentDiagnosticsResponse>) => void)
+      | undefined
+    const agent = buildAgent({ id: 7, hostname: 'client-01', status: 'online' })
+    vi.mocked(managedAgentsAPI.listAgents).mockResolvedValue({ data: [agent] } as AxiosResponse)
+    vi.mocked(managedAgentsAPI.runDiagnostics).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveDiagnostics = resolve
+      })
+    )
+
+    renderWithProviders(<ManagedAgents />, { initialRoute: '/managed-agents' })
+
+    await screen.findByText('client-01', undefined, { timeout: 10000 })
+    await user.click(screen.getByRole('button', { name: /run diagnostics/i }))
+    const dialog = await screen.findByRole('dialog', { name: /agent diagnostics/i })
+    await user.click(within(dialog).getByRole('button', { name: /run check/i }))
+
+    expect(within(dialog).getByRole('button', { name: /running diagnostics/i })).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: /view agent logs/i, hidden: true })
+    ).not.toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: /reinstall agent/i, hidden: true })
+    ).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: /delete agent/i, hidden: true })).not.toBeDisabled()
+
+    resolveDiagnostics?.({
+      data: buildDiagnosticsResult(agent, { session: { status: 'success', elapsed_ms: 15 } }),
+    } as AxiosResponse<AgentDiagnosticsResponse>)
+    expect(await within(dialog).findByText('15 ms')).toBeInTheDocument()
+  }, 60000)
+
+  it('renders diagnostics partial TCP failure details', () => {
+    const agent = buildAgent({ hostname: 'client-01', status: 'online' })
+
+    renderWithProviders(
+      <AgentDiagnosticsDialog
+        open
+        agent={agent}
+        initialResult={buildDiagnosticsResult(agent, {
+          session: { status: 'success', elapsed_ms: 10 },
+          tcp: {
+            target: { host: 'postgres.internal', port: 5432, timeout_seconds: 3 },
+            status: 'failed',
+            elapsed_ms: 4,
+            error: 'connection_refused',
+            message: 'Connection refused',
+          },
+        })}
+        onClose={vi.fn()}
+        onRunDiagnostics={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText(/Session healthy/i)).toBeInTheDocument()
+    expect(screen.getByText(/TCP failed/i)).toBeInTheDocument()
+    expect(screen.getByText(/postgres.internal:5432/i)).toBeInTheDocument()
+    expect(screen.getByText(/connection_refused/i)).toBeInTheDocument()
+    expect(screen.getByText(/Connection refused/i)).toBeInTheDocument()
+  })
+
+  it.each([
+    [
+      'offline',
+      { status: 'offline', elapsed_ms: null, error: 'agent_offline', message: 'Agent offline' },
+      /Agent offline/i,
+    ],
+    [
+      'timeout',
+      {
+        status: 'timeout',
+        elapsed_ms: null,
+        error: 'agent_timeout',
+        message: 'Agent did not return diagnostics before the timeout',
+      },
+      /Timed out/i,
+    ],
+  ])('renders diagnostics %s state', (_state, session, expectedLabel) => {
+    const agent = buildAgent({ hostname: 'client-01', status: 'offline' })
+
+    renderWithProviders(
+      <AgentDiagnosticsDialog
+        open
+        agent={agent}
+        initialResult={buildDiagnosticsResult(agent, { session })}
+        onClose={vi.fn()}
+        onRunDiagnostics={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByText(expectedLabel).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(session.message).length).toBeGreaterThan(0)
   })
 
   it('builds a tokenless reinstall command for existing agents', () => {

--- a/frontend/src/pages/__tests__/ManagedAgents.test.tsx
+++ b/frontend/src/pages/__tests__/ManagedAgents.test.tsx
@@ -568,9 +568,7 @@ describe('ManagedAgents', () => {
 
   it('keeps existing agent card actions enabled while diagnostics are loading', async () => {
     const user = userEvent.setup()
-    let resolveDiagnostics:
-      | ((value: AxiosResponse<AgentDiagnosticsResponse>) => void)
-      | undefined
+    let resolveDiagnostics: ((value: AxiosResponse<AgentDiagnosticsResponse>) => void) | undefined
     const agent = buildAgent({ id: 7, hostname: 'client-01', status: 'online' })
     vi.mocked(managedAgentsAPI.listAgents).mockResolvedValue({ data: [agent] } as AxiosResponse)
     vi.mocked(managedAgentsAPI.runDiagnostics).mockReturnValueOnce(

--- a/frontend/src/pages/__tests__/ManagedAgents.test.tsx
+++ b/frontend/src/pages/__tests__/ManagedAgents.test.tsx
@@ -599,6 +599,24 @@ describe('ManagedAgents', () => {
     expect(await within(dialog).findByText('15 ms')).toBeInTheDocument()
   }, 60000)
 
+  it('validates diagnostics TCP target inputs before running', async () => {
+    const user = userEvent.setup()
+    const agent = buildAgent({ id: 7, hostname: 'client-01', status: 'online' })
+    vi.mocked(managedAgentsAPI.listAgents).mockResolvedValue({ data: [agent] } as AxiosResponse)
+
+    renderWithProviders(<ManagedAgents />, { initialRoute: '/managed-agents' })
+
+    await screen.findByText('client-01', undefined, { timeout: 10000 })
+    await user.click(screen.getByRole('button', { name: /run diagnostics/i }))
+    const dialog = await screen.findByRole('dialog', { name: /agent diagnostics/i })
+
+    await user.type(within(dialog).getByLabelText(/target host/i), 'postgres.internal')
+
+    expect(within(dialog).getByText(/Enter a TCP port between 1 and 65535/i)).toBeInTheDocument()
+    expect(within(dialog).getByRole('button', { name: /run check/i })).toBeDisabled()
+    expect(managedAgentsAPI.runDiagnostics).not.toHaveBeenCalled()
+  }, 60000)
+
   it('renders diagnostics partial TCP failure details', () => {
     const agent = buildAgent({ hostname: 'client-01', status: 'online' })
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1013,6 +1013,54 @@ export interface AgentFilesystemBrowseResponse {
   items_truncated?: boolean
 }
 
+export interface AgentDiagnosticsTargetRequest {
+  host: string
+  port: number
+  timeout_seconds?: number
+}
+
+export interface AgentDiagnosticsRequest {
+  target?: AgentDiagnosticsTargetRequest
+}
+
+export interface AgentDiagnosticsMetadata {
+  id: number
+  name: string
+  agent_id: string
+  hostname?: string | null
+  status: string
+  last_seen_at?: string | null
+  agent_version?: string | null
+  borg_versions?: Array<Record<string, unknown>> | null
+  capabilities?: string[] | null
+  last_error?: string | null
+}
+
+export interface AgentDiagnosticsSessionResult {
+  status: 'success' | 'offline' | 'timeout' | 'failed' | string
+  elapsed_ms?: number | null
+  error?: string | null
+  message?: string | null
+}
+
+export interface AgentDiagnosticsTcpResult {
+  target: {
+    host: string
+    port: number
+    timeout_seconds?: number
+  }
+  status: 'success' | 'failed' | string
+  elapsed_ms?: number | null
+  error?: string | null
+  message?: string | null
+}
+
+export interface AgentDiagnosticsResponse {
+  agent: AgentDiagnosticsMetadata
+  session: AgentDiagnosticsSessionResult
+  tcp?: AgentDiagnosticsTcpResult | null
+}
+
 export interface AgentEnrollmentTokenCreate {
   name: string
   default_path?: string | null
@@ -1046,6 +1094,8 @@ export const managedAgentsAPI = {
       `/managed-machines/agents/${agentId}/filesystem/browse`,
       { params: { path, include_hidden: includeHidden } }
     ),
+  runDiagnostics: (agentId: number, data: AgentDiagnosticsRequest) =>
+    api.post<AgentDiagnosticsResponse>(`/managed-machines/agents/${agentId}/diagnostics`, data),
 }
 
 // Schedule API

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -465,6 +465,11 @@ def test_runtime_advertises_repository_init_capability_and_handler():
 
 
 @pytest.mark.unit
+def test_runtime_advertises_diagnostics_capability():
+    assert "diagnostics.run" in get_capabilities()
+
+
+@pytest.mark.unit
 def test_repository_init_payload_builds_borg1_command():
     payload = RepositoryOperationPayload.from_job_payload(
         {
@@ -613,6 +618,183 @@ def test_session_runtime_handles_ephemeral_filesystem_browse(monkeypatch):
             "current_path": "/home",
             "parent_path": "/",
             "items": [{"name": "docs"}],
+        },
+    }
+
+
+@pytest.mark.unit
+def test_session_runtime_handles_diagnostics_without_tcp_target(monkeypatch):
+    from agent.borg_ui_agent.session import AgentSessionRuntime
+
+    socket = FakeWebSocket(
+        [
+            {
+                "type": "command",
+                "command_id": "cmd-diagnostics",
+                "command": "diagnostics.run",
+                "job_id": None,
+                "payload": {},
+            }
+        ]
+    )
+    monotonic_values = iter([10.0, 10.012])
+
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.detect_platform",
+        lambda: {"hostname": "host.local", "os": "linux", "arch": "amd64"},
+    )
+    monkeypatch.setattr("agent.borg_ui_agent.session.detect_borg_binaries", lambda: [])
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.time.monotonic",
+        lambda: next(monotonic_values),
+    )
+
+    runtime = AgentSessionRuntime(
+        AgentConfig("https://borgui.example.com", "agt_123", "secret"),
+        connect=lambda *args, **kwargs: socket,
+    )
+    runtime.run_session(max_messages=1)
+
+    assert socket.sent[1] == {
+        "type": "command_ack",
+        "command_id": "cmd-diagnostics",
+        "job_id": None,
+    }
+    assert socket.sent[2] == {
+        "type": "command_result",
+        "command_id": "cmd-diagnostics",
+        "job_id": None,
+        "result": {
+            "success": True,
+            "session": {"status": "success", "elapsed_ms": 12},
+        },
+    }
+
+
+@pytest.mark.unit
+def test_session_runtime_handles_diagnostics_tcp_success(monkeypatch):
+    from agent.borg_ui_agent.session import AgentSessionRuntime
+
+    socket = FakeWebSocket(
+        [
+            {
+                "type": "command",
+                "command_id": "cmd-diagnostics-tcp",
+                "command": "diagnostics.run",
+                "job_id": None,
+                "payload": {
+                    "target": {
+                        "host": "postgres.internal",
+                        "port": 5432,
+                        "timeout_seconds": 1.5,
+                    }
+                },
+            }
+        ]
+    )
+    opened = []
+    monotonic_values = iter([20.0, 20.1, 20.35, 20.4])
+
+    def fake_open_tcp_connection(host, port, timeout_seconds):
+        opened.append((host, port, timeout_seconds))
+
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.detect_platform",
+        lambda: {"hostname": "host.local", "os": "linux", "arch": "amd64"},
+    )
+    monkeypatch.setattr("agent.borg_ui_agent.session.detect_borg_binaries", lambda: [])
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.time.monotonic",
+        lambda: next(monotonic_values),
+    )
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session._open_tcp_connection",
+        fake_open_tcp_connection,
+        raising=False,
+    )
+
+    runtime = AgentSessionRuntime(
+        AgentConfig("https://borgui.example.com", "agt_123", "secret"),
+        connect=lambda *args, **kwargs: socket,
+    )
+    runtime.run_session(max_messages=1)
+
+    assert opened == [("postgres.internal", 5432, 1.5)]
+    assert socket.sent[2]["result"] == {
+        "success": True,
+        "session": {"status": "success", "elapsed_ms": 400},
+        "tcp": {
+            "target": {
+                "host": "postgres.internal",
+                "port": 5432,
+                "timeout_seconds": 1.5,
+            },
+            "status": "success",
+            "elapsed_ms": 250,
+        },
+    }
+
+
+@pytest.mark.unit
+def test_session_runtime_handles_diagnostics_tcp_failure(monkeypatch):
+    from agent.borg_ui_agent.session import AgentSessionRuntime
+
+    socket = FakeWebSocket(
+        [
+            {
+                "type": "command",
+                "command_id": "cmd-diagnostics-tcp-failed",
+                "command": "diagnostics.run",
+                "job_id": None,
+                "payload": {
+                    "target": {
+                        "host": "postgres.internal",
+                        "port": 5432,
+                        "timeout_seconds": 1.5,
+                    }
+                },
+            }
+        ]
+    )
+    monotonic_values = iter([30.0, 30.2, 30.24, 30.3])
+
+    def fake_open_tcp_connection(host, port, timeout_seconds):
+        raise ConnectionRefusedError("Connection refused")
+
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.detect_platform",
+        lambda: {"hostname": "host.local", "os": "linux", "arch": "amd64"},
+    )
+    monkeypatch.setattr("agent.borg_ui_agent.session.detect_borg_binaries", lambda: [])
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.time.monotonic",
+        lambda: next(monotonic_values),
+    )
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session._open_tcp_connection",
+        fake_open_tcp_connection,
+        raising=False,
+    )
+
+    runtime = AgentSessionRuntime(
+        AgentConfig("https://borgui.example.com", "agt_123", "secret"),
+        connect=lambda *args, **kwargs: socket,
+    )
+    runtime.run_session(max_messages=1)
+
+    assert socket.sent[2]["result"] == {
+        "success": True,
+        "session": {"status": "success", "elapsed_ms": 300},
+        "tcp": {
+            "target": {
+                "host": "postgres.internal",
+                "port": 5432,
+                "timeout_seconds": 1.5,
+            },
+            "status": "failed",
+            "elapsed_ms": 40,
+            "error": "connection_refused",
+            "message": "Connection refused",
         },
     }
 

--- a/tests/unit/test_api_managed_machines.py
+++ b/tests/unit/test_api_managed_machines.py
@@ -12,7 +12,11 @@ from app.core.agent_constants import (
 from app.core.agent_auth import AGENT_AUTH_HEADER
 from app.core.security import get_password_hash
 from app.database.models import AgentJob, AgentJobLog, AgentMachine, LicensingState
-from app.services.agent_connection_manager import agent_connection_manager
+from app.services.agent_connection_manager import (
+    AgentCommandTimeout,
+    AgentConnectionUnavailable,
+    agent_connection_manager,
+)
 
 
 def _set_plan(test_db, plan: str) -> None:
@@ -406,6 +410,255 @@ def test_agent_filesystem_browse_truncates_oversized_session_result(
     assert response.status_code == 200
     assert [item["name"] for item in response.json()["items"]] == ["a", "b"]
     assert response.json()["items_truncated"] is True
+
+
+def test_agent_diagnostics_uses_live_session_without_agent_job(
+    test_client: TestClient, admin_headers, test_db, monkeypatch
+):
+    seen_commands = []
+    agent = _agent(
+        test_db,
+        hostname="nas.local",
+        agent_id="agt_diagnostics",
+        agent_version="0.4.0",
+        borg_versions=[{"major": 1, "version": "1.2.8", "path": "/usr/bin/borg"}],
+        last_seen_at=datetime(2026, 6, 3, 14, 0, tzinfo=timezone.utc),
+        capabilities=["session.commands", "diagnostics.run"],
+    )
+
+    async def fake_send_command(
+        agent_machine_id,
+        *,
+        command,
+        payload,
+        timeout_seconds,
+        job_id=None,
+        wait_for_result=True,
+    ):
+        seen_commands.append(
+            {
+                "agent_machine_id": agent_machine_id,
+                "command": command,
+                "payload": payload,
+                "timeout_seconds": timeout_seconds,
+                "job_id": job_id,
+                "wait_for_result": wait_for_result,
+            }
+        )
+        return {
+            "success": True,
+            "session": {"status": "success", "elapsed_ms": 12},
+        }
+
+    monkeypatch.setattr(agent_connection_manager, "send_command", fake_send_command)
+
+    response = test_client.post(
+        f"/api/managed-machines/agents/{agent.id}/diagnostics",
+        json={},
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["agent"] == {
+        "id": agent.id,
+        "name": "Agent",
+        "agent_id": "agt_diagnostics",
+        "hostname": "nas.local",
+        "status": "online",
+        "last_seen_at": data["agent"]["last_seen_at"],
+        "agent_version": "0.4.0",
+        "borg_versions": [{"major": 1, "version": "1.2.8", "path": "/usr/bin/borg"}],
+        "capabilities": ["session.commands", "diagnostics.run"],
+        "last_error": None,
+    }
+    assert data["agent"]["last_seen_at"] == "2026-06-03T14:00:00+00:00"
+    assert data["session"] == {"status": "success", "elapsed_ms": 12}
+    assert data["tcp"] is None
+    assert seen_commands == [
+        {
+            "agent_machine_id": agent.id,
+            "command": "diagnostics.run",
+            "payload": {},
+            "timeout_seconds": 5.0,
+            "job_id": None,
+            "wait_for_result": True,
+        }
+    ]
+    assert (
+        test_db.query(AgentJob).filter(AgentJob.agent_machine_id == agent.id).count()
+        == 0
+    )
+
+
+def test_agent_diagnostics_returns_failed_tcp_result(
+    test_client: TestClient, admin_headers, test_db, monkeypatch
+):
+    seen_payloads = []
+    agent = _agent(
+        test_db,
+        hostname="nas.local",
+        agent_id="agt_diagnostics_tcp",
+        capabilities=["session.commands", "diagnostics.run"],
+    )
+
+    async def fake_send_command(
+        agent_machine_id,
+        *,
+        command,
+        payload,
+        timeout_seconds,
+        job_id=None,
+        wait_for_result=True,
+    ):
+        seen_payloads.append(payload)
+        return {
+            "success": True,
+            "session": {"status": "success", "elapsed_ms": 10},
+            "tcp": {
+                "target": {
+                    "host": "postgres.internal",
+                    "port": 5432,
+                    "timeout_seconds": 3.0,
+                },
+                "status": "failed",
+                "elapsed_ms": 4,
+                "error": "connection_refused",
+                "message": "Connection refused",
+            },
+        }
+
+    monkeypatch.setattr(agent_connection_manager, "send_command", fake_send_command)
+
+    response = test_client.post(
+        f"/api/managed-machines/agents/{agent.id}/diagnostics",
+        json={
+            "target": {
+                "host": "postgres.internal",
+                "port": 5432,
+                "timeout_seconds": 3,
+            }
+        },
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session"]["status"] == "success"
+    assert seen_payloads == [
+        {
+            "target": {
+                "host": "postgres.internal",
+                "port": 5432,
+                "timeout_seconds": 3.0,
+            }
+        }
+    ]
+    assert data["tcp"] == {
+        "target": {
+            "host": "postgres.internal",
+            "port": 5432,
+            "timeout_seconds": 3.0,
+        },
+        "status": "failed",
+        "elapsed_ms": 4,
+        "error": "connection_refused",
+        "message": "Connection refused",
+    }
+
+
+def test_agent_diagnostics_reports_offline_agent(
+    test_client: TestClient, admin_headers, test_db, monkeypatch
+):
+    agent = _agent(
+        test_db,
+        hostname="nas.local",
+        agent_id="agt_diagnostics_offline",
+        status="offline",
+        capabilities=["session.commands", "diagnostics.run"],
+    )
+
+    async def fake_send_command(*args, **kwargs):
+        raise AgentConnectionUnavailable("Agent does not have an active session")
+
+    monkeypatch.setattr(agent_connection_manager, "send_command", fake_send_command)
+
+    response = test_client.post(
+        f"/api/managed-machines/agents/{agent.id}/diagnostics",
+        json={},
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["agent"]["status"] == "offline"
+    assert data["session"] == {
+        "status": "offline",
+        "elapsed_ms": None,
+        "error": "agent_offline",
+        "message": "Agent does not have an active session",
+    }
+    assert data["tcp"] is None
+
+
+def test_agent_diagnostics_reports_session_timeout(
+    test_client: TestClient, admin_headers, test_db, monkeypatch
+):
+    agent = _agent(
+        test_db,
+        hostname="nas.local",
+        agent_id="agt_diagnostics_timeout",
+        capabilities=["session.commands", "diagnostics.run"],
+    )
+
+    async def fake_send_command(*args, **kwargs):
+        raise AgentCommandTimeout("diagnostics.run")
+
+    monkeypatch.setattr(agent_connection_manager, "send_command", fake_send_command)
+
+    response = test_client.post(
+        f"/api/managed-machines/agents/{agent.id}/diagnostics",
+        json={},
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["session"] == {
+        "status": "timeout",
+        "elapsed_ms": None,
+        "error": "agent_timeout",
+        "message": "Agent did not return diagnostics before the timeout",
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"target": {"host": "", "port": 5432, "timeout_seconds": 3}},
+        {"target": {"host": "bad host", "port": 5432, "timeout_seconds": 3}},
+        {"target": {"host": "bad-.internal", "port": 5432, "timeout_seconds": 3}},
+        {"target": {"host": "postgres.internal", "port": 0, "timeout_seconds": 3}},
+        {"target": {"host": "postgres.internal", "port": 65536, "timeout_seconds": 3}},
+        {"target": {"host": "postgres.internal", "port": 5432, "timeout_seconds": 0}},
+    ],
+)
+def test_agent_diagnostics_rejects_invalid_tcp_target(
+    test_client: TestClient, admin_headers, test_db, payload
+):
+    agent = _agent(
+        test_db,
+        hostname="nas.local",
+        agent_id="agt_diagnostics_invalid",
+        capabilities=["session.commands", "diagnostics.run"],
+    )
+
+    response = test_client.post(
+        f"/api/managed-machines/agents/{agent.id}/diagnostics",
+        json=payload,
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 422
 
 
 def test_list_agent_logs_returns_recent_session_entries(


### PR DESCRIPTION
## Description
Adds a managed-agent diagnostics flow for enrolled agents. Each agent card now has a diagnostics action that opens a `ResponsiveDialog`, reports the current agent troubleshooting metadata, runs a live outbound session health check, and optionally checks TCP reachability from the agent host to a host/port target.

The backend validates target host, port, and timeout input, sends a `diagnostics.run` command through the existing agent session manager, and normalizes success, offline, timeout, command failure, and TCP failure result states. The agent handles the command with Python socket APIs only; no shell command is built from user input.

## Related Issue
Linear: BOR-133
Related GitHub issue: #252

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Validation run:
- `pytest tests/unit/test_api_managed_machines.py -q -k diagnostic`
- `pytest tests/unit/test_agent_runtime.py -q -k diagnostic`
- `cd frontend && npm run test -- src/pages/__tests__/ManagedAgents.test.tsx --run -t diagnostic`
- `cd frontend && timeout 900s npm run test -- src/pages/__tests__/ManagedAgents.test.tsx --run --reporter=verbose`
- `cd frontend && npm run check:locales`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run format:check`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `ruff check app tests`
- `ruff format --check app tests`
- `git diff --check`

Runtime proof:
- Started dev backend with `DEV_PORT=8093 docker-compose -p borg-ui-dev-bor133 -f docker-compose.dev.yml up -d --build --force-recreate`.
- Started Vite with `VITE_PROXY_TARGET=http://localhost:8093 npm run dev -- --host 127.0.0.1 --port 7879`.
- Confirmed `http://127.0.0.1:7879/managed-agents` returned HTTP 200.
- Enrolled a throwaway local managed agent, kept its outbound session connected, and verified diagnostics returned `session.status=success` plus `tcp.status=success` for target `127.0.0.1:8093`.
- Stopped the agent, Vite, and Compose stack after validation.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Browser screenshot capture was attempted with Playwright from `frontend/`, but Chromium could not launch on this host because `libnspr4.so` is missing. There was no system Chromium/Chrome fallback installed. Storybook stories were added for success, partial TCP failure, and timeout diagnostics states; Argos will generate PR visual snapshots in CI.

## Additional Context
This intentionally does not add a synthetic bandwidth speed test. Borg UI already reports real backup/restore transfer speeds, and a synthetic speed target needs a separate product contract.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Run diagnostics" on managed agent cards with a dialog to perform live session checks and optional TCP reachability tests; displays session/tcp status, elapsed times, and normalized error details.
  * Exposed a diagnostics API endpoint and frontend API/types to run diagnostics from the UI.
* **Documentation**
  * Added spec, plan, and user docs describing managed agent diagnostics and troubleshooting.
* **Tests**
  * Added unit, integration, and Storybook coverage for diagnostics flows, UI states, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 1 changed, 6 added, 0 removed, 285 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-618/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/26898403595
<details>
<summary>Changed files</summary>
- `pages-managedagents--fleet-overview.png` (0.02%)
</details>
<details>
<summary>New screenshots</summary>
- `pages-managedagents--agent-diagnostics-partial-failure--mobile.png`
- `pages-managedagents--agent-diagnostics-partial-failure.png`
- `pages-managedagents--agent-diagnostics-success--mobile.png`
- `pages-managedagents--agent-diagnostics-success.png`
- `pages-managedagents--agent-diagnostics-timeout--mobile.png`
- `pages-managedagents--agent-diagnostics-timeout.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->