### PR TITLE
Apply log save policy to Activity log visibility

### DIFF
--- a/app/api/activity.py
+++ b/app/api/activity.py
@@ -36,6 +36,7 @@ from app.api.auth import get_current_user, User
 from app.core.security import get_current_download_user
 from app.utils.datetime_utils import serialize_datetime
 from app.services.backup_service import backup_service
+from app.services.log_policy import get_log_save_policy, job_has_logs_by_policy
 
 logger = structlog.get_logger()
 
@@ -173,6 +174,7 @@ async def list_recent_activity(
     """
 
     activities = []
+    log_save_policy = get_log_save_policy(db)
 
     # Fetch backup jobs
     if not job_type or job_type == "backup":
@@ -236,7 +238,12 @@ async def list_recent_activity(
                     "backup_plan_name": backup_plan_name,
                     "archive_name": getattr(job, "archive_name", None),
                     "package_name": None,
-                    "has_logs": bool(job.log_file_path or job.logs),
+                    "has_logs": job_has_logs_by_policy(
+                        job,
+                        log_save_policy,
+                        output_text=[job.logs, job.error_message],
+                        file_path=job.log_file_path,
+                    ),
                 }
             )
 
@@ -272,9 +279,11 @@ async def list_recent_activity(
                     "schedule_id": None,
                     "archive_name": job.archive,
                     "package_name": None,
-                    "has_logs": bool(
-                        job.logs
-                    ),  # Check logs field instead of log_file_path
+                    "has_logs": job_has_logs_by_policy(
+                        job,
+                        log_save_policy,
+                        output_text=[job.logs, job.error_message],
+                    ),
                 }
             )
 
@@ -309,7 +318,15 @@ async def list_recent_activity(
                     "schedule_id": None,
                     "archive_name": None,
                     "package_name": None,
-                    "has_logs": bool(getattr(job, "log_file_path", None)),
+                    "has_logs": job_has_logs_by_policy(
+                        job,
+                        log_save_policy,
+                        output_text=[
+                            getattr(job, "logs", None),
+                            job.error_message,
+                        ],
+                        file_path=getattr(job, "log_file_path", None),
+                    ),
                     "_sort_at": job.started_at or job.created_at,
                 }
             )
@@ -351,10 +368,14 @@ async def list_recent_activity(
                     "schedule_id": None,
                     "archive_name": job.archive_name,
                     "package_name": None,
-                    "has_logs": bool(
-                        getattr(job, "has_logs", False)
-                        or getattr(job, "log_file_path", None)
-                        or getattr(job, "logs", None)
+                    "has_logs": job_has_logs_by_policy(
+                        job,
+                        log_save_policy,
+                        output_text=[
+                            getattr(job, "logs", None),
+                            job.error_message,
+                        ],
+                        file_path=getattr(job, "log_file_path", None),
                     ),
                     "_sort_at": job.started_at or job.created_at,
                 }
@@ -398,7 +419,15 @@ async def list_recent_activity(
                     "schedule_id": None,
                     "archive_name": None,
                     "package_name": None,
-                    "has_logs": bool(getattr(job, "log_file_path", None)),
+                    "has_logs": job_has_logs_by_policy(
+                        job,
+                        log_save_policy,
+                        output_text=[
+                            getattr(job, "logs", None),
+                            job.error_message,
+                        ],
+                        file_path=getattr(job, "log_file_path", None),
+                    ),
                 }
             )
 
@@ -437,7 +466,15 @@ async def list_recent_activity(
                     "schedule_id": None,
                     "archive_name": None,
                     "package_name": None,
-                    "has_logs": bool(job.logs),
+                    "has_logs": job_has_logs_by_policy(
+                        job,
+                        log_save_policy,
+                        output_text=[
+                            getattr(job, "logs", None),
+                            job.error_message,
+                        ],
+                        file_path=getattr(job, "log_file_path", None),
+                    ),
                 }
             )
 
@@ -474,7 +511,16 @@ async def list_recent_activity(
                     "schedule_id": None,
                     "archive_name": None,
                     "package_name": package_name,
-                    "has_logs": bool(getattr(job, "log_file_path", None)),
+                    "has_logs": job_has_logs_by_policy(
+                        job,
+                        log_save_policy,
+                        output_text=[
+                            getattr(job, "stdout", None),
+                            getattr(job, "stderr", None),
+                            job.error_message,
+                        ],
+                        file_path=getattr(job, "log_file_path", None),
+                    ),
                 }
             )
 
@@ -520,8 +566,15 @@ async def list_recent_activity(
                     "backup_plan_name": backup_plan_name,
                     "archive_name": execution.hook_type,
                     "package_name": script_name,
-                    "has_logs": bool(
-                        execution.stdout or execution.stderr or execution.error_message
+                    "has_logs": job_has_logs_by_policy(
+                        execution,
+                        log_save_policy,
+                        output_text=[
+                            execution.stdout,
+                            execution.stderr,
+                            execution.error_message,
+                        ],
+                        exit_code=execution.exit_code,
                     ),
                     "_sort_at": execution.started_at,
                 }
@@ -566,7 +619,12 @@ async def list_recent_activity(
                     "schedule_id": None,
                     "archive_name": None,
                     "package_name": None,
-                    "has_logs": bool(job.log_path or job.log_text or job.error_text),
+                    "has_logs": job_has_logs_by_policy(
+                        job,
+                        log_save_policy,
+                        output_text=[job.log_text, job.error_text],
+                        file_path=job.log_path,
+                    ),
                     "_sort_at": job.started_at or job.created_at,
                 }
             )

--- a/app/api/activity.py
+++ b/app/api/activity.py
@@ -7,7 +7,7 @@ Provides a unified view of all operations (backups, restores, checks, compacts, 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
-from typing import List, Optional
+from typing import Any, List, Optional
 from datetime import datetime
 from pydantic import BaseModel
 import os
@@ -140,6 +140,13 @@ RCLONE_ACTIVITY_OPERATIONS = {
 }
 
 
+def _no_logs_available_exception() -> HTTPException:
+    return HTTPException(
+        status_code=404,
+        detail={"key": "backend.errors.activity.noLogsAvailableForJob"},
+    )
+
+
 def _format_rclone_job_logs(job: RcloneSyncJob) -> str:
     parts = []
     if job.log_text:
@@ -149,6 +156,25 @@ def _format_rclone_job_logs(job: RcloneSyncJob) -> str:
     return "\n".join(parts)
 
 
+def _format_package_install_logs(job: PackageInstallJob) -> str:
+    lines = [f"PACKAGE: Package #{job.package_id}", f"STATUS: {job.status}"]
+    if job.exit_code is not None:
+        lines.append(f"EXIT CODE: {job.exit_code}")
+    lines.extend(
+        [
+            "",
+            "STDOUT:",
+            job.stdout or "(empty)",
+            "",
+            "STDERR:",
+            job.stderr or "(empty)",
+        ]
+    )
+    if job.error_message:
+        lines.extend(["", "ERROR:", job.error_message])
+    return "\n".join(lines)
+
+
 def _get_rclone_job(db: Session, job_type: str, job_id: int) -> RcloneSyncJob | None:
     operation = RCLONE_ACTIVITY_OPERATIONS[job_type]
     return (
@@ -156,6 +182,81 @@ def _get_rclone_job(db: Session, job_type: str, job_id: int) -> RcloneSyncJob | 
         .filter(RcloneSyncJob.id == job_id, RcloneSyncJob.operation == operation)
         .first()
     )
+
+
+def _activity_log_policy_sources(job_type: str, job: Any) -> dict[str, Any]:
+    if job_type == "script_execution":
+        return {
+            "output_text": [
+                getattr(job, "stdout", None),
+                getattr(job, "stderr", None),
+                getattr(job, "error_message", None),
+            ],
+            "file_path": None,
+            "exit_code": getattr(job, "exit_code", None),
+        }
+    if job_type in RCLONE_ACTIVITY_OPERATIONS:
+        return {
+            "output_text": [
+                getattr(job, "log_text", None),
+                getattr(job, "error_text", None),
+            ],
+            "file_path": getattr(job, "log_path", None),
+            "exit_code": None,
+        }
+    if job_type == "package":
+        return {
+            "output_text": [
+                getattr(job, "stdout", None),
+                getattr(job, "stderr", None),
+                getattr(job, "error_message", None),
+            ],
+            "file_path": getattr(job, "log_file_path", None),
+            "exit_code": getattr(job, "exit_code", None),
+        }
+    return {
+        "output_text": [
+            getattr(job, "logs", None),
+            getattr(job, "error_message", None),
+        ],
+        "file_path": getattr(job, "log_file_path", None),
+        "exit_code": getattr(job, "exit_code", None),
+    }
+
+
+def _activity_job_has_logs(job_type: str, job: Any, *, log_save_policy: str) -> bool:
+    sources = _activity_log_policy_sources(job_type, job)
+    return job_has_logs_by_policy(
+        job,
+        log_save_policy,
+        output_text=sources["output_text"],
+        file_path=sources["file_path"],
+        exit_code=sources["exit_code"],
+    )
+
+
+def _ensure_activity_logs_visible(job_type: str, job: Any, db: Session) -> None:
+    if not _activity_job_has_logs(
+        job_type, job, log_save_policy=get_log_save_policy(db)
+    ):
+        raise _no_logs_available_exception()
+
+
+def _text_download_response(log_text: str, *, filename: str) -> FileResponse:
+    temp_file = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt")
+    try:
+        temp_file.write(log_text)
+        temp_file.flush()
+        temp_file.close()
+        return FileResponse(
+            path=temp_file.name,
+            filename=filename,
+            media_type="text/plain",
+        )
+    except Exception as e:
+        if os.path.exists(temp_file.name):
+            os.unlink(temp_file.name)
+        raise e
 
 
 @router.get("/recent", response_model=List[ActivityItem])
@@ -684,6 +785,7 @@ async def get_job_logs(
                     "params": {"jobType": job_type},
                 },
             )
+        _ensure_activity_logs_visible(job_type, execution, db)
         return _paginate_log_text(
             _format_script_execution_logs(execution), offset, limit
         )
@@ -698,6 +800,7 @@ async def get_job_logs(
                     "params": {"jobType": job_type},
                 },
             )
+        _ensure_activity_logs_visible(job_type, job, db)
         log_text = _format_rclone_job_logs(job)
         if log_text:
             return _paginate_log_text(log_text, offset, limit)
@@ -727,6 +830,11 @@ async def get_job_logs(
                 "params": {"jobType": job_type},
             },
         )
+
+    _ensure_activity_logs_visible(job_type, job, db)
+
+    if job_type == "package":
+        return _paginate_log_text(_format_package_install_logs(job), offset, limit)
 
     if job_type == "backup" and getattr(job, "execution_mode", None) == "agent":
         agent_job = _get_agent_job_for_backup(db, job.id)
@@ -789,8 +897,9 @@ async def get_job_logs(
                 )
 
         # Fallback to stored logs in database (hooks or error messages)
-        if job.logs:
-            lines = job.logs.split("\n")
+        stored_logs = getattr(job, "logs", None)
+        if stored_logs:
+            lines = stored_logs.split("\n")
             total_lines = len(lines)
 
             # Apply offset and limit
@@ -995,26 +1104,14 @@ async def download_job_logs(
                     "key": "backend.errors.activity.cannotDownloadLogsForRunningJob"
                 },
             )
+        _ensure_activity_logs_visible(job_type, execution, db)
         log_text = _format_script_execution_logs(execution)
         if not log_text.strip():
-            raise HTTPException(
-                status_code=404,
-                detail={"key": "backend.errors.activity.noLogsAvailableForJob"},
-            )
-        temp_file = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt")
-        try:
-            temp_file.write(log_text)
-            temp_file.flush()
-            temp_file.close()
-            return FileResponse(
-                path=temp_file.name,
-                filename=f"{job_type}_job_{job_id}_logs.txt",
-                media_type="text/plain",
-            )
-        except Exception as e:
-            if os.path.exists(temp_file.name):
-                os.unlink(temp_file.name)
-            raise e
+            raise _no_logs_available_exception()
+        return _text_download_response(
+            log_text,
+            filename=f"{job_type}_job_{job_id}_logs.txt",
+        )
 
     if job_type in RCLONE_ACTIVITY_OPERATIONS:
         job = _get_rclone_job(db, job_type, job_id)
@@ -1033,6 +1130,7 @@ async def download_job_logs(
                     "key": "backend.errors.activity.cannotDownloadLogsForRunningJob"
                 },
             )
+        _ensure_activity_logs_visible(job_type, job, db)
         if job.log_path and os.path.exists(job.log_path):
             return FileResponse(
                 path=job.log_path,
@@ -1041,24 +1139,11 @@ async def download_job_logs(
             )
         log_text = _format_rclone_job_logs(job)
         if not log_text.strip():
-            raise HTTPException(
-                status_code=404,
-                detail={"key": "backend.errors.activity.noLogsAvailableForJob"},
-            )
-        temp_file = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt")
-        try:
-            temp_file.write(log_text)
-            temp_file.flush()
-            temp_file.close()
-            return FileResponse(
-                path=temp_file.name,
-                filename=f"{job_type}_job_{job_id}_logs.txt",
-                media_type="text/plain",
-            )
-        except Exception as e:
-            if os.path.exists(temp_file.name):
-                os.unlink(temp_file.name)
-            raise e
+            raise _no_logs_available_exception()
+        return _text_download_response(
+            log_text,
+            filename=f"{job_type}_job_{job_id}_logs.txt",
+        )
 
     if job_type not in job_models:
         raise HTTPException(
@@ -1086,6 +1171,17 @@ async def download_job_logs(
         raise HTTPException(
             status_code=400,
             detail={"key": "backend.errors.activity.cannotDownloadLogsForRunningJob"},
+        )
+
+    _ensure_activity_logs_visible(job_type, job, db)
+
+    if job_type == "package":
+        log_text = _format_package_install_logs(job)
+        if not log_text.strip():
+            raise _no_logs_available_exception()
+        return _text_download_response(
+            log_text,
+            filename=f"{job_type}_job_{job_id}_logs.txt",
         )
 
     # Try to get logs from log file first
@@ -1137,9 +1233,7 @@ async def download_job_logs(
                 raise e
 
     # No logs available
-    raise HTTPException(
-        status_code=404, detail={"key": "backend.errors.activity.noLogsAvailableForJob"}
-    )
+    raise _no_logs_available_exception()
 
 
 @router.delete("/{job_type}/{job_id}")

--- a/app/api/activity.py
+++ b/app/api/activity.py
@@ -627,7 +627,6 @@ async def list_recent_activity(
 
     # Fetch script executions
     if not job_type or job_type == "script_execution":
-        log_save_policy = get_log_save_policy(db)
         script_executions = (
             db.query(ScriptExecution)
             .order_by(ScriptExecution.started_at.desc())

--- a/app/api/backup_plans.py
+++ b/app/api/backup_plans.py
@@ -42,6 +42,7 @@ from app.services.check_flag_validation import (
     validate_check_flags_for_max_duration,
 )
 from app.services.backup_progress_contract import serialize_backup_progress_details
+from app.services.log_policy import get_log_save_policy, job_has_logs_by_policy
 from app.services.repository_executor import repository_executor_type
 from app.utils.datetime_utils import serialize_datetime
 from app.utils.schedule_time import (
@@ -539,7 +540,7 @@ def _serialize_plan(plan: BackupPlan, *, detail: bool = False) -> dict[str, Any]
 
 
 def _serialize_backup_job(
-    job: Optional[BackupJob], repo: Optional[Repository]
+    job: Optional[BackupJob], repo: Optional[Repository], *, log_save_policy: str
 ) -> Optional[dict[str, Any]]:
     if not job:
         return None
@@ -552,7 +553,12 @@ def _serialize_backup_job(
         "completed_at": serialize_datetime(job.completed_at),
         "progress": job.progress,
         "error_message": job.error_message,
-        "has_logs": bool(job.log_file_path or job.logs),
+        "has_logs": job_has_logs_by_policy(
+            job,
+            log_save_policy,
+            output_text=[job.logs, job.error_message],
+            file_path=job.log_file_path,
+        ),
         "maintenance_status": job.maintenance_status,
         "archive_name": job.archive_name,
         "execution_mode": job.execution_mode or "local",
@@ -566,7 +572,9 @@ def _serialize_backup_job(
     }
 
 
-def _serialize_plan_run_repository(link: BackupPlanRunRepository) -> dict[str, Any]:
+def _serialize_plan_run_repository(
+    link: BackupPlanRunRepository, *, log_save_policy: str
+) -> dict[str, Any]:
     repo = link.repository
     return {
         "id": link.id,
@@ -589,11 +597,17 @@ def _serialize_plan_run_repository(link: BackupPlanRunRepository) -> dict[str, A
         }
         if repo
         else None,
-        "backup_job": _serialize_backup_job(link.backup_job, repo),
+        "backup_job": _serialize_backup_job(
+            link.backup_job,
+            repo,
+            log_save_policy=log_save_policy,
+        ),
     }
 
 
-def _serialize_script_execution(execution: ScriptExecution) -> dict[str, Any]:
+def _serialize_script_execution(
+    execution: ScriptExecution, *, log_save_policy: str
+) -> dict[str, Any]:
     return {
         "id": execution.id,
         "script_id": execution.script_id,
@@ -607,13 +621,22 @@ def _serialize_script_execution(execution: ScriptExecution) -> dict[str, Any]:
         "execution_time": execution.execution_time,
         "exit_code": execution.exit_code,
         "error_message": execution.error_message,
-        "has_logs": bool(
-            execution.stdout or execution.stderr or execution.error_message
+        "has_logs": job_has_logs_by_policy(
+            execution,
+            log_save_policy,
+            output_text=[
+                execution.stdout,
+                execution.stderr,
+                execution.error_message,
+            ],
+            exit_code=execution.exit_code,
         ),
     }
 
 
-def _serialize_plan_run(run: BackupPlanRun, *, detail: bool = True) -> dict[str, Any]:
+def _serialize_plan_run(
+    run: BackupPlanRun, *, log_save_policy: str, detail: bool = True
+) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "id": run.id,
         "backup_plan_id": run.backup_plan_id,
@@ -631,11 +654,14 @@ def _serialize_plan_run(run: BackupPlanRun, *, detail: bool = True) -> dict[str,
     }
     if detail:
         payload["repositories"] = [
-            _serialize_plan_run_repository(link)
+            _serialize_plan_run_repository(link, log_save_policy=log_save_policy)
             for link in sorted(run.repositories, key=lambda item: item.id)
         ]
         payload["script_executions"] = [
-            _serialize_script_execution(execution)
+            _serialize_script_execution(
+                execution,
+                log_save_policy=log_save_policy,
+            )
             for execution in sorted(
                 run.script_executions,
                 key=lambda item: (item.started_at or datetime.min, item.id),
@@ -1191,7 +1217,12 @@ async def list_backup_plan_runs(
         .limit(limit)
         .all()
     )
-    return {"runs": [_serialize_plan_run(run) for run in runs]}
+    log_save_policy = get_log_save_policy(db)
+    return {
+        "runs": [
+            _serialize_plan_run(run, log_save_policy=log_save_policy) for run in runs
+        ]
+    }
 
 
 @router.get("/runs/{run_id}")
@@ -1208,7 +1239,7 @@ async def get_backup_plan_run(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail={"key": "backend.errors.auth.notEnoughPermissions"},
             )
-    return _serialize_plan_run(run)
+    return _serialize_plan_run(run, log_save_policy=get_log_save_policy(db))
 
 
 @router.post("/runs/{run_id}/cancel")
@@ -1229,7 +1260,7 @@ async def cancel_backup_plan_run(
     )
     return {
         "message": "backend.success.backupPlans.runCancelled",
-        "run": _serialize_plan_run(run),
+        "run": _serialize_plan_run(run, log_save_policy=get_log_save_policy(db)),
         **result,
     }
 
@@ -1263,7 +1294,7 @@ async def retry_backup_plan_run(
         retry_backup_plan_run_id=retry_run.id,
         user=current_user.username,
     )
-    return _serialize_plan_run(retry_run)
+    return _serialize_plan_run(retry_run, log_save_policy=get_log_save_policy(db))
 
 
 @router.post("/from-repository/{repo_id}", status_code=status.HTTP_201_CREATED)
@@ -1442,7 +1473,7 @@ async def run_backup_plan(
         backup_plan_run_id=run.id,
         user=current_user.username,
     )
-    return _serialize_plan_run(run)
+    return _serialize_plan_run(run, log_save_policy=get_log_save_policy(db))
 
 
 @router.get("/{plan_id}/runs")
@@ -1476,7 +1507,12 @@ async def list_backup_plan_runs_for_plan(
         .limit(limit)
         .all()
     )
-    return {"runs": [_serialize_plan_run(run) for run in runs]}
+    log_save_policy = get_log_save_policy(db)
+    return {
+        "runs": [
+            _serialize_plan_run(run, log_save_policy=log_save_policy) for run in runs
+        ]
+    }
 
 
 @router.post("/{plan_id}/toggle")

--- a/app/services/log_policy.py
+++ b/app/services/log_policy.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -96,6 +96,8 @@ def _text_parts(output_text: Any) -> list[str]:
         return []
     if isinstance(output_text, str):
         return [output_text]
+    if isinstance(output_text, Mapping):
+        return [str(part) for part in output_text.values() if part is not None]
     if isinstance(output_text, Iterable):
         return [str(part) for part in output_text if part is not None]
     return [str(output_text)]

--- a/app/services/log_policy.py
+++ b/app/services/log_policy.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.database.models import SystemSettings
+
+DEFAULT_LOG_SAVE_POLICY = "failed_and_warnings"
+LOG_SAVE_POLICIES = {"failed_only", "failed_and_warnings", "all_jobs"}
+PENDING_STATUSES = {"pending", "queued", "scheduled"}
+RUNNING_STATUSES = {"running", "installing", "in_progress"}
+FAILED_STATUSES = {"failed", "cancelled", "canceled"}
+WARNING_STATUSES = {"completed_with_warnings"}
+WARNING_MARKERS = ("warning", "error")
+
+
+def get_log_save_policy(db: Session) -> str:
+    settings = db.query(SystemSettings).first()
+    policy = getattr(settings, "log_save_policy", None) if settings else None
+    return policy if policy in LOG_SAVE_POLICIES else DEFAULT_LOG_SAVE_POLICY
+
+
+def job_has_logs_by_policy(
+    job: Any,
+    log_save_policy: str,
+    output_text: Any = None,
+    file_path: str | None = None,
+    status: str | None = None,
+    exit_code: int | str | None = None,
+) -> bool:
+    job_status = _normalize_status(
+        status if status is not None else getattr(job, "status", None)
+    )
+    if job_status in PENDING_STATUSES:
+        return False
+
+    resolved_exit_code = exit_code
+    if resolved_exit_code is None:
+        resolved_exit_code = getattr(job, "exit_code", None)
+
+    has_source = _has_log_source(output_text=output_text, file_path=file_path)
+    is_log_capable = job is not None
+    if job_status in RUNNING_STATUSES:
+        return has_source or is_log_capable
+
+    policy = (
+        log_save_policy
+        if log_save_policy in LOG_SAVE_POLICIES
+        else DEFAULT_LOG_SAVE_POLICY
+    )
+    has_failed = job_status in FAILED_STATUSES or _is_nonzero_exit(resolved_exit_code)
+
+    if policy == "failed_only":
+        return has_failed
+    if policy == "failed_and_warnings":
+        return (
+            has_failed
+            or job_status in WARNING_STATUSES
+            or _has_warning_or_error_output(output_text)
+        )
+    if policy == "all_jobs":
+        return has_source or is_log_capable
+
+    return False
+
+
+def _normalize_status(status: Any) -> str:
+    return str(status or "").strip().lower()
+
+
+def _is_nonzero_exit(exit_code: int | str | None) -> bool:
+    if exit_code in (None, ""):
+        return False
+    try:
+        return int(exit_code) != 0
+    except (TypeError, ValueError):
+        return True
+
+
+def _has_log_source(*, output_text: Any, file_path: str | None) -> bool:
+    return bool(file_path) or any(part.strip() for part in _text_parts(output_text))
+
+
+def _has_warning_or_error_output(output_text: Any) -> bool:
+    haystack = "\n".join(_text_parts(output_text)).lower()
+    return any(marker in haystack for marker in WARNING_MARKERS)
+
+
+def _text_parts(output_text: Any) -> list[str]:
+    if output_text is None:
+        return []
+    if isinstance(output_text, str):
+        return [output_text]
+    if isinstance(output_text, Iterable):
+        return [str(part) for part in output_text if part is not None]
+    return [str(output_text)]

--- a/docs/engineering/plans/2026-06-05-activity-log-policy.md
+++ b/docs/engineering/plans/2026-06-05-activity-log-policy.md
@@ -1,0 +1,116 @@
+# Activity Log Policy Implementation Plan
+
+> **For agentic workers:** Use the repository execution workflow and keep the
+> Linear workpad checklist in sync while implementing this plan.
+
+**Goal:** Make Activity and backup-plan run `has_logs` serialization honor
+`SystemSettings.log_save_policy` consistently across supported job types.
+
+**Architecture:** Add a small shared policy service that reads the configured
+policy once and exposes one helper for job log visibility. Serializers pass each
+job's status, exit code, output text, and file-backed log source into that helper
+instead of duplicating boolean checks.
+
+**Tech Stack:** FastAPI, SQLAlchemy models, pytest, Ruff.
+
+---
+
+## File Map
+
+- Create: `app/services/log_policy.py`
+  - Owns `get_log_save_policy(db)` and `job_has_logs_by_policy(...)`.
+  - Encodes `all_jobs`, `failed_only`, and `failed_and_warnings` behavior.
+- Modify: `app/api/activity.py`
+  - Imports the shared helpers.
+  - Reads `log_save_policy` once in `list_recent_activity`.
+  - Replaces `has_logs` checks for backup, restore, check, restore_check,
+    compact, prune, package, script_execution, rclone_sync, and rclone_hydrate.
+- Modify: `app/api/backup_plans.py`
+  - Imports the shared helpers.
+  - Applies the helper to serialized backup jobs and script executions in plan
+    run detail responses.
+- Modify: `tests/unit/test_api_activity.py`
+  - Adds policy matrix coverage for persisted-log, file-backed, script, and
+    rclone representative rows.
+- Modify: `tests/unit/test_api_backup_plans.py`
+  - Adds/updates plan-run coverage for backup job and script execution rows.
+
+## Tasks
+
+### Task 1: Reproduce Current Policy Mismatch
+
+- [ ] Add failing tests in `tests/unit/test_api_activity.py` that seed
+      `SystemSettings.log_save_policy` and assert:
+  - quiet successful backup with DB `logs` is hidden under `failed_only`;
+  - quiet successful file-backed check is hidden under `failed_and_warnings`;
+  - quiet successful file-backed check is visible under `all_jobs`;
+  - failed restore/rclone/script examples are visible under all policies;
+  - warning/error output is visible under `failed_and_warnings`.
+- [ ] Add failing tests in `tests/unit/test_api_backup_plans.py` for plan-run
+      backup/script `has_logs` serialization under the same policy helper.
+- [ ] Run the narrow failing tests and record the output in the Linear workpad.
+
+### Task 2: Add Shared Log Policy Helper
+
+- [ ] Create `app/services/log_policy.py`.
+- [ ] Implement `get_log_save_policy(db)` using `SystemSettings`, defaulting to
+      `failed_and_warnings` when the row or value is absent.
+- [ ] Implement `job_has_logs_by_policy(job, log_save_policy, output_text=None,
+      file_path=None, status=None, exit_code=None)` with these rules:
+  - pending jobs return `False`;
+  - running jobs return `True` when a log source exists or the job type is
+    log-capable;
+  - `all_jobs` returns `True` for non-pending jobs with a source or a
+    log-capable job object;
+  - `failed_only` returns `True` only for failed, cancelled, or non-zero jobs;
+  - `failed_and_warnings` returns `True` for failed/cancelled/non-zero jobs or
+    output/error text containing warning/error signals.
+
+### Task 3: Wire Activity Serialization
+
+- [ ] Import `get_log_save_policy` and `job_has_logs_by_policy` in
+      `app/api/activity.py`.
+- [ ] Fetch `log_save_policy = get_log_save_policy(db)` once near the top of
+      `list_recent_activity`.
+- [ ] For each job type, pass the ticket-specified sources:
+  - backup: `job.log_file_path`, `job.logs`, `job.error_message`;
+  - restore: `job.logs`, `job.error_message`;
+  - check/restore_check/compact/prune: `job.log_file_path`, `job.logs`,
+    `job.error_message`;
+  - package: `job.log_file_path`, `job.stdout`, `job.stderr`,
+    `job.error_message`;
+  - script_execution: `stdout`, `stderr`, `error_message`, `exit_code`;
+  - rclone: `log_path`, `log_text`, `error_text`.
+
+### Task 4: Wire Backup-Plan Run Serialization
+
+- [ ] Import the shared helpers in `app/api/backup_plans.py`.
+- [ ] Add a private serializer helper or optional argument so the plan-run
+      response can pass a single `log_save_policy` through backup job and script
+      execution serialization.
+- [ ] Keep response shape unchanged except for policy-correct `has_logs`.
+
+### Task 5: Validate and Handoff
+
+- [ ] Run:
+      `python -m pytest tests/unit/test_api_activity.py tests/unit/test_api_backup_plans.py -q`
+- [ ] Run:
+      `python -m pytest tests/unit/test_source_discovery.py -q`
+- [ ] Run:
+      `ruff check app/services/log_policy.py app/api/activity.py app/api/backup_plans.py tests/unit/test_api_activity.py tests/unit/test_api_backup_plans.py`
+- [ ] Run:
+      `ruff format --check app/services/log_policy.py app/api/activity.py app/api/backup_plans.py tests/unit/test_api_activity.py tests/unit/test_api_backup_plans.py`
+- [ ] Skip frontend checks unless the backend response shape or UI behavior
+      contract changes.
+- [ ] Record validation evidence in the Linear workpad, commit, push, create or
+      update the PR, attach it to Linear, apply the `symphony` PR label, run the
+      PR feedback sweep, and move the issue to `Human Review` only after checks
+      are green.
+
+## Self-Review
+
+- Spec coverage: all requested job types, policy modes, backup-plan run
+  serialization, running/pending behavior, and validation commands are covered.
+- Placeholder scan: no implementation placeholders remain in this plan.
+- Type consistency: the planned helper arguments match the existing model fields
+  found in `app/api/activity.py` and `app/api/backup_plans.py`.

--- a/tests/unit/test_api_activity.py
+++ b/tests/unit/test_api_activity.py
@@ -328,9 +328,9 @@ class TestRecentActivityEndpoint:
     def test_recent_activity_marks_quiet_script_executions_loggable_for_all_jobs_policy(
         self, test_client, admin_headers, test_db
     ):
-        from app.database.models import Script, ScriptExecution, SystemSettings
+        from app.database.models import Script, ScriptExecution
 
-        test_db.add(SystemSettings(log_save_policy="all_jobs"))
+        _set_log_save_policy(test_db, "all_jobs")
         script = Script(
             name="Clean Docker export",
             file_path="library/clean-docker-export.sh",
@@ -368,9 +368,9 @@ class TestRecentActivityEndpoint:
     def test_recent_activity_hides_quiet_script_logs_when_policy_skips_success(
         self, test_client, admin_headers, test_db
     ):
-        from app.database.models import Script, ScriptExecution, SystemSettings
+        from app.database.models import Script, ScriptExecution
 
-        test_db.add(SystemSettings(log_save_policy="failed_only"))
+        _set_log_save_policy(test_db, "failed_only")
         script = Script(
             name="Clean Docker export",
             file_path="library/clean-docker-export.sh",

--- a/tests/unit/test_api_activity.py
+++ b/tests/unit/test_api_activity.py
@@ -596,6 +596,25 @@ class TestRecentActivityEndpoint:
 class TestRecentActivityLogPolicy:
     """Test Activity has_logs serialization against SystemSettings.log_save_policy."""
 
+    def test_mapping_output_uses_values_for_warning_detection(self):
+        from types import SimpleNamespace
+
+        from app.services.log_policy import job_has_logs_by_policy
+
+        job = SimpleNamespace(status="completed")
+
+        assert (
+            job_has_logs_by_policy(
+                job,
+                "failed_and_warnings",
+                output_text={
+                    "stdout": "completed successfully",
+                    "stderr": "WARNING: skipped one optional file",
+                },
+            )
+            is True
+        )
+
     def test_quiet_successful_backup_db_logs_hidden_under_failed_only(
         self, test_client, admin_headers, test_db
     ):

--- a/tests/unit/test_api_activity.py
+++ b/tests/unit/test_api_activity.py
@@ -6,6 +6,33 @@ import pytest
 from datetime import datetime, timedelta
 
 
+def _set_log_save_policy(test_db, policy: str) -> None:
+    from app.database.models import SystemSettings
+
+    settings = test_db.query(SystemSettings).first()
+    if settings is None:
+        settings = SystemSettings()
+        test_db.add(settings)
+    settings.log_save_policy = policy
+    test_db.commit()
+
+
+def _create_activity_repository(test_db, name: str = "Policy Repo"):
+    from app.database.models import Repository
+
+    repo = Repository(
+        name=name,
+        path=f"/tmp/{name.lower().replace(' ', '-')}",
+        encryption="none",
+        compression="lz4",
+        repository_type="local",
+    )
+    test_db.add(repo)
+    test_db.commit()
+    test_db.refresh(repo)
+    return repo
+
+
 class TestBackupServiceLogBuffer:
     """Test BackupService log buffer methods"""
 
@@ -124,6 +151,7 @@ class TestRecentActivityEndpoint:
             ScheduledJob,
         )
 
+        _set_log_save_policy(test_db, "all_jobs")
         base = datetime(2024, 1, 1, 12, 0, 0)
         repository = Repository(
             name="Activity Repo",
@@ -302,6 +330,7 @@ class TestRecentActivityEndpoint:
     ):
         from app.database.models import Repository, RcloneSyncJob
 
+        _set_log_save_policy(test_db, "all_jobs")
         repository = Repository(
             name="Cloud File Logs Repo",
             path="/tmp/cloud-file-logs-repo",
@@ -481,6 +510,294 @@ class TestRecentActivityEndpoint:
         assert activity[0]["id"] == completed_job.id
         assert activity[0]["status"] == "completed"
         assert activity[0]["type"] == "backup"
+
+
+@pytest.mark.unit
+class TestRecentActivityLogPolicy:
+    """Test Activity has_logs serialization against SystemSettings.log_save_policy."""
+
+    def test_quiet_successful_backup_db_logs_hidden_under_failed_only(
+        self, test_client, admin_headers, test_db
+    ):
+        from app.database.models import BackupJob
+
+        _set_log_save_policy(test_db, "failed_only")
+        repo = _create_activity_repository(test_db, "Policy Backup Repo")
+        job = BackupJob(
+            repository=repo.path,
+            repository_id=repo.id,
+            status="completed",
+            started_at=datetime.now(),
+            completed_at=datetime.now(),
+            logs="quiet successful transcript",
+        )
+        test_db.add(job)
+        test_db.commit()
+
+        response = test_client.get(
+            "/api/activity/recent?job_type=backup", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        activity = response.json()
+        assert activity[0]["id"] == job.id
+        assert activity[0]["has_logs"] is False
+
+    def test_quiet_successful_file_backed_check_hidden_under_failed_and_warnings(
+        self, test_client, admin_headers, test_db
+    ):
+        from app.database.models import CheckJob
+
+        _set_log_save_policy(test_db, "failed_and_warnings")
+        repo = _create_activity_repository(test_db, "Policy Check Repo")
+        job = CheckJob(
+            repository_id=repo.id,
+            repository_path=repo.path,
+            status="completed",
+            started_at=datetime.now(),
+            completed_at=datetime.now(),
+            log_file_path="/tmp/check-policy.log",
+        )
+        test_db.add(job)
+        test_db.commit()
+
+        response = test_client.get(
+            "/api/activity/recent?job_type=check", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        activity = response.json()
+        assert activity[0]["id"] == job.id
+        assert activity[0]["has_logs"] is False
+
+    def test_quiet_successful_file_backed_check_visible_under_all_jobs(
+        self, test_client, admin_headers, test_db
+    ):
+        from app.database.models import CheckJob
+
+        _set_log_save_policy(test_db, "all_jobs")
+        repo = _create_activity_repository(test_db, "All Jobs Check Repo")
+        job = CheckJob(
+            repository_id=repo.id,
+            repository_path=repo.path,
+            status="completed",
+            started_at=datetime.now(),
+            completed_at=datetime.now(),
+            log_file_path="/tmp/check-all-jobs.log",
+        )
+        test_db.add(job)
+        test_db.commit()
+
+        response = test_client.get(
+            "/api/activity/recent?job_type=check", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        activity = response.json()
+        assert activity[0]["id"] == job.id
+        assert activity[0]["has_logs"] is True
+
+    @pytest.mark.parametrize(
+        "policy", ["failed_only", "failed_and_warnings", "all_jobs"]
+    )
+    def test_failed_restore_visible_under_all_policies(
+        self, test_client, admin_headers, test_db, policy
+    ):
+        from app.database.models import RestoreJob
+
+        _set_log_save_policy(test_db, policy)
+        repo = _create_activity_repository(test_db, f"Failed Restore {policy}")
+        job = RestoreJob(
+            repository=repo.path,
+            archive="archive-1",
+            destination="/restore",
+            status="failed",
+            started_at=datetime.now(),
+            completed_at=datetime.now(),
+            error_message="restore failed",
+        )
+        test_db.add(job)
+        test_db.commit()
+
+        response = test_client.get(
+            "/api/activity/recent?job_type=restore", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        activity = response.json()
+        assert activity[0]["id"] == job.id
+        assert activity[0]["has_logs"] is True
+
+    def test_quiet_successful_script_hidden_but_warning_visible_under_failed_and_warnings(
+        self, test_client, admin_headers, test_db
+    ):
+        from app.database.models import Script, ScriptExecution
+
+        _set_log_save_policy(test_db, "failed_and_warnings")
+        quiet_script = Script(
+            name="Quiet Policy Script",
+            file_path="library/quiet-policy.sh",
+            category="custom",
+            timeout=300,
+        )
+        warning_script = Script(
+            name="Warning Policy Script",
+            file_path="library/warning-policy.sh",
+            category="custom",
+            timeout=300,
+        )
+        test_db.add_all([quiet_script, warning_script])
+        test_db.flush()
+        quiet_execution = ScriptExecution(
+            script_id=quiet_script.id,
+            hook_type="standalone",
+            status="completed",
+            started_at=datetime(2024, 1, 1, 10, 0, 0),
+            completed_at=datetime(2024, 1, 1, 10, 0, 1),
+            exit_code=0,
+            stdout="completed successfully",
+            stderr="",
+            triggered_by="manual",
+        )
+        warning_execution = ScriptExecution(
+            script_id=warning_script.id,
+            hook_type="standalone",
+            status="completed",
+            started_at=datetime(2024, 1, 1, 10, 1, 0),
+            completed_at=datetime(2024, 1, 1, 10, 1, 1),
+            exit_code=0,
+            stdout="completed with warning",
+            stderr="WARNING: disk almost full",
+            triggered_by="manual",
+        )
+        test_db.add_all([quiet_execution, warning_execution])
+        test_db.commit()
+
+        response = test_client.get(
+            "/api/activity/recent?job_type=script_execution", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        activity = response.json()
+        rows = {row["id"]: row for row in activity}
+        assert rows[quiet_execution.id]["has_logs"] is False
+        assert rows[warning_execution.id]["has_logs"] is True
+
+    def test_warning_package_output_visible_under_failed_and_warnings(
+        self, test_client, admin_headers, test_db
+    ):
+        from app.database.models import InstalledPackage, PackageInstallJob
+
+        _set_log_save_policy(test_db, "failed_and_warnings")
+        package = InstalledPackage(
+            name="policy-package",
+            install_command="apt-get install -y policy-package",
+            status="installed",
+        )
+        test_db.add(package)
+        test_db.flush()
+        job = PackageInstallJob(
+            package_id=package.id,
+            status="completed",
+            started_at=datetime.now(),
+            completed_at=datetime.now(),
+            exit_code=0,
+            stdout="WARNING: package already installed",
+        )
+        test_db.add(job)
+        test_db.commit()
+
+        response = test_client.get(
+            "/api/activity/recent?job_type=package", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        activity = response.json()
+        assert activity[0]["id"] == job.id
+        assert activity[0]["has_logs"] is True
+
+    def test_quiet_successful_rclone_logs_hidden_under_failed_only(
+        self, test_client, admin_headers, test_db
+    ):
+        from app.database.models import RcloneSyncJob
+
+        _set_log_save_policy(test_db, "failed_only")
+        repo = _create_activity_repository(test_db, "Policy Rclone Repo")
+        job = RcloneSyncJob(
+            repository_id=repo.id,
+            direction="primary_to_remote",
+            operation="sync",
+            status="completed",
+            triggered_by="manual",
+            started_at=datetime.now(),
+            completed_at=datetime.now(),
+            log_text="sync completed quietly",
+        )
+        test_db.add(job)
+        test_db.commit()
+
+        response = test_client.get(
+            "/api/activity/recent?job_type=rclone_sync", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        activity = response.json()
+        assert activity[0]["id"] == job.id
+        assert activity[0]["has_logs"] is False
+
+    def test_running_log_capable_rclone_visible_under_failed_only(
+        self, test_client, admin_headers, test_db
+    ):
+        from app.database.models import RcloneSyncJob
+
+        _set_log_save_policy(test_db, "failed_only")
+        repo = _create_activity_repository(test_db, "Running Rclone Repo")
+        job = RcloneSyncJob(
+            repository_id=repo.id,
+            direction="primary_to_remote",
+            operation="sync",
+            status="running",
+            triggered_by="manual",
+            started_at=datetime.now(),
+            log_path="/tmp/rclone-running.log",
+        )
+        test_db.add(job)
+        test_db.commit()
+
+        response = test_client.get(
+            "/api/activity/recent?job_type=rclone_sync", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        activity = response.json()
+        assert activity[0]["id"] == job.id
+        assert activity[0]["has_logs"] is True
+
+    def test_pending_log_capable_check_hidden_under_all_jobs(
+        self, test_client, admin_headers, test_db
+    ):
+        from app.database.models import CheckJob
+
+        _set_log_save_policy(test_db, "all_jobs")
+        repo = _create_activity_repository(test_db, "Pending Policy Check Repo")
+        job = CheckJob(
+            repository_id=repo.id,
+            repository_path=repo.path,
+            status="pending",
+            started_at=None,
+            log_file_path="/tmp/check-pending.log",
+        )
+        test_db.add(job)
+        test_db.commit()
+
+        response = test_client.get(
+            "/api/activity/recent?job_type=check", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        activity = response.json()
+        assert activity[0]["id"] == job.id
+        assert activity[0]["has_logs"] is False
 
 
 @pytest.mark.unit

--- a/tests/unit/test_api_activity.py
+++ b/tests/unit/test_api_activity.py
@@ -919,6 +919,7 @@ class TestActivityLogContracts:
     ):
         from app.database.models import BackupJob
 
+        _set_log_save_policy(test_db, "all_jobs")
         log_file = tmp_path / "activity-log.txt"
         log_file.write_text("line-1\nline-2\nline-3\nline-4\n")
 
@@ -944,6 +945,66 @@ class TestActivityLogContracts:
         assert payload["has_more"] is True
         assert [line["content"] for line in payload["lines"]] == ["line-2", "line-3"]
         assert [line["line_number"] for line in payload["lines"]] == [2, 3]
+
+    def test_get_job_logs_hides_successful_file_logs_when_policy_skips_success(
+        self, test_client, admin_headers, test_db, tmp_path
+    ):
+        from app.database.models import BackupJob
+
+        _set_log_save_policy(test_db, "failed_only")
+        log_file = tmp_path / "hidden-success.log"
+        log_file.write_text("successful backup log\n", encoding="utf-8")
+        job = BackupJob(
+            repository="/tmp/repo",
+            status="completed",
+            started_at=datetime.now(),
+            completed_at=datetime.now(),
+            log_file_path=str(log_file),
+        )
+        test_db.add(job)
+        test_db.commit()
+        test_db.refresh(job)
+
+        response = test_client.get(
+            f"/api/activity/backup/{job.id}/logs",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 404
+        assert (
+            response.json()["detail"]["key"]
+            == "backend.errors.activity.noLogsAvailableForJob"
+        )
+
+    def test_download_job_logs_hides_successful_file_logs_when_policy_skips_success(
+        self, test_client, admin_headers, test_db, tmp_path
+    ):
+        from app.database.models import BackupJob
+
+        _set_log_save_policy(test_db, "failed_only")
+        log_file = tmp_path / "hidden-download.log"
+        log_file.write_text("successful backup log\n", encoding="utf-8")
+        job = BackupJob(
+            repository="/tmp/repo",
+            status="completed",
+            started_at=datetime.now(),
+            completed_at=datetime.now(),
+            log_file_path=str(log_file),
+        )
+        test_db.add(job)
+        test_db.commit()
+        test_db.refresh(job)
+
+        response = test_client.get(
+            f"/api/activity/backup/{job.id}/logs/download",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 404
+        assert (
+            response.json()["detail"]["key"]
+            == "backend.errors.activity.noLogsAvailableForJob"
+        )
 
     def test_download_job_logs_without_logs_returns_404(
         self, test_client, admin_headers, test_db
@@ -976,6 +1037,7 @@ class TestActivityLogContracts:
     ):
         from app.database.models import BackupJob
 
+        _set_log_save_policy(test_db, "all_jobs")
         job = BackupJob(
             repository="/tmp/repo",
             status="completed",
@@ -1039,11 +1101,124 @@ class TestActivityLogContracts:
         assert "stderr line" in contents
         assert "script failed" in contents
 
+    def test_get_script_execution_logs_hides_quiet_success_under_failed_only(
+        self, test_client, admin_headers, test_db
+    ):
+        from app.database.models import Script, ScriptExecution
+
+        _set_log_save_policy(test_db, "failed_only")
+        script = Script(
+            name="Quiet Script",
+            file_path="library/quiet.sh",
+            category="custom",
+            timeout=300,
+        )
+        test_db.add(script)
+        test_db.flush()
+        execution = ScriptExecution(
+            script_id=script.id,
+            hook_type="pre-backup",
+            status="completed",
+            started_at=datetime.now(),
+            completed_at=datetime.now(),
+            exit_code=0,
+            stdout="",
+            stderr="",
+            triggered_by="backup_plan",
+        )
+        test_db.add(execution)
+        test_db.commit()
+        test_db.refresh(execution)
+
+        response = test_client.get(
+            f"/api/activity/script_execution/{execution.id}/logs",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 404
+        assert (
+            response.json()["detail"]["key"]
+            == "backend.errors.activity.noLogsAvailableForJob"
+        )
+
+    def test_get_package_job_logs_allows_warning_output_under_warning_policy(
+        self, test_client, admin_headers, test_db
+    ):
+        from app.database.models import InstalledPackage, PackageInstallJob
+
+        _set_log_save_policy(test_db, "failed_and_warnings")
+        package = InstalledPackage(
+            name="restic",
+            install_command="apt-get install -y restic",
+            status="installed",
+        )
+        test_db.add(package)
+        test_db.flush()
+        job = PackageInstallJob(
+            package_id=package.id,
+            status="completed",
+            started_at=datetime.now(),
+            completed_at=datetime.now(),
+            exit_code=0,
+            stdout="WARNING: package already installed",
+            stderr="",
+        )
+        test_db.add(job)
+        test_db.commit()
+        test_db.refresh(job)
+
+        response = test_client.get(
+            f"/api/activity/package/{job.id}/logs",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        contents = [line["content"] for line in response.json()["lines"]]
+        assert "WARNING: package already installed" in contents
+
+    def test_download_package_job_logs_hides_quiet_success_under_warning_policy(
+        self, test_client, admin_headers, test_db
+    ):
+        from app.database.models import InstalledPackage, PackageInstallJob
+
+        _set_log_save_policy(test_db, "failed_and_warnings")
+        package = InstalledPackage(
+            name="borgmatic",
+            install_command="apt-get install -y borgmatic",
+            status="installed",
+        )
+        test_db.add(package)
+        test_db.flush()
+        job = PackageInstallJob(
+            package_id=package.id,
+            status="completed",
+            started_at=datetime.now(),
+            completed_at=datetime.now(),
+            exit_code=0,
+            stdout="installed cleanly",
+            stderr="",
+        )
+        test_db.add(job)
+        test_db.commit()
+        test_db.refresh(job)
+
+        response = test_client.get(
+            f"/api/activity/package/{job.id}/logs/download",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 404
+        assert (
+            response.json()["detail"]["key"]
+            == "backend.errors.activity.noLogsAvailableForJob"
+        )
+
     def test_get_restore_check_job_logs_uses_activity_log_contract(
         self, test_client, admin_headers, test_db
     ):
         from app.database.models import Repository, RestoreCheckJob
 
+        _set_log_save_policy(test_db, "all_jobs")
         repository = Repository(
             name="Restore Check Repo",
             path="/tmp/restore-check-repo",
@@ -1117,11 +1292,52 @@ class TestActivityLogContracts:
         assert payload["has_more"] is True
         assert payload["lines"][0]["content"] == "sync line 2"
 
+    def test_get_rclone_job_logs_hides_quiet_success_under_failed_only(
+        self, test_client, admin_headers, test_db
+    ):
+        from app.database.models import Repository, RcloneSyncJob
+
+        _set_log_save_policy(test_db, "failed_only")
+        repository = Repository(
+            name="Cloud Hidden Logs Repo",
+            path="/tmp/cloud-hidden-logs-repo",
+            encryption="none",
+            repository_type="local",
+        )
+        test_db.add(repository)
+        test_db.commit()
+        test_db.refresh(repository)
+        job = RcloneSyncJob(
+            repository_id=repository.id,
+            direction="primary_to_remote",
+            operation="sync",
+            status="completed",
+            triggered_by="initial",
+            started_at=datetime.now(),
+            completed_at=datetime.now(),
+            log_text="sync completed quietly",
+        )
+        test_db.add(job)
+        test_db.commit()
+        test_db.refresh(job)
+
+        response = test_client.get(
+            f"/api/activity/rclone_sync/{job.id}/logs",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 404
+        assert (
+            response.json()["detail"]["key"]
+            == "backend.errors.activity.noLogsAvailableForJob"
+        )
+
     def test_download_rclone_hydrate_job_logs_uses_database_text(
         self, test_client, admin_headers, test_db
     ):
         from app.database.models import Repository, RcloneSyncJob
 
+        _set_log_save_policy(test_db, "all_jobs")
         repository = Repository(
             name="Cloud Hydrate Logs Repo",
             path="/tmp/cloud-hydrate-logs-repo",
@@ -1153,6 +1369,53 @@ class TestActivityLogContracts:
         assert response.status_code == 200
         assert "text/plain" in response.headers.get("content-type", "")
         assert response.content.decode() == "hydrated repository"
+
+    def test_get_agent_backup_logs_hides_success_under_failed_only(
+        self, test_client, admin_headers, test_db
+    ):
+        from app.database.models import AgentJob, AgentJobLog, BackupJob
+
+        _set_log_save_policy(test_db, "failed_only")
+        backup_job = BackupJob(
+            repository="/tmp/repo",
+            status="completed",
+            started_at=datetime.now(),
+            completed_at=datetime.now(),
+            execution_mode="agent",
+        )
+        test_db.add(backup_job)
+        test_db.flush()
+        agent_job = AgentJob(
+            agent_machine_id=1,
+            backup_job_id=backup_job.id,
+            job_type="backup",
+            status="completed",
+            payload={},
+        )
+        test_db.add(agent_job)
+        test_db.flush()
+        test_db.add(
+            AgentJobLog(
+                agent_job_id=agent_job.id,
+                sequence=1,
+                stream="stdout",
+                message="agent backup completed",
+                created_at=datetime.now(),
+            )
+        )
+        test_db.commit()
+        test_db.refresh(backup_job)
+
+        response = test_client.get(
+            f"/api/activity/backup/{backup_job.id}/logs",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 404
+        assert (
+            response.json()["detail"]["key"]
+            == "backend.errors.activity.noLogsAvailableForJob"
+        )
 
     def test_delete_rclone_sync_job_removes_log_path(
         self, test_client, admin_headers, test_db, tmp_path

--- a/tests/unit/test_api_backup.py
+++ b/tests/unit/test_api_backup.py
@@ -36,6 +36,15 @@ def _close_background_task(coro):
     return None
 
 
+def _set_log_save_policy(test_db, policy: str) -> None:
+    settings = test_db.query(SystemSettings).first()
+    if settings is None:
+        settings = SystemSettings()
+        test_db.add(settings)
+    settings.log_save_policy = policy
+    test_db.flush()
+
+
 @pytest.mark.unit
 class TestBackupStart:
     """Test starting backup operations"""
@@ -572,6 +581,7 @@ class TestBackupStart:
     def test_agent_completion_updates_linked_backup_job(
         self, test_client: TestClient, admin_headers, test_db
     ):
+        _set_log_save_policy(test_db, "all_jobs")
         raw_token = "borgui_agent_secret"
         agent = AgentMachine(
             name="Laptop",

--- a/tests/unit/test_api_backup_plans.py
+++ b/tests/unit/test_api_backup_plans.py
@@ -28,6 +28,7 @@ from app.database.models import (
     ScheduledJob,
     ScheduledJobRepository,
     SSHConnection,
+    SystemSettings,
     UserRepositoryPermission,
 )
 from app.core.security import get_password_hash
@@ -85,6 +86,15 @@ def _create_script(test_db, name: str, **kwargs) -> Script:
     test_db.commit()
     test_db.refresh(script)
     return script
+
+
+def _set_log_save_policy(test_db, policy: str) -> None:
+    settings_row = test_db.query(SystemSettings).first()
+    if settings_row is None:
+        settings_row = SystemSettings()
+        test_db.add(settings_row)
+    settings_row.log_save_policy = policy
+    test_db.commit()
 
 
 def _set_plan(test_db, plan: str) -> None:
@@ -737,6 +747,74 @@ class TestBackupPlanRoutes:
         assert row["has_logs"] is True
         assert row["started_at"]
         assert row["completed_at"]
+
+    def test_run_response_hides_quiet_backup_logs_under_failed_only(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        _set_log_save_policy(test_db, "failed_only")
+        repo = _create_repo(test_db, "Primary", "/repos/primary")
+        _plan, run = _create_execution_plan(test_db, [repo])
+        backup_job = BackupJob(
+            repository=repo.path,
+            repository_id=repo.id,
+            backup_plan_run_id=run.id,
+            status="completed",
+            started_at=datetime.utcnow(),
+            completed_at=datetime.utcnow(),
+            logs="quiet successful transcript",
+        )
+        test_db.add(backup_job)
+        test_db.flush()
+        run_repo = (
+            test_db.query(BackupPlanRunRepository)
+            .filter_by(backup_plan_run_id=run.id, repository_id=repo.id)
+            .one()
+        )
+        run_repo.status = "completed"
+        run_repo.backup_job_id = backup_job.id
+        test_db.commit()
+
+        response = test_client.get(
+            f"/api/backup-plans/runs/{run.id}", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        backup_row = response.json()["repositories"][0]["backup_job"]
+        assert backup_row["id"] == backup_job.id
+        assert backup_row["has_logs"] is False
+
+    def test_run_response_applies_log_policy_to_quiet_script_execution(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        _set_log_save_policy(test_db, "failed_and_warnings")
+        repo = _create_repo(test_db, "Primary", "/repos/primary")
+        script = _create_script(test_db, "Quiet Source Prepare")
+        plan, run = _create_execution_plan(test_db, [repo])
+        execution = ScriptExecution(
+            script_id=script.id,
+            backup_plan_id=plan.id,
+            backup_plan_run_id=run.id,
+            hook_type="pre-backup",
+            status="completed",
+            started_at=datetime.utcnow(),
+            completed_at=datetime.utcnow(),
+            execution_time=1.25,
+            exit_code=0,
+            stdout="completed successfully",
+            stderr="",
+            triggered_by="backup_plan",
+        )
+        test_db.add(execution)
+        test_db.commit()
+
+        response = test_client.get(
+            f"/api/backup-plans/runs/{run.id}", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        row = response.json()["script_executions"][0]
+        assert row["id"] == execution.id
+        assert row["has_logs"] is False
 
     def test_create_plan_supports_remote_source(
         self, test_client: TestClient, admin_headers, test_db


### PR DESCRIPTION
## Description
Apply `SystemSettings.log_save_policy` consistently to Activity log visibility. This adds shared log-policy helpers, routes Activity and backup-plan run `has_logs` serialization through them, and enforces the same policy on direct Activity log view/download endpoints for backup, restore, check, restore-check, compact, prune, package, script execution, rclone sync, and rclone hydrate jobs.

The review update also prevents successful file-backed and agent-backed Activity logs from bypassing `failed_only` or `failed_and_warnings` policy through `/api/activity/{job_type}/{job_id}/logs` and `/api/activity/{job_type}/{job_id}/logs/download`, while preserving running-job live log access.

## Related Issue
Linear: https://linear.app/nullcodeai/issue/BOR-150/apply-log-save-policy-to-activity-log-visibility

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [x] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `.venv/bin/python -m pytest tests/unit/test_api_activity.py::TestRecentActivityLogPolicy::test_mapping_output_uses_values_for_warning_detection -q` (`1 passed, 4 warnings`)
- `.venv/bin/python -m pytest tests/unit/test_api_activity.py::TestRecentActivityEndpoint::test_recent_activity_marks_quiet_script_executions_loggable_for_all_jobs_policy tests/unit/test_api_activity.py::TestRecentActivityEndpoint::test_recent_activity_hides_quiet_script_logs_when_policy_skips_success -q` (`2 passed, 36 warnings`)
- `.venv/bin/python -m pytest tests/unit/test_api_activity.py::TestActivityLogContracts::test_get_job_logs_hides_successful_file_logs_when_policy_skips_success tests/unit/test_api_activity.py::TestActivityLogContracts::test_download_job_logs_hides_successful_file_logs_when_policy_skips_success tests/unit/test_api_activity.py::TestActivityLogContracts::test_get_script_execution_logs_hides_quiet_success_under_failed_only tests/unit/test_api_activity.py::TestActivityLogContracts::test_get_package_job_logs_allows_warning_output_under_warning_policy tests/unit/test_api_activity.py::TestActivityLogContracts::test_download_package_job_logs_hides_quiet_success_under_warning_policy tests/unit/test_api_activity.py::TestActivityLogContracts::test_get_rclone_job_logs_hides_quiet_success_under_failed_only tests/unit/test_api_activity.py::TestActivityLogContracts::test_get_agent_backup_logs_hides_success_under_failed_only -q` (`7 passed, 36 warnings`)
- `.venv/bin/python -m pytest tests/unit/test_api_activity.py::TestActivityLogContracts -q` (`18 passed, 36 warnings`)
- `.venv/bin/python -m pytest tests/unit/test_api_backup.py::TestBackupStart::test_agent_completion_updates_linked_backup_job -q` (`1 passed, 36 warnings`; reproduced CI failure first as `1 failed, 36 warnings` before the test policy setup fix)
- `.venv/bin/python -m pytest tests/unit/test_api_activity.py tests/unit/test_api_backup_plans.py -q` (`150 passed, 40 warnings`)
- `.venv/bin/python -m pytest tests/unit/test_source_discovery.py -q` (`33 passed, 36 warnings`)
- `.venv/bin/ruff check app/services/log_policy.py app/api/activity.py app/api/backup_plans.py tests/unit/test_api_activity.py tests/unit/test_api_backup_plans.py tests/unit/test_api_backup.py`
- `.venv/bin/ruff format --check app/services/log_policy.py app/api/activity.py app/api/backup_plans.py tests/unit/test_api_activity.py tests/unit/test_api_backup_plans.py tests/unit/test_api_backup.py`
- `git diff --check`
- `cd frontend && npm run check:locales` (`PASSED`, 4125 keys)
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build` (exit 0; Vite reported existing `webauthn.ts` chunking and large-chunk warnings)

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new lint or format warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; backend policy and serialization change with unchanged UI and response shape.

## Additional Context
A review follow-up issue was created for non-Activity raw log surfaces outside this ticket's Activity scope: BOR-152. The follow-up is related to BOR-150 and blocked by this policy foundation.

The earlier frontend validation required `npm ci` because local `frontend/node_modules` had stale TypeScript `5.9.3` while the lockfile pins `6.0.2`; that changed no tracked frontend files.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
