### PR TITLE
Gate Remote Clients by plan entitlement

### DIFF
--- a/app/core/features.py
+++ b/app/core/features.py
@@ -23,6 +23,7 @@ FEATURES: dict[str, Plan] = {
     "backup_plan_mixed_sources": Plan.PRO,
     "rclone": Plan.PRO,
     "managed_agents": Plan.PRO,
+    "remote_clients": Plan.PRO,
     "multi_user": Plan.COMMUNITY,  # up to 5 users
     "extra_users": Plan.PRO,  # >5 users (up to 10 on Pro)
     "rbac": Plan.ENTERPRISE,  # role-based access control

--- a/docs/engineering/plans/2026-06-06-remote-clients-plan-gate.md
+++ b/docs/engineering/plans/2026-06-06-remote-clients-plan-gate.md
@@ -1,0 +1,109 @@
+# Remote Clients Plan Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:test-driven-development for implementation and
+> superpowers:verification-before-completion before claiming completion. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Gate Remote Clients to Pro and Enterprise plans while keeping local
+server access available for every plan.
+
+**Architecture:** Add a shared `remote_clients` Pro-minimum feature key, then
+reuse the existing `usePlan` and `PlanGate` primitives in the Remote Clients
+route, sidebar navigation, and global server target switcher. Selector logic
+will treat local targets separately from remote targets so Community users can
+always return to or stay on this server.
+
+**Tech Stack:** FastAPI feature catalog, React, TypeScript, MUI, lucide-react,
+Vitest, Storybook.
+
+---
+
+## Task 1: Reproduction and Failing Tests
+
+**Files:**
+
+- Modify: `frontend/src/components/__tests__/AppSidebar.test.tsx`
+- Modify: `frontend/src/pages/__tests__/RemoteClients.test.tsx`
+- Modify: `frontend/src/components/__tests__/BackendTargetSwitcher.test.tsx`
+- Modify if backend feature key is added: `tests/unit/test_core_features.py`
+
+- [ ] Add a failing sidebar test proving Community users with SSH management
+      permission do not see the Remote Clients link.
+- [ ] Add a failing Remote Clients page test proving Community users see the
+      plan gate instead of the management controls.
+- [ ] Add a failing server switcher test proving Community users can keep local
+      server access but cannot switch to a compatible remote client.
+- [ ] Add a failing server switcher test proving Community users cannot open
+      Remote Clients management from the global selector.
+- [ ] Add a backend feature-catalog assertion if `remote_clients` is added to
+      `app/core/features.py`.
+- [ ] Run the targeted tests and record the red evidence.
+
+## Task 2: Shared Entitlement Key
+
+**Files:**
+
+- Modify: `app/core/features.py`
+- Modify: `frontend/src/core/features.ts`
+- Modify: `frontend/src/locales/en.json`
+- Modify: `frontend/src/locales/es.json`
+- Modify: `frontend/src/locales/de.json`
+- Modify: `frontend/src/locales/it.json`
+
+- [ ] Add `remote_clients` as a Pro feature in backend and frontend catalogs.
+- [ ] Add Remote Clients-specific upgrade copy under existing locale sections.
+- [ ] Keep the feature key name consistent across backend, frontend, tests, and
+      analytics surfaces.
+
+## Task 3: Gate Navigation and Management
+
+**Files:**
+
+- Modify: `frontend/src/components/AppSidebar.tsx`
+- Modify: `frontend/src/pages/RemoteClients.tsx`
+- Modify: `docs/navigation.md`
+- Modify: `docs/remote-clients.md`
+
+- [ ] Read `can('remote_clients')` in the sidebar and hide the Remote Clients
+      nav item when the plan lacks access.
+- [ ] Wrap `RemoteClientsContent` in `PlanGate feature="remote_clients"` after
+      the existing permission check.
+- [ ] Use a Remote Clients-specific fallback copy that points to upgrading to
+      Pro.
+- [ ] Update user docs to say Remote Clients require Pro or Enterprise and that
+      this server remains available locally.
+
+## Task 4: Gate Global Server Selection
+
+**Files:**
+
+- Modify: `frontend/src/components/BackendTargetSwitcher.tsx`
+- Modify if needed: `frontend/src/components/backendTargetPresentation.tsx`
+- Modify if needed: `frontend/src/components/BackendTargetSwitcher.stories.tsx`
+
+- [ ] Use `can('remote_clients')` in the switcher.
+- [ ] Leave the local target enabled for every plan.
+- [ ] Disable remote target menu items when the plan lacks access, even if the
+      remote target is otherwise compatible.
+- [ ] Replace the manage-menu action with a disabled upgrade item for denied
+      plans, so clicking it cannot navigate silently.
+- [ ] Preserve the existing incompatible-client disabled state for all plans.
+
+## Task 5: Stories and Final Validation
+
+**Files:**
+
+- Modify: `frontend/src/pages/RemoteClients.stories.tsx`
+- Modify: `frontend/src/components/BackendTargetSwitcher.stories.tsx`
+
+- [ ] Add locked Community stories for the Remote Clients page and global
+      switcher.
+- [ ] Run targeted Vitest tests for sidebar, management, switcher, and backend
+      feature catalog if touched.
+- [ ] Run required frontend validation: locales, typecheck, lint, build.
+- [ ] Run backend validation required by changed backend files.
+- [ ] Run a local runtime walkthrough for denied and allowed user paths.
+- [ ] Commit, push, create/update PR from the repository template, add the
+      `symphony` label, sweep PR feedback/checks, update the workpad handoff,
+      and move the issue to Human Review only when all gates are green.

--- a/docs/engineering/specs/2026-06-06-remote-clients-plan-gate.md
+++ b/docs/engineering/specs/2026-06-06-remote-clients-plan-gate.md
@@ -1,0 +1,73 @@
+# Remote Clients Plan Gate Spec
+
+## Problem
+
+Remote Clients are currently available to any user who has the SSH management
+permission. The workflow lets a browser register other Borg UI servers and
+switch frontend API traffic to those servers, but it is not tied to the plan
+entitlement system. Community users can therefore see and use a workflow that
+should be limited to paid plans.
+
+## Desired Outcome
+
+Remote Clients are available only when the `remote_clients` feature is included
+in the current plan. The minimum plan is Pro, so Enterprise inherits access.
+Community users should keep using this local server normally, while remote
+client registration, management, and switching are blocked with existing Borg UI
+upgrade messaging.
+
+## Entitlement
+
+Add a `remote_clients` feature key as Pro-minimum in the shared backend and
+frontend feature catalogs. The backend catalog feeds `/api/system/info`
+`features` and `feature_access`; the frontend catalog remains the fallback when
+older responses do not include a feature access override.
+
+## UI Behavior
+
+- Sidebar navigation should show Remote Clients only when the user has SSH
+  management permission and the plan can access `remote_clients`.
+- The `/remote-clients` route should continue to enforce SSH management
+  permission and should render the shared `PlanGate` upgrade treatment for
+  users whose plan lacks `remote_clients`.
+- The global server target switcher should keep the local server selectable for
+  every plan.
+- The global server target switcher should not silently allow unavailable-plan
+  users to switch to a remote target or open Remote Clients management.
+- Upgrade copy should be specific to Remote Clients and use the existing Borg UI
+  upgrade prompt treatment rather than adding a new gate pattern.
+- Disabled remote targets should remain visibly disabled and keyboard-safe.
+
+## Non-Goals
+
+- Removing stored remote clients on downgrade.
+- Adding backend persistence or API enforcement for remote clients; the current
+  Remote Clients implementation is browser-local.
+- Changing permissions for Remote Machines, Managed Agents, Cloud Storage, or
+  other Infrastructure items.
+- Changing plan pricing, licensing activation, or entitlement refresh behavior.
+
+## Acceptance Mapping
+
+- Remote Clients navigation and management access are gated to Pro and
+  Enterprise users.
+- Community users see the existing plan-gate upgrade treatment on the management
+  page.
+- The global server selector preserves local server access and blocks remote
+  add/switch/manage paths for Community users.
+- Pro and Enterprise users retain Remote Clients navigation, management, and
+  switching.
+- Tests cover allowed and denied plan states for navigation, management, and
+  server selection.
+- Storybook covers locked and allowed states for the changed UI surfaces.
+
+## Validation
+
+- Targeted Vitest tests for `AppSidebar`, `RemoteClients`, and
+  `BackendTargetSwitcher`.
+- `cd frontend && npm run check:locales`
+- `cd frontend && npm run typecheck`
+- `cd frontend && npm run lint`
+- `cd frontend && npm run build`
+- Backend feature-catalog tests if `app/core/features.py` changes.
+- Runtime walkthrough covering a denied Community path and an allowed Pro path.

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -16,7 +16,7 @@ For a new setup, follow the sidebar in this order:
 
 1. Open Dashboard to check overall health.
 2. Add storage targets from Repositories or Cloud Storage, and register infrastructure endpoints
-   from Remote Clients or Remote Machines.
+   from Remote Clients on Pro/Enterprise plans or from Remote Machines.
 3. Create a plan from Backup Plans.
 4. Configure automatic runs from the plan schedule or the Schedule page.
 5. Watch work in Activity and browse results in Archives.
@@ -28,7 +28,7 @@ For a new setup, follow the sidebar in this order:
 | --- | --- | --- |
 | Main | Dashboard | Check repository health, recent activity, backup freshness, and restore-check status. |
 | Main | Activity | Review job history, live or recent logs, failures, and completed backup, restore, check, prune, compact, script, or package work. |
-| Infrastructure | Remote Clients | Register other Borg UI client servers, check health and version compatibility, and switch this browser to a remote client. |
+| Infrastructure | Remote Clients | Register other Borg UI client servers, check health and version compatibility, and switch this browser to a remote client. Requires Pro or Enterprise. |
 | Infrastructure | Remote Machines | Add SSH-connected machines for remote repositories, remote backup sources, and SSH restore destinations. |
 | Infrastructure | Managed Agents | Enroll and manage Borg UI agents on remote machines. |
 | Infrastructure | Cloud Storage | Configure reusable rclone remotes for Cloud Mirror targets and advanced direct Borg 2 rclone repository URLs. |

--- a/docs/remote-clients.md
+++ b/docs/remote-clients.md
@@ -15,6 +15,10 @@ Open Remote Clients from the Infrastructure navigation group. The global
 server target control near the account menu shows whether the browser is using
 this server or a registered remote client.
 
+Remote Clients require a Pro or Enterprise plan. Community installations keep
+using this server locally, but cannot add remote clients or switch the browser
+to a remote Borg UI server until the instance is upgraded.
+
 ## Add a Remote Client
 
 In Remote Clients, choose **Add remote client** and enter:

--- a/frontend/src/components/AppSidebar.stories.tsx
+++ b/frontend/src/components/AppSidebar.stories.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import MockAdapter from 'axios-mock-adapter'
+import { Box } from '@mui/material'
+import { BrowserRouter } from 'react-router-dom'
+import AppSidebar from './AppSidebar'
+import { AppProvider } from '../context/AppContext'
+import { AuthProvider } from '../hooks/useAuth'
+import api from '../services/api'
+import { RemoteBackendProvider } from '../services/remoteBackends/context'
+import {
+  communitySystemInfo,
+  proSystemInfo,
+} from '../services/remoteBackends/planStoryFixtures'
+import type { SystemInfo } from '../hooks/useSystemInfo'
+
+const adminUser = {
+  id: 1,
+  username: 'admin',
+  full_name: 'Admin User',
+  email: 'admin@example.com',
+  is_active: true,
+  role: 'admin',
+  deployment_type: 'individual' as const,
+  created_at: '2026-06-06T00:00:00.000Z',
+  global_permissions: [
+    'settings.users.manage',
+    'settings.system.manage',
+    'settings.mqtt.manage',
+    'settings.packages.manage',
+    'settings.scripts.manage',
+    'settings.export_import.manage',
+    'settings.beta.manage',
+    'settings.mounts.manage',
+    'settings.ssh.manage',
+  ],
+}
+
+function installApiMocks(systemInfo: SystemInfo): MockAdapter {
+  const mock = new MockAdapter(api)
+  mock.onGet('/auth/config').reply(200, {
+    proxy_auth_enabled: true,
+    insecure_no_auth_enabled: false,
+    authentication_required: true,
+    oidc_enabled: false,
+    oidc_provider_name: null,
+    oidc_disable_local_auth: false,
+    proxy_auth_header: 'x-auth-user',
+    proxy_auth_health: { enabled: true, warnings: [] },
+  })
+  mock.onGet('/auth/me').reply(200, adminUser)
+  mock.onGet('/system/info').reply(200, systemInfo)
+  mock.onGet('/settings/system').reply(200, { settings: {} })
+  mock.onGet('/backup-plans/').reply(200, { backup_plans: [] })
+  mock.onGet('/repositories/').reply(200, { repositories: [{ id: 1, name: 'Main repo' }] })
+  mock.onGet('/ssh-keys').reply(200, { ssh_keys: [{ id: 1, name: 'System key' }] })
+  mock.onAny().reply(200, {})
+  return mock
+}
+
+function SidebarStoryProviders({
+  children,
+  systemInfo,
+}: {
+  children: ReactNode
+  systemInfo: SystemInfo
+}) {
+  const [isReady, setIsReady] = useState(false)
+
+  useEffect(() => {
+    const mock = installApiMocks(systemInfo)
+    setIsReady(true)
+
+    return () => {
+      mock.restore()
+    }
+  }, [systemInfo])
+
+  if (!isReady) return null
+
+  return (
+    <BrowserRouter>
+      <RemoteBackendProvider>
+        <AuthProvider>
+          <AppProvider>{children}</AppProvider>
+        </AuthProvider>
+      </RemoteBackendProvider>
+    </BrowserRouter>
+  )
+}
+
+function renderSidebar(systemInfo: SystemInfo) {
+  return (
+    <SidebarStoryProviders systemInfo={systemInfo}>
+      <Box sx={{ width: 260, height: 720, bgcolor: 'background.default' }}>
+        <AppSidebar mobileOpen={false} onClose={() => {}} />
+      </Box>
+    </SidebarStoryProviders>
+  )
+}
+
+const meta = {
+  title: 'Components/AppSidebar',
+  component: AppSidebar,
+  args: {
+    mobileOpen: false,
+    onClose: () => {},
+  },
+  parameters: {
+    layout: 'fullscreen',
+    systemInfo: proSystemInfo,
+  },
+} satisfies Meta<typeof AppSidebar>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const WithRemoteClients: Story = {
+  render: () => renderSidebar(proSystemInfo),
+}
+
+export const WithoutRemoteClients: Story = {
+  parameters: {
+    systemInfo: communitySystemInfo,
+  },
+  render: () => renderSidebar(communitySystemInfo),
+}

--- a/frontend/src/components/AppSidebar.stories.tsx
+++ b/frontend/src/components/AppSidebar.stories.tsx
@@ -8,10 +8,7 @@ import { AppProvider } from '../context/AppContext'
 import { AuthProvider } from '../hooks/useAuth'
 import api from '../services/api'
 import { RemoteBackendProvider } from '../services/remoteBackends/context'
-import {
-  communitySystemInfo,
-  proSystemInfo,
-} from '../services/remoteBackends/planStoryFixtures'
+import { communitySystemInfo, proSystemInfo } from '../services/remoteBackends/planStoryFixtures'
 import type { SystemInfo } from '../hooks/useSystemInfo'
 
 const adminUser = {

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -34,6 +34,7 @@ import {
 } from 'lucide-react'
 import api, { settingsAPI, backupPlansAPI } from '../services/api'
 import { useAuth } from '../hooks/useAuth'
+import { usePlan } from '../hooks/usePlan'
 import NavItem from './NavItem'
 import NavGroup from './NavGroup'
 import SidebarVersionInfo from './SidebarVersionInfo'
@@ -87,6 +88,8 @@ export default function AppSidebar({ mobileOpen, onClose }: AppSidebarProps) {
   const canManageBeta = hasGlobalPermission('settings.beta.manage')
   const canManageMounts = hasGlobalPermission('settings.mounts.manage')
   const canManageSsh = hasGlobalPermission('settings.ssh.manage')
+  const { can: canUsePlanFeature, isLoading: isPlanLoading } = usePlan()
+  const canUseRemoteClients = !isPlanLoading && canUsePlanFeature('remote_clients')
   const { tabEnablement, getTabDisabledReason } = useTabEnablement()
   const [systemInfo, setSystemInfo] = useState<SystemInfo | null>(null)
   const [expandedMenus, setExpandedMenus] = useState<Record<string, boolean>>({})
@@ -166,12 +169,16 @@ export default function AppSidebar({ mobileOpen, onClose }: AppSidebarProps) {
     }> = [
       ...(canManageSsh
         ? [
-            {
-              name: 'Remote Clients',
-              href: '/remote-clients',
-              icon: Network,
-              key: 'connections' as const,
-            },
+            ...(canUseRemoteClients
+              ? [
+                  {
+                    name: 'Remote Clients',
+                    href: '/remote-clients',
+                    icon: Network,
+                    key: 'connections' as const,
+                  },
+                ]
+              : []),
             {
               name: 'Remote Machines',
               href: '/ssh-connections',
@@ -317,6 +324,7 @@ export default function AppSidebar({ mobileOpen, onClose }: AppSidebarProps) {
     canManageBeta,
     canManageMounts,
     canManageSsh,
+    canUseRemoteClients,
   ])
 
   // Auto-expand menus based on current route

--- a/frontend/src/components/BackendTargetSelect.stories.tsx
+++ b/frontend/src/components/BackendTargetSelect.stories.tsx
@@ -2,34 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Box } from '@mui/material'
 import BackendTargetSelect from './BackendTargetSelect'
 import { RemoteBackendStoryProvider } from '../services/remoteBackends/storyFixtures'
-import type { SystemInfo } from '../hooks/useSystemInfo'
-
-const featureMap = {
-  borg_v2: 'pro',
-  backup_plan_multi_repository: 'pro',
-  backup_plan_mixed_sources: 'pro',
-  rclone: 'pro',
-  managed_agents: 'pro',
-  remote_clients: 'pro',
-  multi_user: 'community',
-  extra_users: 'pro',
-  rbac: 'enterprise',
-} as const
-
-const proSystemInfo: SystemInfo = {
-  app_version: '2.2.2-alpha.1',
-  borg_version: 'borg 1.4.1',
-  borg2_version: 'borg2 2.0.0b19',
-  plan: 'pro',
-  features: featureMap,
-  feature_access: { remote_clients: true },
-}
-
-const communitySystemInfo: SystemInfo = {
-  ...proSystemInfo,
-  plan: 'community',
-  feature_access: { remote_clients: false },
-}
+import { communitySystemInfo, proSystemInfo } from '../services/remoteBackends/planStoryFixtures'
 
 const meta = {
   title: 'Components/BackendTargetSelect',

--- a/frontend/src/components/BackendTargetSelect.stories.tsx
+++ b/frontend/src/components/BackendTargetSelect.stories.tsx
@@ -2,12 +2,41 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Box } from '@mui/material'
 import BackendTargetSelect from './BackendTargetSelect'
 import { RemoteBackendStoryProvider } from '../services/remoteBackends/storyFixtures'
+import type { SystemInfo } from '../hooks/useSystemInfo'
+
+const featureMap = {
+  borg_v2: 'pro',
+  backup_plan_multi_repository: 'pro',
+  backup_plan_mixed_sources: 'pro',
+  rclone: 'pro',
+  managed_agents: 'pro',
+  remote_clients: 'pro',
+  multi_user: 'community',
+  extra_users: 'pro',
+  rbac: 'enterprise',
+} as const
+
+const proSystemInfo: SystemInfo = {
+  app_version: '2.2.2-alpha.1',
+  borg_version: 'borg 1.4.1',
+  borg2_version: 'borg2 2.0.0b19',
+  plan: 'pro',
+  features: featureMap,
+  feature_access: { remote_clients: true },
+}
+
+const communitySystemInfo: SystemInfo = {
+  ...proSystemInfo,
+  plan: 'community',
+  feature_access: { remote_clients: false },
+}
 
 const meta = {
   title: 'Components/BackendTargetSelect',
   component: BackendTargetSelect,
   parameters: {
     layout: 'centered',
+    systemInfo: proSystemInfo,
   },
 } satisfies Meta<typeof BackendTargetSelect>
 
@@ -28,6 +57,19 @@ export const LoginFormSelector: Story = {
 export const RemoteSelected: Story = {
   render: () => (
     <RemoteBackendStoryProvider state="activeRemote">
+      <Box sx={{ width: 360 }}>
+        <BackendTargetSelect />
+      </Box>
+    </RemoteBackendStoryProvider>
+  ),
+}
+
+export const LockedCommunity: Story = {
+  parameters: {
+    systemInfo: communitySystemInfo,
+  },
+  render: () => (
+    <RemoteBackendStoryProvider state="mixed">
       <Box sx={{ width: 360 }}>
         <BackendTargetSelect />
       </Box>

--- a/frontend/src/components/BackendTargetSelect.tsx
+++ b/frontend/src/components/BackendTargetSelect.tsx
@@ -1,8 +1,10 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { Chip, type SxProps, type Theme } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import RichSelect, { type RichSelectOption } from './shared/RichSelect'
+import { usePlan } from '@/hooks/usePlan'
 import { useRemoteBackends } from '@/services/remoteBackends/context'
+import { LOCAL_BACKEND_ID } from '@/services/remoteBackends/storage'
 import {
   buildBackendTargets,
   getBackendTargetName,
@@ -25,17 +27,30 @@ export default function BackendTargetSelect({
 }: BackendTargetSelectProps) {
   const { t } = useTranslation()
   const { activeTarget, clients, switchTarget } = useRemoteBackends()
+  const { can } = usePlan()
+  const canUseRemoteClients = can('remote_clients')
   const targets = useMemo(() => buildBackendTargets(clients, t), [clients, t])
+
+  useEffect(() => {
+    if (!canUseRemoteClients && activeTarget.kind === 'remote') {
+      switchTarget(LOCAL_BACKEND_ID)
+    }
+  }, [activeTarget.kind, canUseRemoteClients, switchTarget])
+
   const options = useMemo<RichSelectOption[]>(
     () =>
       targets.map((target) => {
-        const status = getBackendTargetStatus(target, t)
+        const status = getBackendTargetStatus(target, t, {
+          remoteClientsAvailable: canUseRemoteClients,
+        })
         return {
           value: target.id,
           primary: getBackendTargetName(target, t),
           secondary: status.helper,
           icon: status.icon,
-          disabled: isBackendTargetDisabled(target),
+          disabled: isBackendTargetDisabled(target, {
+            remoteClientsAvailable: canUseRemoteClients,
+          }),
           indicator: (
             <Chip
               size="small"
@@ -46,12 +61,17 @@ export default function BackendTargetSelect({
           ),
         }
       }),
-    [targets, t]
+    [canUseRemoteClients, targets, t]
   )
 
   const handleChange = (targetId: string) => {
     const target = targets.find((item) => item.id === targetId)
-    if (!target || isBackendTargetDisabled(target)) return
+    if (
+      !target ||
+      isBackendTargetDisabled(target, { remoteClientsAvailable: canUseRemoteClients })
+    ) {
+      return
+    }
     switchTarget(targetId)
   }
 

--- a/frontend/src/components/BackendTargetSwitcher.stories.tsx
+++ b/frontend/src/components/BackendTargetSwitcher.stories.tsx
@@ -3,12 +3,41 @@ import { Box } from '@mui/material'
 import { BrowserRouter } from 'react-router-dom'
 import BackendTargetSwitcher from './BackendTargetSwitcher'
 import { RemoteBackendStoryProvider } from '../services/remoteBackends/storyFixtures'
+import type { SystemInfo } from '../hooks/useSystemInfo'
+
+const featureMap = {
+  borg_v2: 'pro',
+  backup_plan_multi_repository: 'pro',
+  backup_plan_mixed_sources: 'pro',
+  rclone: 'pro',
+  managed_agents: 'pro',
+  remote_clients: 'pro',
+  multi_user: 'community',
+  extra_users: 'pro',
+  rbac: 'enterprise',
+} as const
+
+const proSystemInfo: SystemInfo = {
+  app_version: '2.2.2-alpha.1',
+  borg_version: 'borg 1.4.1',
+  borg2_version: 'borg2 2.0.0b19',
+  plan: 'pro',
+  features: featureMap,
+  feature_access: { remote_clients: true },
+}
+
+const communitySystemInfo: SystemInfo = {
+  ...proSystemInfo,
+  plan: 'community',
+  feature_access: { remote_clients: false },
+}
 
 const meta = {
   title: 'Components/BackendTargetSwitcher',
   component: BackendTargetSwitcher,
   parameters: {
     layout: 'centered',
+    systemInfo: proSystemInfo,
   },
 } satisfies Meta<typeof BackendTargetSwitcher>
 
@@ -41,4 +70,15 @@ export const Compact: Story = {
     compact: true,
   },
   render: (args) => renderSwitcher('activeRemote', args),
+}
+
+export const LockedCommunity: Story = {
+  parameters: {
+    systemInfo: communitySystemInfo,
+  },
+  render: () => renderSwitcher('mixed'),
+  play: async ({ canvasElement }) => {
+    await new Promise((resolve) => window.setTimeout(resolve, 0))
+    canvasElement.querySelector('button')?.click()
+  },
 }

--- a/frontend/src/components/BackendTargetSwitcher.stories.tsx
+++ b/frontend/src/components/BackendTargetSwitcher.stories.tsx
@@ -3,34 +3,7 @@ import { Box } from '@mui/material'
 import { BrowserRouter } from 'react-router-dom'
 import BackendTargetSwitcher from './BackendTargetSwitcher'
 import { RemoteBackendStoryProvider } from '../services/remoteBackends/storyFixtures'
-import type { SystemInfo } from '../hooks/useSystemInfo'
-
-const featureMap = {
-  borg_v2: 'pro',
-  backup_plan_multi_repository: 'pro',
-  backup_plan_mixed_sources: 'pro',
-  rclone: 'pro',
-  managed_agents: 'pro',
-  remote_clients: 'pro',
-  multi_user: 'community',
-  extra_users: 'pro',
-  rbac: 'enterprise',
-} as const
-
-const proSystemInfo: SystemInfo = {
-  app_version: '2.2.2-alpha.1',
-  borg_version: 'borg 1.4.1',
-  borg2_version: 'borg2 2.0.0b19',
-  plan: 'pro',
-  features: featureMap,
-  feature_access: { remote_clients: true },
-}
-
-const communitySystemInfo: SystemInfo = {
-  ...proSystemInfo,
-  plan: 'community',
-  feature_access: { remote_clients: false },
-}
+import { communitySystemInfo, proSystemInfo } from '../services/remoteBackends/planStoryFixtures'
 
 const meta = {
   title: 'Components/BackendTargetSwitcher',

--- a/frontend/src/components/BackendTargetSwitcher.tsx
+++ b/frontend/src/components/BackendTargetSwitcher.tsx
@@ -1,11 +1,13 @@
-import { type MouseEvent, useState } from 'react'
+import { type MouseEvent, useEffect, useState } from 'react'
 import { Box, Button, Chip, Divider, MenuItem, MenuList, Popover, Typography } from '@mui/material'
 import { alpha, useTheme } from '@mui/material/styles'
-import { Settings } from 'lucide-react'
+import { Lock, Settings } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { useRemoteBackends } from '@/services/remoteBackends/context'
+import { LOCAL_BACKEND_ID } from '@/services/remoteBackends/storage'
 import type { BackendTarget } from '@/services/remoteBackends/types'
+import { usePlan } from '@/hooks/usePlan'
 import {
   buildBackendTargets,
   getBackendTargetName,
@@ -22,11 +24,21 @@ export default function BackendTargetSwitcher({ compact = false }: BackendTarget
   const muiTheme = useTheme()
   const navigate = useNavigate()
   const { activeTarget, clients, switchTarget } = useRemoteBackends()
+  const { can } = usePlan()
+  const canUseRemoteClients = can('remote_clients')
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const open = Boolean(anchorEl)
   const targets = buildBackendTargets(clients, t)
-  const activeStatus = getBackendTargetStatus(activeTarget, t)
+  const activeStatus = getBackendTargetStatus(activeTarget, t, {
+    remoteClientsAvailable: canUseRemoteClients,
+  })
   const activeName = getBackendTargetName(activeTarget, t)
+
+  useEffect(() => {
+    if (!canUseRemoteClients && activeTarget.kind === 'remote') {
+      switchTarget(LOCAL_BACKEND_ID)
+    }
+  }, [activeTarget.kind, canUseRemoteClients, switchTarget])
 
   const closeMenu = () => setAnchorEl(null)
 
@@ -35,7 +47,7 @@ export default function BackendTargetSwitcher({ compact = false }: BackendTarget
   }
 
   const handleSwitch = (target: BackendTarget) => {
-    if (target.kind === 'remote' && target.health.compatibility === 'incompatible') {
+    if (isBackendTargetDisabled(target, { remoteClientsAvailable: canUseRemoteClients })) {
       return
     }
 
@@ -126,8 +138,12 @@ export default function BackendTargetSwitcher({ compact = false }: BackendTarget
           sx={{ py: 0.75 }}
         >
           {targets.map((target) => {
-            const status = getBackendTargetStatus(target, t)
-            const disabled = isBackendTargetDisabled(target)
+            const status = getBackendTargetStatus(target, t, {
+              remoteClientsAvailable: canUseRemoteClients,
+            })
+            const disabled = isBackendTargetDisabled(target, {
+              remoteClientsAvailable: canUseRemoteClients,
+            })
             const selected = activeTarget.id === target.id
 
             return (
@@ -169,19 +185,37 @@ export default function BackendTargetSwitcher({ compact = false }: BackendTarget
             )
           })}
           <Divider sx={{ my: 0.75 }} />
-          <MenuItem
-            role="menuitem"
-            onClick={() => {
-              closeMenu()
-              navigate('/remote-clients')
-            }}
-            sx={{ mx: 0.75, borderRadius: 1, gap: 1.25 }}
-          >
-            <Settings size={14} />
-            <Typography variant="body2" sx={{ fontWeight: 700 }}>
-              {t('remoteClients.switcher.manage')}
-            </Typography>
-          </MenuItem>
+          {canUseRemoteClients ? (
+            <MenuItem
+              role="menuitem"
+              onClick={() => {
+                closeMenu()
+                navigate('/remote-clients')
+              }}
+              sx={{ mx: 0.75, borderRadius: 1, gap: 1.25 }}
+            >
+              <Settings size={14} />
+              <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                {t('remoteClients.switcher.manage')}
+              </Typography>
+            </MenuItem>
+          ) : (
+            <MenuItem
+              role="menuitem"
+              disabled
+              sx={{ mx: 0.75, borderRadius: 1, gap: 1.25, alignItems: 'flex-start' }}
+            >
+              <Lock size={14} />
+              <Box>
+                <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                  {t('remoteClients.switcher.manageRequiresPlan')}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {t('remoteClients.switcher.remotePlanUnavailable')}
+                </Typography>
+              </Box>
+            </MenuItem>
+          )}
         </MenuList>
       </Popover>
     </>

--- a/frontend/src/components/__tests__/AppHeader.test.tsx
+++ b/frontend/src/components/__tests__/AppHeader.test.tsx
@@ -87,6 +87,7 @@ vi.mock('../../hooks/usePlan', () => ({
     features: {},
     entitlement: undefined,
     isLoading: false,
+    can: () => true,
   }),
 }))
 

--- a/frontend/src/components/__tests__/AppSidebar.test.tsx
+++ b/frontend/src/components/__tests__/AppSidebar.test.tsx
@@ -7,6 +7,7 @@ const {
   mockApiGet,
   mockGetSystemSettings,
   mockListBackupPlans,
+  mockPlanCan,
   mockSetAppVersion,
   mockTabEnablement,
   mockGetTabDisabledReason,
@@ -14,6 +15,7 @@ const {
   mockApiGet: vi.fn().mockResolvedValue({ data: {} }),
   mockGetSystemSettings: vi.fn().mockResolvedValue({ data: { settings: {} } }),
   mockListBackupPlans: vi.fn().mockResolvedValue({ data: { backup_plans: [] } }),
+  mockPlanCan: vi.fn((_feature: string) => true),
   mockSetAppVersion: vi.fn(),
   mockTabEnablement: {
     dashboard: true,
@@ -74,6 +76,16 @@ vi.mock('../../hooks/useAuth', () => ({
   }),
 }))
 
+vi.mock('../../hooks/usePlan', () => ({
+  usePlan: () => ({
+    plan: 'pro',
+    features: {},
+    entitlement: undefined,
+    isLoading: false,
+    can: mockPlanCan,
+  }),
+}))
+
 function renderSidebar({
   initialRoute,
   systemSettings = {},
@@ -110,6 +122,7 @@ describe('AppSidebar', () => {
     mockGetTabDisabledReason.mockReturnValue(null)
     mockGetSystemSettings.mockResolvedValue({ data: { settings: {} } })
     mockListBackupPlans.mockResolvedValue({ data: { backup_plans: [] } })
+    mockPlanCan.mockReturnValue(true)
     mockApiGet.mockResolvedValue({
       data: { app_version: '1.78.0', borg_version: 'borg 1.4.0', borg2_version: 'borg2 2.0.0' },
     })
@@ -155,6 +168,21 @@ describe('AppSidebar', () => {
 
     const managedAgentLinks = screen.getAllByRole('link', { name: /managed agents/i })
     expect(managedAgentLinks[0]).toHaveAttribute('href', '/managed-agents')
+  })
+
+  it('hides Remote Clients navigation when the plan lacks remote client access', async () => {
+    mockPlanCan.mockImplementation((feature) => feature !== 'remote_clients')
+
+    renderSidebar()
+
+    await waitFor(() => {
+      expect(screen.queryAllByRole('link', { name: /remote clients/i })).toHaveLength(0)
+      expect(screen.queryByText('Remote Clients')).not.toBeInTheDocument()
+    })
+    expect(screen.getAllByRole('link', { name: /remote machines/i })[0]).toHaveAttribute(
+      'href',
+      '/ssh-connections'
+    )
   })
 
   it('renders the version info section', async () => {

--- a/frontend/src/components/__tests__/BackendTargetSwitcher.test.tsx
+++ b/frontend/src/components/__tests__/BackendTargetSwitcher.test.tsx
@@ -10,11 +10,24 @@ import {
 } from '../../services/remoteBackends/storage'
 
 const navigateMock = vi.fn()
+const { mockPlanCan } = vi.hoisted(() => ({
+  mockPlanCan: vi.fn((_feature: string) => true),
+}))
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
   return { ...actual, useNavigate: () => navigateMock }
 })
+
+vi.mock('../../hooks/usePlan', () => ({
+  usePlan: () => ({
+    plan: 'community',
+    features: {},
+    entitlement: undefined,
+    isLoading: false,
+    can: mockPlanCan,
+  }),
+}))
 
 function renderSwitcher() {
   return renderWithProviders(
@@ -29,6 +42,7 @@ describe('BackendTargetSwitcher', () => {
     vi.clearAllMocks()
     localStorage.clear()
     resetRemoteBackendStateForTests()
+    mockPlanCan.mockReturnValue(true)
   })
 
   it('shows this server as the default target', () => {
@@ -61,6 +75,37 @@ describe('BackendTargetSwitcher', () => {
       expect(screen.getByRole('button', { name: /server target studio nas/i })).toBeInTheDocument()
       expect(screen.getByText('Remote client')).toBeInTheDocument()
     })
+  })
+
+  it('keeps the local server available but blocks remote switching when the plan lacks access', async () => {
+    mockPlanCan.mockImplementation((feature) => feature !== 'remote_clients')
+    const remote = createRemoteBackendClient({
+      name: 'Studio NAS',
+      backendUrl: 'nas.local:9000',
+    })
+    updateRemoteBackendHealth(remote.id, {
+      status: 'online',
+      checkedAt: '2026-06-05T00:00:00.000Z',
+      appVersion: '2.2.1',
+      compatibility: 'compatible',
+      compatibilityMessage: 'Compatible',
+    })
+    const user = userEvent.setup()
+    renderSwitcher()
+
+    await user.click(screen.getByRole('button', { name: /server target this server/i }))
+    const menu = await screen.findByRole('menu', { name: /server targets/i })
+
+    expect(within(menu).getByRole('menuitem', { name: /this server/i })).not.toHaveAttribute(
+      'aria-disabled',
+      'true'
+    )
+    expect(within(menu).getByRole('menuitem', { name: /studio nas/i })).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    )
+
+    expect(navigateMock).not.toHaveBeenCalled()
   })
 
   it('disables incompatible remote targets', async () => {
@@ -100,5 +145,20 @@ describe('BackendTargetSwitcher', () => {
     await user.click(await screen.findByRole('menuitem', { name: /manage remote clients/i }))
 
     expect(navigateMock).toHaveBeenCalledWith('/remote-clients')
+  })
+
+  it('does not navigate to remote client management when the plan lacks access', async () => {
+    mockPlanCan.mockImplementation((feature) => feature !== 'remote_clients')
+    const user = userEvent.setup()
+    renderSwitcher()
+
+    await user.click(screen.getByRole('button', { name: /server target this server/i }))
+    const menu = await screen.findByRole('menu', { name: /server targets/i })
+    const upgradeItem = within(menu).getByRole('menuitem', {
+      name: /remote clients require pro/i,
+    })
+
+    expect(upgradeItem).toHaveAttribute('aria-disabled', 'true')
+    expect(navigateMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/backendTargetPresentation.tsx
+++ b/frontend/src/components/backendTargetPresentation.tsx
@@ -1,8 +1,12 @@
-import { CheckCircle2, CircleAlert, Monitor, Server, WifiOff } from 'lucide-react'
+import { CheckCircle2, CircleAlert, Lock, Monitor, Server, WifiOff } from 'lucide-react'
 import { getLocalBackendTarget } from '@/services/remoteBackends/storage'
 import type { BackendTarget, RemoteBackendClient } from '@/services/remoteBackends/types'
 
 type Translate = (key: string, options?: Record<string, unknown>) => string
+
+interface BackendTargetPresentationOptions {
+  remoteClientsAvailable?: boolean
+}
 
 export function buildBackendTargets(clients: RemoteBackendClient[], t: Translate): BackendTarget[] {
   const localTarget = getLocalBackendTarget()
@@ -23,17 +27,38 @@ export function getBackendTargetName(target: BackendTarget, t: Translate): strin
   return target.kind === 'local' ? t('remoteClients.switcher.localName') : target.name
 }
 
-export function isBackendTargetDisabled(target: BackendTarget): boolean {
-  return target.kind === 'remote' && target.health.compatibility === 'incompatible'
+export function isBackendTargetDisabled(
+  target: BackendTarget,
+  options: BackendTargetPresentationOptions = {}
+): boolean {
+  const remoteClientsAvailable = options.remoteClientsAvailable ?? true
+  return (
+    target.kind === 'remote' &&
+    (!remoteClientsAvailable || target.health.compatibility === 'incompatible')
+  )
 }
 
-export function getBackendTargetStatus(target: BackendTarget, t: Translate) {
+export function getBackendTargetStatus(
+  target: BackendTarget,
+  t: Translate,
+  options: BackendTargetPresentationOptions = {}
+) {
+  const remoteClientsAvailable = options.remoteClientsAvailable ?? true
   if (target.kind === 'local') {
     return {
       label: t('remoteClients.labels.local'),
       color: 'default' as const,
       icon: <Monitor size={14} />,
       helper: t('remoteClients.switcher.localHelper'),
+    }
+  }
+
+  if (!remoteClientsAvailable) {
+    return {
+      label: t('remoteClients.labels.requiresPlan'),
+      color: 'warning' as const,
+      icon: <Lock size={14} />,
+      helper: t('remoteClients.switcher.remotePlanUnavailable'),
     }
   }
 

--- a/frontend/src/components/shared/PlanGate.stories.tsx
+++ b/frontend/src/components/shared/PlanGate.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box, Typography } from '@mui/material'
+import PlanGate from './PlanGate'
+import { communitySystemInfo } from '../../services/remoteBackends/planStoryFixtures'
+
+const meta = {
+  title: 'Components/PlanGate',
+  component: PlanGate,
+  parameters: {
+    layout: 'centered',
+    systemInfo: communitySystemInfo,
+  },
+} satisfies Meta<typeof PlanGate>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const WithMessage: Story = {
+  args: {
+    feature: 'remote_clients',
+    message:
+      'Remote client switching is available on Pro and Enterprise plans. Upgrade to add or switch to remote Borg UI servers.',
+    surface: 'plan_gate_story',
+    operation: 'view_message_story',
+    children: (
+      <Typography variant="body2">
+        Remote client management is visible when the plan includes the feature.
+      </Typography>
+    ),
+  },
+  render: (args) => (
+    <Box sx={{ width: 420, maxWidth: 'calc(100vw - 32px)' }}>
+      <PlanGate {...args} />
+    </Box>
+  ),
+}

--- a/frontend/src/components/shared/PlanGate.tsx
+++ b/frontend/src/components/shared/PlanGate.tsx
@@ -20,6 +20,8 @@ interface PlanGateProps {
   operation?: string
   /** Extra non-sensitive analytics data for blocked feature events */
   analyticsData?: Record<string, unknown>
+  /** Optional feature-specific upgrade prompt message */
+  message?: string
 }
 
 export default function PlanGate({
@@ -31,6 +33,7 @@ export default function PlanGate({
   surface = 'plan_gate',
   operation = 'render_gate',
   analyticsData,
+  message,
 }: PlanGateProps) {
   const { t } = useTranslation()
   const { can, isLoading } = usePlan()
@@ -77,5 +80,5 @@ export default function PlanGate({
     )
   }
   if (fallback !== undefined) return <>{fallback}</>
-  return <UpgradePrompt requiredPlan={FEATURES[feature]} />
+  return <UpgradePrompt requiredPlan={FEATURES[feature]} message={message} />
 }

--- a/frontend/src/core/features.ts
+++ b/frontend/src/core/features.ts
@@ -13,6 +13,7 @@ export const FEATURES = {
   backup_plan_mixed_sources: 'pro',
   rclone: 'pro',
   managed_agents: 'pro',
+  remote_clients: 'pro',
   multi_user: 'community',
   extra_users: 'pro',
   rbac: 'enterprise',

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -178,7 +178,7 @@
       "activeTarget": "Aktives Ziel",
       "local": "Lokal",
       "remoteClient": "Remote-Client",
-      "requiresPlan": "Pro erforderlich"
+      "requiresPlan": "Pro oder Enterprise erforderlich"
     },
     "switcher": {
       "title": "Serverziele",
@@ -192,11 +192,11 @@
       "localCompatibility": "Dieser Browser ist mit diesem Borg-UI-Server verbunden.",
       "remoteHelper": "Remote-Client-Server",
       "remoteUnavailable": "Remote-Client nicht verfügbar",
-      "remotePlanUnavailable": "Remote-Client-Wechsel erfordert Pro.",
+      "remotePlanUnavailable": "Remote-Client-Wechsel erfordert Pro oder Enterprise.",
       "versionMismatch": "Versionskonflikt",
       "versionHelper": "Borg UI {{version}}",
       "manage": "Remote-Clients verwalten",
-      "manageRequiresPlan": "Remote-Clients erfordern Pro"
+      "manageRequiresPlan": "Remote-Clients erfordern Pro oder Enterprise"
     },
     "localBackend": {
       "title": "Dieser Server",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -164,6 +164,9 @@
     "title": "Remote-Clients",
     "description": "Registriere Borg-UI-Client-Server auf anderen Maschinen, prüfe ihre Verfügbarkeit und nutze diesen Browser mit dem ausgewählten Server.",
     "addButton": "Remote-Client hinzufügen",
+    "planGate": {
+      "message": "Remote-Client-Wechsel ist in Pro- und Enterprise-Plänen verfügbar. Führe ein Upgrade durch, um entfernte Borg UI-Server hinzuzufügen oder zu ihnen zu wechseln."
+    },
     "status": {
       "incompatible": "Inkompatibel",
       "online": "Online",
@@ -174,7 +177,8 @@
     "labels": {
       "activeTarget": "Aktives Ziel",
       "local": "Lokal",
-      "remoteClient": "Remote-Client"
+      "remoteClient": "Remote-Client",
+      "requiresPlan": "Pro erforderlich"
     },
     "switcher": {
       "title": "Serverziele",
@@ -188,9 +192,11 @@
       "localCompatibility": "Dieser Browser ist mit diesem Borg-UI-Server verbunden.",
       "remoteHelper": "Remote-Client-Server",
       "remoteUnavailable": "Remote-Client nicht verfügbar",
+      "remotePlanUnavailable": "Remote-Client-Wechsel erfordert Pro.",
       "versionMismatch": "Versionskonflikt",
       "versionHelper": "Borg UI {{version}}",
-      "manage": "Remote-Clients verwalten"
+      "manage": "Remote-Clients verwalten",
+      "manageRequiresPlan": "Remote-Clients erfordern Pro"
     },
     "localBackend": {
       "title": "Dieser Server",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -164,6 +164,9 @@
     "title": "Remote Clients",
     "description": "Register Borg UI client servers on other machines, check their health, and use this browser against the selected server.",
     "addButton": "Add remote client",
+    "planGate": {
+      "message": "Remote client switching is available on Pro and Enterprise plans. Upgrade to add or switch to remote Borg UI servers."
+    },
     "status": {
       "incompatible": "Incompatible",
       "online": "Online",
@@ -174,7 +177,8 @@
     "labels": {
       "activeTarget": "Active target",
       "local": "Local",
-      "remoteClient": "Remote client"
+      "remoteClient": "Remote client",
+      "requiresPlan": "Requires Pro"
     },
     "switcher": {
       "title": "Server targets",
@@ -188,9 +192,11 @@
       "localCompatibility": "This browser is connected to this Borg UI server.",
       "remoteHelper": "Remote client server",
       "remoteUnavailable": "Remote client unavailable",
+      "remotePlanUnavailable": "Remote client switching requires Pro.",
       "versionMismatch": "Version mismatch",
       "versionHelper": "Borg UI {{version}}",
-      "manage": "Manage remote clients"
+      "manage": "Manage remote clients",
+      "manageRequiresPlan": "Remote Clients require Pro"
     },
     "localBackend": {
       "title": "This server",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -178,7 +178,7 @@
       "activeTarget": "Active target",
       "local": "Local",
       "remoteClient": "Remote client",
-      "requiresPlan": "Requires Pro"
+      "requiresPlan": "Requires Pro or Enterprise"
     },
     "switcher": {
       "title": "Server targets",
@@ -192,11 +192,11 @@
       "localCompatibility": "This browser is connected to this Borg UI server.",
       "remoteHelper": "Remote client server",
       "remoteUnavailable": "Remote client unavailable",
-      "remotePlanUnavailable": "Remote client switching requires Pro.",
+      "remotePlanUnavailable": "Remote client switching requires Pro or Enterprise.",
       "versionMismatch": "Version mismatch",
       "versionHelper": "Borg UI {{version}}",
       "manage": "Manage remote clients",
-      "manageRequiresPlan": "Remote Clients require Pro"
+      "manageRequiresPlan": "Remote Clients require Pro or Enterprise"
     },
     "localBackend": {
       "title": "This server",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -164,6 +164,9 @@
     "title": "Clientes remotos",
     "description": "Registra servidores cliente de Borg UI en otras máquinas, comprueba su estado y usa este navegador con el servidor seleccionado.",
     "addButton": "Añadir cliente remoto",
+    "planGate": {
+      "message": "El cambio a clientes remotos está disponible en los planes Pro y Enterprise. Mejora el plan para añadir o cambiar a servidores Borg UI remotos."
+    },
     "status": {
       "incompatible": "Incompatible",
       "online": "En línea",
@@ -174,7 +177,8 @@
     "labels": {
       "activeTarget": "Destino activo",
       "local": "Local",
-      "remoteClient": "Cliente remoto"
+      "remoteClient": "Cliente remoto",
+      "requiresPlan": "Requiere Pro"
     },
     "switcher": {
       "title": "Destinos de servidor",
@@ -188,9 +192,11 @@
       "localCompatibility": "Este navegador está conectado a este servidor Borg UI.",
       "remoteHelper": "Servidor del cliente remoto",
       "remoteUnavailable": "Cliente remoto no disponible",
+      "remotePlanUnavailable": "El cambio a clientes remotos requiere Pro.",
       "versionMismatch": "Conflicto de versión",
       "versionHelper": "Borg UI {{version}}",
-      "manage": "Gestionar clientes remotos"
+      "manage": "Gestionar clientes remotos",
+      "manageRequiresPlan": "Los clientes remotos requieren Pro"
     },
     "localBackend": {
       "title": "Este servidor",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -178,7 +178,7 @@
       "activeTarget": "Destino activo",
       "local": "Local",
       "remoteClient": "Cliente remoto",
-      "requiresPlan": "Requiere Pro"
+      "requiresPlan": "Requiere Pro o Enterprise"
     },
     "switcher": {
       "title": "Destinos de servidor",
@@ -192,11 +192,11 @@
       "localCompatibility": "Este navegador está conectado a este servidor Borg UI.",
       "remoteHelper": "Servidor del cliente remoto",
       "remoteUnavailable": "Cliente remoto no disponible",
-      "remotePlanUnavailable": "El cambio a clientes remotos requiere Pro.",
+      "remotePlanUnavailable": "El cambio a clientes remotos requiere Pro o Enterprise.",
       "versionMismatch": "Conflicto de versión",
       "versionHelper": "Borg UI {{version}}",
       "manage": "Gestionar clientes remotos",
-      "manageRequiresPlan": "Los clientes remotos requieren Pro"
+      "manageRequiresPlan": "Los clientes remotos requieren Pro o Enterprise"
     },
     "localBackend": {
       "title": "Este servidor",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -164,6 +164,9 @@
     "title": "Client remoti",
     "description": "Registra server client Borg UI su altre macchine, controllane lo stato e usa questo browser con il server selezionato.",
     "addButton": "Aggiungi client remoto",
+    "planGate": {
+      "message": "Il passaggio ai client remoti è disponibile nei piani Pro ed Enterprise. Esegui l'upgrade per aggiungere o passare a server Borg UI remoti."
+    },
     "status": {
       "incompatible": "Incompatibile",
       "online": "Online",
@@ -174,7 +177,8 @@
     "labels": {
       "activeTarget": "Destinazione attiva",
       "local": "Locale",
-      "remoteClient": "Client remoto"
+      "remoteClient": "Client remoto",
+      "requiresPlan": "Richiede Pro"
     },
     "switcher": {
       "title": "Destinazioni server",
@@ -188,9 +192,11 @@
       "localCompatibility": "Questo browser è connesso a questo server Borg UI.",
       "remoteHelper": "Server del client remoto",
       "remoteUnavailable": "Client remoto non disponibile",
+      "remotePlanUnavailable": "Il passaggio ai client remoti richiede Pro.",
       "versionMismatch": "Conflitto di versione",
       "versionHelper": "Borg UI {{version}}",
-      "manage": "Gestisci client remoti"
+      "manage": "Gestisci client remoti",
+      "manageRequiresPlan": "I client remoti richiedono Pro"
     },
     "localBackend": {
       "title": "Questo server",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -178,7 +178,7 @@
       "activeTarget": "Destinazione attiva",
       "local": "Locale",
       "remoteClient": "Client remoto",
-      "requiresPlan": "Richiede Pro"
+      "requiresPlan": "Richiede Pro o Enterprise"
     },
     "switcher": {
       "title": "Destinazioni server",
@@ -192,11 +192,11 @@
       "localCompatibility": "Questo browser è connesso a questo server Borg UI.",
       "remoteHelper": "Server del client remoto",
       "remoteUnavailable": "Client remoto non disponibile",
-      "remotePlanUnavailable": "Il passaggio ai client remoti richiede Pro.",
+      "remotePlanUnavailable": "Il passaggio ai client remoti richiede Pro o Enterprise.",
       "versionMismatch": "Conflitto di versione",
       "versionHelper": "Borg UI {{version}}",
       "manage": "Gestisci client remoti",
-      "manageRequiresPlan": "I client remoti richiedono Pro"
+      "manageRequiresPlan": "I client remoti richiedono Pro o Enterprise"
     },
     "localBackend": {
       "title": "Questo server",

--- a/frontend/src/pages/RemoteClients.stories.tsx
+++ b/frontend/src/pages/RemoteClients.stories.tsx
@@ -3,28 +3,7 @@ import { Box } from '@mui/material'
 import { RemoteClientsContent } from './RemoteClients'
 import PlanGate from '../components/shared/PlanGate'
 import { RemoteBackendStoryProvider } from '../services/remoteBackends/storyFixtures'
-import type { SystemInfo } from '../hooks/useSystemInfo'
-
-const featureMap = {
-  borg_v2: 'pro',
-  backup_plan_multi_repository: 'pro',
-  backup_plan_mixed_sources: 'pro',
-  rclone: 'pro',
-  managed_agents: 'pro',
-  remote_clients: 'pro',
-  multi_user: 'community',
-  extra_users: 'pro',
-  rbac: 'enterprise',
-} as const
-
-const communitySystemInfo: SystemInfo = {
-  app_version: '2.2.2-alpha.1',
-  borg_version: 'borg 1.4.1',
-  borg2_version: 'borg2 2.0.0b19',
-  plan: 'community',
-  features: featureMap,
-  feature_access: { remote_clients: false },
-}
+import { communitySystemInfo } from '../services/remoteBackends/planStoryFixtures'
 
 const meta = {
   title: 'Pages/RemoteClients',

--- a/frontend/src/pages/RemoteClients.stories.tsx
+++ b/frontend/src/pages/RemoteClients.stories.tsx
@@ -1,7 +1,30 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Box } from '@mui/material'
 import { RemoteClientsContent } from './RemoteClients'
+import PlanGate from '../components/shared/PlanGate'
 import { RemoteBackendStoryProvider } from '../services/remoteBackends/storyFixtures'
+import type { SystemInfo } from '../hooks/useSystemInfo'
+
+const featureMap = {
+  borg_v2: 'pro',
+  backup_plan_multi_repository: 'pro',
+  backup_plan_mixed_sources: 'pro',
+  rclone: 'pro',
+  managed_agents: 'pro',
+  remote_clients: 'pro',
+  multi_user: 'community',
+  extra_users: 'pro',
+  rbac: 'enterprise',
+} as const
+
+const communitySystemInfo: SystemInfo = {
+  app_version: '2.2.2-alpha.1',
+  borg_version: 'borg 1.4.1',
+  borg2_version: 'borg2 2.0.0b19',
+  plan: 'community',
+  features: featureMap,
+  feature_access: { remote_clients: false },
+}
 
 const meta = {
   title: 'Pages/RemoteClients',
@@ -25,6 +48,23 @@ function renderPage(state: 'empty' | 'mixed' | 'activeRemote') {
   )
 }
 
+function renderLockedPage() {
+  return (
+    <RemoteBackendStoryProvider state="mixed">
+      <Box sx={{ minHeight: '100vh', bgcolor: 'background.default', p: 3 }}>
+        <PlanGate
+          feature="remote_clients"
+          message="Remote client switching is available on Pro and Enterprise plans. Upgrade to add or switch to remote Borg UI servers."
+          surface="remote_clients_story"
+          operation="view_locked_story"
+        >
+          <RemoteClientsContent />
+        </PlanGate>
+      </Box>
+    </RemoteBackendStoryProvider>
+  )
+}
+
 export const Overview: Story = {
   render: () => renderPage('mixed'),
 }
@@ -35,4 +75,11 @@ export const Empty: Story = {
 
 export const ActiveRemote: Story = {
   render: () => renderPage('activeRemote'),
+}
+
+export const LockedCommunity: Story = {
+  parameters: {
+    systemInfo: communitySystemInfo,
+  },
+  render: () => renderLockedPage(),
 }

--- a/frontend/src/pages/RemoteClients.tsx
+++ b/frontend/src/pages/RemoteClients.tsx
@@ -27,6 +27,7 @@ import {
   WifiOff,
 } from 'lucide-react'
 import ResponsiveDialog from '../components/shared/ResponsiveDialog'
+import PlanGate from '../components/shared/PlanGate'
 import EmptyStateCard from '../components/EmptyStateCard'
 import { useAuth } from '../hooks/useAuth'
 import { useRemoteBackends } from '../services/remoteBackends/context'
@@ -504,5 +505,14 @@ export default function RemoteClients() {
     return <Navigate to="/dashboard" replace />
   }
 
-  return <RemoteClientsContent />
+  return (
+    <PlanGate
+      feature="remote_clients"
+      message={t('remoteClients.planGate.message')}
+      surface="remote_clients"
+      operation="view_management"
+    >
+      <RemoteClientsContent />
+    </PlanGate>
+  )
 }

--- a/frontend/src/pages/__tests__/RemoteClients.test.tsx
+++ b/frontend/src/pages/__tests__/RemoteClients.test.tsx
@@ -7,13 +7,24 @@ import {
   resetRemoteBackendStateForTests,
 } from '../../services/remoteBackends/storage'
 
-const { mockHasGlobalPermission } = vi.hoisted(() => ({
+const { mockHasGlobalPermission, mockPlanCan } = vi.hoisted(() => ({
   mockHasGlobalPermission: vi.fn(() => true),
+  mockPlanCan: vi.fn((_feature: string) => true),
 }))
 
 vi.mock('../../hooks/useAuth', () => ({
   useAuth: () => ({
     hasGlobalPermission: mockHasGlobalPermission,
+  }),
+}))
+
+vi.mock('../../hooks/usePlan', () => ({
+  usePlan: () => ({
+    plan: 'community',
+    features: {},
+    entitlement: undefined,
+    isLoading: false,
+    can: mockPlanCan,
   }),
 }))
 
@@ -33,6 +44,7 @@ describe('RemoteClients', () => {
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
     mockHasGlobalPermission.mockReturnValue(true)
+    mockPlanCan.mockReturnValue(true)
   })
 
   it('redirects when the user lacks SSH management permission', async () => {
@@ -65,6 +77,18 @@ describe('RemoteClients', () => {
     expect(screen.getByText('Studio NAS')).toBeInTheDocument()
     expect(screen.getByText('http://nas.local:9000/api')).toBeInTheDocument()
     expect(screen.getByText('Unknown')).toBeInTheDocument()
+  })
+
+  it('shows the plan gate instead of management controls when remote clients are unavailable', async () => {
+    mockPlanCan.mockImplementation((feature) => feature !== 'remote_clients')
+
+    renderPage()
+
+    expect(
+      await screen.findByText(/remote client switching is available on pro and enterprise plans/i)
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /add remote client/i })).not.toBeInTheDocument()
+    expect(screen.queryByText('No remote clients yet')).not.toBeInTheDocument()
   })
 
   it('vertically centers the local server status and use action', () => {

--- a/frontend/src/services/remoteBackends/planStoryFixtures.ts
+++ b/frontend/src/services/remoteBackends/planStoryFixtures.ts
@@ -1,0 +1,28 @@
+import type { SystemInfo } from '../../hooks/useSystemInfo'
+
+export const storyFeatureMap = {
+  borg_v2: 'pro',
+  backup_plan_multi_repository: 'pro',
+  backup_plan_mixed_sources: 'pro',
+  rclone: 'pro',
+  managed_agents: 'pro',
+  remote_clients: 'pro',
+  multi_user: 'community',
+  extra_users: 'pro',
+  rbac: 'enterprise',
+} as const
+
+export const proSystemInfo: SystemInfo = {
+  app_version: '2.2.2-alpha.1',
+  borg_version: 'borg 1.4.1',
+  borg2_version: 'borg2 2.0.0b19',
+  plan: 'pro',
+  features: storyFeatureMap,
+  feature_access: { remote_clients: true },
+}
+
+export const communitySystemInfo: SystemInfo = {
+  ...proSystemInfo,
+  plan: 'community',
+  feature_access: { remote_clients: false },
+}

--- a/tests/unit/test_core_features.py
+++ b/tests/unit/test_core_features.py
@@ -27,6 +27,12 @@ class TestPlanIncludes:
     def test_plan_includes(self, current, required, expected):
         assert plan_includes(current, required) is expected
 
+    def test_remote_clients_are_a_pro_feature(self):
+        assert FEATURES["remote_clients"] == Plan.PRO
+        assert plan_includes(Plan.PRO, FEATURES["remote_clients"]) is True
+        assert plan_includes(Plan.ENTERPRISE, FEATURES["remote_clients"]) is True
+        assert plan_includes(Plan.COMMUNITY, FEATURES["remote_clients"]) is False
+
 
 @pytest.mark.unit
 class TestCurrentPlan:


### PR DESCRIPTION
## Description
Gates Remote Clients behind the shared `remote_clients` plan entitlement. The feature is Pro-minimum, so Pro and Enterprise users keep Remote Clients navigation, management, and switching, while Community users see the shared Borg UI upgrade treatment and cannot silently switch to stored remote clients.

This keeps the local server target available for all plans, disables remote target rows and the management action in the global server selector for denied plans, and updates stories, docs, locales, and targeted tests.

## Related Issue
Linear: https://linear.app/nullcodeai/issue/BOR-153/gate-remote-clients-behind-pro-and-enterprise-plans

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update
- [x] UI/UX improvement
- [x] Test addition/improvement
- [ ] Refactoring

## Testing
- [x] `pytest tests/unit/test_core_features.py -q`
- [x] `cd frontend && npm run test -- --run src/components/__tests__/AppHeader.test.tsx`
- [x] `cd frontend && npm run test -- --run src/components/__tests__/BackendTargetSwitcher.test.tsx`
- [x] `cd frontend && npm run test -- --run src/pages/__tests__/RemoteClients.test.tsx`
- [x] `cd frontend && npm run test -- --run src/components/__tests__/AppSidebar.test.tsx`
- [x] `cd frontend && npm run check:locales`
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run format:check`
- [x] `cd frontend && npm run build`
- [x] `ruff check app tests`
- [x] `ruff format --check app tests`
- [x] `git diff --check`
- [ ] Runtime browser walkthrough. The Vite dev server launched locally, but Playwright browsers cannot start in this host image because required shared libraries are missing: Chromium needs `libnspr4.so`; Firefox needs `libXdamage.so.1`, `libgtk-3.so.0`, `libgdk-3.so.0`, and `libpangocairo-1.0.so.0`; WebKit needs `libgtk-4.so.1`, `libpangocairo-1.0.so.0`, `libpango-1.0.so.0`, and `libharfbuzz.so.0`.

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass

## Checklist
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Screenshots were not captured because every available Playwright browser runtime fails before app load due missing host shared libraries. The changed UI states are covered by Storybook stories and focused component tests.

## Additional Context
Remote Clients remain browser-local. This change blocks denied-plan use and switching without deleting stored remote client records, so upgrades or later entitlement changes can reuse existing browser state.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote Clients are plan-gated: only Pro/Enterprise users can add or switch to remote clients; restricted UI shows locked/upgrade messaging and preserves local-server access.
  * Plan-gate messaging is now customizable and shown in gated views and switcher menus.
  * Storybook scenarios demonstrate locked/unlocked states.

* **Documentation**
  * Docs updated to state Remote Clients require Pro/Enterprise and outline UI behavior.

* **Tests**
  * Unit and UI tests added/updated to cover plan-gating and locked-state behaviors.

* **Localization**
  * Translations added/updated for plan-gate messages and switcher labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 2 changed, 12 added, 0 removed, 366 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-636/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/27064874893
<details>
<summary>Changed files</summary>
- `pages-remoteclients--overview--mobile.png` (28.09%)
- `pages-remoteclients--overview.png` (31.68%)
</details>
<details>
<summary>New screenshots</summary>
- `components-appsidebar--with-remote-clients--mobile.png`
- `components-appsidebar--with-remote-clients.png`
- `components-appsidebar--without-remote-clients--mobile.png`
- `components-appsidebar--without-remote-clients.png`
- `components-backendtargetselect--locked-community--mobile.png`
- `components-backendtargetselect--locked-community.png`
- `components-backendtargetswitcher--locked-community--mobile.png`
- `components-backendtargetswitcher--locked-community.png`
- `components-plangate--with-message--mobile.png`
- `components-plangate--with-message.png`
- `pages-remoteclients--locked-community--mobile.png`
- `pages-remoteclients--locked-community.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->