### PR TITLE
Honor log save policy across non-Activity log APIs

### DIFF
--- a/app/api/archives.py
+++ b/app/api/archives.py
@@ -23,6 +23,7 @@ from app.core.security import (
 from app.database.database import get_db
 from app.database.models import DeleteArchiveJob, Repository, User
 from app.services.agent_job_dispatcher import dispatch_agent_job_best_effort
+from app.services.log_policy import get_log_save_policy, job_has_logs_by_policy
 from app.services.repository_executor import (
     is_agent_executor,
     queue_agent_repository_operation_job,
@@ -462,9 +463,16 @@ async def get_delete_job_status(
         if repo:
             check_repo_access(db, current_user, repo, "viewer")
 
-        # Read log file if it exists
+        has_logs = job_has_logs_by_policy(
+            job,
+            get_log_save_policy(db),
+            output_text=[job.logs, job.error_message],
+            file_path=job.log_file_path,
+        )
+
+        # Read log file only when the current policy allows this job's logs.
         logs = None
-        if job.log_file_path and os.path.exists(job.log_file_path):
+        if has_logs and job.log_file_path and os.path.exists(job.log_file_path):
             try:
                 with open(job.log_file_path, "r") as f:
                     logs = f.read()
@@ -482,7 +490,7 @@ async def get_delete_job_status(
             "progress_message": job.progress_message,
             "error_message": job.error_message,
             "logs": logs,
-            "has_logs": job.has_logs,
+            "has_logs": has_logs,
         }
     except HTTPException:
         raise

--- a/app/api/backup.py
+++ b/app/api/backup.py
@@ -35,6 +35,7 @@ from app.services.job_admission import (
     ensure_manual_backup_capacity,
     ensure_repository_admission,
 )
+from app.services.log_policy import get_log_save_policy, job_has_logs_by_policy
 from app.services.repository_executor import (
     cancel_agent_backup_job,
     get_agent_job_for_backup,
@@ -152,20 +153,67 @@ def _agent_job_logs_response(db: Session, backup_job: BackupJob, offset: int) ->
     }
 
 
-def _backup_job_has_logs(db: Session, job: BackupJob) -> bool:
-    if bool(job.logs):
-        return True
-    if job.execution_mode != "agent":
-        return False
-    agent_job = get_agent_job_for_backup(db, job.id)
-    if not agent_job:
-        return False
+def _empty_backup_log_response(job: BackupJob) -> dict[str, Any]:
+    return {
+        "job_id": job.id,
+        "status": job.status,
+        "lines": [],
+        "total_lines": 0,
+        "has_more": False,
+    }
+
+
+def _get_agent_log_messages(db: Session, agent_job_id: int) -> list[str]:
+    logs = (
+        db.query(AgentJobLog)
+        .filter(AgentJobLog.agent_job_id == agent_job_id)
+        .order_by(AgentJobLog.sequence.asc(), AgentJobLog.id.asc())
+        .all()
+    )
+    return [log.message for log in logs]
+
+
+def _agent_log_rows_exist(db: Session, agent_job_id: int) -> bool:
     return (
         db.query(AgentJobLog.id)
-        .filter(AgentJobLog.agent_job_id == agent_job.id)
+        .filter(AgentJobLog.agent_job_id == agent_job_id)
         .first()
         is not None
     )
+
+
+def _backup_job_has_logs(
+    db: Session, job: BackupJob, *, log_save_policy: str | None = None
+) -> bool:
+    policy = log_save_policy or get_log_save_policy(db)
+    output_text: list[Any] = [job.logs, job.error_message]
+    agent_job = None
+    if job.execution_mode == "agent":
+        agent_job = get_agent_job_for_backup(db, job.id)
+        if agent_job:
+            output_text.append(agent_job.error_message)
+
+    if job_has_logs_by_policy(
+        job,
+        policy,
+        output_text=output_text,
+        file_path=job.log_file_path,
+    ):
+        return True
+
+    if (
+        policy == "failed_and_warnings"
+        and agent_job is not None
+        and _agent_log_rows_exist(db, agent_job.id)
+    ):
+        return job_has_logs_by_policy(
+            job,
+            policy,
+            output_text=[*output_text, *_get_agent_log_messages(db, agent_job.id)],
+            file_path=job.log_file_path,
+        )
+
+    return False
 
 
 def _get_backup_plan_name(db: Session, backup_plan_id: Optional[int]) -> Optional[str]:
@@ -596,6 +644,7 @@ async def get_all_backup_jobs(
             except HTTPException:
                 continue
 
+        log_save_policy = get_log_save_policy(db)
         return {
             "jobs": [
                 {
@@ -606,7 +655,9 @@ async def get_all_backup_jobs(
                     "completed_at": serialize_datetime(job.completed_at),
                     "progress": job.progress,
                     "error_message": job.error_message,
-                    "has_logs": _backup_job_has_logs(db, job),
+                    "has_logs": _backup_job_has_logs(
+                        db, job, log_save_policy=log_save_policy
+                    ),
                     "maintenance_status": job.maintenance_status,
                     "scheduled_job_id": job.scheduled_job_id,  # Include for filtering by schedule
                     "backup_plan_id": job.backup_plan_id,
@@ -656,6 +707,7 @@ async def get_backup_status(
         repo = _get_job_repository(db, job.repository)
         if repo:
             check_repo_access(db, current_user, repo, "viewer")
+        has_logs = _backup_job_has_logs(db, job)
 
         return {
             "id": job.id,
@@ -665,7 +717,7 @@ async def get_backup_status(
             "completed_at": serialize_datetime(job.completed_at),
             "progress": job.progress,
             "error_message": job.error_message,
-            "logs": job.logs,
+            "logs": job.logs if has_logs else None,
             "maintenance_status": job.maintenance_status,
             "backup_plan_id": job.backup_plan_id,
             "backup_plan_run_id": job.backup_plan_run_id,
@@ -785,6 +837,12 @@ async def download_backup_logs(
                 },
             )
 
+        if not _backup_job_has_logs(db, job):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"key": "backend.errors.backup.noLogsAvailable"},
+            )
+
         if job.execution_mode == "agent":
             agent_job = get_agent_job_for_backup(db, job.id)
             if not agent_job:
@@ -888,6 +946,9 @@ async def stream_backup_logs(
         repo = _get_job_repository(db, job.repository)
         if repo:
             check_repo_access(db, current_user, repo, "viewer")
+
+        if not _backup_job_has_logs(db, job):
+            return _empty_backup_log_response(job)
 
         if job.execution_mode == "agent":
             return _agent_job_logs_response(db, job, offset)

--- a/app/api/dashboard.py
+++ b/app/api/dashboard.py
@@ -22,6 +22,7 @@ from app.database.models import (
     SystemSettings,
 )
 from app.core.security import get_current_user
+from app.services.log_policy import get_log_save_policy, job_has_logs_by_policy
 from app.utils.datetime_utils import serialize_datetime
 from app.utils.schedule_time import (
     DEFAULT_SCHEDULE_TIMEZONE,
@@ -507,6 +508,7 @@ def get_scheduled_jobs(db: Session) -> List[ScheduledJobInfo]:
 def get_recent_jobs(db: Session, limit: int = 10) -> List[Dict[str, Any]]:
     """Get recent backup jobs"""
     try:
+        log_save_policy = get_log_save_policy(db)
         jobs = (
             db.query(BackupJob).order_by(BackupJob.started_at.desc()).limit(limit).all()
         )
@@ -527,7 +529,12 @@ def get_recent_jobs(db: Session, limit: int = 10) -> List[Dict[str, Any]]:
                     "error_message": job.error_message,
                     "triggered_by": triggered_by,
                     "schedule_id": job.scheduled_job_id,
-                    "has_logs": bool(job.log_file_path or job.logs),
+                    "has_logs": job_has_logs_by_policy(
+                        job,
+                        log_save_policy,
+                        output_text=[job.logs, job.error_message],
+                        file_path=job.log_file_path,
+                    ),
                 }
             )
 

--- a/app/api/maintenance_jobs.py
+++ b/app/api/maintenance_jobs.py
@@ -13,6 +13,7 @@ from app.services.job_admission import (
     ensure_repository_admission,
     operation_for_maintenance_model,
 )
+from app.services.log_policy import DEFAULT_LOG_SAVE_POLICY, job_has_logs_by_policy
 from app.utils.datetime_utils import serialize_datetime
 
 
@@ -208,7 +209,29 @@ def get_repository_jobs(
     )
 
 
-def read_job_logs(job: Any, *, fallback_to_logs: bool = True) -> str:
+def job_has_logs_for_policy(
+    job: Any, *, log_save_policy: str = DEFAULT_LOG_SAVE_POLICY
+) -> bool:
+    return job_has_logs_by_policy(
+        job,
+        log_save_policy,
+        output_text=[
+            getattr(job, "logs", None),
+            getattr(job, "error_message", None),
+        ],
+        file_path=getattr(job, "log_file_path", None),
+    )
+
+
+def read_job_logs(
+    job: Any,
+    *,
+    fallback_to_logs: bool = True,
+    log_save_policy: str = DEFAULT_LOG_SAVE_POLICY,
+) -> str:
+    if not job_has_logs_for_policy(job, log_save_policy=log_save_policy):
+        return ""
+
     log_file_path = getattr(job, "log_file_path", None)
     if log_file_path and os.path.exists(log_file_path):
         try:
@@ -229,6 +252,7 @@ def serialize_job_status(
     include_logs: bool = False,
     include_has_logs: bool = False,
     fallback_to_logs: bool = True,
+    log_save_policy: str = DEFAULT_LOG_SAVE_POLICY,
 ) -> dict[str, Any]:
     payload = {
         "id": job.id,
@@ -242,9 +266,15 @@ def serialize_job_status(
         payload["progress"] = getattr(job, "progress", None)
         payload["progress_message"] = getattr(job, "progress_message", None)
     if include_logs:
-        payload["logs"] = read_job_logs(job, fallback_to_logs=fallback_to_logs)
+        payload["logs"] = read_job_logs(
+            job,
+            fallback_to_logs=fallback_to_logs,
+            log_save_policy=log_save_policy,
+        )
     if include_has_logs:
-        payload["has_logs"] = bool(getattr(job, "has_logs", False))
+        payload["has_logs"] = job_has_logs_for_policy(
+            job, log_save_policy=log_save_policy
+        )
     return payload
 
 
@@ -253,6 +283,7 @@ def serialize_job_summary(
     *,
     include_progress: bool = False,
     include_has_logs: bool = False,
+    log_save_policy: str = DEFAULT_LOG_SAVE_POLICY,
 ) -> dict[str, Any]:
     payload = {
         "id": job.id,
@@ -266,5 +297,7 @@ def serialize_job_summary(
         payload["progress"] = getattr(job, "progress", None)
         payload["progress_message"] = getattr(job, "progress_message", None)
     if include_has_logs:
-        payload["has_logs"] = bool(getattr(job, "has_logs", False))
+        payload["has_logs"] = job_has_logs_for_policy(
+            job, log_save_policy=log_save_policy
+        )
     return payload

--- a/app/api/managed_machines.py
+++ b/app/api/managed_machines.py
@@ -32,6 +32,7 @@ from app.services.agent_connection_manager import (
     AgentCommandTimeout,
     AgentConnectionUnavailable,
 )
+from app.services.log_policy import get_log_save_policy, job_has_logs_by_policy
 from app.utils.datetime_utils import serialize_datetime
 
 logger = structlog.get_logger()
@@ -692,12 +693,20 @@ async def list_agent_job_logs(
             detail={"key": "backend.errors.agents.jobNotFound"},
         )
 
-    return (
+    logs = (
         db.query(AgentJobLog)
         .filter(AgentJobLog.agent_job_id == job.id)
         .order_by(AgentJobLog.sequence.asc(), AgentJobLog.id.asc())
         .all()
     )
+    if not job_has_logs_by_policy(
+        job,
+        get_log_save_policy(db),
+        output_text=[*(log.message for log in logs), job.error_message],
+    ):
+        return []
+
+    return logs
 
 
 @router.post(

--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -78,6 +78,7 @@ from app.services.job_admission import (
     OPERATION_PRUNE,
     ensure_repository_admission,
 )
+from app.services.log_policy import get_log_save_policy, job_has_logs_by_policy
 from app.services.repository_command_lock import run_serialized_repository_command
 from app.services.rclone_repository_service import (
     SYNC_DIRECTION_AGENT_TO_REMOTE,
@@ -1584,7 +1585,7 @@ def _discard_rclone_repository_record(
 
 
 def _serialize_rclone_storage(
-    repository: Repository, db: Session
+    repository: Repository, db: Session, *, log_save_policy: str | None = None
 ) -> Optional[Dict[str, Any]]:
     storage = (
         db.query(RepositoryStorage)
@@ -1606,6 +1607,8 @@ def _serialize_rclone_storage(
         .order_by(RcloneSyncJob.created_at.desc(), RcloneSyncJob.id.desc())
         .first()
     )
+    if log_save_policy is None:
+        log_save_policy = get_log_save_policy(db)
     status["latest_sync_job"] = (
         {
             "id": latest_job.id,
@@ -1616,8 +1619,11 @@ def _serialize_rclone_storage(
             "completed_at": format_datetime(latest_job.completed_at),
             "error_text": latest_job.error_text,
             "operation": latest_job.operation,
-            "has_log": bool(
-                latest_job.log_path or latest_job.log_text or latest_job.error_text
+            "has_log": job_has_logs_by_policy(
+                latest_job,
+                log_save_policy,
+                output_text=[latest_job.log_text, latest_job.error_text],
+                file_path=latest_job.log_path,
             ),
         }
         if latest_job
@@ -2622,6 +2628,7 @@ async def get_repositories(
 
         # Check for running maintenance jobs for each repository
         repo_list = []
+        log_save_policy = get_log_save_policy(db)
         for repo in repositories:
             # Check if this repository has running check, compact, or prune jobs
             has_check = (
@@ -2703,7 +2710,9 @@ async def get_repositories(
                 "source_ssh_connection_id": repo.source_ssh_connection_id,
                 "borg_version": repo.borg_version or 1,
             }
-            rclone_storage = _serialize_rclone_storage(repo, db)
+            rclone_storage = _serialize_rclone_storage(
+                repo, db, log_save_policy=log_save_policy
+            )
             if rclone_storage:
                 repo_payload["storage_backend"] = _primary_storage_backend(repo)
                 repo_payload["rclone_storage"] = rclone_storage
@@ -5298,6 +5307,7 @@ async def get_repository_wipe_job(
             job,
             include_preview=True,
             include_logs=True,
+            log_save_policy=get_log_save_policy(db),
         )
     except HTTPException:
         raise
@@ -5849,7 +5859,12 @@ async def get_check_job_status(
             job_id,
             not_found_key="backend.errors.repo.checkJobNotFound",
         )
-        return serialize_job_status(job, include_progress=True, include_logs=True)
+        return serialize_job_status(
+            job,
+            include_progress=True,
+            include_logs=True,
+            log_save_policy=get_log_save_policy(db),
+        )
     except HTTPException:
         raise
     except Exception as e:
@@ -5872,11 +5887,15 @@ async def get_repository_check_jobs(
         jobs = get_repository_jobs(db, current_user, repo_id, CheckJob, limit=limit)
         if scheduled_only:
             jobs = [job for job in jobs if bool(getattr(job, "scheduled_check", False))]
+        log_save_policy = get_log_save_policy(db)
         return {
             "jobs": [
                 {
                     **serialize_job_summary(
-                        job, include_progress=True, include_has_logs=True
+                        job,
+                        include_progress=True,
+                        include_has_logs=True,
+                        log_save_policy=log_save_policy,
                     ),
                     "scheduled_check": bool(getattr(job, "scheduled_check", False)),
                 }
@@ -5908,7 +5927,11 @@ async def get_restore_check_job_status(
             not_found_key="backend.errors.repo.restoreCheckJobNotFound",
         )
         payload = serialize_job_status(
-            job, include_progress=True, include_logs=True, include_has_logs=True
+            job,
+            include_progress=True,
+            include_logs=True,
+            include_has_logs=True,
+            log_save_policy=get_log_save_policy(db),
         )
         probe_paths = json.loads(job.probe_paths) if job.probe_paths else []
         payload["archive_name"] = job.archive_name
@@ -5942,12 +5965,16 @@ async def get_repository_restore_check_jobs(
         jobs = get_repository_jobs(
             db, current_user, repo_id, RestoreCheckJob, limit=limit
         )
+        log_save_policy = get_log_save_policy(db)
         return {
             "jobs": [
                 (
                     lambda probe_paths: {
                         **serialize_job_summary(
-                            job, include_progress=True, include_has_logs=True
+                            job,
+                            include_progress=True,
+                            include_has_logs=True,
+                            log_save_policy=log_save_policy,
                         ),
                         "archive_name": job.archive_name,
                         "probe_paths": probe_paths,
@@ -5989,7 +6016,12 @@ async def get_compact_job_status(
             job_id,
             not_found_key="backend.errors.repo.compactJobNotFound",
         )
-        return serialize_job_status(job, include_progress=True, include_logs=True)
+        return serialize_job_status(
+            job,
+            include_progress=True,
+            include_logs=True,
+            log_save_policy=get_log_save_policy(db),
+        )
     except HTTPException:
         raise
     except Exception as e:
@@ -6009,8 +6041,16 @@ async def get_repository_compact_jobs(
     """Get recent compact jobs for a repository"""
     try:
         jobs = get_repository_jobs(db, current_user, repo_id, CompactJob, limit=limit)
+        log_save_policy = get_log_save_policy(db)
         return {
-            "jobs": [serialize_job_summary(job, include_progress=True) for job in jobs]
+            "jobs": [
+                serialize_job_summary(
+                    job,
+                    include_progress=True,
+                    log_save_policy=log_save_policy,
+                )
+                for job in jobs
+            ]
         }
     except HTTPException:
         raise
@@ -6037,7 +6077,11 @@ async def get_prune_job_status(
             job_id,
             not_found_key="backend.errors.repo.pruneJobNotFound",
         )
-        return serialize_job_status(job, include_logs=True)
+        return serialize_job_status(
+            job,
+            include_logs=True,
+            log_save_policy=get_log_save_policy(db),
+        )
     except HTTPException:
         raise
     except Exception as e:
@@ -6057,8 +6101,16 @@ async def get_repository_prune_jobs(
     """Get recent prune jobs for a repository"""
     try:
         jobs = get_repository_jobs(db, current_user, repo_id, PruneJob, limit=limit)
+        log_save_policy = get_log_save_policy(db)
         return {
-            "jobs": [serialize_job_summary(job, include_has_logs=True) for job in jobs]
+            "jobs": [
+                serialize_job_summary(
+                    job,
+                    include_has_logs=True,
+                    log_save_policy=log_save_policy,
+                )
+                for job in jobs
+            ]
         }
     except HTTPException:
         raise

--- a/app/api/restore.py
+++ b/app/api/restore.py
@@ -16,6 +16,7 @@ from app.core.security import (
     check_repo_access,
     require_repository_access_by_path,
 )
+from app.services.log_policy import get_log_save_policy, job_has_logs_by_policy
 from app.services.restore_service import restore_service
 from app.utils.datetime_utils import serialize_datetime
 from app.utils.borg_env import (
@@ -37,6 +38,14 @@ def _get_restore_job_repository(
     if not repository_path:
         return None
     return db.query(Repository).filter(Repository.path == repository_path).first()
+
+
+def _restore_job_logs_visible(job: RestoreJob, log_save_policy: str) -> bool:
+    return job_has_logs_by_policy(
+        job,
+        log_save_policy,
+        output_text=[job.logs, job.error_message],
+    )
 
 
 def _build_repo_env(repo: Repository, db: Session):
@@ -261,6 +270,7 @@ async def get_restore_jobs(
             except HTTPException:
                 continue
 
+        log_save_policy = get_log_save_policy(db)
         return {
             "jobs": [
                 {
@@ -273,7 +283,11 @@ async def get_restore_jobs(
                     "completed_at": serialize_datetime(job.completed_at),
                     "progress": job.progress,
                     "error_message": job.error_message,
-                    "logs": job.logs,
+                    "logs": (
+                        job.logs
+                        if _restore_job_logs_visible(job, log_save_policy)
+                        else None
+                    ),
                     "progress_details": {
                         "nfiles": job.nfiles or 0,
                         "current_file": job.current_file or "",
@@ -310,6 +324,7 @@ async def get_restore_status(
         repo = _get_restore_job_repository(db, job.repository)
         if repo:
             check_repo_access(db, current_user, repo, "operator")
+        log_save_policy = get_log_save_policy(db)
 
         return {
             "id": job.id,
@@ -321,7 +336,9 @@ async def get_restore_status(
             "completed_at": serialize_datetime(job.completed_at),
             "progress": job.progress,
             "error_message": job.error_message,
-            "logs": job.logs,
+            "logs": job.logs
+            if _restore_job_logs_visible(job, log_save_policy)
+            else None,
             "progress_details": {
                 "nfiles": job.nfiles or 0,
                 "current_file": job.current_file or "",

--- a/app/api/v2/archives.py
+++ b/app/api/v2/archives.py
@@ -26,6 +26,7 @@ from app.services.archive_browse_service import (
     parse_archive_items,
 )
 from app.services.cache_service import archive_cache
+from app.services.log_policy import get_log_save_policy, job_has_logs_by_policy
 from app.services.v2.archive_browse import get_browse_depth, is_fast_browse_enabled
 from app.utils.borg_env import repository_borg_env
 from app.utils.datetime_utils import serialize_datetime
@@ -544,8 +545,15 @@ async def get_delete_job_status(
             status_code=404, detail={"key": "backend.errors.archives.deleteJobNotFound"}
         )
 
+    has_logs = job_has_logs_by_policy(
+        job,
+        get_log_save_policy(db),
+        output_text=[job.logs, job.error_message],
+        file_path=job.log_file_path,
+    )
+
     logs = None
-    if job.log_file_path and os.path.exists(job.log_file_path):
+    if has_logs and job.log_file_path and os.path.exists(job.log_file_path):
         try:
             with open(job.log_file_path) as f:
                 logs = f.read()
@@ -563,5 +571,5 @@ async def get_delete_job_status(
         "progress_message": job.progress_message,
         "error_message": job.error_message,
         "logs": logs,
-        "has_logs": job.has_logs,
+        "has_logs": has_logs,
     }

--- a/app/services/repository_wipe_service.py
+++ b/app/services/repository_wipe_service.py
@@ -23,6 +23,7 @@ from app.database.models import (
     RestoreJob,
     User,
 )
+from app.services.log_policy import DEFAULT_LOG_SAVE_POLICY, job_has_logs_by_policy
 from app.services.repository_command_lock import run_serialized_repository_command
 from app.utils.borg_env import build_repository_borg_env, cleanup_temp_key_file
 from app.utils.datetime_utils import serialize_datetime
@@ -535,7 +536,14 @@ class RepositoryWipeService:
         *,
         include_preview: bool = False,
         include_logs: bool = False,
+        log_save_policy: str = DEFAULT_LOG_SAVE_POLICY,
     ) -> dict[str, Any]:
+        has_logs = job_has_logs_by_policy(
+            job,
+            log_save_policy,
+            output_text=[job.logs, job.error_message],
+            file_path=job.log_file_path,
+        )
         payload = {
             "id": job.id,
             "repository_id": job.repository_id,
@@ -550,7 +558,7 @@ class RepositoryWipeService:
             "archive_count": job.archive_count,
             "archive_fingerprint": job.archive_fingerprint,
             "run_compact": bool(job.run_compact),
-            "has_logs": bool(job.has_logs),
+            "has_logs": has_logs,
         }
         if include_preview:
             manifest = _decode_json_list(job.archive_manifest_json)
@@ -565,7 +573,7 @@ class RepositoryWipeService:
                 }
             )
         if include_logs:
-            payload["logs"] = self._read_logs(job)
+            payload["logs"] = self._read_logs(job) if has_logs else ""
         return payload
 
     def _read_logs(self, job: RepositoryWipeJob) -> str:
@@ -576,7 +584,7 @@ class RepositoryWipeService:
                     return path.read_text()
                 except Exception as exc:
                     return f"Failed to read log file: {exc}"
-        return job.logs or ""
+        return job.logs or job.error_message or ""
 
 
 repository_wipe_service = RepositoryWipeService()

--- a/docs/engineering/plans/2026-06-06-log-save-policy-non-activity.md
+++ b/docs/engineering/plans/2026-06-06-log-save-policy-non-activity.md
@@ -1,0 +1,88 @@
+# Non-Activity Log Save Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align non-Activity log advertisements and direct log-returning API surfaces with `SystemSettings.log_save_policy`.
+
+**Architecture:** Reuse `app.services.log_policy` for policy decisions and add only small adapter helpers where endpoint-specific log sources differ. Direct log reads should first check policy visibility, while running jobs keep live log access and pending jobs do not advertise logs.
+
+**Tech Stack:** FastAPI, SQLAlchemy ORM models, pytest unit/integration tests, Ruff.
+
+---
+
+## Task 1: Shared Policy Adapters
+
+**Files:**
+- Modify: `app/services/log_policy.py`
+- Test: covered through API serializer tests in later tasks
+
+- [ ] Keep the existing `job_has_logs_by_policy` contract as the shared policy source.
+- [ ] Add only narrowly-scoped helper functions if repeated endpoint code needs a common way to check log text/file visibility.
+- [ ] Preserve the established policy semantics:
+  - `pending`, `queued`, and `scheduled` return `False`.
+  - `running`, `installing`, and `in_progress` retain live log visibility.
+  - `failed_only` returns visible for failed or cancelled jobs.
+  - `failed_and_warnings` returns visible for failed, cancelled, warning-status, or warning/error log output.
+  - `all_jobs` returns visible for non-pending log-capable jobs.
+
+## Task 2: Legacy Backup Surfaces
+
+**Files:**
+- Modify: `app/api/backup.py`
+- Test: `tests/unit/test_api_backup.py`
+
+- [ ] Write failing tests for `/api/backup/jobs`, `/api/backup/status/{job_id}`, `/api/backup/logs/{job_id}/stream`, and `/api/backup/logs/{job_id}/download`.
+- [ ] Cover `failed_only` hiding successful completed logs, `failed_and_warnings` exposing warning logs, and `all_jobs` exposing successful logs.
+- [ ] Include agent-backed backup logs so `AgentJobLog` rows cannot bypass policy after the linked backup completes.
+- [ ] Implement policy checks through shared helpers before serializing `has_logs`, status `logs`, stream lines, or download files.
+
+## Task 3: Dashboard and Maintenance Surfaces
+
+**Files:**
+- Modify: `app/api/dashboard.py`
+- Modify: `app/api/maintenance_jobs.py`
+- Modify: `app/api/repositories.py`
+- Test: `tests/unit/test_api_dashboard.py`
+- Test: `tests/unit/test_api_maintenance_jobs.py`
+- Test: `tests/unit/test_api_repositories_routes.py`
+
+- [ ] Write failing tests showing dashboard recent jobs do not advertise successful hidden logs under `failed_only`.
+- [ ] Write failing tests showing repository maintenance status payloads hide raw `logs` and list payloads hide `has_logs` when policy hides them.
+- [ ] Preserve running maintenance status live access and pending job non-advertisement.
+- [ ] Ensure repository route serializers pass the current `get_log_save_policy(db)` into maintenance serialization.
+
+## Task 4: Archive Delete and Rclone Metadata
+
+**Files:**
+- Modify: `app/api/archives.py`
+- Modify: `app/api/v2/archives.py`
+- Modify: `app/api/repositories.py`
+- Test: `tests/unit/test_api_archives.py`
+- Test: `tests/unit/test_api_v2_archives.py`
+- Test: `tests/unit/test_api_rclone.py`
+
+- [ ] Write failing tests for archive delete status payloads hiding `logs` and `has_logs` under `failed_only` for successful jobs.
+- [ ] Write a failing test for rclone `latest_sync_job.has_log` using policy instead of raw `log_path`, `log_text`, or `error_text`.
+- [ ] Keep failed rclone jobs visible under failure policies and successful rclone jobs visible under `all_jobs`.
+
+## Task 5: Managed-Agent and Restore Payloads
+
+**Files:**
+- Modify: `app/api/managed_machines.py`
+- Modify: `app/api/restore.py`
+- Test: `tests/unit/test_api_managed_machines.py`
+- Test: `tests/unit/test_api_restore.py`
+
+- [ ] Write failing tests for managed-agent job log row reads so terminal successful logs are hidden under `failed_only`, while running jobs keep live rows.
+- [ ] Hide restore job `logs` in list/status payloads when policy hides them.
+- [ ] Keep `app/api/agents.py` unchanged for this change set. Its agent log ingestion endpoints are write-side transport, not user-facing log exposure; modify `app/api/agents.py` only if `OperationSummary` or another persisted operation summary is returned directly to user-facing APIs and must be filtered by policy.
+
+## Task 6: Validation and Handoff
+
+**Files:**
+- Update Linear workpad only
+
+- [ ] Run targeted pytest paths for changed API surfaces.
+- [ ] Run `ruff check app tests` or a narrowed command justified by touched files.
+- [ ] Run `ruff format --check app tests` or a narrowed command justified by touched files.
+- [ ] Push branch, create PR, attach it to Linear, ensure the PR has label `symphony`, sweep PR feedback, and move BOR-152 to Human Review only after green checks.

--- a/tests/integration/test_api_restore_integration.py
+++ b/tests/integration/test_api_restore_integration.py
@@ -33,6 +33,17 @@ def _enable_borg_v2(test_db) -> None:
     test_db.commit()
 
 
+def _set_log_save_policy(test_db, policy: str) -> None:
+    from app.database.models import SystemSettings
+
+    settings = test_db.query(SystemSettings).first()
+    if settings is None:
+        settings = SystemSettings()
+        test_db.add(settings)
+    settings.log_save_policy = policy
+    test_db.commit()
+
+
 def _create_borg2_repo_with_archives(test_db, tmp_path):
     from app.database.models import Repository
     from tests.utils.borg import (
@@ -826,10 +837,12 @@ class TestRestoreLogsIntegration:
         self,
         test_client: TestClient,
         admin_headers,
+        test_db,
         db_borg_repo_with_archives,
         tmp_path,
     ):
         """Test that restore logs are accessible via /api/restore/jobs"""
+        _set_log_save_policy(test_db, "all_jobs")
         repo, repo_path, test_data_path, archive_names = db_borg_repo_with_archives
         latest_archive = archive_names[-1]
         restore_dest = tmp_path / "restore_api_logs_test"
@@ -866,10 +879,12 @@ class TestRestoreLogsIntegration:
         self,
         test_client: TestClient,
         admin_headers,
+        test_db,
         db_borg_repo_with_archives,
         tmp_path,
     ):
         """Test that restore logs are accessible via /api/restore/status/{id}"""
+        _set_log_save_policy(test_db, "all_jobs")
         repo, repo_path, test_data_path, archive_names = db_borg_repo_with_archives
         latest_archive = archive_names[-1]
         restore_dest = tmp_path / "restore_status_logs_test"

--- a/tests/unit/test_api_archives.py
+++ b/tests/unit/test_api_archives.py
@@ -17,12 +17,18 @@ Integration tests (test_api_archives_integration.py) handle:
 import asyncio
 import base64
 import os
+from datetime import datetime
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 from app.core.security import get_password_hash
-from app.database.models import AgentMachine, Repository
+from app.database.models import (
+    AgentMachine,
+    DeleteArchiveJob,
+    Repository,
+    SystemSettings,
+)
 
 
 def _create_agent(test_db, *capabilities: str) -> AgentMachine:
@@ -160,6 +166,47 @@ class TestArchivesResourceValidation:
 
         asyncio.run(created["coro"])
         fake_router.delete_archive.assert_awaited_once()
+
+    def test_delete_job_status_applies_log_save_policy(
+        self, test_client: TestClient, admin_headers, test_db, tmp_path
+    ):
+        settings = test_db.query(SystemSettings).first()
+        if settings is None:
+            settings = SystemSettings()
+            test_db.add(settings)
+        settings.log_save_policy = "failed_only"
+        repo = Repository(
+            name="Archive Repo",
+            path="/tmp/archive-repo",
+            encryption="none",
+            repository_type="local",
+        )
+        test_db.add(repo)
+        test_db.flush()
+        log_file = tmp_path / "delete.log"
+        log_file.write_text("archive deleted", encoding="utf-8")
+        job = DeleteArchiveJob(
+            repository_id=repo.id,
+            repository_path=repo.path,
+            archive_name="archive-1",
+            status="completed",
+            started_at=datetime(2026, 4, 27, 3, 0, 6),
+            completed_at=datetime(2026, 4, 27, 3, 5, 6),
+            log_file_path=str(log_file),
+            has_logs=True,
+        )
+        test_db.add(job)
+        test_db.commit()
+
+        response = test_client.get(
+            f"/api/archives/delete-jobs/{job.id}",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["logs"] is None
+        assert body["has_logs"] is False
 
 
 @pytest.mark.unit

--- a/tests/unit/test_api_backup.py
+++ b/tests/unit/test_api_backup.py
@@ -10,6 +10,7 @@ from app.core.agent_auth import AGENT_AUTH_HEADER
 from app.core.security import get_password_hash
 from app.database.models import (
     AgentJob,
+    AgentJobLog,
     AgentMachine,
     Repository,
     BackupJob,
@@ -1586,6 +1587,7 @@ class TestBackupLogs:
         self, test_client: TestClient, admin_headers, test_db
     ):
         """Test downloading backup logs accepts standard bearer auth."""
+        _set_log_save_policy(test_db, "all_jobs")
         job = BackupJob(
             repository="/test/repo",
             status="completed",
@@ -1647,6 +1649,7 @@ class TestBackupLogs:
         """Proxy-auth mode should not require a JWT query token for log downloads."""
         from app import config
 
+        _set_log_save_policy(test_db, "all_jobs")
         monkeypatch.setattr(config.settings, "disable_authentication", True)
 
         job = BackupJob(
@@ -1667,6 +1670,194 @@ class TestBackupLogs:
 
         assert response.status_code == 200
         assert "text/plain" in response.headers.get("content-type", "")
+
+    @pytest.mark.parametrize(
+        ("policy", "job_status", "logs", "expected_has_logs"),
+        [
+            ("failed_only", "completed", "successful backup log", False),
+            (
+                "failed_and_warnings",
+                "completed",
+                "WARNING: skipped unreadable file",
+                True,
+            ),
+            ("all_jobs", "completed", "successful backup log", True),
+        ],
+    )
+    def test_legacy_backup_log_surfaces_follow_log_save_policy(
+        self,
+        test_client: TestClient,
+        admin_headers,
+        test_db,
+        policy,
+        job_status,
+        logs,
+        expected_has_logs,
+    ):
+        _set_log_save_policy(test_db, policy)
+        job = BackupJob(
+            repository="/test/repo",
+            status=job_status,
+            started_at=datetime.now(),
+            completed_at=datetime.now(),
+            logs=logs,
+        )
+        test_db.add(job)
+        test_db.commit()
+        test_db.refresh(job)
+
+        jobs_response = test_client.get(
+            "/api/backup/jobs", params={"manual_only": True}, headers=admin_headers
+        )
+        assert jobs_response.status_code == 200
+        history_job = next(
+            item for item in jobs_response.json()["jobs"] if item["id"] == job.id
+        )
+        assert history_job["has_logs"] is expected_has_logs
+
+        status_response = test_client.get(
+            f"/api/backup/status/{job.id}", headers=admin_headers
+        )
+        assert status_response.status_code == 200
+        assert status_response.json()["logs"] == (logs if expected_has_logs else None)
+
+        stream_response = test_client.get(
+            f"/api/backup/logs/{job.id}/stream", headers=admin_headers
+        )
+        assert stream_response.status_code == 200
+        stream_body = stream_response.json()
+        if expected_has_logs:
+            assert stream_body["lines"] == [{"line_number": 1, "content": logs}]
+        else:
+            assert stream_body["lines"] == []
+
+        download_response = test_client.get(
+            f"/api/backup/logs/{job.id}/download", headers=admin_headers
+        )
+        assert download_response.status_code == (200 if expected_has_logs else 404)
+
+    def test_agent_backup_log_rows_follow_log_save_policy(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        _set_log_save_policy(test_db, "failed_only")
+        agent = AgentMachine(
+            name="Laptop",
+            agent_id="agt_policy",
+            token_hash=get_password_hash("agent-secret"),
+            token_prefix="agent-secret",
+            status="online",
+        )
+        test_db.add(agent)
+        test_db.flush()
+        backup_job = BackupJob(
+            repository="/agent/repo",
+            status="completed",
+            started_at=datetime.now(),
+            completed_at=datetime.now(),
+            execution_mode="agent",
+        )
+        test_db.add(backup_job)
+        test_db.flush()
+        agent_job = AgentJob(
+            agent_machine_id=agent.id,
+            backup_job_id=backup_job.id,
+            job_type="backup.create",
+            status="completed",
+            payload={},
+            completed_at=datetime.now(),
+        )
+        test_db.add(agent_job)
+        test_db.flush()
+        test_db.add(
+            AgentJobLog(
+                agent_job_id=agent_job.id,
+                sequence=1,
+                stream="stdout",
+                message="agent success log",
+                created_at=datetime.now(),
+            )
+        )
+        test_db.commit()
+
+        jobs_response = test_client.get(
+            "/api/backup/jobs", params={"manual_only": True}, headers=admin_headers
+        )
+        assert jobs_response.status_code == 200
+        history_job = next(
+            item for item in jobs_response.json()["jobs"] if item["id"] == backup_job.id
+        )
+        assert history_job["has_logs"] is False
+
+        stream_response = test_client.get(
+            f"/api/backup/logs/{backup_job.id}/stream", headers=admin_headers
+        )
+        assert stream_response.status_code == 200
+        assert stream_response.json()["lines"] == []
+
+        download_response = test_client.get(
+            f"/api/backup/logs/{backup_job.id}/download", headers=admin_headers
+        )
+        assert download_response.status_code == 404
+
+    def test_agent_backup_warning_log_rows_are_visible_for_warning_policy(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        _set_log_save_policy(test_db, "failed_and_warnings")
+        agent = AgentMachine(
+            name="Laptop",
+            agent_id="agt_policy_warning",
+            token_hash=get_password_hash("agent-secret"),
+            token_prefix="agent-secret",
+            status="online",
+        )
+        test_db.add(agent)
+        test_db.flush()
+        backup_job = BackupJob(
+            repository="/agent/repo",
+            status="completed",
+            started_at=datetime.now(),
+            completed_at=datetime.now(),
+            execution_mode="agent",
+        )
+        test_db.add(backup_job)
+        test_db.flush()
+        agent_job = AgentJob(
+            agent_machine_id=agent.id,
+            backup_job_id=backup_job.id,
+            job_type="backup.create",
+            status="completed",
+            payload={},
+            completed_at=datetime.now(),
+        )
+        test_db.add(agent_job)
+        test_db.flush()
+        test_db.add(
+            AgentJobLog(
+                agent_job_id=agent_job.id,
+                sequence=1,
+                stream="stderr",
+                message="WARNING: skipped unreadable file",
+                created_at=datetime.now(),
+            )
+        )
+        test_db.commit()
+
+        jobs_response = test_client.get(
+            "/api/backup/jobs", params={"manual_only": True}, headers=admin_headers
+        )
+        assert jobs_response.status_code == 200
+        history_job = next(
+            item for item in jobs_response.json()["jobs"] if item["id"] == backup_job.id
+        )
+        assert history_job["has_logs"] is True
+
+        stream_response = test_client.get(
+            f"/api/backup/logs/{backup_job.id}/stream", headers=admin_headers
+        )
+        assert stream_response.status_code == 200
+        assert stream_response.json()["lines"] == [
+            {"line_number": 1, "content": "WARNING: skipped unreadable file"}
+        ]
 
     def test_stream_backup_logs_success(
         self, test_client: TestClient, admin_headers, test_db

--- a/tests/unit/test_api_dashboard.py
+++ b/tests/unit/test_api_dashboard.py
@@ -468,6 +468,8 @@ class TestDashboardHelpers:
 
     def test_get_recent_jobs_normalizes_trigger_state_and_logs(self):
         now = datetime.now(timezone.utc)
+        settings_query = MagicMock()
+        settings_query.first.return_value = SystemSettings(log_save_policy="all_jobs")
         jobs = [
             BackupJob(
                 id=1,
@@ -500,7 +502,7 @@ class TestDashboardHelpers:
         query = MagicMock()
         query.order_by.return_value = order_query
         db = MagicMock()
-        db.query.return_value = query
+        db.query.side_effect = [settings_query, query]
 
         result = get_recent_jobs(db, limit=2)
 
@@ -509,6 +511,39 @@ class TestDashboardHelpers:
         assert result[0]["has_logs"] is True
         assert result[1]["triggered_by"] == "manual"
         assert result[1]["error_message"] == "boom"
+
+    def test_get_recent_jobs_applies_log_save_policy(self, test_db):
+        settings = test_db.query(SystemSettings).first()
+        if settings is None:
+            settings = SystemSettings()
+            test_db.add(settings)
+        settings.log_save_policy = "failed_only"
+        now = datetime.now(timezone.utc)
+        success_job = BackupJob(
+            repository="/srv/backups/success",
+            status="completed",
+            started_at=now,
+            completed_at=now,
+            progress=100,
+            logs="successful log",
+        )
+        failed_job = BackupJob(
+            repository="/srv/backups/failed",
+            status="failed",
+            started_at=now - timedelta(minutes=5),
+            completed_at=now - timedelta(minutes=1),
+            progress=10,
+            error_message="failed",
+            logs="failed log",
+        )
+        test_db.add_all([success_job, failed_job])
+        test_db.commit()
+
+        result = get_recent_jobs(test_db, limit=2)
+
+        by_id = {job["id"]: job for job in result}
+        assert by_id[success_job.id]["has_logs"] is False
+        assert by_id[failed_job.id]["has_logs"] is True
 
     def test_get_recent_jobs_returns_empty_on_query_error(self):
         db = MagicMock()

--- a/tests/unit/test_api_maintenance_jobs.py
+++ b/tests/unit/test_api_maintenance_jobs.py
@@ -196,8 +196,8 @@ class TestMaintenanceJobsHelpers:
         )
         legacy_job = CheckJob(repository_id=repo.id, logs="legacy only")
 
-        assert read_job_logs(file_job) == "from file\n"
-        assert read_job_logs(legacy_job) == "legacy only"
+        assert read_job_logs(file_job, log_save_policy="all_jobs") == "from file\n"
+        assert read_job_logs(legacy_job, log_save_policy="all_jobs") == "legacy only"
 
     def test_serialize_job_helpers_include_requested_fields(self, test_db):
         repo = _create_repo(test_db)
@@ -218,11 +218,13 @@ class TestMaintenanceJobsHelpers:
             include_progress=True,
             include_logs=True,
             include_has_logs=True,
+            log_save_policy="all_jobs",
         )
         summary_payload = serialize_job_summary(
             job,
             include_progress=True,
             include_has_logs=True,
+            log_save_policy="all_jobs",
         )
 
         assert status_payload["progress"] == 100
@@ -231,3 +233,50 @@ class TestMaintenanceJobsHelpers:
         assert status_payload["has_logs"] is True
         assert summary_payload["progress"] == 100
         assert summary_payload["has_logs"] is True
+
+    def test_serialize_job_helpers_apply_log_save_policy(self, test_db):
+        repo = _create_repo(test_db)
+        job = CheckJob(
+            repository_id=repo.id,
+            status="completed",
+            started_at=datetime(2026, 1, 1, 12, 0, 0),
+            completed_at=datetime(2026, 1, 1, 12, 5, 0),
+            logs="successful check output",
+            has_logs=True,
+        )
+
+        status_payload = serialize_job_status(
+            job,
+            include_logs=True,
+            include_has_logs=True,
+            log_save_policy="failed_only",
+        )
+        summary_payload = serialize_job_summary(
+            job,
+            include_has_logs=True,
+            log_save_policy="failed_only",
+        )
+
+        assert status_payload["logs"] == ""
+        assert status_payload["has_logs"] is False
+        assert summary_payload["has_logs"] is False
+
+    def test_serialize_job_helpers_keep_running_logs_visible(self, test_db):
+        repo = _create_repo(test_db)
+        job = CheckJob(
+            repository_id=repo.id,
+            status="running",
+            started_at=datetime(2026, 1, 1, 12, 0, 0),
+            logs="live check output",
+            has_logs=True,
+        )
+
+        status_payload = serialize_job_status(
+            job,
+            include_logs=True,
+            include_has_logs=True,
+            log_save_policy="failed_only",
+        )
+
+        assert status_payload["logs"] == "live check output"
+        assert status_payload["has_logs"] is True

--- a/tests/unit/test_api_managed_machines.py
+++ b/tests/unit/test_api_managed_machines.py
@@ -11,7 +11,13 @@ from app.core.agent_constants import (
 )
 from app.core.agent_auth import AGENT_AUTH_HEADER
 from app.core.security import get_password_hash
-from app.database.models import AgentJob, AgentJobLog, AgentMachine, LicensingState
+from app.database.models import (
+    AgentJob,
+    AgentJobLog,
+    AgentMachine,
+    LicensingState,
+    SystemSettings,
+)
 from app.services.agent_connection_manager import (
     AgentCommandTimeout,
     AgentConnectionUnavailable,
@@ -27,6 +33,15 @@ def _set_plan(test_db, plan: str) -> None:
     state.plan = plan
     state.status = "active"
     test_db.commit()
+
+
+def _set_log_save_policy(test_db, policy: str) -> None:
+    settings = test_db.query(SystemSettings).first()
+    if settings is None:
+        settings = SystemSettings()
+        test_db.add(settings)
+    settings.log_save_policy = policy
+    test_db.flush()
 
 
 @pytest.fixture(autouse=True)
@@ -692,6 +707,7 @@ def test_delete_agent_hides_it_from_list_and_keeps_job_logs(
 ):
     agent = _agent(test_db)
     job = _agent_job(test_db, agent)
+    job.status = "failed"
     now = datetime.now(timezone.utc)
     test_db.add(
         AgentJobLog(
@@ -725,3 +741,61 @@ def test_delete_agent_hides_it_from_list_and_keeps_job_logs(
     )
     assert logs.status_code == 200
     assert logs.json()[0]["message"] == "still readable"
+
+
+def test_agent_job_logs_apply_log_save_policy(
+    test_client: TestClient, admin_headers, test_db
+):
+    _set_log_save_policy(test_db, "failed_only")
+    agent = _agent(test_db)
+    job = _agent_job(test_db, agent)
+    job.status = "completed"
+    now = datetime.now(timezone.utc)
+    test_db.add(
+        AgentJobLog(
+            agent_job_id=job.id,
+            sequence=1,
+            stream="stdout",
+            message="successful agent log",
+            created_at=now,
+            received_at=now,
+        )
+    )
+    test_db.commit()
+
+    response = test_client.get(
+        f"/api/managed-machines/agent-jobs/{job.id}/logs",
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_agent_job_logs_keep_running_logs_visible(
+    test_client: TestClient, admin_headers, test_db
+):
+    _set_log_save_policy(test_db, "failed_only")
+    agent = _agent(test_db)
+    job = _agent_job(test_db, agent)
+    job.status = "running"
+    now = datetime.now(timezone.utc)
+    test_db.add(
+        AgentJobLog(
+            agent_job_id=job.id,
+            sequence=1,
+            stream="stdout",
+            message="live agent log",
+            created_at=now,
+            received_at=now,
+        )
+    )
+    test_db.commit()
+
+    response = test_client.get(
+        f"/api/managed-machines/agent-jobs/{job.id}/logs",
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()[0]["message"] == "live agent log"

--- a/tests/unit/test_api_rclone.py
+++ b/tests/unit/test_api_rclone.py
@@ -2346,6 +2346,52 @@ def test_repository_rclone_status_endpoint(
 
 
 @pytest.mark.unit
+def test_repository_rclone_status_applies_log_save_policy_to_latest_sync_job(
+    test_client: TestClient, admin_headers, test_db
+):
+    settings = test_db.query(SystemSettings).first()
+    if settings is None:
+        settings = SystemSettings()
+        test_db.add(settings)
+    settings.log_save_policy = "failed_only"
+    remote = RcloneRemote(name="prod-s3", provider="s3", config_source="managed")
+    repository = Repository(
+        name="App",
+        path="/cache/repositories/1",
+        encryption="none",
+        repository_type="rclone",
+    )
+    test_db.add_all([remote, repository])
+    test_db.flush()
+    storage = RepositoryStorage(
+        repository_id=repository.id,
+        backend="rclone",
+        rclone_remote_id=remote.id,
+        rclone_remote_path="borg-ui/repositories/app",
+        cache_path="/cache/repositories/1",
+        sync_policy="after_success",
+        sync_status="synced",
+    )
+    sync_job = RcloneSyncJob(
+        repository_id=repository.id,
+        direction="primary_to_remote",
+        operation="sync",
+        status="completed",
+        triggered_by="manual",
+        log_text="successful sync output",
+    )
+    test_db.add_all([storage, sync_job])
+    test_db.commit()
+
+    response = test_client.get(
+        f"/api/repositories/{repository.id}/rclone/status", headers=admin_headers
+    )
+
+    assert response.status_code == 200
+    assert response.json()["latest_sync_job"]["has_log"] is False
+
+
+@pytest.mark.unit
 def test_create_rclone_repository_rejects_client_cache_path(
     test_client: TestClient, admin_headers, test_db
 ):

--- a/tests/unit/test_api_repositories_routes.py
+++ b/tests/unit/test_api_repositories_routes.py
@@ -33,6 +33,15 @@ def _create_repo(test_db, name: str, path: str, **kwargs) -> Repository:
     return repo
 
 
+def _set_log_save_policy(test_db, policy: str) -> None:
+    settings = test_db.query(SystemSettings).first()
+    if settings is None:
+        settings = SystemSettings()
+        test_db.add(settings)
+    settings.log_save_policy = policy
+    test_db.flush()
+
+
 @pytest.mark.unit
 class TestRepositoryRouteContracts:
     def test_repositories_register_single_canonical_break_lock_route(self):
@@ -171,6 +180,7 @@ class TestRepositoryRouteContracts:
     def test_get_check_job_status_reads_log_file(
         self, test_client: TestClient, admin_headers, test_db, tmp_path
     ):
+        _set_log_save_policy(test_db, "all_jobs")
         repo = _create_repo(test_db, "Repo", "/repos/main")
         log_path = tmp_path / "check.log"
         log_path.write_text("first line\nsecond line\n", encoding="utf-8")
@@ -194,6 +204,7 @@ class TestRepositoryRouteContracts:
     def test_get_compact_job_status_reads_log_file(
         self, test_client: TestClient, admin_headers, test_db, tmp_path
     ):
+        _set_log_save_policy(test_db, "all_jobs")
         repo = _create_repo(test_db, "Repo", "/repos/main")
         log_path = tmp_path / "compact.log"
         log_path.write_text("compact output\n", encoding="utf-8")
@@ -217,6 +228,7 @@ class TestRepositoryRouteContracts:
     def test_get_prune_job_status_reads_log_file(
         self, test_client: TestClient, admin_headers, test_db, tmp_path
     ):
+        _set_log_save_policy(test_db, "all_jobs")
         repo = _create_repo(test_db, "Repo", "/repos/main")
         log_path = tmp_path / "prune.log"
         log_path.write_text("prune output\n", encoding="utf-8")

--- a/tests/unit/test_api_repository_wipe.py
+++ b/tests/unit/test_api_repository_wipe.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from app.database.models import Repository, RepositoryWipeJob
+from app.database.models import Repository, RepositoryWipeJob, SystemSettings
 
 
 def _create_repository(test_db, *, name: str = "Primary") -> Repository:
@@ -177,6 +177,83 @@ class TestRepositoryWipeApi:
         assert body["id"] == job.id
         assert body["status"] == "completed"
         assert body["repository_id"] == repo.id
+
+    def test_status_applies_log_save_policy(
+        self, test_client: TestClient, admin_headers, test_db, tmp_path
+    ):
+        settings = test_db.query(SystemSettings).first()
+        if settings is None:
+            settings = SystemSettings()
+            test_db.add(settings)
+        settings.log_save_policy = "failed_only"
+        repo = _create_repository(test_db)
+        log_file = tmp_path / "wipe.log"
+        log_file.write_text("successful wipe log", encoding="utf-8")
+        job = RepositoryWipeJob(
+            repository_id=repo.id,
+            repository_path=repo.path,
+            repository_name=repo.name,
+            borg_version=1,
+            status="completed",
+            phase="completed",
+            archive_count=2,
+            archive_fingerprint="sha256:abc",
+            run_compact=True,
+            started_at=datetime.utcnow(),
+            completed_at=datetime.utcnow(),
+            progress=100,
+            log_file_path=str(log_file),
+            has_logs=True,
+        )
+        test_db.add(job)
+        test_db.commit()
+
+        response = test_client.get(
+            f"/api/repositories/{repo.id}/wipe-jobs/{job.id}",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["has_logs"] is False
+        assert body["logs"] == ""
+
+    def test_status_returns_error_message_when_policy_treats_it_as_log(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        settings = test_db.query(SystemSettings).first()
+        if settings is None:
+            settings = SystemSettings()
+            test_db.add(settings)
+        settings.log_save_policy = "failed_only"
+        repo = _create_repository(test_db)
+        job = RepositoryWipeJob(
+            repository_id=repo.id,
+            repository_path=repo.path,
+            repository_name=repo.name,
+            borg_version=1,
+            status="failed",
+            phase="failed",
+            archive_count=2,
+            archive_fingerprint="sha256:abc",
+            run_compact=True,
+            started_at=datetime.utcnow(),
+            completed_at=datetime.utcnow(),
+            progress=40,
+            error_message="Repository wipe failed before log file creation",
+        )
+        test_db.add(job)
+        test_db.commit()
+
+        response = test_client.get(
+            f"/api/repositories/{repo.id}/wipe-jobs/{job.id}",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["has_logs"] is True
+        assert body["logs"] == "Repository wipe failed before log file creation"
 
     def test_cancel_preview_records_cancelled_audit_state(
         self, test_client: TestClient, admin_headers, test_db

--- a/tests/unit/test_api_restore.py
+++ b/tests/unit/test_api_restore.py
@@ -5,8 +5,17 @@ Comprehensive unit tests for restore API endpoints
 import pytest
 from unittest.mock import ANY, patch, AsyncMock
 from fastapi.testclient import TestClient
-from app.database.models import Repository, RestoreJob
+from app.database.models import Repository, RestoreJob, SystemSettings
 from tests.unit.helpers import assert_auth_required
+
+
+def _set_log_save_policy(test_db, policy: str) -> None:
+    settings = test_db.query(SystemSettings).first()
+    if settings is None:
+        settings = SystemSettings()
+        test_db.add(settings)
+    settings.log_save_policy = policy
+    test_db.flush()
 
 
 @pytest.mark.unit
@@ -764,6 +773,7 @@ class TestRestoreJobLogs:
         from app.database.models import RestoreJob
         from datetime import datetime, timezone
 
+        _set_log_save_policy(test_db, "all_jobs")
         job = RestoreJob(
             repository="/test/repo",
             archive="test-archive",
@@ -797,6 +807,7 @@ class TestRestoreJobLogs:
         from app.database.models import RestoreJob
         from datetime import datetime, timezone
 
+        _set_log_save_policy(test_db, "all_jobs")
         job = RestoreJob(
             repository="/test/repo",
             archive="test-archive",
@@ -818,6 +829,38 @@ class TestRestoreJobLogs:
         data = response.json()
         assert "logs" in data
         assert data["logs"] == job.logs
+
+    def test_restore_logs_follow_log_save_policy(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        from datetime import datetime, timezone
+
+        _set_log_save_policy(test_db, "failed_only")
+        job = RestoreJob(
+            repository="/test/repo",
+            archive="test-archive",
+            destination="/test/dest",
+            status="completed",
+            started_at=datetime.now(timezone.utc),
+            completed_at=datetime.now(timezone.utc),
+            logs="successful restore log",
+        )
+        test_db.add(job)
+        test_db.commit()
+        test_db.refresh(job)
+
+        jobs_response = test_client.get("/api/restore/jobs", headers=admin_headers)
+        assert jobs_response.status_code == 200
+        listed_job = next(
+            item for item in jobs_response.json()["jobs"] if item["id"] == job.id
+        )
+        assert listed_job["logs"] is None
+
+        status_response = test_client.get(
+            f"/api/restore/status/{job.id}", headers=admin_headers
+        )
+        assert status_response.status_code == 200
+        assert status_response.json()["logs"] is None
 
     def test_restore_jobs_with_null_logs(
         self, test_client: TestClient, admin_headers, test_db
@@ -853,6 +896,7 @@ class TestRestoreJobLogs:
         from app.database.models import RestoreJob
         from datetime import datetime, timezone
 
+        _set_log_save_policy(test_db, "all_jobs")
         job = RestoreJob(
             repository="/test/repo",
             archive="test-archive",
@@ -882,6 +926,7 @@ class TestRestoreJobLogs:
         from app.database.models import RestoreJob
         from datetime import datetime, timezone
 
+        _set_log_save_policy(test_db, "all_jobs")
         multiline_logs = """Starting restore operation
 Repository: /test/repo
 Archive: test-archive

--- a/tests/unit/test_api_v2_archives.py
+++ b/tests/unit/test_api_v2_archives.py
@@ -866,6 +866,8 @@ class TestV2ArchiveRoutes:
         self, test_client: TestClient, admin_headers, test_db, tmp_path
     ):
         _enable_borg_v2(test_db)
+        settings = test_db.query(SystemSettings).first()
+        settings.log_save_policy = "all_jobs"
         log_file = tmp_path / "delete.log"
         log_file.write_text("archive deleted")
         job = DeleteArchiveJob(
@@ -893,6 +895,38 @@ class TestV2ArchiveRoutes:
         assert body["has_logs"] is True
         assert body["started_at"] == "2026-04-27T03:00:06+00:00"
         assert body["completed_at"] == "2026-04-27T03:05:06+00:00"
+
+    def test_delete_job_status_applies_log_save_policy(
+        self, test_client: TestClient, admin_headers, test_db, tmp_path
+    ):
+        _enable_borg_v2(test_db)
+        settings = test_db.query(SystemSettings).first()
+        settings.log_save_policy = "failed_only"
+        log_file = tmp_path / "delete.log"
+        log_file.write_text("archive deleted", encoding="utf-8")
+        job = DeleteArchiveJob(
+            repository_id=1,
+            repository_path="/tmp/v2-archive-repo",
+            archive_name="archive-1",
+            status="completed",
+            started_at=datetime(2026, 4, 27, 3, 0, 6),
+            completed_at=datetime(2026, 4, 27, 3, 5, 6),
+            log_file_path=str(log_file),
+            has_logs=True,
+        )
+        test_db.add(job)
+        test_db.commit()
+        test_db.refresh(job)
+
+        response = test_client.get(
+            f"/api/v2/archives/delete-jobs/{job.id}",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["logs"] is None
+        assert body["has_logs"] is False
 
     def test_delete_job_status_returns_404_when_missing(
         self, test_client: TestClient, admin_headers, test_db


### PR DESCRIPTION
## Description
Applies `SystemSettings.log_save_policy` consistently to non-Activity log read and advertisement surfaces. Legacy backup list/status/stream/download, dashboard recent jobs, repository maintenance serializers, archive delete status, rclone latest-sync metadata, restore payloads, repository wipe status, and managed-agent job log reads now use the shared policy helpers before exposing `has_logs`, `has_log`, `logs`, or log rows.

Running log-capable jobs retain live log access, pending jobs do not advertise logs, and direct backup stream/download requests cannot retrieve logs hidden by policy. Agent backup history avoids loading full agent log rows unless warning/error text can affect the `failed_and_warnings` policy decision.

## Related Issue
BOR-152: https://linear.app/nullcodeai/issue/BOR-152/honor-log-save-policy-across-non-activity-log-apis

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `pytest tests/integration/test_api_restore_integration.py::TestRestoreLogsIntegration::test_restore_logs_available_via_jobs_api tests/integration/test_api_restore_integration.py::TestRestoreLogsIntegration::test_restore_logs_available_via_status_api -q` -> 2 passed, 35 warnings
- `pytest tests/unit/test_api_backup.py::TestBackupLogs tests/unit/test_api_dashboard.py::TestDashboardHelpers tests/unit/test_api_maintenance_jobs.py tests/unit/test_api_archives.py::TestArchivesResourceValidation::test_delete_job_status_applies_log_save_policy tests/unit/test_api_v2_archives.py::TestV2ArchiveRoutes::test_delete_job_status_returns_logs tests/unit/test_api_v2_archives.py::TestV2ArchiveRoutes::test_delete_job_status_applies_log_save_policy tests/unit/test_api_rclone.py::test_repository_rclone_status_endpoint tests/unit/test_api_rclone.py::test_repository_rclone_status_applies_log_save_policy_to_latest_sync_job tests/unit/test_api_managed_machines.py::test_delete_agent_hides_it_from_list_and_keeps_job_logs tests/unit/test_api_managed_machines.py::test_agent_job_logs_apply_log_save_policy tests/unit/test_api_managed_machines.py::test_agent_job_logs_keep_running_logs_visible tests/unit/test_api_restore.py::TestRestoreJobLogs tests/unit/test_api_repository_wipe.py::TestRepositoryWipeApi tests/unit/test_api_repositories_routes.py::TestRepositoryRouteContracts::test_get_check_job_status_reads_log_file tests/unit/test_api_repositories_routes.py::TestRepositoryRouteContracts::test_get_compact_job_status_reads_log_file tests/unit/test_api_repositories_routes.py::TestRepositoryRouteContracts::test_get_prune_job_status_reads_log_file -q` -> 73 passed, 35 warnings
- `rg -n '^### Task' docs/engineering/plans/2026-06-06-log-save-policy-non-activity.md || true` -> no output
- `ruff check app tests` -> passed
- `ruff format --check app tests` -> passed
- `git diff --check` -> passed

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; backend API behavior only.

## Additional Context
Agent log ingestion endpoints are intentionally unchanged because they are write-side transport/persistence paths rather than user-facing log read surfaces. User-facing managed-agent log row reads are gated at the admin read endpoint.

CodeRabbit feedback addressed in `6051994`:
- Avoided eager full-row agent log scans in backup `has_logs` checks.
- Returned repository wipe `error_message` as log content when policy says error-only failures have logs.
- Cached rclone log policy once in repository list serialization.
- Clarified the implementation plan's `app/api/agents.py` exclusion criteria.
- Fixed implementation-plan task heading levels for markdownlint MD001.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enforced a configurable log-save policy across job, repository and agent APIs so has_logs, logs, streams and downloads follow the configured policy.

* **Tests**
  * Expanded unit and integration tests to validate policy-driven log visibility for multiple job types and endpoints, including stream/download behaviors.

* **Documentation**
  * Added an engineering plan describing rollout and verification of the log-save policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->