### PR TITLE
Surface new Borg UI capabilities on the dashboard

### DIFF
--- a/docs/engineering/plans/2026-06-06-dashboard-capability-launchpad.md
+++ b/docs/engineering/plans/2026-06-06-dashboard-capability-launchpad.md
@@ -1,0 +1,120 @@
+# Dashboard Capability Launchpad Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:test-driven-development for implementation and
+> superpowers:verification-before-completion before claiming completion. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dashboard launchpad that helps users discover and act on newer
+Borg UI capabilities, including backup plans, cloud storage, remote clients, and
+restore verification.
+
+**Architecture:** Add a focused `CapabilityLaunchpad` component under
+`frontend/src/pages/dashboard-v3/`, derive row state from existing dashboard
+overview data, `rcloneAPI.listRemotes()`, and remote-backend local storage,
+place it in the DashboardV3 left rail, mirror it in the loading skeleton, and
+add Storybook plus docs coverage. No backend contract changes are required.
+
+**Tech Stack:** React, TypeScript, MUI, Lucide icons, TanStack Query existing
+dashboard data, rclone API, remote-backend local storage, Vitest, Storybook,
+VitePress docs.
+
+---
+
+## Task 1: Failing Dashboard Coverage
+
+**Files:**
+
+- Modify: `frontend/src/pages/__tests__/DashboardV3.test.tsx`
+
+- [ ] Add a failing test that renders the existing `makeOverview()` fixture and
+      expects an Operations launchpad with Backup plans, Cloud storage, Remote
+      clients, and Restore verification rows.
+- [ ] Add a failing test that clicks each launchpad action and expects
+      navigation to `/backup-plans`, `/cloud-storage`, `/remote-clients`, and
+      `/schedule/restore-checks`.
+- [ ] Run:
+      `cd frontend && npm test -- --run src/pages/__tests__/DashboardV3.test.tsx --testNamePattern "operations launchpad"`
+      Expected: fail because the launchpad does not exist yet.
+
+## Task 2: Launchpad Component
+
+**Files:**
+
+- Create: `frontend/src/pages/dashboard-v3/CapabilityLaunchpad.tsx`
+- Modify: `frontend/src/pages/dashboard-v3/types.ts`
+
+- [ ] Implement `CapabilityLaunchpad` props for `summary`, `repositories`,
+      `cloudRemoteCount`, `remoteClientCount`, and an
+      `onNavigate(destination, source)` callback.
+- [ ] Derive backup-plan count from `summary.total_backup_plans` with legacy
+      schedule fallback through `summary.total_schedules`.
+- [ ] Derive cloud storage count from `rcloneAPI.listRemotes()` in DashboardV3.
+- [ ] Derive remote client count from browser-registered remote backend clients.
+- [ ] Derive restore verification count from repositories where
+      `restore_check_configured` is true.
+- [ ] Render four stable compact rows using existing dashboard tokens, MUI,
+      Lucide icons, neutral text colors, hover/focus states, and row-level
+      buttons.
+- [ ] Run the operations launchpad tests and keep fixing until they pass.
+
+## Task 3: Dashboard Integration and Skeleton
+
+**Files:**
+
+- Modify: `frontend/src/pages/DashboardV3.tsx`
+- Modify: `frontend/src/pages/dashboard-v3/DashboardSkeleton.tsx`
+
+- [ ] Import and render `CapabilityLaunchpad` in the left rail between
+      Resources and Upcoming backups.
+- [ ] Wire launchpad actions through the existing `trackNavigation` hook and
+      `navigate()` calls.
+- [ ] Add a matching skeleton panel with four compact rows so the loading
+      layout does not jump.
+- [ ] Run:
+      `cd frontend && npm test -- --run src/pages/__tests__/DashboardV3.test.tsx --testNamePattern "operations launchpad"`
+      Expected: pass.
+
+## Task 4: Storybook and Locales
+
+**Files:**
+
+- Create: `frontend/src/pages/dashboard-v3/CapabilityLaunchpad.stories.tsx`
+- Modify: `frontend/src/locales/en.json`
+- Modify: `frontend/src/locales/de.json`
+- Modify: `frontend/src/locales/es.json`
+- Modify: `frontend/src/locales/it.json`
+
+- [ ] Add dashboard locale keys for launchpad title, row labels, status text,
+      count text, and accessible action labels in all locale files.
+- [ ] Add Storybook stories for MixedAdoption and EmptyStart states using
+      `TokenContext` and the dashboard surface width.
+- [ ] Run `cd frontend && npm run check:locales`.
+
+## Task 5: Documentation
+
+**Files:**
+
+- Modify: `docs/navigation.md`
+
+- [ ] Update Dashboard guidance to mention the launchpad's setup-gap actions.
+- [ ] Keep the docs concise and focused on the user path.
+
+## Task 6: Final Validation and Handoff
+
+**Commands:**
+
+- `cd frontend && npm test -- --run src/pages/__tests__/DashboardV3.test.tsx`
+- `cd frontend && npm run check:locales`
+- `cd frontend && npm run typecheck`
+- `cd frontend && npm run lint`
+- `cd frontend && npm run build`
+- Local UI walkthrough via Storybook or Borg UI at desktop and mobile widths.
+
+- [ ] Run the targeted DashboardV3 Vitest suite.
+- [ ] Run locale, typecheck, lint, and build gates.
+- [ ] Run a local UI walkthrough and record evidence.
+- [ ] Commit changes.
+- [ ] Push branch, create/update PR from `.github/PULL_REQUEST_TEMPLATE.md`,
+      add GitHub label `symphony`, attach/link PR to Linear, sweep PR feedback
+      and checks, then move BOR-154 to Human Review when green.

