### PR TITLE
Serialize Borg repository commands during backups

### DIFF
--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -2336,6 +2336,14 @@ class BackupService:
                     job_id=job_id,
                     repository_id=repo_record.id,
                 )
+                db.refresh(job)
+                if job.status == "cancelled":
+                    logger.info(
+                        "Backup cancelled while waiting for repository command lock",
+                        job_id=job_id,
+                        repository_id=repo_record.id,
+                    )
+                    return
 
             # Execute command - NO LOG FILE FOR MAXIMUM PERFORMANCE
             process = await asyncio.create_subprocess_exec(

--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -39,6 +39,10 @@ from app.utils.borg_env import (
     cleanup_temp_key_file,
     setup_borg_env,
 )
+from app.services.repository_command_lock import (
+    acquire_repository_command_lock,
+    run_serialized_repository_command,
+)
 from app.utils.ssh_utils import (
     resolve_repo_ssh_key_file,  # noqa: F401
     resolve_ssh_key_file_by_id,
@@ -484,60 +488,65 @@ class BackupService:
             # Get timeouts from DB settings (with fallback to config)
             timeouts = self._get_operation_timeouts(db)
 
-            info_cmd = router.build_archive_info_command(repository_path, archive_name)
-            info_process = await asyncio.create_subprocess_exec(
-                *info_cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=env,
-            )
-            info_stdout, info_stderr = await asyncio.wait_for(
-                info_process.communicate(), timeout=timeouts["info_timeout"]
-            )
-
-            if info_process.returncode == 0:
-                try:
-                    info_data = json.loads(info_stdout.decode())
-                    archives = info_data.get("archives", [])
-                    if archives:
-                        archive_info = archives[0]
-                        stats = archive_info.get("stats", {})
-
-                        # Update job with final statistics
-                        job.original_size = stats.get(
-                            "original_size", job.original_size or 0
-                        )
-                        job.compressed_size = stats.get(
-                            "compressed_size", job.compressed_size or 0
-                        )
-                        job.deduplicated_size = stats.get(
-                            "deduplicated_size", job.deduplicated_size or 0
-                        )
-                        job.nfiles = stats.get("nfiles", job.nfiles or 0)
-
-                        db.commit()
-                        logger.info(
-                            "Updated archive statistics",
-                            job_id=job_id,
-                            archive=archive_name,
-                            original_size=job.original_size,
-                            compressed_size=job.compressed_size,
-                            deduplicated_size=job.deduplicated_size,
-                            nfiles=job.nfiles,
-                        )
-                except json.JSONDecodeError as e:
-                    logger.warning(
-                        "Failed to parse borg info output for archive",
-                        job_id=job_id,
-                        error=str(e),
-                    )
-            else:
-                logger.warning(
-                    "Failed to get archive info",
-                    job_id=job_id,
-                    archive=archive_name,
-                    returncode=info_process.returncode,
+            async def _operation():
+                info_cmd = router.build_archive_info_command(
+                    repository_path, archive_name
                 )
+                info_process = await asyncio.create_subprocess_exec(
+                    *info_cmd,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=env,
+                )
+                info_stdout, info_stderr = await asyncio.wait_for(
+                    info_process.communicate(), timeout=timeouts["info_timeout"]
+                )
+
+                if info_process.returncode == 0:
+                    try:
+                        info_data = json.loads(info_stdout.decode())
+                        archives = info_data.get("archives", [])
+                        if archives:
+                            archive_info = archives[0]
+                            stats = archive_info.get("stats", {})
+
+                            # Update job with final statistics
+                            job.original_size = stats.get(
+                                "original_size", job.original_size or 0
+                            )
+                            job.compressed_size = stats.get(
+                                "compressed_size", job.compressed_size or 0
+                            )
+                            job.deduplicated_size = stats.get(
+                                "deduplicated_size", job.deduplicated_size or 0
+                            )
+                            job.nfiles = stats.get("nfiles", job.nfiles or 0)
+
+                            db.commit()
+                            logger.info(
+                                "Updated archive statistics",
+                                job_id=job_id,
+                                archive=archive_name,
+                                original_size=job.original_size,
+                                compressed_size=job.compressed_size,
+                                deduplicated_size=job.deduplicated_size,
+                                nfiles=job.nfiles,
+                            )
+                    except json.JSONDecodeError as e:
+                        logger.warning(
+                            "Failed to parse borg info output for archive",
+                            job_id=job_id,
+                            error=str(e),
+                        )
+                else:
+                    logger.warning(
+                        "Failed to get archive info",
+                        job_id=job_id,
+                        archive=archive_name,
+                        returncode=info_process.returncode,
+                    )
+
+            await run_serialized_repository_command(repo_record.id, _operation)
 
         except asyncio.TimeoutError:
             logger.warning("Timeout while updating archive stats", job_id=job_id)
@@ -563,67 +572,70 @@ class BackupService:
             # Get timeouts from DB settings (with fallback to config)
             timeouts = self._get_operation_timeouts(db)
 
-            list_cmd = router.build_repo_list_command(repository_path)
-            list_process = await asyncio.create_subprocess_exec(
-                *list_cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=env,
-            )
-            list_stdout, list_stderr = await asyncio.wait_for(
-                list_process.communicate(), timeout=timeouts["list_timeout"]
-            )
+            async def _operation():
+                list_cmd = router.build_repo_list_command(repository_path)
+                list_process = await asyncio.create_subprocess_exec(
+                    *list_cmd,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=env,
+                )
+                list_stdout, list_stderr = await asyncio.wait_for(
+                    list_process.communicate(), timeout=timeouts["list_timeout"]
+                )
 
-            if list_process.returncode == 0:
-                try:
-                    archives_data = json.loads(list_stdout.decode())
-                    archive_count = len(archives_data.get("archives", []))
-                    repo_record.archive_count = archive_count
-                    logger.info(
-                        "Updated archive count",
-                        repository=repository_path,
-                        count=archive_count,
-                    )
-                except json.JSONDecodeError as e:
-                    logger.warning("Failed to parse borg list output", error=str(e))
-
-            info_cmd = router.build_repo_info_command(repository_path)
-            info_process = await asyncio.create_subprocess_exec(
-                *info_cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=env,
-            )
-            info_stdout, info_stderr = await asyncio.wait_for(
-                info_process.communicate(), timeout=timeouts["info_timeout"]
-            )
-
-            if info_process.returncode == 0:
-                try:
-                    info_data = json.loads(info_stdout.decode())
-                    cache_stats = info_data.get("cache", {}).get("stats", {})
-
-                    # Get total repository size (unique_size is deduplicated size)
-                    unique_size = cache_stats.get("unique_size", 0)
-                    if unique_size > 0:
-                        # Format size to human readable
-                        repo_record.total_size = self._format_bytes(unique_size)
+                if list_process.returncode == 0:
+                    try:
+                        archives_data = json.loads(list_stdout.decode())
+                        archive_count = len(archives_data.get("archives", []))
+                        repo_record.archive_count = archive_count
                         logger.info(
-                            "Updated repository size",
+                            "Updated archive count",
                             repository=repository_path,
-                            size=repo_record.total_size,
+                            count=archive_count,
                         )
-                except json.JSONDecodeError as e:
-                    logger.warning("Failed to parse borg info output", error=str(e))
+                    except json.JSONDecodeError as e:
+                        logger.warning("Failed to parse borg list output", error=str(e))
 
-            # Update last_backup timestamp
-            repo_record.last_backup = datetime.utcnow()
+                info_cmd = router.build_repo_info_command(repository_path)
+                info_process = await asyncio.create_subprocess_exec(
+                    *info_cmd,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=env,
+                )
+                info_stdout, info_stderr = await asyncio.wait_for(
+                    info_process.communicate(), timeout=timeouts["info_timeout"]
+                )
 
-            db.commit()
-            logger.info("Repository statistics updated", repository=repository_path)
+                if info_process.returncode == 0:
+                    try:
+                        info_data = json.loads(info_stdout.decode())
+                        cache_stats = info_data.get("cache", {}).get("stats", {})
 
-            # Publish a full DB-derived MQTT snapshot immediately after stats changes.
-            mqtt_service.sync_state_with_db(db, reason="repository stats updated")
+                        # Get total repository size (unique_size is deduplicated size)
+                        unique_size = cache_stats.get("unique_size", 0)
+                        if unique_size > 0:
+                            # Format size to human readable
+                            repo_record.total_size = self._format_bytes(unique_size)
+                            logger.info(
+                                "Updated repository size",
+                                repository=repository_path,
+                                size=repo_record.total_size,
+                            )
+                    except json.JSONDecodeError as e:
+                        logger.warning("Failed to parse borg info output", error=str(e))
+
+                # Update last_backup timestamp
+                repo_record.last_backup = datetime.utcnow()
+
+                db.commit()
+                logger.info("Repository statistics updated", repository=repository_path)
+
+                # Publish a full DB-derived MQTT snapshot immediately after stats changes.
+                mqtt_service.sync_state_with_db(db, reason="repository stats updated")
+
+            await run_serialized_repository_command(repo_record.id, _operation)
 
         except asyncio.TimeoutError:
             logger.warning(
@@ -1709,6 +1721,7 @@ class BackupService:
             db = SessionLocal()
             close_db = True
         temp_key_file = None  # Track SSH key file for cleanup
+        borg_command_lock = None
 
         try:
             # Get job
@@ -2314,6 +2327,16 @@ class BackupService:
             except Exception as e:
                 logger.warning("Failed to send backup start notification", error=str(e))
 
+            if repo_record and repo_record.id:
+                borg_command_lock = await acquire_repository_command_lock(
+                    repo_record.id
+                )
+                logger.info(
+                    "Acquired repository command lock for borg backup",
+                    job_id=job_id,
+                    repository_id=repo_record.id,
+                )
+
             # Execute command - NO LOG FILE FOR MAXIMUM PERFORMANCE
             process = await asyncio.create_subprocess_exec(
                 *cmd,
@@ -2803,6 +2826,15 @@ class BackupService:
                     captured_exit_code=captured_exit_code,
                 )
                 actual_returncode = captured_exit_code
+
+            if borg_command_lock is not None:
+                borg_command_lock.release()
+                borg_command_lock = None
+                logger.info(
+                    "Released repository command lock for borg backup",
+                    job_id=job_id,
+                    repository_id=repo_record.id if repo_record else None,
+                )
 
             # Update job status using modern exit codes (if not already cancelled)
             # 0 = success, 1 = warning (legacy), 2 = error (legacy)
@@ -3410,6 +3442,17 @@ class BackupService:
                 finally:
                     retry_db.close()
         finally:
+            if borg_command_lock is not None:
+                try:
+                    borg_command_lock.release()
+                    logger.info(
+                        "Released repository command lock during backup cleanup",
+                        job_id=job_id,
+                    )
+                except RuntimeError:
+                    pass
+                borg_command_lock = None
+
             # Ensure log file handle is closed
             if "log_file_handle" in locals() and log_file_handle:
                 try:

--- a/app/services/repository_command_lock.py
+++ b/app/services/repository_command_lock.py
@@ -24,6 +24,16 @@ async def _get_lock(repo_id: int, scope: str) -> asyncio.Lock:
         return lock
 
 
+async def acquire_repository_command_lock(
+    repo_id: int,
+    *,
+    scope: str = "metadata",
+) -> asyncio.Lock:
+    lock = await _get_lock(repo_id, scope)
+    await lock.acquire()
+    return lock
+
+
 async def run_serialized_repository_command(
     repo_id: int,
     operation: Callable[[], Awaitable[T]],
@@ -31,12 +41,12 @@ async def run_serialized_repository_command(
     scope: str = "metadata",
 ) -> T:
     """
-    Serialize repository-scoped Borg reads that can contend on the local cache.
+    Serialize repository-scoped Borg commands that can contend on Borg locks.
 
-    Borg can still require an exclusive local cache lock for read-only commands
-    like `info` and `list`, especially on SSH/remote repositories. Queueing
-    those commands per repository avoids the first-load race without blocking
-    unrelated repositories.
+    Borg can require exclusive repository or local cache locks even for
+    read-only commands like `info` and `list`, especially on SSH/remote
+    repositories. Queueing commands per repository avoids those races without
+    blocking unrelated repositories.
     """
     lock = await _get_lock(repo_id, scope)
     async with lock:

--- a/tests/unit/test_backup_service.py
+++ b/tests/unit/test_backup_service.py
@@ -8,6 +8,7 @@ import tempfile
 from pathlib import Path
 from datetime import datetime
 from unittest.mock import Mock, patch, AsyncMock, MagicMock
+from sqlalchemy.orm import sessionmaker
 from app.services.backup_service import BackupService
 from app.services.filesystem_snapshot_service import PreparedFilesystemSnapshot
 from app.database.models import BackupJob, Repository, SSHConnection, SystemSettings
@@ -811,6 +812,132 @@ class TestBackupService:
                 await asyncio.gather(*pending_tasks, return_exceptions=True)
 
         assert order[:3] == ["lock-held", "lock-released", "subprocess:create"]
+
+    @pytest.mark.asyncio
+    async def test_execute_backup_skips_create_when_cancelled_waiting_for_lock(
+        self, backup_service, test_db, tmp_path
+    ):
+        from app.services.repository_command_lock import (
+            run_serialized_repository_command,
+        )
+
+        repo_path = tmp_path / "repo"
+        repo_path.mkdir()
+        (repo_path / "data").mkdir()
+        (repo_path / "config").write_text("[repository]\nversion = 1\n")
+        source_path = tmp_path / "source"
+        source_path.mkdir()
+        repo = Repository(
+            name="Repo",
+            path=str(repo_path),
+            encryption="none",
+            repository_type="local",
+            source_directories=f'["{source_path}"]',
+            compression="lz4",
+        )
+        settings_row = SystemSettings(log_save_policy="all_jobs")
+        job = BackupJob(repository=repo.path, status="pending")
+        test_db.add_all([repo, settings_row, job])
+        test_db.commit()
+        test_db.refresh(repo)
+        test_db.refresh(job)
+
+        holder_started = asyncio.Event()
+        release_holder = asyncio.Event()
+
+        async def hold_repository_lock():
+            async def operation():
+                holder_started.set()
+                await release_holder.wait()
+
+            await run_serialized_repository_command(repo.id, operation)
+
+        holder_task = asyncio.create_task(hold_repository_lock())
+        await holder_started.wait()
+        execute_task = None
+        real_create_task = asyncio.create_task
+        notifications = MagicMock()
+        notifications.send_backup_start = AsyncMock()
+        notifications.send_backup_success = AsyncMock()
+        notifications.send_backup_warning = AsyncMock()
+        notifications.send_backup_failure = AsyncMock()
+        create_subprocess = AsyncMock()
+
+        try:
+            with (
+                patch.object(
+                    backup_service,
+                    "_execute_hooks",
+                    AsyncMock(
+                        return_value={
+                            "success": True,
+                            "execution_logs": [],
+                            "scripts_executed": 0,
+                            "scripts_failed": 0,
+                            "using_library": False,
+                        }
+                    ),
+                ),
+                patch.object(
+                    backup_service,
+                    "_prepare_source_paths",
+                    AsyncMock(return_value=([str(source_path)], [])),
+                ),
+                patch.object(
+                    backup_service, "_calculate_and_update_size_background", AsyncMock()
+                ),
+                patch.object(backup_service, "_update_archive_stats", AsyncMock()),
+                patch.object(backup_service, "_update_repository_stats", AsyncMock()),
+                patch(
+                    "app.services.backup_service.resolve_repo_ssh_key_file",
+                    return_value=None,
+                ),
+                patch(
+                    "app.services.backup_service.asyncio.create_subprocess_exec",
+                    create_subprocess,
+                ),
+                patch(
+                    "app.services.backup_service.asyncio.create_task",
+                    side_effect=_discard_background_task,
+                ),
+                patch(
+                    "app.services.backup_service.notification_service", notifications
+                ),
+                patch("app.services.backup_service.mqtt_service") as mqtt,
+            ):
+                mqtt.sync_state_with_db = Mock()
+                execute_task = real_create_task(
+                    backup_service.execute_backup(job.id, repo.path, db=test_db)
+                )
+                await asyncio.sleep(0.05)
+
+                cancel_session_factory = sessionmaker(bind=test_db.get_bind())
+                cancel_db = cancel_session_factory()
+                try:
+                    cancelled_job = (
+                        cancel_db.query(BackupJob).filter(BackupJob.id == job.id).one()
+                    )
+                    cancelled_job.status = "cancelled"
+                    cancel_db.commit()
+                finally:
+                    cancel_db.close()
+
+                release_holder.set()
+                await asyncio.wait_for(execute_task, timeout=1)
+                await asyncio.wait_for(holder_task, timeout=1)
+        finally:
+            release_holder.set()
+            pending_tasks = [
+                task
+                for task in (holder_task, execute_task)
+                if task is not None and not task.done()
+            ]
+            if pending_tasks:
+                await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+        create_subprocess.assert_not_awaited()
+        test_db.refresh(job)
+        assert job.status == "cancelled"
 
     @pytest.mark.asyncio
     async def test_execute_backup_fails_missing_local_source_before_borg_create(

--- a/tests/unit/test_backup_service.py
+++ b/tests/unit/test_backup_service.py
@@ -391,6 +391,97 @@ class TestBackupService:
         assert job.nfiles == 12
 
     @pytest.mark.asyncio
+    async def test_update_archive_stats_waits_for_repository_command_lock(
+        self, backup_service, test_db, tmp_path
+    ):
+        from app.services.repository_command_lock import (
+            run_serialized_repository_command,
+        )
+
+        repo_path = tmp_path / "repo"
+        repo_path.mkdir()
+        (repo_path / "data").mkdir()
+        (repo_path / "config").write_text("[repository]\nversion = 1\n")
+        repo = Repository(
+            name="Repo",
+            path=str(repo_path),
+            encryption="none",
+            repository_type="local",
+            compression="lz4",
+        )
+        job = BackupJob(
+            repository=str(repo_path),
+            status="running",
+            started_at=datetime.now(),
+        )
+        test_db.add_all([repo, job])
+        test_db.commit()
+        test_db.refresh(repo)
+        test_db.refresh(job)
+
+        order: list[str] = []
+        holder_started = asyncio.Event()
+        release_holder = asyncio.Event()
+
+        async def hold_repository_lock():
+            async def operation():
+                order.append("lock-held")
+                holder_started.set()
+                await release_holder.wait()
+                order.append("lock-released")
+
+            await run_serialized_repository_command(repo.id, operation)
+
+        holder_task = asyncio.create_task(hold_repository_lock())
+        await holder_started.wait()
+        stats_task = None
+
+        async def fake_create_subprocess_exec(*cmd, **kwargs):
+            order.append(f"subprocess:{cmd[1]}")
+            process = AsyncMock()
+            process.communicate = AsyncMock(
+                return_value=(
+                    b'{"archives": [{"stats": {"original_size": 1}}]}',
+                    b"",
+                )
+            )
+            process.returncode = 0
+            return process
+
+        try:
+            with patch(
+                "asyncio.create_subprocess_exec",
+                side_effect=fake_create_subprocess_exec,
+            ):
+                stats_task = asyncio.create_task(
+                    backup_service._update_archive_stats(
+                        test_db,
+                        job.id,
+                        str(repo_path),
+                        "test-archive",
+                        {},
+                    )
+                )
+                await asyncio.sleep(0.01)
+
+                assert not any(item.startswith("subprocess:") for item in order)
+
+                release_holder.set()
+                await asyncio.wait_for(holder_task, timeout=1)
+                await asyncio.wait_for(stats_task, timeout=1)
+        finally:
+            release_holder.set()
+            pending_tasks = [
+                task
+                for task in (holder_task, stats_task)
+                if task is not None and not task.done()
+            ]
+            if pending_tasks:
+                await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+        assert order[:3] == ["lock-held", "lock-released", "subprocess:info"]
+
+    @pytest.mark.asyncio
     async def test_update_repository_stats_updates_repository_and_publishes_snapshot(
         self, backup_service, test_db
     ):
@@ -431,6 +522,80 @@ class TestBackupService:
         assert repo.total_size == "1.00 MB"
         assert repo.last_backup is not None
         mqtt.sync_state_with_db.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_repository_stats_waits_for_repository_command_lock(
+        self, backup_service, test_db
+    ):
+        from app.services.repository_command_lock import (
+            run_serialized_repository_command,
+        )
+
+        repo = Repository(
+            name="Test Repo",
+            path="/test/repo",
+            encryption="none",
+            repository_type="local",
+        )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+
+        order: list[str] = []
+        holder_started = asyncio.Event()
+        release_holder = asyncio.Event()
+
+        async def hold_repository_lock():
+            async def operation():
+                order.append("lock-held")
+                holder_started.set()
+                await release_holder.wait()
+                order.append("lock-released")
+
+            await run_serialized_repository_command(repo.id, operation)
+
+        holder_task = asyncio.create_task(hold_repository_lock())
+        await holder_started.wait()
+        stats_task = None
+
+        async def fake_create_subprocess_exec(*cmd, **kwargs):
+            order.append(f"subprocess:{cmd[1]}")
+            process = AsyncMock()
+            stdout = (
+                b'{"archives": []}'
+                if cmd[1] in {"list", "repo-list"}
+                else b'{"cache": {"stats": {"unique_size": 0}}}'
+            )
+            process.communicate = AsyncMock(return_value=(stdout, b""))
+            process.returncode = 0
+            return process
+
+        try:
+            with patch(
+                "asyncio.create_subprocess_exec",
+                side_effect=fake_create_subprocess_exec,
+            ):
+                stats_task = asyncio.create_task(
+                    backup_service._update_repository_stats(test_db, repo.path, {})
+                )
+                await asyncio.sleep(0.01)
+
+                assert not any(item.startswith("subprocess:") for item in order)
+
+                release_holder.set()
+                await asyncio.wait_for(holder_task, timeout=1)
+                await asyncio.wait_for(stats_task, timeout=1)
+        finally:
+            release_holder.set()
+            pending_tasks = [
+                task
+                for task in (holder_task, stats_task)
+                if task is not None and not task.done()
+            ]
+            if pending_tasks:
+                await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+        assert order[:3] == ["lock-held", "lock-released", "subprocess:list"]
 
     @pytest.mark.asyncio
     async def test_execute_backup_success_saves_logs_and_notifies_success(
@@ -519,6 +684,133 @@ class TestBackupService:
         assert Path(job.log_file_path).exists()
         notifications.send_backup_success.assert_awaited_once()
         notifications.send_backup_failure.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_execute_backup_waits_for_repository_command_lock_before_create(
+        self, backup_service, test_db, tmp_path
+    ):
+        from app.services.repository_command_lock import (
+            run_serialized_repository_command,
+        )
+
+        repo_path = tmp_path / "repo"
+        repo_path.mkdir()
+        (repo_path / "data").mkdir()
+        (repo_path / "config").write_text("[repository]\nversion = 1\n")
+        source_path = tmp_path / "source"
+        source_path.mkdir()
+        repo = Repository(
+            name="Repo",
+            path=str(repo_path),
+            encryption="none",
+            repository_type="local",
+            source_directories=f'["{source_path}"]',
+            compression="lz4",
+        )
+        settings_row = SystemSettings(log_save_policy="all_jobs")
+        job = BackupJob(repository=repo.path, status="pending")
+        test_db.add_all([repo, settings_row, job])
+        test_db.commit()
+        test_db.refresh(repo)
+        test_db.refresh(job)
+
+        order: list[str] = []
+        holder_started = asyncio.Event()
+        release_holder = asyncio.Event()
+
+        async def hold_repository_lock():
+            async def operation():
+                order.append("lock-held")
+                holder_started.set()
+                await release_holder.wait()
+                order.append("lock-released")
+
+            await run_serialized_repository_command(repo.id, operation)
+
+        holder_task = asyncio.create_task(hold_repository_lock())
+        await holder_started.wait()
+        execute_task = None
+        real_create_task = asyncio.create_task
+        fake_process = FakeProcess(
+            returncode=0,
+            stdout_lines=[
+                '{"type":"archive_progress","original_size":1024,"compressed_size":512,"deduplicated_size":256,"nfiles":3,"finished":true}',
+            ],
+        )
+        notifications = MagicMock()
+        notifications.send_backup_start = AsyncMock()
+        notifications.send_backup_success = AsyncMock()
+        notifications.send_backup_warning = AsyncMock()
+        notifications.send_backup_failure = AsyncMock()
+
+        async def fake_create_subprocess_exec(*cmd, **kwargs):
+            order.append(f"subprocess:{cmd[1]}")
+            return fake_process
+
+        try:
+            with (
+                patch.object(
+                    backup_service,
+                    "_execute_hooks",
+                    AsyncMock(
+                        return_value={
+                            "success": True,
+                            "execution_logs": [],
+                            "scripts_executed": 0,
+                            "scripts_failed": 0,
+                            "using_library": False,
+                        }
+                    ),
+                ),
+                patch.object(
+                    backup_service,
+                    "_prepare_source_paths",
+                    AsyncMock(return_value=([str(source_path)], [])),
+                ),
+                patch.object(
+                    backup_service, "_calculate_and_update_size_background", AsyncMock()
+                ),
+                patch.object(backup_service, "_update_archive_stats", AsyncMock()),
+                patch.object(backup_service, "_update_repository_stats", AsyncMock()),
+                patch(
+                    "app.services.backup_service.resolve_repo_ssh_key_file",
+                    return_value=None,
+                ),
+                patch(
+                    "app.services.backup_service.asyncio.create_subprocess_exec",
+                    side_effect=fake_create_subprocess_exec,
+                ),
+                patch(
+                    "app.services.backup_service.asyncio.create_task",
+                    side_effect=_discard_background_task,
+                ),
+                patch(
+                    "app.services.backup_service.notification_service", notifications
+                ),
+                patch("app.services.backup_service.mqtt_service") as mqtt,
+            ):
+                mqtt.sync_state_with_db = Mock()
+                execute_task = real_create_task(
+                    backup_service.execute_backup(job.id, repo.path, db=test_db)
+                )
+                await asyncio.sleep(0.05)
+
+                assert not any(item.startswith("subprocess:") for item in order)
+
+                release_holder.set()
+                await asyncio.wait_for(execute_task, timeout=1)
+                await asyncio.wait_for(holder_task, timeout=1)
+        finally:
+            release_holder.set()
+            pending_tasks = [
+                task
+                for task in (holder_task, execute_task)
+                if task is not None and not task.done()
+            ]
+            if pending_tasks:
+                await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+        assert order[:3] == ["lock-held", "lock-released", "subprocess:create"]
 
     @pytest.mark.asyncio
     async def test_execute_backup_fails_missing_local_source_before_borg_create(


### PR DESCRIPTION
## Description
Borg UI now serializes backup-service Borg commands through the existing per-repository command lock. Backup creation holds the lock while the Borg create process is running, and post-backup archive/repository stats run through the same serialized path. This prevents overlapping Borg create/list/info commands for the same repository from racing into `lock.exclusive` timeout failures.

The PR also handles the cancellation edge case found during review: if a backup is cancelled while waiting for the repository command lock, the job status is refreshed after the wait and Borg create is skipped before any subprocess is spawned.

## Related Issue
Fixes #626
Linear: BOR-145

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [x] Test addition/improvement
- [ ] Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `pytest tests/unit/test_backup_service.py::TestBackupService::test_execute_backup_skips_create_when_cancelled_waiting_for_lock -q` -> 1 passed, 35 warnings
- `pytest tests/unit/test_backup_service.py -q` -> 51 passed, 6 skipped, 35 warnings
- `ruff check app tests` -> All checks passed
- `ruff format --check app tests` -> 436 files already formatted
- `git diff --check` -> passed

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; backend repository command coordination only.

## Additional Context
The previous behavior allowed backup-service Borg subprocesses to launch outside the lock used by repository metadata endpoints. The tests now hold the repository command lock and assert that backup create, archive stats, and repository stats wait before launching Borg; cancellation coverage also asserts that a cancelled job does not spawn Borg after waiting for the lock.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
