### PR TITLE
Color remote machine deploy preset icons

### DIFF
--- a/frontend/src/components/shared/WizardStepIndicator.tsx
+++ b/frontend/src/components/shared/WizardStepIndicator.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Box, Typography, alpha, useTheme, useMediaQuery } from '@mui/material'
+import { getWizardStepColor } from './wizardStepColors'
 
 interface WizardStep {
   key: string
@@ -13,22 +14,6 @@ interface WizardStepIndicatorProps {
   onStepClick?: (stepIndex: number) => void
 }
 
-// Step colors - tuned for each theme
-const stepColors = {
-  // RepositoryWizard colors
-  location: { light: '#1565c0', dark: '#64b5f6' }, // blue
-  source: { light: '#2e7d32', dark: '#81c784' }, // green
-  security: { light: '#7b1fa2', dark: '#ce93d8' }, // purple
-  config: { light: '#e65100', dark: '#ffb74d' }, // orange
-  review: { light: '#0277bd', dark: '#4fc3f7' }, // cyan
-
-  // ScheduleWizard colors (same palette, different mapping)
-  basic: { light: '#1565c0', dark: '#64b5f6' }, // blue (like location)
-  schedule: { light: '#e65100', dark: '#ffb74d' }, // orange (like config)
-  scripts: { light: '#7b1fa2', dark: '#ce93d8' }, // purple (like security)
-  maintenance: { light: '#2e7d32', dark: '#81c784' }, // green (like source)
-}
-
 export default function WizardStepIndicator({
   steps,
   currentStep,
@@ -39,8 +24,7 @@ export default function WizardStepIndicator({
   const isMobile = useMediaQuery(theme.breakpoints.down('md'))
 
   const getStepColor = (stepKey: string) => {
-    const colors = stepColors[stepKey as keyof typeof stepColors] || stepColors.location
-    return isDark ? colors.dark : colors.light
+    return getWizardStepColor(stepKey, isDark ? 'dark' : 'light')
   }
 
   // ── Mobile: compact icon-circles row + current step label ──

--- a/frontend/src/components/shared/wizardStepColors.ts
+++ b/frontend/src/components/shared/wizardStepColors.ts
@@ -1,0 +1,22 @@
+export const wizardStepColors = {
+  // RepositoryWizard colors
+  location: { light: '#1565c0', dark: '#64b5f6' },
+  source: { light: '#2e7d32', dark: '#81c784' },
+  security: { light: '#7b1fa2', dark: '#ce93d8' },
+  config: { light: '#e65100', dark: '#ffb74d' },
+  review: { light: '#0277bd', dark: '#4fc3f7' },
+
+  // ScheduleWizard colors (same palette, different mapping)
+  basic: { light: '#1565c0', dark: '#64b5f6' },
+  schedule: { light: '#e65100', dark: '#ffb74d' },
+  scripts: { light: '#7b1fa2', dark: '#ce93d8' },
+  maintenance: { light: '#2e7d32', dark: '#81c784' },
+} as const
+
+export type WizardStepColorKey = keyof typeof wizardStepColors
+export type WizardStepColorMode = keyof (typeof wizardStepColors)['location']
+
+export function getWizardStepColor(stepKey: string, mode: WizardStepColorMode) {
+  const colors = wizardStepColors[stepKey as WizardStepColorKey] ?? wizardStepColors.location
+  return colors[mode]
+}

--- a/frontend/src/pages/__tests__/SSHConnectionsSingleKey.test.tsx
+++ b/frontend/src/pages/__tests__/SSHConnectionsSingleKey.test.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, waitFor as rtlWaitFor, within } from '@testing-library/react'
+import { getWizardStepColor } from '../../components/shared/wizardStepColors'
 import i18n from '../../i18n'
 import { renderWithProviders, screen, userEvent, waitFor } from '../../test/test-utils'
 import SSHConnectionsSingleKey from '../SSHConnectionsSingleKey'
@@ -495,6 +496,7 @@ describe('SSHConnectionsSingleKey', () => {
 
   it('renders deploy preset icons with their configured colors', async () => {
     const selectedPreset = remoteMachineSetupPresets.find((preset) => preset.id === 'hetzner')
+    expect(selectedPreset).toBeDefined()
 
     renderWithProviders(
       <DeployDialogHarness
@@ -511,14 +513,16 @@ describe('SSHConnectionsSingleKey', () => {
 
     const dialog = await screen.findByRole('dialog', { name: /deploy ssh key to server/i })
     const selectedIcon = within(dialog).getByTestId('remote-machine-preset-icon-hetzner')
-    expect(selectedIcon).toHaveStyle({ color: selectedPreset?.color })
+    expect(selectedIcon).toHaveStyle({
+      color: getWizardStepColor(selectedPreset!.colorKey, 'light'),
+    })
 
     fireEvent.mouseDown(within(dialog).getByRole('combobox', { name: /setup preset/i }))
     const listbox = await screen.findByRole('listbox')
 
     remoteMachineSetupPresets.forEach((preset) => {
       expect(within(listbox).getByTestId(`remote-machine-preset-icon-${preset.id}`)).toHaveStyle({
-        color: preset.color,
+        color: getWizardStepColor(preset.colorKey, 'light'),
       })
     })
   }, 30000)

--- a/frontend/src/pages/__tests__/SSHConnectionsSingleKey.test.tsx
+++ b/frontend/src/pages/__tests__/SSHConnectionsSingleKey.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, waitFor as rtlWaitFor, within } from '@testing-library/react
 import i18n from '../../i18n'
 import { renderWithProviders, screen, userEvent, waitFor } from '../../test/test-utils'
 import SSHConnectionsSingleKey from '../SSHConnectionsSingleKey'
+import { remoteMachineSetupPresets } from '../ssh-connections-single-key/connectionPresets'
 import { createConnectionForm } from '../ssh-connections-single-key/formDefaults'
 import { ConnectionDiagnosticsDialog } from '../ssh-connections-single-key/dialogs/ConnectionDiagnosticsDialog'
 import { DeployKeyDialog } from '../ssh-connections-single-key/dialogs/DeployKeyDialog'
@@ -14,6 +15,26 @@ async function chooseDeployPreset(dialog: HTMLElement, name: RegExp) {
   const listbox = await screen.findByRole('listbox')
   fireEvent.click(within(listbox).getByRole('option', { name }))
   await rtlWaitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument())
+}
+
+function DeployDialogHarness({ initialForm }: { initialForm: DeployConnectionPayload }) {
+  const [open, setOpen] = useState(true)
+  const [connectionForm, setConnectionForm] = useState(initialForm)
+  const [hostError, setHostError] = useState<string>()
+
+  return (
+    <DeployKeyDialog
+      t={i18n.t.bind(i18n)}
+      open={open}
+      setOpen={setOpen}
+      connectionForm={connectionForm}
+      setConnectionForm={setConnectionForm}
+      hostError={hostError}
+      setHostError={setHostError}
+      pending={false}
+      onDeploy={() => {}}
+    />
+  )
 }
 
 const { track, toastSuccess, toastError, mockState } = vi.hoisted(() => ({
@@ -470,6 +491,36 @@ describe('SSHConnectionsSingleKey', () => {
       within(reopenedDialog).getByRole('combobox', { name: /setup preset/i })
     ).toHaveTextContent(/custom setup/i)
     expect(within(reopenedDialog).getByLabelText(/^port$/i)).toHaveValue(22)
+  }, 30000)
+
+  it('renders deploy preset icons with their configured colors', async () => {
+    const selectedPreset = remoteMachineSetupPresets.find((preset) => preset.id === 'hetzner')
+
+    renderWithProviders(
+      <DeployDialogHarness
+        initialForm={{
+          ...createConnectionForm(),
+          port: 23,
+          use_sftp_mode: true,
+          default_path: '/./borg-repository',
+          ssh_path_prefix: '',
+          mount_point: 'hetzner',
+        }}
+      />
+    )
+
+    const dialog = await screen.findByRole('dialog', { name: /deploy ssh key to server/i })
+    const selectedIcon = within(dialog).getByTestId('remote-machine-preset-icon-hetzner')
+    expect(selectedIcon).toHaveStyle({ color: selectedPreset?.color })
+
+    fireEvent.mouseDown(within(dialog).getByRole('combobox', { name: /setup preset/i }))
+    const listbox = await screen.findByRole('listbox')
+
+    remoteMachineSetupPresets.forEach((preset) => {
+      expect(within(listbox).getByTestId(`remote-machine-preset-icon-${preset.id}`)).toHaveStyle({
+        color: preset.color,
+      })
+    })
   }, 30000)
 
   it('tests and adds a manual connection with the expected payload', async () => {

--- a/frontend/src/pages/ssh-connections-single-key/connectionPresets.ts
+++ b/frontend/src/pages/ssh-connections-single-key/connectionPresets.ts
@@ -8,18 +8,29 @@ export type RemoteMachineSetupPresetId = 'custom' | 'linux' | 'borgbase' | 'hetz
 export interface RemoteMachineSetupPreset {
   id: RemoteMachineSetupPresetId
   icon: ComponentType<{ size?: number | string }>
+  color: string
   defaults: Partial<DeployConnectionPayload>
 }
+
+export const remoteMachineSetupPresetIconColors = {
+  custom: '#7c3aed',
+  linux: '#ca8a04',
+  borgbase: '#16a34a',
+  hetzner: '#d50c2d',
+  nas: '#0891b2',
+} satisfies Record<RemoteMachineSetupPresetId, string>
 
 export const remoteMachineSetupPresets: RemoteMachineSetupPreset[] = [
   {
     id: 'custom',
     icon: Settings2,
+    color: remoteMachineSetupPresetIconColors.custom,
     defaults: {},
   },
   {
     id: 'linux',
     icon: SiLinux,
+    color: remoteMachineSetupPresetIconColors.linux,
     defaults: {
       username: 'root',
       port: 22,
@@ -32,6 +43,7 @@ export const remoteMachineSetupPresets: RemoteMachineSetupPreset[] = [
   {
     id: 'borgbase',
     icon: SiBorgbackup,
+    color: remoteMachineSetupPresetIconColors.borgbase,
     defaults: {
       username: '',
       port: 22,
@@ -44,6 +56,7 @@ export const remoteMachineSetupPresets: RemoteMachineSetupPreset[] = [
   {
     id: 'hetzner',
     icon: SiHetzner,
+    color: remoteMachineSetupPresetIconColors.hetzner,
     defaults: {
       username: '',
       port: 23,
@@ -56,6 +69,7 @@ export const remoteMachineSetupPresets: RemoteMachineSetupPreset[] = [
   {
     id: 'nas',
     icon: SiSynology,
+    color: remoteMachineSetupPresetIconColors.nas,
     defaults: {
       username: '',
       port: 22,

--- a/frontend/src/pages/ssh-connections-single-key/connectionPresets.ts
+++ b/frontend/src/pages/ssh-connections-single-key/connectionPresets.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from 'react'
 import { Settings2 } from 'lucide-react'
 import { SiBorgbackup, SiHetzner, SiLinux, SiSynology } from 'react-icons/si'
+import type { WizardStepColorKey } from '../../components/shared/wizardStepColors'
 import type { DeployConnectionPayload } from './types'
 
 export type RemoteMachineSetupPresetId = 'custom' | 'linux' | 'borgbase' | 'hetzner' | 'nas'
@@ -8,29 +9,29 @@ export type RemoteMachineSetupPresetId = 'custom' | 'linux' | 'borgbase' | 'hetz
 export interface RemoteMachineSetupPreset {
   id: RemoteMachineSetupPresetId
   icon: ComponentType<{ size?: number | string }>
-  color: string
+  colorKey: WizardStepColorKey
   defaults: Partial<DeployConnectionPayload>
 }
 
-export const remoteMachineSetupPresetIconColors = {
-  custom: '#7c3aed',
-  linux: '#ca8a04',
-  borgbase: '#16a34a',
-  hetzner: '#d50c2d',
-  nas: '#0891b2',
-} satisfies Record<RemoteMachineSetupPresetId, string>
+export const remoteMachineSetupPresetIconColorKeys = {
+  custom: 'config',
+  linux: 'basic',
+  borgbase: 'source',
+  hetzner: 'location',
+  nas: 'maintenance',
+} satisfies Record<RemoteMachineSetupPresetId, WizardStepColorKey>
 
 export const remoteMachineSetupPresets: RemoteMachineSetupPreset[] = [
   {
     id: 'custom',
     icon: Settings2,
-    color: remoteMachineSetupPresetIconColors.custom,
+    colorKey: remoteMachineSetupPresetIconColorKeys.custom,
     defaults: {},
   },
   {
     id: 'linux',
     icon: SiLinux,
-    color: remoteMachineSetupPresetIconColors.linux,
+    colorKey: remoteMachineSetupPresetIconColorKeys.linux,
     defaults: {
       username: 'root',
       port: 22,
@@ -43,7 +44,7 @@ export const remoteMachineSetupPresets: RemoteMachineSetupPreset[] = [
   {
     id: 'borgbase',
     icon: SiBorgbackup,
-    color: remoteMachineSetupPresetIconColors.borgbase,
+    colorKey: remoteMachineSetupPresetIconColorKeys.borgbase,
     defaults: {
       username: '',
       port: 22,
@@ -56,7 +57,7 @@ export const remoteMachineSetupPresets: RemoteMachineSetupPreset[] = [
   {
     id: 'hetzner',
     icon: SiHetzner,
-    color: remoteMachineSetupPresetIconColors.hetzner,
+    colorKey: remoteMachineSetupPresetIconColorKeys.hetzner,
     defaults: {
       username: '',
       port: 23,
@@ -69,7 +70,7 @@ export const remoteMachineSetupPresets: RemoteMachineSetupPreset[] = [
   {
     id: 'nas',
     icon: SiSynology,
-    color: remoteMachineSetupPresetIconColors.nas,
+    colorKey: remoteMachineSetupPresetIconColorKeys.nas,
     defaults: {
       username: '',
       port: 22,

--- a/frontend/src/pages/ssh-connections-single-key/dialogs/DeployKeyDialog.stories.tsx
+++ b/frontend/src/pages/ssh-connections-single-key/dialogs/DeployKeyDialog.stories.tsx
@@ -65,3 +65,16 @@ export const HetznerDefaults: Story = {
     },
   },
 }
+
+export const PresetIconColors: Story = {
+  args: {
+    initialForm: {
+      ...createConnectionForm(),
+      port: 23,
+      use_sftp_mode: true,
+      default_path: '/./borg-repository',
+      ssh_path_prefix: '',
+      mount_point: 'hetzner',
+    },
+  },
+}

--- a/frontend/src/pages/ssh-connections-single-key/dialogs/DeployKeyDialog.tsx
+++ b/frontend/src/pages/ssh-connections-single-key/dialogs/DeployKeyDialog.tsx
@@ -144,7 +144,16 @@ export function DeployKeyDialog({
 
     return (
       <RichSelectRow
-        icon={<Icon size={18} />}
+        icon={
+          <Box
+            aria-hidden
+            component="span"
+            data-testid={`remote-machine-preset-icon-${preset.id}`}
+            style={{ color: preset.color, display: 'inline-flex', lineHeight: 0 }}
+          >
+            <Icon size={18} />
+          </Box>
+        }
         primary={label.title}
         secondary={`${label.description} ${label.defaults}`}
       />

--- a/frontend/src/pages/ssh-connections-single-key/dialogs/DeployKeyDialog.tsx
+++ b/frontend/src/pages/ssh-connections-single-key/dialogs/DeployKeyDialog.tsx
@@ -19,10 +19,12 @@ import {
   TextField,
   Tooltip,
   Typography,
+  useTheme,
 } from '@mui/material'
 import { Info } from 'lucide-react'
 import RichSelectRow from '../../../components/shared/RichSelectRow'
 import ResponsiveDialog from '../../../components/shared/ResponsiveDialog'
+import { getWizardStepColor } from '../../../components/shared/wizardStepColors'
 import { createConnectionForm } from '../formDefaults'
 import {
   remoteMachineSetupPresets,
@@ -69,6 +71,7 @@ export function DeployKeyDialog({
   pending,
   onDeploy,
 }: DeployKeyDialogProps) {
+  const theme = useTheme()
   const [selectedPreset, setSelectedPreset] = useState<RemoteMachineSetupPresetId>(() =>
     getPresetIdForForm(connectionForm)
   )
@@ -141,6 +144,7 @@ export function DeployKeyDialog({
   const renderPresetRow = (preset: RemoteMachineSetupPreset) => {
     const Icon = preset.icon
     const label = getPresetLabel(preset.id)
+    const presetColor = getWizardStepColor(preset.colorKey, theme.palette.mode)
 
     return (
       <RichSelectRow
@@ -149,7 +153,7 @@ export function DeployKeyDialog({
             aria-hidden
             component="span"
             data-testid={`remote-machine-preset-icon-${preset.id}`}
-            style={{ color: preset.color, display: 'inline-flex', lineHeight: 0 }}
+            style={{ color: presetColor, display: 'inline-flex', lineHeight: 0 }}
           >
             <Icon size={18} />
           </Box>


### PR DESCRIPTION
## Description
- Adds color-key metadata for each remote machine deploy setup preset using the shared Borg UI wizard step color palette.
- Renders deploy modal preset icons with those resolved theme-aware colors while preserving the existing RichSelectRow layout and select behavior.
- Adds regression coverage plus a Storybook state for reviewer inspection.

## Related Issue
Linear: https://linear.app/nullcodeai/issue/BOR-149/color-remote-machine-preset-icons-in-the-deploy-modal

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [x] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `cd frontend && npm run test -- src/pages/__tests__/SSHConnectionsSingleKey.test.tsx --run -t "renders deploy preset icons with their configured colors"`
- `cd frontend && npm run test -- src/components/shared/__tests__/WizardStepIndicator.test.tsx --run`
- `cd frontend && npm run test -- src/pages/__tests__/SSHConnectionsSingleKey.test.tsx --run`
- `cd frontend && npm run check:locales`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `cd frontend && npm run build-storybook`

## Checklist
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines (the repository does not contain `CONTRIBUTING.md` in this checkout)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (no new complex logic required comments)
- [x] I have made corresponding changes to the documentation (not applicable; no user navigation or docs path changed)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
No screenshots attached. `npm run snapshots` built Storybook successfully but screenshot capture could not launch in this host because Playwright reports missing system browser libraries (`libnspr4`, `libnss3`, `libatk1.0-0`, `libatk-bridge2.0-0`, `libcups2`, `libxkbcommon0`, `libcairo2`, `libpango-1.0-0`, `libxdamage1`, `libatspi2.0-0`).

## Additional Context
The initial tinted-frame approach made MUI Select menu closing unreliable under the existing tests. The final implementation colors the SVG glyph inside the existing rich-select icon frame, keeps the original menu structure and interaction behavior intact, and resolves colors through the shared wizard step color helper to avoid one-off preset hex values.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment presets now feature color-coded icons for enhanced visual identification. Each preset type (custom, Linux, Borgbase, Hetzner, and NAS) is distinguished by a unique color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 4 changed, 2 added, 0 removed, 334 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-632/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/27015089281
<details>
<summary>Changed files</summary>
- `remote-machines-deploykeydialog--custom-defaults--mobile.png` (0.03%)
- `remote-machines-deploykeydialog--custom-defaults.png` (0.01%)
- `remote-machines-deploykeydialog--hetzner-defaults--mobile.png` (0.08%)
- `remote-machines-deploykeydialog--hetzner-defaults.png` (0.03%)
</details>
<details>
<summary>New screenshots</summary>
- `remote-machines-deploykeydialog--preset-icon-colors--mobile.png`
- `remote-machines-deploykeydialog--preset-icon-colors.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->