### PR TITLE
Document manual backup API flow

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,4 +1,4 @@
-import { copyFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitepress';
@@ -25,6 +25,7 @@ export default defineConfig({
       {
         name: 'copy-docs-manifests',
         closeBundle() {
+          mkdirSync(outDir, { recursive: true });
           for (const file of publicManifests) {
             copyFileSync(resolve(docsRoot, file), resolve(outDir, file));
           }
@@ -91,6 +92,7 @@ export default defineConfig({
       {
         text: 'Reference',
         items: [
+          { text: 'API', link: '/api' },
           { text: 'Architecture', link: '/SPECIFICATION' },
           { text: 'Job System', link: '/architecture/job-system' },
           { text: 'Managed Agent Spec', link: '/managed-agent-spec' },

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -112,10 +112,14 @@ Settings > Account
 
 Generated tokens are shown once.
 
-Current backend authentication still uses the normal login bearer token for API requests. Do not rely on generated API tokens as standalone API credentials until token authentication is wired through the backend.
+Current backend authentication still uses the normal login bearer token for API
+requests. Do not rely on generated API tokens as standalone API credentials
+until token authentication is wired through the backend. See [API](api) for the
+supported bearer-token flow and manual backup examples.
 
 ## Related
 
 - [Authentication and SSO](authentication)
+- [API](api)
 - [Usage Guide](usage-guide)
 - [Security](security)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,165 @@
+---
+title: API
+nav_order: 13
+description: "Authenticated API examples for developer and automation clients"
+---
+
+# API
+
+Borg UI exposes authenticated API routes under `/api`. This page focuses on the
+manual backup flow that automation clients commonly need: get an access token,
+start an existing repository backup, then poll status and logs.
+
+The examples use `X-Borg-Authorization` because Borg UI gives that header
+precedence when both headers are present. The legacy `Authorization: Bearer
+TOKEN` header is still accepted for compatibility.
+
+## Create an access token
+
+For local username/password auth, create a short-lived bearer token with the
+login endpoint:
+
+```bash
+BASE_URL="https://backups.example.com"
+
+TOKEN="$(
+  curl -sS -X POST "$BASE_URL/api/auth/login" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    --data-urlencode "username=admin" \
+    --data-urlencode "password=change-this-password" |
+    jq -r .access_token
+)"
+```
+
+SSO, TOTP, and passkey deployments may require their normal interactive login
+flow to produce an accepted bearer token. Generated tokens from
+`Settings > Account` are shown once and can be revoked there, but current
+backend authentication still expects the normal bearer access token for API
+requests. Do not use generated `borgui_...` account tokens as standalone
+credentials for manual backup endpoints until backend token authentication is
+wired through.
+
+The token inherits the signed-in user's permissions:
+
+- starting or cancelling a backup requires operator access to the repository
+- polling status, streaming logs, or downloading logs requires viewer access to
+  the repository
+- admins have access to every repository
+
+## Start a manual backup
+
+Start an existing repository backup with `POST /api/backup/start`:
+
+```bash
+REPOSITORY="/backups/server1"
+
+START_RESPONSE="$(
+  curl -sS -X POST "$BASE_URL/api/backup/start" \
+    -H "X-Borg-Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"repository\":\"$REPOSITORY\"}"
+)"
+
+JOB_ID="$(printf '%s\n' "$START_RESPONSE" | jq -r .job_id)"
+printf '%s\n' "$START_RESPONSE"
+```
+
+Successful responses use this shape:
+
+```json
+{
+  "job_id": 123,
+  "status": "pending",
+  "message": "Backup job started"
+}
+```
+
+The JSON body uses the `repository` string accepted by Borg UI's manual backup
+flow. For the current `/api/backup/start` and `/api/backup/run` endpoints, pass
+the repository path shown in Borg UI and stored as `Repository.path`. The
+backend keeps legacy compatibility for omitted or unknown repository strings,
+but automation should send a registered repository path so permissions,
+admission checks, routing, and logs resolve against the intended repository.
+
+## Compatibility alias
+
+`POST /api/backup/run` is a compatibility alias for clients that use `run`
+instead of `start`. It accepts the same request body and returns the same
+response shape:
+
+```bash
+curl -sS -X POST "$BASE_URL/api/backup/run" \
+  -H "X-Borg-Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"repository\":\"$REPOSITORY\"}"
+```
+
+## Poll job status
+
+After receiving `job_id`, poll `/api/backup/status/{job_id}` until the job
+reaches a terminal status:
+
+```bash
+curl -sS "$BASE_URL/api/backup/status/$JOB_ID" \
+  -H "X-Borg-Authorization: Bearer $TOKEN"
+```
+
+The status payload includes the repository, current status, timestamps, progress,
+error details, logs summary, and progress details:
+
+```json
+{
+  "id": 123,
+  "repository": "/backups/server1",
+  "status": "running",
+  "started_at": "2026-06-04T17:30:00+00:00",
+  "completed_at": null,
+  "progress": 42.0,
+  "error_message": null,
+  "logs": null,
+  "progress_details": {
+    "progress_percent": 42.0,
+    "current_file": "/srv/app.db"
+  }
+}
+```
+
+Common statuses include `pending`, `running`, `completed`,
+`completed_with_warnings`, `failed`, and `cancelled`.
+
+## Poll job logs
+
+Use `/api/backup/logs/{job_id}/stream` for incremental log polling. Start with
+`offset=0`; for later calls, use the previous `total_lines` value as the next
+offset.
+
+```bash
+curl -sS "$BASE_URL/api/backup/logs/$JOB_ID/stream?offset=0" \
+  -H "X-Borg-Authorization: Bearer $TOKEN"
+```
+
+The log stream response is line-oriented:
+
+```json
+{
+  "job_id": 123,
+  "status": "running",
+  "lines": [
+    {
+      "line_number": 1,
+      "content": "Starting backup"
+    }
+  ],
+  "total_lines": 1,
+  "has_more": false
+}
+```
+
+For completed non-running jobs with stored logs, you can also download a text
+file:
+
+```bash
+curl -sS "$BASE_URL/api/backup/logs/$JOB_ID/download" \
+  -H "X-Borg-Authorization: Bearer $TOKEN" \
+  -o "backup_job_${JOB_ID}_logs.txt"
+```


### PR DESCRIPTION
## Description
Add a public API documentation page for token-based manual backup clients. The page shows how to obtain the currently supported bearer access token, start a manual backup through `/api/backup/start`, use the `/api/backup/run` compatibility alias, poll job status, and stream or download logs. It also clarifies repository path semantics and permission requirements.

This also links the new API page from Access Control and the VitePress Reference sidebar. While validating the docs build, the existing manifest copy hook failed when `.vitepress/dist` did not exist yet, so the hook now creates the output directory before copying manifests.

## Related Issue
Linear: BOR-142 - Document manual backup API flow

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Validation run:
- `cd docs && npm run build`
- `git diff --check`
- Contract check comparing documented endpoints/body against `app/api/backup.py` with `rg`
- GitHub PR checks passed, including backend, frontend, smoke, security, coverage, and CI summary checks

No unit tests were added because this change documents existing API behavior and adjusts docs build configuration only.

## Checklist
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; documentation-only change.

## Additional Context
The docs intentionally say generated `borgui_...` account tokens are not standalone credentials for these endpoints because `get_current_user` currently resolves normal bearer access tokens. This preserves the current backend contract while giving API clients an authenticated curl flow.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