--- a/docs/engineering/specs/2026-06-06-dashboard-capability-launchpad.md
+++ b/docs/engineering/specs/2026-06-06-dashboard-capability-launchpad.md
@@ -1,0 +1,90 @@
+# Dashboard Capability Launchpad Spec
+
+## Problem
+
+Borg UI has gained several newer operational workflows: backup plans, cloud
+storage remotes, remote Borg UI clients, restore verification, and scheduled
+plan automation. The dashboard already summarizes system health, storage,
+repository status, upcoming work, and recent activity, but it does not give
+users a compact way to discover those newer capabilities or act on the next
+useful setup gap.
+
+The Linear reference image is not directly available outside Linear auth during
+this session, so the implementation should use the request's intent rather than
+pixel-matching the image: take dashboard inspiration and add a useful Borg
+UI-specific overview surface.
+
+## Desired Outcome
+
+Add a compact dashboard launchpad that summarizes key Borg UI capabilities and
+links to the right workflow:
+
+- Backup plan and automation coverage.
+- Cloud storage remotes.
+- Remote Borg UI clients.
+- Restore verification coverage.
+
+The launchpad should feel like part of the current operational dashboard: dense,
+scan-friendly, neutral-surface rows, restrained Lucide icons, neutral text for
+contrast, and responsive one-column behavior in the narrow left rail.
+
+## Design
+
+Create a focused `CapabilityLaunchpad` component under
+`frontend/src/pages/dashboard-v3/`. It accepts the current dashboard summary and
+repository health arrays plus cloud remote and remote client counts. It derives
+four capability rows and reports interaction through callbacks passed by
+`DashboardV3`.
+
+The implementation intentionally does not add a dashboard backend field. It uses
+existing frontend data sources:
+
+- `summary.active_backup_plans`, `summary.total_backup_plans`,
+  `summary.active_automations`, and `summary.total_automations` for plan and
+  automation readiness.
+- `rcloneAPI.listRemotes()` for configured Cloud Storage remotes.
+- `listRemoteBackendClients()` for browser-registered remote Borg UI clients.
+- `restore_check_configured` and `latest_restore_check_status` for restore
+  verification coverage.
+
+Each row shows a short title, mono numeric value, concise status label, icon, and
+trailing arrow. The whole row is the action target with an accessible label.
+Rows navigate to existing routes:
+
+- Backup plans: `/backup-plans`.
+- Cloud storage: `/cloud-storage`.
+- Remote clients: `/remote-clients`.
+- Restore verification: `/schedule/restore-checks`.
+
+The launchpad belongs in the left dashboard rail between resource gauges and
+upcoming/storage panels. That keeps it visible without competing with the main
+repository health and activity panels. The dashboard skeleton should mirror the
+new panel so loading layout stays stable.
+
+## Testing
+
+Use test-first coverage for the derived behavior:
+
+- A DashboardV3 test should fail until the launchpad renders backup plan, cloud
+  storage, remote client, and restore verification rows with expected counts.
+- A DashboardV3 test should fail until launchpad actions navigate to the
+  expected existing routes.
+- A component Storybook story should cover mixed adoption and empty-start
+  states for the launchpad.
+
+## Documentation
+
+Update `docs/navigation.md` so Dashboard is described as a place to identify
+capability setup gaps and jump to backup plans, cloud storage, remote clients,
+or restore-check scheduling. This is a main dashboard flow change, but it does
+not alter sidebar tabs or navigation groups.
+
+## Validation
+
+- `cd frontend && npm test -- --run src/pages/__tests__/DashboardV3.test.tsx`
+- `cd frontend && npm run check:locales`
+- `cd frontend && npm run typecheck`
+- `cd frontend && npm run lint`
+- `cd frontend && npm run build`
+- Local UI walkthrough through the dashboard or Storybook at desktop and mobile
+  widths, confirming the launchpad renders and actions target existing routes.

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -14,7 +14,7 @@ license supports it.
 
 For a new setup, follow the sidebar in this order:
 
-1. Open Dashboard to check overall health.
+1. Open Dashboard to check overall health and spot setup gaps.
 2. Add storage targets from Repositories or Cloud Storage, and register infrastructure endpoints
    from Remote Clients or Remote Machines.
 3. Create a plan from Backup Plans.
@@ -26,7 +26,7 @@ For a new setup, follow the sidebar in this order:
 
 | Sidebar area | Tab | Use it for |
 | --- | --- | --- |
-| Main | Dashboard | Check repository health, recent activity, backup freshness, and restore-check status. |
+| Main | Dashboard | Check repository health, recent activity, backup freshness, restore-check status, and setup-gap actions for backup plans, cloud storage, remote clients, and verification. |
 | Main | Activity | Review job history, live or recent logs, failures, and completed backup, restore, check, prune, compact, script, or package work. |
 | Infrastructure | Remote Clients | Register other Borg UI client servers, check health and version compatibility, and switch this browser to a remote client. |
 | Infrastructure | Remote Machines | Add SSH-connected machines for remote repositories, remote backup sources, and SSH restore destinations. |

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -410,6 +410,41 @@
     "upcomingBackups": {
       "title": "Anstehende Backups"
     },
+    "launchpad": {
+      "title": "Operations-Launchpad",
+      "openAction": "{{title}} öffnen: {{value}}, {{status}}",
+      "backupPlans": {
+        "title": "Backup-Pläne",
+        "value_one": "{{count}} Plan",
+        "value_other": "{{count}} Pläne",
+        "active_one": "{{count}} aktiv",
+        "active_other": "{{count}} aktiv",
+        "empty": "Ersten erstellen",
+        "action": "Pläne öffnen"
+      },
+      "cloudStorage": {
+        "title": "Cloud-Speicher",
+        "value_one": "{{count}} Remote",
+        "value_other": "{{count}} Remotes",
+        "active": "Konfiguriert",
+        "empty": "Keine Remotes"
+      },
+      "remoteClients": {
+        "title": "Remote-Clients",
+        "value_one": "{{count}} Client",
+        "value_other": "{{count}} Clients",
+        "active": "Verfügbar",
+        "empty": "Dieser Server"
+      },
+      "restoreVerification": {
+        "title": "Restore-Verifizierung",
+        "value": "{{configured}}/{{total}} abgedeckt",
+        "noRepositories": "Keine Repos",
+        "complete": "Abgedeckt",
+        "partial": "Einrichtung nötig",
+        "action": "Checks planen"
+      }
+    },
     "scheduleBadge": {
       "noSchedule": "Kein automatischer Zeitplan",
       "manual": "manuell",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -410,6 +410,41 @@
     "upcomingBackups": {
       "title": "Upcoming backups"
     },
+    "launchpad": {
+      "title": "Operations launchpad",
+      "openAction": "Open {{title}}: {{value}}, {{status}}",
+      "backupPlans": {
+        "title": "Backup plans",
+        "value_one": "{{count}} plan",
+        "value_other": "{{count}} plans",
+        "active_one": "{{count}} active",
+        "active_other": "{{count}} active",
+        "empty": "Create first",
+        "action": "Open plans"
+      },
+      "cloudStorage": {
+        "title": "Cloud storage",
+        "value_one": "{{count}} remote",
+        "value_other": "{{count}} remotes",
+        "active": "Configured",
+        "empty": "No remotes"
+      },
+      "remoteClients": {
+        "title": "Remote clients",
+        "value_one": "{{count}} client",
+        "value_other": "{{count}} clients",
+        "active": "Available",
+        "empty": "This server"
+      },
+      "restoreVerification": {
+        "title": "Restore verification",
+        "value": "{{configured}}/{{total}} covered",
+        "noRepositories": "No repos",
+        "complete": "Covered",
+        "partial": "Needs setup",
+        "action": "Schedule checks"
+      }
+    },
     "scheduleBadge": {
       "noSchedule": "No automated schedule",
       "manual": "manual",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -410,6 +410,41 @@
     "upcomingBackups": {
       "title": "Copias próximas"
     },
+    "launchpad": {
+      "title": "Panel de operaciones",
+      "openAction": "Abrir {{title}}: {{value}}, {{status}}",
+      "backupPlans": {
+        "title": "Planes de backup",
+        "value_one": "{{count}} plan",
+        "value_other": "{{count}} planes",
+        "active_one": "{{count}} activo",
+        "active_other": "{{count}} activos",
+        "empty": "Crear primero",
+        "action": "Abrir planes"
+      },
+      "cloudStorage": {
+        "title": "Almacenamiento cloud",
+        "value_one": "{{count}} remoto",
+        "value_other": "{{count}} remotos",
+        "active": "Configurado",
+        "empty": "Sin remotos"
+      },
+      "remoteClients": {
+        "title": "Clientes remotos",
+        "value_one": "{{count}} cliente",
+        "value_other": "{{count}} clientes",
+        "active": "Disponible",
+        "empty": "Este servidor"
+      },
+      "restoreVerification": {
+        "title": "Verificación de restauración",
+        "value": "{{configured}}/{{total}} cubiertos",
+        "noRepositories": "Sin repos",
+        "complete": "Cubierto",
+        "partial": "Configurar",
+        "action": "Programar checks"
+      }
+    },
     "scheduleBadge": {
       "noSchedule": "Sin programación automática",
       "manual": "manual",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -410,6 +410,41 @@
     "upcomingBackups": {
       "title": "Backup imminenti"
     },
+    "launchpad": {
+      "title": "Launchpad operativo",
+      "openAction": "Apri {{title}}: {{value}}, {{status}}",
+      "backupPlans": {
+        "title": "Piani di backup",
+        "value_one": "{{count}} piano",
+        "value_other": "{{count}} piani",
+        "active_one": "{{count}} attivo",
+        "active_other": "{{count}} attivi",
+        "empty": "Crea il primo",
+        "action": "Apri piani"
+      },
+      "cloudStorage": {
+        "title": "Storage cloud",
+        "value_one": "{{count}} remoto",
+        "value_other": "{{count}} remoti",
+        "active": "Configurato",
+        "empty": "Nessun remoto"
+      },
+      "remoteClients": {
+        "title": "Client remoti",
+        "value_one": "{{count}} client",
+        "value_other": "{{count}} client",
+        "active": "Disponibile",
+        "empty": "Questo server"
+      },
+      "restoreVerification": {
+        "title": "Verifica ripristino",
+        "value": "{{configured}}/{{total}} coperti",
+        "noRepositories": "Nessun repo",
+        "complete": "Coperto",
+        "partial": "Da configurare",
+        "action": "Pianifica check"
+      }
+    },
     "scheduleBadge": {
       "noSchedule": "Nessuna pianificazione automatica",
       "manual": "manuale",

--- a/frontend/src/pages/DashboardV3.tsx
+++ b/frontend/src/pages/DashboardV3.tsx
@@ -17,12 +17,14 @@ import { Activity, ArrowRight, Cpu, HardDrive } from 'lucide-react'
 import { differenceInDays, formatDistanceToNow } from 'date-fns'
 import { useTheme } from '../context/ThemeContext'
 import { useAnalytics } from '../hooks/useAnalytics'
-import { dashboardAPI } from '../services/api'
+import { dashboardAPI, rcloneAPI } from '../services/api'
+import { listRemoteBackendClients } from '../services/remoteBackends/storage'
 import { ActivityTimeline } from './dashboard-v3/ActivityTimeline'
 import { ArcGauge, StorageDonut, SuccessDonut } from './dashboard-v3/charts'
 import { DashboardSkeleton } from './dashboard-v3/DashboardSkeleton'
 import { PulseDot } from './dashboard-v3/health'
 import { UpcomingBackupsPanel } from './dashboard-v3/UpcomingBackupsPanel'
+import { CapabilityLaunchpad } from './dashboard-v3/CapabilityLaunchpad'
 import { RepositoryHealthPanel } from './dashboard-v3/RepositoryHealthPanel'
 import { ResourceGaugeGrid } from './dashboard-v3/ResourceGaugeGrid'
 import { makeT, STATUS, TokenContext } from './dashboard-v3/tokens'
@@ -72,6 +74,22 @@ export default function DashboardV3() {
     queryFn: () => dashboardAPI.getOverview().then((response) => response.data),
     refetchInterval: 30_000,
   })
+
+  const { data: cloudRemotes = [] } = useQuery({
+    queryKey: ['dashboard-v3', 'cloud-remotes'],
+    queryFn: () => rcloneAPI.listRemotes().then((response) => response.data.remotes),
+    enabled: !isLoading && !error,
+    retry: false,
+    staleTime: 30_000,
+  })
+
+  const remoteClientCount = React.useMemo(() => {
+    try {
+      return listRemoteBackendClients().length
+    } catch {
+      return 0
+    }
+  }, [])
 
   if (isLoading) return <DashboardSkeleton T={T} />
   if (error || !ov)
@@ -445,6 +463,21 @@ export default function DashboardV3() {
                 />
               </ResourceGaugeGrid>
             </Box>
+
+            <CapabilityLaunchpad
+              summary={summary}
+              repositories={repos}
+              cloudRemoteCount={cloudRemotes.length}
+              remoteClientCount={remoteClientCount}
+              onNavigate={(route, source) => {
+                trackNavigation(EventAction.VIEW, {
+                  section: 'dashboard',
+                  destination: route.substring(1),
+                  source,
+                })
+                navigate(route)
+              }}
+            />
 
             <UpcomingBackupsPanel tasks={ov.upcoming_tasks} />
 

--- a/frontend/src/pages/__tests__/DashboardV3.test.tsx
+++ b/frontend/src/pages/__tests__/DashboardV3.test.tsx
@@ -7,8 +7,9 @@ import { formatDateTimeFull } from '../../utils/dateUtils'
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
 const mockNavigate = vi.fn()
-const { getOverviewMock } = vi.hoisted(() => ({
+const { getOverviewMock, listRemotesMock } = vi.hoisted(() => ({
   getOverviewMock: vi.fn(),
+  listRemotesMock: vi.fn(),
 }))
 
 vi.mock('react-router-dom', () => ({
@@ -26,6 +27,9 @@ vi.mock('../../utils/basePath', () => ({
 vi.mock('../../services/api', () => ({
   dashboardAPI: {
     getOverview: getOverviewMock,
+  },
+  rcloneAPI: {
+    listRemotes: listRemotesMock,
   },
 }))
 
@@ -178,6 +182,7 @@ function makeOverview(overrides: Record<string, unknown> = {}) {
 beforeEach(() => {
   vi.clearAllMocks()
   getOverviewMock.mockResolvedValue({ data: makeOverview() })
+  listRemotesMock.mockResolvedValue({ data: { remotes: [] } })
   // Default: suppress localStorage access
   vi.stubGlobal('localStorage', { getItem: () => 'test-token' })
 })
@@ -692,6 +697,59 @@ describe('DashboardV3', () => {
       expect(screen.getByText('Backup Plan')).toBeInTheDocument()
       expect(screen.getAllByText('Nightly Documents').length).toBeGreaterThan(0)
       expect(screen.getByText('2 repositories')).toBeInTheDocument()
+    })
+  })
+
+  describe('operations launchpad', () => {
+    it('summarizes newer Borg UI capabilities and routes actions to existing workflows', async () => {
+      listRemotesMock.mockResolvedValueOnce({
+        data: {
+          remotes: [
+            { id: 10, name: 'prod-s3', provider: 's3' },
+            { id: 11, name: 'archive-b2', provider: 'b2' },
+          ],
+        },
+      })
+      vi.stubGlobal('localStorage', {
+        getItem: (key: string) => {
+          if (key === 'borg_ui_remote_backends') {
+            return JSON.stringify([
+              {
+                id: 'remote-1',
+                name: 'Offsite client',
+                apiBaseUrl: 'https://offsite.example.com/api',
+                webBaseUrl: 'https://offsite.example.com',
+              },
+            ])
+          }
+          return key === 'borg_ui_active_backend_target' ? null : 'test-token'
+        },
+      })
+      mockFetchSuccess(makeOverview())
+      renderDashboard()
+
+      await waitFor(() => screen.getAllByText('my-server'))
+      expect(screen.getByText('Operations launchpad')).toBeInTheDocument()
+      expect(screen.getByText('Backup plans')).toBeInTheDocument()
+      expect(screen.getByText('2 plans')).toBeInTheDocument()
+      await waitFor(() => expect(screen.getByText('Cloud storage')).toBeInTheDocument())
+      expect(screen.getByText('2 remotes')).toBeInTheDocument()
+      expect(screen.getByText('Remote clients')).toBeInTheDocument()
+      expect(screen.getByText('1 client')).toBeInTheDocument()
+      expect(screen.getByText('Restore verification')).toBeInTheDocument()
+      expect(screen.getByText('1/2 covered')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: /open backup plans/i }))
+      expect(mockNavigate).toHaveBeenCalledWith('/backup-plans')
+
+      fireEvent.click(screen.getByRole('button', { name: /open cloud storage/i }))
+      expect(mockNavigate).toHaveBeenCalledWith('/cloud-storage')
+
+      fireEvent.click(screen.getByRole('button', { name: /open remote clients/i }))
+      expect(mockNavigate).toHaveBeenCalledWith('/remote-clients')
+
+      fireEvent.click(screen.getByRole('button', { name: /open restore verification/i }))
+      expect(mockNavigate).toHaveBeenCalledWith('/schedule/restore-checks')
     })
   })
 

--- a/frontend/src/pages/dashboard-v3/CapabilityLaunchpad.stories.tsx
+++ b/frontend/src/pages/dashboard-v3/CapabilityLaunchpad.stories.tsx
@@ -1,0 +1,187 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box } from '@mui/material'
+import type { ComponentProps } from 'react'
+import { fn } from 'storybook/test'
+import { CapabilityLaunchpad } from './CapabilityLaunchpad'
+import { makeT, TokenContext } from './tokens'
+import type { DashboardOverview } from './types'
+
+type Summary = DashboardOverview['summary']
+type Repositories = DashboardOverview['repository_health']
+type LaunchpadArgs = ComponentProps<typeof CapabilityLaunchpad>
+
+const T = makeT(true)
+const handlers = {
+  onNavigate: fn(),
+}
+
+const summary: Summary = {
+  total_repositories: 3,
+  local_repositories: 1,
+  ssh_repositories: 2,
+  active_schedules: 1,
+  total_schedules: 2,
+  active_backup_plans: 2,
+  total_backup_plans: 3,
+  active_automations: 3,
+  total_automations: 4,
+  success_rate_30d: 94,
+  successful_jobs_30d: 31,
+  failed_jobs_30d: 2,
+  total_jobs_30d: 33,
+}
+
+const repositories: Repositories = [
+  {
+    id: 1,
+    name: 'Documents',
+    type: 'local',
+    mode: 'full',
+    last_backup: '2026-06-05T10:00:00.000Z',
+    last_check: '2026-06-05T10:30:00.000Z',
+    last_compact: '2026-06-01T10:00:00.000Z',
+    last_restore_check: '2026-06-04T10:00:00.000Z',
+    archive_count: 42,
+    total_size: '248 GB',
+    health_status: 'healthy',
+    warnings: [],
+    next_run: null,
+    has_schedule: true,
+    schedule_enabled: true,
+    schedule_name: 'Nightly',
+    backup_plan_count: 1,
+    backup_plan_scheduled_count: 1,
+    backup_plan_names: ['Nightly Documents'],
+    backup_plan_next_run: '2026-06-06T03:00:00.000Z',
+    restore_check_configured: true,
+    latest_restore_check_status: 'completed',
+    latest_restore_check_error: null,
+    dimension_health: {
+      backup: 'healthy',
+      check: 'healthy',
+      compact: 'healthy',
+      restore: 'healthy',
+    },
+  },
+  {
+    id: 2,
+    name: 'NAS Offsite',
+    type: 'ssh',
+    mode: 'full',
+    last_backup: '2026-06-05T11:00:00.000Z',
+    last_check: null,
+    last_compact: null,
+    last_restore_check: null,
+    archive_count: 12,
+    total_size: '1.1 TB',
+    health_status: 'warning',
+    warnings: ['Restore check is not configured'],
+    next_run: null,
+    has_schedule: false,
+    schedule_enabled: false,
+    schedule_name: null,
+    backup_plan_count: 1,
+    backup_plan_scheduled_count: 0,
+    backup_plan_names: ['Media Offsite'],
+    backup_plan_next_run: null,
+    restore_check_configured: false,
+    latest_restore_check_status: null,
+    latest_restore_check_error: null,
+    dimension_health: {
+      backup: 'healthy',
+      check: 'unknown',
+      compact: 'unknown',
+      restore: 'unknown',
+    },
+  },
+  {
+    id: 3,
+    name: 'Imported Provider',
+    type: 'rclone',
+    mode: 'observe',
+    last_backup: null,
+    last_check: '2026-06-03T10:00:00.000Z',
+    last_compact: null,
+    last_restore_check: '2026-06-03T11:00:00.000Z',
+    archive_count: 78,
+    total_size: '624 GB',
+    health_status: 'healthy',
+    warnings: [],
+    next_run: null,
+    has_schedule: false,
+    schedule_enabled: false,
+    schedule_name: null,
+    backup_plan_count: 0,
+    backup_plan_scheduled_count: 0,
+    backup_plan_names: [],
+    backup_plan_next_run: null,
+    restore_check_configured: true,
+    latest_restore_check_status: 'completed',
+    latest_restore_check_error: null,
+    dimension_health: {
+      backup: 'healthy',
+      check: 'healthy',
+      compact: 'unknown',
+      restore: 'healthy',
+    },
+  },
+]
+
+const meta = {
+  title: 'Pages/DashboardV3/CapabilityLaunchpad',
+  component: CapabilityLaunchpad,
+  parameters: {
+    layout: 'centered',
+    backgrounds: {
+      default: 'Dashboard dark',
+      values: [{ name: 'Dashboard dark', value: '#111827' }],
+    },
+  },
+} satisfies Meta<typeof CapabilityLaunchpad>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+function renderLaunchpad(args: LaunchpadArgs) {
+  return (
+    <TokenContext.Provider value={T}>
+      <Box sx={{ width: 232, maxWidth: 'calc(100vw - 32px)', color: T.textPrimary }}>
+        <CapabilityLaunchpad {...args} />
+      </Box>
+    </TokenContext.Provider>
+  )
+}
+
+export const MixedAdoption: Story = {
+  args: {
+    summary,
+    repositories,
+    cloudRemoteCount: 2,
+    remoteClientCount: 1,
+    ...handlers,
+  },
+  render: renderLaunchpad,
+}
+
+export const EmptyStart: Story = {
+  args: {
+    summary: {
+      ...summary,
+      total_repositories: 0,
+      local_repositories: 0,
+      ssh_repositories: 0,
+      active_schedules: 0,
+      total_schedules: 0,
+      active_backup_plans: 0,
+      total_backup_plans: 0,
+      active_automations: 0,
+      total_automations: 0,
+    },
+    repositories: [],
+    cloudRemoteCount: 0,
+    remoteClientCount: 0,
+    ...handlers,
+  },
+  render: renderLaunchpad,
+}

--- a/frontend/src/pages/dashboard-v3/CapabilityLaunchpad.tsx
+++ b/frontend/src/pages/dashboard-v3/CapabilityLaunchpad.tsx
@@ -1,0 +1,269 @@
+import { Box, Stack, Typography } from '@mui/material'
+import { alpha } from '@mui/material/styles'
+import { ArrowRight, Cloud, ListChecks, Server, ShieldCheck, type LucideIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { useT } from './tokens'
+import type { DashboardOverview } from './types'
+
+type LaunchpadRoute =
+  | '/backup-plans'
+  | '/cloud-storage'
+  | '/remote-clients'
+  | '/schedule/restore-checks'
+type LaunchpadSource = 'backup_plans' | 'cloud_storage' | 'remote_clients' | 'restore_verification'
+
+type LaunchpadCard = {
+  key: LaunchpadSource
+  title: string
+  value: string
+  status: string
+  route: LaunchpadRoute
+  color: string
+  icon: LucideIcon
+  ariaLabel: string
+}
+
+function pluralKey(baseKey: string, count: number) {
+  return `${baseKey}_${count === 1 ? 'one' : 'other'}`
+}
+
+export function CapabilityLaunchpad({
+  summary,
+  repositories,
+  cloudRemoteCount = 0,
+  remoteClientCount = 0,
+  onNavigate,
+}: {
+  summary: DashboardOverview['summary']
+  repositories: DashboardOverview['repository_health']
+  cloudRemoteCount?: number
+  remoteClientCount?: number
+  onNavigate: (route: LaunchpadRoute, source: LaunchpadSource) => void
+}) {
+  const T = useT()
+  const { t } = useTranslation()
+  const backupPlanCount = summary.total_backup_plans ?? summary.total_schedules
+  const activeBackupPlanCount = summary.active_backup_plans ?? summary.active_schedules
+  const restoreConfiguredCount = repositories.filter(
+    (repository) => repository.restore_check_configured
+  ).length
+  const repositoryCount = repositories.length
+
+  const cards: LaunchpadCard[] = [
+    {
+      key: 'backup_plans',
+      title: t('dashboard.launchpad.backupPlans.title'),
+      value: t(pluralKey('dashboard.launchpad.backupPlans.value', backupPlanCount), {
+        count: backupPlanCount,
+      }),
+      status:
+        backupPlanCount > 0
+          ? t(pluralKey('dashboard.launchpad.backupPlans.active', activeBackupPlanCount), {
+              count: activeBackupPlanCount,
+            })
+          : t('dashboard.launchpad.backupPlans.empty'),
+      route: '/backup-plans',
+      color: T.blue,
+      icon: ListChecks,
+      ariaLabel: t('dashboard.launchpad.openAction', {
+        title: t('dashboard.launchpad.backupPlans.title'),
+        value: t(pluralKey('dashboard.launchpad.backupPlans.value', backupPlanCount), {
+          count: backupPlanCount,
+        }),
+        status:
+          backupPlanCount > 0
+            ? t(pluralKey('dashboard.launchpad.backupPlans.active', activeBackupPlanCount), {
+                count: activeBackupPlanCount,
+              })
+            : t('dashboard.launchpad.backupPlans.empty'),
+      }),
+    },
+    {
+      key: 'cloud_storage',
+      title: t('dashboard.launchpad.cloudStorage.title'),
+      value: t(pluralKey('dashboard.launchpad.cloudStorage.value', cloudRemoteCount), {
+        count: cloudRemoteCount,
+      }),
+      status:
+        cloudRemoteCount > 0
+          ? t('dashboard.launchpad.cloudStorage.active')
+          : t('dashboard.launchpad.cloudStorage.empty'),
+      route: '/cloud-storage',
+      color: T.indigo,
+      icon: Cloud,
+      ariaLabel: t('dashboard.launchpad.openAction', {
+        title: t('dashboard.launchpad.cloudStorage.title'),
+        value: t(pluralKey('dashboard.launchpad.cloudStorage.value', cloudRemoteCount), {
+          count: cloudRemoteCount,
+        }),
+        status:
+          cloudRemoteCount > 0
+            ? t('dashboard.launchpad.cloudStorage.active')
+            : t('dashboard.launchpad.cloudStorage.empty'),
+      }),
+    },
+    {
+      key: 'remote_clients',
+      title: t('dashboard.launchpad.remoteClients.title'),
+      value: t(pluralKey('dashboard.launchpad.remoteClients.value', remoteClientCount), {
+        count: remoteClientCount,
+      }),
+      status:
+        remoteClientCount > 0
+          ? t('dashboard.launchpad.remoteClients.active')
+          : t('dashboard.launchpad.remoteClients.empty'),
+      route: '/remote-clients',
+      color: T.blue,
+      icon: Server,
+      ariaLabel: t('dashboard.launchpad.openAction', {
+        title: t('dashboard.launchpad.remoteClients.title'),
+        value: t(pluralKey('dashboard.launchpad.remoteClients.value', remoteClientCount), {
+          count: remoteClientCount,
+        }),
+        status:
+          remoteClientCount > 0
+            ? t('dashboard.launchpad.remoteClients.active')
+            : t('dashboard.launchpad.remoteClients.empty'),
+      }),
+    },
+    {
+      key: 'restore_verification',
+      title: t('dashboard.launchpad.restoreVerification.title'),
+      value: t('dashboard.launchpad.restoreVerification.value', {
+        configured: restoreConfiguredCount,
+        total: repositoryCount,
+      }),
+      status:
+        repositoryCount === 0
+          ? t('dashboard.launchpad.restoreVerification.noRepositories')
+          : restoreConfiguredCount === repositoryCount
+            ? t('dashboard.launchpad.restoreVerification.complete')
+            : t('dashboard.launchpad.restoreVerification.partial'),
+      route: '/schedule/restore-checks',
+      color: restoreConfiguredCount === repositoryCount && repositoryCount > 0 ? T.green : T.amber,
+      icon: ShieldCheck,
+      ariaLabel: t('dashboard.launchpad.openAction', {
+        title: t('dashboard.launchpad.restoreVerification.title'),
+        value: t('dashboard.launchpad.restoreVerification.value', {
+          configured: restoreConfiguredCount,
+          total: repositoryCount,
+        }),
+        status:
+          repositoryCount === 0
+            ? t('dashboard.launchpad.restoreVerification.noRepositories')
+            : restoreConfiguredCount === repositoryCount
+              ? t('dashboard.launchpad.restoreVerification.complete')
+              : t('dashboard.launchpad.restoreVerification.partial'),
+      }),
+    },
+  ]
+
+  return (
+    <Box
+      component="section"
+      aria-labelledby="dashboard-launchpad-heading"
+      sx={{
+        bgcolor: T.bgCard,
+        border: `1px solid ${T.border}`,
+        borderRadius: T.radius,
+        transition: 'border-color 0.2s',
+        p: 2,
+        '&:hover': { borderColor: T.borderHover },
+      }}
+    >
+      <Typography
+        id="dashboard-launchpad-heading"
+        sx={{ fontSize: '0.8125rem', fontWeight: 600, color: T.textPrimary, mb: 1.5 }}
+      >
+        {t('dashboard.launchpad.title')}
+      </Typography>
+
+      <Stack spacing={0.5}>
+        {cards.map(({ key, title, value, status, route, color, icon: Icon, ariaLabel }) => (
+          <Box
+            key={key}
+            component="button"
+            type="button"
+            aria-label={ariaLabel}
+            onClick={() => onNavigate(route, key)}
+            sx={{
+              appearance: 'none',
+              border: '1px solid transparent',
+              borderRadius: '8px',
+              bgcolor: 'transparent',
+              color: 'inherit',
+              cursor: 'pointer',
+              display: 'grid',
+              gridTemplateColumns: '28px minmax(0, 1fr) 16px',
+              alignItems: 'center',
+              gap: 1,
+              font: 'inherit',
+              minWidth: 0,
+              p: 0.75,
+              textAlign: 'left',
+              width: '100%',
+              transition: 'background-color 0.16s, border-color 0.16s',
+              '&:hover': {
+                bgcolor: T.hoverBg,
+                borderColor: alpha(color, 0.24),
+              },
+              '&:focus-visible': {
+                outline: `2px solid ${alpha(color, 0.65)}`,
+                outlineOffset: 2,
+              },
+            }}
+          >
+            <Box
+              sx={{
+                width: 28,
+                height: 28,
+                borderRadius: '8px',
+                display: 'grid',
+                placeItems: 'center',
+                bgcolor: alpha(color, 0.11),
+                color,
+                flexShrink: 0,
+              }}
+            >
+              <Icon size={14} />
+            </Box>
+            <Box sx={{ minWidth: 0 }}>
+              <Typography
+                sx={{
+                  fontSize: '0.8125rem',
+                  fontWeight: 600,
+                  color: T.textPrimary,
+                  lineHeight: 1.25,
+                  minWidth: 0,
+                }}
+              >
+                {title}
+              </Typography>
+              <Typography
+                sx={{
+                  color: T.textMuted,
+                  fontSize: '0.75rem',
+                  lineHeight: 1.35,
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                <Box
+                  component="span"
+                  sx={{ color: T.textPrimary, fontFamily: T.mono, fontWeight: 700 }}
+                >
+                  {value}
+                </Box>
+                {' · '}
+                {status}
+              </Typography>
+            </Box>
+            <ArrowRight size={14} color={T.textMuted} aria-hidden="true" />
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  )
+}

--- a/frontend/src/pages/dashboard-v3/DashboardSkeleton.tsx
+++ b/frontend/src/pages/dashboard-v3/DashboardSkeleton.tsx
@@ -8,7 +8,8 @@ import { ResourceGaugeGrid } from './ResourceGaugeGrid'
  * dashboard:
  *
  * - 200px + 1fr bento grid (md+).
- * - Left rail: success donut (96px), resources (3 arc gauges), storage donut.
+ * - Left rail: success donut (96px), resources (3 arc gauges), launchpad,
+ *   upcoming backups, storage donut.
  * - Right rail: repository health panel (with recent failures strip and
  *   mixed compact + full card grid), then activity lane chart.
  * - Banner stat strip with 5 cells (System Status + 4 stats).
@@ -126,7 +127,7 @@ export function DashboardSkeleton({ T }: { T: Tokens }) {
           alignItems: 'start',
         }}
       >
-        {/* Left column: success donut + resources + storage */}
+        {/* Left column: success donut + resources + launchpad + upcoming backups + storage */}
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5 }}>
           {/* Success donut card */}
           <Box
@@ -217,6 +218,97 @@ export function DashboardSkeleton({ T }: { T: Tokens }) {
                 </Box>
               ))}
             </ResourceGaugeGrid>
+          </Box>
+
+          {/* Capability launchpad */}
+          <Box
+            sx={{
+              bgcolor: T.bgCard,
+              border: `1px solid ${T.border}`,
+              borderRadius: '14px',
+              p: 2,
+            }}
+          >
+            <Skeleton
+              variant="text"
+              width={136}
+              height={14}
+              sx={{ mb: 1.5, transform: 'none', borderRadius: 0.5 }}
+            />
+            <Stack spacing={0.5}>
+              {[0, 1, 2, 3].map((i) => (
+                <Box
+                  key={i}
+                  sx={{
+                    borderRadius: '8px',
+                    border: `1px solid ${T.border}`,
+                    p: 0.75,
+                  }}
+                >
+                  <Box
+                    sx={{
+                      display: 'grid',
+                      gridTemplateColumns: '28px minmax(0, 1fr) 16px',
+                      alignItems: 'center',
+                      gap: 1,
+                      minWidth: 0,
+                    }}
+                  >
+                    <Skeleton variant="rounded" width={28} height={28} sx={{ borderRadius: 2 }} />
+                    <Box sx={{ minWidth: 0 }}>
+                      <Skeleton
+                        variant="text"
+                        width={[84, 92, 96, 118][i]}
+                        height={14}
+                        sx={{ transform: 'none', borderRadius: 0.5 }}
+                      />
+                      <Skeleton
+                        variant="text"
+                        width={[88, 78, 76, 90][i]}
+                        height={12}
+                        sx={{ mt: 0.35, transform: 'none', borderRadius: 0.5 }}
+                      />
+                    </Box>
+                    <Skeleton variant="circular" width={14} height={14} />
+                  </Box>
+                </Box>
+              ))}
+            </Stack>
+          </Box>
+
+          {/* Upcoming backups */}
+          <Box
+            sx={{
+              bgcolor: T.bgCard,
+              border: `1px solid ${T.border}`,
+              borderRadius: '14px',
+              p: 2,
+            }}
+          >
+            <Skeleton
+              variant="text"
+              width={126}
+              height={14}
+              sx={{ mb: 1.25, transform: 'none', borderRadius: 0.5 }}
+            />
+            <Stack spacing={1}>
+              {[0, 1].map((i) => (
+                <Box key={i}>
+                  <Skeleton
+                    variant="text"
+                    width={[118, 94][i]}
+                    height={14}
+                    sx={{ transform: 'none', borderRadius: 0.5 }}
+                  />
+                  <Skeleton
+                    variant="text"
+                    width={[84, 72][i]}
+                    height={12}
+                    sx={{ mt: 0.35, transform: 'none', borderRadius: 0.5 }}
+                  />
+                </Box>
+              ))}
+            </Stack>
           </Box>
 
           {/* Storage donut card */}


### PR DESCRIPTION
## Description
Adds a compact Operations launchpad to DashboardV3 so users can see and act on newer Borg UI capabilities: backup plans, Cloud Storage remotes, Remote Clients, and restore verification coverage. The launchpad now uses compact row-level actions with neutral text colors for better density and contrast, while preserving existing dashboard tokens, MUI, and Lucide icon patterns.

This also adds loading skeleton coverage, Storybook states, localized strings, navigation docs, and durable engineering spec/plan files.

## Related Issue
BOR-154: https://linear.app/nullcodeai/issue/BOR-154/surface-new-borg-ui-capabilities-on-the-dashboard

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- `cd frontend && npm test -- --run src/pages/__tests__/DashboardV3.test.tsx --testNamePattern "operations launchpad"`
- `cd frontend && npm test -- --run src/pages/__tests__/DashboardV3.test.tsx`
- `cd frontend && npm run format:check`
- `cd frontend && npm run check:locales && npm run typecheck && npm run lint && npm run build`
- `cd frontend && npm run build-storybook`
- `curl -I 'http://127.0.0.1:6006/iframe.html?id=pages-dashboardv3-capabilitylaunchpad--mixed-adoption&viewMode=story'`
- `git diff --check`

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Local screenshot capture was blocked by missing host browser libraries. Storybook static build passed and the launchpad story iframe returned HTTP 200. Chromium requires `libnspr4.so`; Firefox requires `libXdamage.so.1`, GTK, Pango, Cairo, and ATK libraries.

## Additional Context
The implementation does not change the dashboard backend contract. DashboardV3 reuses the existing dashboard overview data, `rcloneAPI.listRemotes()` for Cloud Storage remotes, and browser-registered remote backend clients for Remote Clients.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Operations Launchpad to the dashboard: four capability cards (backup plans, cloud storage, remote clients, restore verification) showing counts/status, clickable navigation to relevant sections, and integrated skeleton/loading placeholders.
* **Documentation**
  * Added spec and rollout plan, updated navigation guidance, and included a launchpad validation checklist.
* **Localization**
  * Added translations for English, German, Spanish, and Italian.
* **Tests**
  * Added tests verifying launchpad rendering and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 0 changed, 4 added, 0 removed, 380 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-637/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/27067595357
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- `pages-dashboardv3-capabilitylaunchpad--empty-start--mobile.png`
- `pages-dashboardv3-capabilitylaunchpad--empty-start.png`
- `pages-dashboardv3-capabilitylaunchpad--mixed-adoption--mobile.png`
- `pages-dashboardv3-capabilitylaunchpad--mixed-adoption.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->