### PR TITLE
Persist saved remote clients in the database

### DIFF
--- a/app/api/remote_clients.py
+++ b/app/api/remote_clients.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Literal, Optional
+from urllib.parse import urlsplit
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.core.security import get_current_admin_user
+from app.database.database import get_db
+from app.database.models import RemoteBackendClient, User
+from app.utils.datetime_utils import serialize_datetime
+
+router = APIRouter(tags=["Remote Clients"])
+
+RemoteBackendStatus = Literal["unknown", "checking", "online", "offline"]
+RemoteBackendCompatibility = Literal["compatible", "incompatible", "unknown"]
+
+
+class RemoteClientCreate(BaseModel):
+    id: Optional[str] = Field(default=None, max_length=128)
+    name: str = Field(min_length=1, max_length=255)
+    backend_url: str = Field(min_length=1, max_length=2048)
+
+
+class RemoteClientUpdate(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+    backend_url: str = Field(min_length=1, max_length=2048)
+
+
+class RemoteClientHealthUpdate(BaseModel):
+    status: RemoteBackendStatus
+    checked_at: Optional[datetime] = None
+    app_version: Optional[str] = None
+    borg_version: Optional[str] = None
+    borg2_version: Optional[str] = None
+    error: Optional[str] = None
+    compatibility: RemoteBackendCompatibility
+    compatibility_message: Optional[str] = None
+
+
+class RemoteClientHealthResponse(BaseModel):
+    status: RemoteBackendStatus
+    checked_at: Optional[str] = None
+    app_version: Optional[str] = None
+    borg_version: Optional[str] = None
+    borg2_version: Optional[str] = None
+    error: Optional[str] = None
+    compatibility: RemoteBackendCompatibility
+    compatibility_message: Optional[str] = None
+
+
+class RemoteClientResponse(BaseModel):
+    id: str
+    name: str
+    api_base_url: str
+    web_base_url: str
+    created_at: str
+    updated_at: str
+    health: RemoteClientHealthResponse
+
+
+def _is_http_private_host(hostname: str) -> bool:
+    normalized = hostname.lower()
+    if (
+        normalized == "localhost"
+        or normalized == "::1"
+        or normalized.endswith(".local")
+        or normalized.startswith("127.")
+    ):
+        return True
+
+    octets = normalized.split(".")
+    if len(octets) != 4:
+        return False
+
+    try:
+        first, second, *_ = [int(part) for part in octets]
+    except ValueError:
+        return False
+
+    return (
+        first == 10
+        or (first == 192 and second == 168)
+        or (first == 172 and 16 <= second <= 31)
+    )
+
+
+def _ensure_url_protocol(raw_input: str) -> str:
+    if re.match(r"^[a-z][a-z\d+.-]*://", raw_input, re.IGNORECASE):
+        return raw_input
+
+    if raw_input.startswith("/"):
+        raise ValueError("Enter a valid server URL.")
+
+    host_part = re.split(r"[/?#]", raw_input, maxsplit=1)[0] or ""
+    if host_part.startswith("["):
+        closing = host_part.find("]")
+        hostname = host_part[1:closing] if closing > 0 else host_part
+    else:
+        hostname = host_part.split(":", 1)[0]
+
+    protocol = "http" if _is_http_private_host(hostname) else "https"
+    return f"{protocol}://{raw_input}"
+
+
+def normalize_remote_backend_url(backend_url: str) -> tuple[str, str]:
+    trimmed = backend_url.strip()
+    if not trimmed:
+        raise ValueError("Enter a server URL.")
+
+    parsed = urlsplit(_ensure_url_protocol(trimmed))
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError("Server URL must use HTTP or HTTPS.")
+
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    clean_path = parsed.path.rstrip("/")
+    api_path = clean_path if clean_path.endswith("/api") else f"{clean_path}/api"
+    normalized_api_path = "/api" if api_path == "/api" else re.sub(r"/+", "/", api_path)
+    web_path = (
+        normalized_api_path[:-4]
+        if normalized_api_path.endswith("/api")
+        else normalized_api_path
+    )
+
+    return (
+        f"{origin}{normalized_api_path}",
+        f"{origin}{web_path}" if web_path else origin,
+    )
+
+
+def _remote_client_error(status_code: int, key: str) -> HTTPException:
+    return HTTPException(status_code=status_code, detail={"key": key})
+
+
+def _get_client_or_404(db: Session, client_id: str) -> RemoteBackendClient:
+    client = (
+        db.query(RemoteBackendClient)
+        .filter(RemoteBackendClient.id == client_id)
+        .first()
+    )
+    if not client:
+        raise _remote_client_error(
+            status.HTTP_404_NOT_FOUND, "backend.errors.remoteClients.notFound"
+        )
+    return client
+
+
+def _serialize_client(client: RemoteBackendClient) -> RemoteClientResponse:
+    return RemoteClientResponse(
+        id=client.id,
+        name=client.name,
+        api_base_url=client.api_base_url,
+        web_base_url=client.web_base_url,
+        created_at=serialize_datetime(client.created_at) or "",
+        updated_at=serialize_datetime(client.updated_at) or "",
+        health=RemoteClientHealthResponse(
+            status=client.health_status,
+            checked_at=serialize_datetime(client.health_checked_at),
+            app_version=client.app_version,
+            borg_version=client.borg_version,
+            borg2_version=client.borg2_version,
+            error=client.health_error,
+            compatibility=client.compatibility,
+            compatibility_message=client.compatibility_message,
+        ),
+    )
+
+
+def _normalize_or_422(backend_url: str) -> tuple[str, str]:
+    try:
+        return normalize_remote_backend_url(backend_url)
+    except ValueError as exc:
+        raise _remote_client_error(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            "backend.errors.remoteClients.invalidUrl",
+        ) from exc
+
+
+@router.get("", response_model=list[RemoteClientResponse])
+async def list_remote_clients(
+    _: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    clients = (
+        db.query(RemoteBackendClient).order_by(RemoteBackendClient.name.asc()).all()
+    )
+    return [_serialize_client(client) for client in clients]
+
+
+@router.post(
+    "",
+    response_model=RemoteClientResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_remote_client(
+    payload: RemoteClientCreate,
+    _: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    client_id = (payload.id or str(uuid4())).strip()
+    if not client_id:
+        raise _remote_client_error(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            "backend.errors.remoteClients.invalidId",
+        )
+    if (
+        db.query(RemoteBackendClient)
+        .filter(RemoteBackendClient.id == client_id)
+        .first()
+    ):
+        raise _remote_client_error(
+            status.HTTP_409_CONFLICT, "backend.errors.remoteClients.alreadyExists"
+        )
+
+    api_base_url, web_base_url = _normalize_or_422(payload.backend_url)
+    timestamp = datetime.now(timezone.utc)
+    client = RemoteBackendClient(
+        id=client_id,
+        name=payload.name.strip(),
+        api_base_url=api_base_url,
+        web_base_url=web_base_url,
+        created_at=timestamp,
+        updated_at=timestamp,
+    )
+    db.add(client)
+    db.commit()
+    db.refresh(client)
+    return _serialize_client(client)
+
+
+@router.put("/{client_id}", response_model=RemoteClientResponse)
+async def update_remote_client(
+    client_id: str,
+    payload: RemoteClientUpdate,
+    _: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    client = _get_client_or_404(db, client_id)
+    api_base_url, web_base_url = _normalize_or_422(payload.backend_url)
+
+    client.name = payload.name.strip()
+    client.api_base_url = api_base_url
+    client.web_base_url = web_base_url
+    client.updated_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(client)
+    return _serialize_client(client)
+
+
+@router.patch("/{client_id}/health", response_model=RemoteClientResponse)
+async def update_remote_client_health(
+    client_id: str,
+    payload: RemoteClientHealthUpdate,
+    _: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    client = _get_client_or_404(db, client_id)
+    client.health_status = payload.status
+    client.health_checked_at = payload.checked_at
+    client.app_version = payload.app_version
+    client.borg_version = payload.borg_version
+    client.borg2_version = payload.borg2_version
+    client.health_error = payload.error
+    client.compatibility = payload.compatibility
+    client.compatibility_message = payload.compatibility_message
+    client.updated_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(client)
+    return _serialize_client(client)
+
+
+@router.delete("/{client_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_remote_client(
+    client_id: str,
+    _: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    client = _get_client_or_404(db, client_id)
+    db.delete(client)
+    db.commit()

--- a/app/database/migrations/122_add_remote_backend_clients.py
+++ b/app/database/migrations/122_add_remote_backend_clients.py
@@ -1,0 +1,47 @@
+"""Add database-backed remote backend clients."""
+
+from sqlalchemy import inspect, text
+
+
+def _bind(db):
+    return db.get_bind() if hasattr(db, "get_bind") else db
+
+
+def _table_exists(db, table_name: str) -> bool:
+    return inspect(_bind(db)).has_table(table_name)
+
+
+def _timestamp_type(db) -> str:
+    return "TIMESTAMP" if _bind(db).dialect.name == "postgresql" else "DATETIME"
+
+
+def upgrade(db):
+    if not _table_exists(db, "remote_backend_clients"):
+        timestamp_type = _timestamp_type(db)
+        db.execute(
+            text(
+                "CREATE TABLE remote_backend_clients ("
+                "id VARCHAR PRIMARY KEY, "
+                "name VARCHAR NOT NULL, "
+                "api_base_url VARCHAR NOT NULL, "
+                "web_base_url VARCHAR NOT NULL, "
+                "health_status VARCHAR NOT NULL DEFAULT 'unknown', "
+                f"health_checked_at {timestamp_type}, "
+                "app_version VARCHAR, "
+                "borg_version VARCHAR, "
+                "borg2_version VARCHAR, "
+                "health_error TEXT, "
+                "compatibility VARCHAR NOT NULL DEFAULT 'unknown', "
+                "compatibility_message TEXT, "
+                f"created_at {timestamp_type} NOT NULL, "
+                f"updated_at {timestamp_type} NOT NULL"
+                ")"
+            )
+        )
+    db.commit()
+
+
+def downgrade(db):
+    if _table_exists(db, "remote_backend_clients"):
+        db.execute(text("DROP TABLE remote_backend_clients"))
+    db.commit()

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -492,6 +492,25 @@ class RcloneOAuthProviderCredential(Base):
     updated_at = Column(DateTime, default=utc_now, onupdate=utc_now, nullable=False)
 
 
+class RemoteBackendClient(Base):
+    __tablename__ = "remote_backend_clients"
+
+    id = Column(String, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    api_base_url = Column(String, nullable=False)
+    web_base_url = Column(String, nullable=False)
+    health_status = Column(String, default="unknown", nullable=False)
+    health_checked_at = Column(DateTime, nullable=True)
+    app_version = Column(String, nullable=True)
+    borg_version = Column(String, nullable=True)
+    borg2_version = Column(String, nullable=True)
+    health_error = Column(Text, nullable=True)
+    compatibility = Column(String, default="unknown", nullable=False)
+    compatibility_message = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=utc_now, nullable=False)
+    updated_at = Column(DateTime, default=utc_now, onupdate=utc_now, nullable=False)
+
+
 class RepositoryStorage(Base):
     __tablename__ = "repository_storage"
 

--- a/app/main.py
+++ b/app/main.py
@@ -34,6 +34,7 @@ from app.api import (
     metrics,
     tokens,
     permissions,
+    remote_clients,
     agent_installer,
     managed_machines,
     agents,
@@ -227,6 +228,9 @@ app.include_router(mounts.router)  # Mount management API
 
 app.include_router(tokens.router, prefix="/api")
 app.include_router(permissions.router, prefix="/api")
+app.include_router(
+    remote_clients.router, prefix="/api/remote-clients", tags=["Remote Clients"]
+)
 app.include_router(agent_installer.router)
 app.include_router(managed_machines.router)
 app.include_router(agents.router)

--- a/docs/engineering/plans/2026-06-06-remote-clients-database-persistence.md
+++ b/docs/engineering/plans/2026-06-06-remote-clients-database-persistence.md
@@ -1,0 +1,192 @@
+# Remote Clients Database Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development or superpowers:executing-plans to
+> implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for
+> tracking.
+
+**Goal:** Store saved Remote Clients in the database with admin-only backend
+access while keeping JWT tokens and active target selection browser-local.
+
+**Architecture:** Add a small global `remote_backend_clients` table and
+admin-only FastAPI router. Refactor the frontend remote backend provider so the
+client list is hydrated from the API, legacy localStorage rows are imported once
+for admins, and the target switcher blocks stale remote targets for non-admins.
+
+**Tech Stack:** FastAPI, SQLAlchemy, custom SQLite/Postgres migrations, React,
+Vite, MUI, Vitest, Storybook.
+
+---
+
+## Task 1: Backend Persistence Contract
+
+**Files:**
+
+- Create: `app/api/remote_clients.py`
+- Create: `tests/unit/test_api_remote_clients.py`
+- Create: `app/database/migrations/122_add_remote_backend_clients.py`
+- Modify: `app/database/models.py`
+- Modify: `app/main.py`
+
+- [ ] **Step 1: Write failing backend API tests**
+
+  Add tests that create a remote client as admin, verify the response shape,
+  verify list/readback from the database, update URL/name, patch health, delete,
+  and assert a viewer receives 403 on all endpoints.
+
+- [ ] **Step 2: Run backend tests and verify RED**
+
+  Run:
+
+  ```bash
+  pytest tests/unit/test_api_remote_clients.py -q
+  ```
+
+  Expected: fail because `/api/remote-clients` routes and model do not exist.
+
+- [ ] **Step 3: Add model and migration**
+
+  Add `RemoteBackendClient` to `app/database/models.py` and migration
+  `122_add_remote_backend_clients.py` creating the table and indexes.
+
+- [ ] **Step 4: Add admin-only router**
+
+  Implement `/api/remote-clients` CRUD and health endpoints using
+  `get_current_admin_user`, backend URL normalization, serialized UTC
+  timestamps, and stable string IDs.
+
+- [ ] **Step 5: Register router and verify GREEN**
+
+  Include the router in `app/main.py`, then rerun:
+
+  ```bash
+  pytest tests/unit/test_api_remote_clients.py -q
+  ```
+
+  Expected: all tests in the new file pass.
+
+## Task 2: Frontend API-Backed Remote Backend State
+
+**Files:**
+
+- Modify: `frontend/src/services/remoteBackends/storage.ts`
+- Modify: `frontend/src/services/remoteBackends/context.tsx`
+- Modify: `frontend/src/services/remoteBackends/storage.test.ts`
+- Modify: `frontend/src/services/remoteBackends/context.test.tsx`
+- Modify: `frontend/src/services/remoteBackends/types.ts`
+
+- [ ] **Step 1: Write failing provider/storage tests**
+
+  Update tests so remote clients are loaded from mocked `/remote-clients`
+  responses, create/update/delete/health calls hit the API, legacy
+  `borg_ui_remote_backends` entries import once, and the legacy `access_token`
+  key remains unchanged for local JWTs.
+
+- [ ] **Step 2: Run frontend tests and verify RED**
+
+  Run:
+
+  ```bash
+  cd frontend && npm run test -- --run src/services/remoteBackends/storage.test.ts src/services/remoteBackends/context.test.tsx
+  ```
+
+  Expected: fail because the provider is still localStorage-backed.
+
+- [ ] **Step 3: Refactor storage boundaries**
+
+  Keep active target ID and target-scoped token helpers in localStorage. Move
+  remote client list state to an in-memory snapshot managed by the provider,
+  with legacy read/import helpers for `borg_ui_remote_backends`.
+
+- [ ] **Step 4: Implement API hydration and mutations**
+
+  In `RemoteBackendProvider`, fetch `/remote-clients` with the selected target's
+  JWT, refresh after token changes, import legacy entries after successful admin
+  hydration, and convert create/update/delete/check flows to async API
+  mutations.
+
+- [ ] **Step 5: Verify frontend state tests GREEN**
+
+  Rerun the targeted storage/context Vitest command and keep it green.
+
+## Task 3: UI Permission Gate and Story Coverage
+
+**Files:**
+
+- Modify: `frontend/src/pages/RemoteClients.tsx`
+- Modify: `frontend/src/pages/__tests__/RemoteClients.test.tsx`
+- Modify: `frontend/src/components/BackendTargetSwitcher.tsx`
+- Modify: `frontend/src/components/__tests__/BackendTargetSwitcher.test.tsx`
+- Modify: `frontend/src/pages/RemoteClients.stories.tsx`
+- Modify: `docs/navigation.md` if navigation text changes
+
+- [ ] **Step 1: Write failing UI tests**
+
+  Assert the Remote Clients page uses async persistence, non-admins are
+  redirected, and the switcher disables or hides remote switching when
+  `settings.ssh.manage` is absent even if stale remote clients exist.
+
+- [ ] **Step 2: Run UI tests and verify RED**
+
+  Run:
+
+  ```bash
+  cd frontend && npm run test -- --run src/pages/__tests__/RemoteClients.test.tsx src/components/__tests__/BackendTargetSwitcher.test.tsx
+  ```
+
+  Expected: fail until UI handlers and switcher permission checks are updated.
+
+- [ ] **Step 3: Update UI handlers and permission checks**
+
+  Make add/edit/delete/check handlers async, render existing loading/error state
+  cleanly, and gate switcher remote targets with both plan access and
+  `settings.ssh.manage`.
+
+- [ ] **Step 4: Update Storybook**
+
+  Update `RemoteClients.stories.tsx` to demonstrate the database-backed admin
+  state and any loading/error state introduced by API hydration.
+
+- [ ] **Step 5: Verify UI tests GREEN**
+
+  Rerun the targeted Remote Clients and switcher Vitest command.
+
+## Task 4: Full Validation and Handoff
+
+**Files:**
+
+- Modify as needed based on validation findings.
+
+- [ ] **Step 1: Backend validation**
+
+  Run:
+
+  ```bash
+  ruff check app tests
+  ruff format --check app tests
+  pytest tests/unit/test_api_remote_clients.py -q
+  ```
+
+- [ ] **Step 2: Frontend validation**
+
+  Run:
+
+  ```bash
+  cd frontend && npm run check:locales
+  cd frontend && npm run typecheck
+  cd frontend && npm run lint
+  cd frontend && npm run build
+  ```
+
+- [ ] **Step 3: Runtime walkthrough**
+
+  Launch Borg UI locally, log in as admin, save a remote client, confirm the
+  network request writes to `/api/remote-clients`, refresh in a fresh browser
+  context, confirm the saved client loads from DB, switch to it, and confirm a
+  non-admin cannot see or call the remote-client endpoints.
+
+- [ ] **Step 4: Commit, push, PR, and Linear handoff**
+
+  Commit the scoped changes, push the branch, create/update the PR with the
+  repository template, attach it to Linear, run the PR feedback sweep, and move
+  BOR-155 to Human Review only after checks and feedback are green.

--- a/docs/engineering/specs/2026-06-06-remote-clients-database-persistence.md
+++ b/docs/engineering/specs/2026-06-06-remote-clients-database-persistence.md
@@ -1,0 +1,112 @@
+# Remote Clients Database Persistence Spec
+
+## Problem
+
+Remote Clients are currently stored in browser localStorage. A saved remote
+client is therefore available only in the browser where it was created, and an
+admin loses the saved list when signing in from another device.
+
+Remote Clients also represent a system-wide switching capability. The existing
+UI is already hidden behind `settings.ssh.manage`, which maps to admin, but the
+storage layer and target switcher still rely on browser-local state. The new
+server-side contract needs to enforce admin-only access instead of trusting the
+frontend.
+
+## Desired Outcome
+
+Persist saved remote clients in the Borg UI database. Any authenticated admin
+can list, create, update, delete, check, and switch to the saved remote clients
+from another browser or device.
+
+The login JWT remains stored in localStorage using the current target-scoped
+token behavior. The active backend target remains browser-local because it is a
+per-browser routing choice, not a shared system setting. Switching to a remote
+client still causes the selected target's normal auth flow to run when a token
+is missing.
+
+## Design
+
+Add a `remote_backend_clients` table with string IDs so legacy browser-saved
+client IDs can be migrated without breaking the active-target localStorage key.
+Rows are global, not per-user, because the feature is admin-only and represents
+registered Borg UI servers for the installation.
+
+Each row stores:
+
+- `id`;
+- `name`;
+- normalized `api_base_url`;
+- normalized `web_base_url`;
+- creation and update timestamps;
+- latest health status, checked-at timestamp, app version, Borg versions,
+  error, compatibility state, and compatibility message.
+
+Add an admin-only FastAPI router at `/api/remote-clients`:
+
+- `GET /api/remote-clients` lists saved clients.
+- `POST /api/remote-clients` creates a client from a name and backend URL.
+- `PUT /api/remote-clients/{client_id}` renames or retargets a client.
+- `PATCH /api/remote-clients/{client_id}/health` persists the latest UI-run
+  health check result.
+- `DELETE /api/remote-clients/{client_id}` removes a client.
+
+The backend normalizes the URL with the same rules as the frontend so the
+database contract is stable and independently testable.
+
+## Frontend Behavior
+
+Replace client-list localStorage reads/writes with a provider-owned in-memory
+snapshot hydrated from the active backend's `/remote-clients` API. The provider
+continues to keep the active target and JWT token keys in localStorage.
+
+After login or token changes, the provider refreshes the saved client list. If
+legacy `borg_ui_remote_backends` localStorage entries exist, an authenticated
+admin imports them into the database once, preserving their IDs where possible,
+then removes the legacy list only after successful import.
+
+Remote Clients UI remains visually consistent with the existing page: dense
+admin controls, lucide icons, MUI surfaces, subtle full outlines, and shared
+`ResponsiveDialog`/`PlanGate` primitives. No new decorative layout pattern is
+introduced.
+
+## RBAC
+
+Backend endpoints require `get_current_admin_user`. Non-admin users receive
+403 for list, create, update, health update, and delete.
+
+Frontend surfaces continue to use `settings.ssh.manage` for admin visibility.
+The target switcher also treats remote clients as unavailable when the user
+lacks that permission, so old browser state cannot expose a remote switching
+path to non-admin users.
+
+## Non-Goals
+
+- Sharing the active backend target across devices.
+- Moving JWTs out of localStorage.
+- Storing remote server passwords or API secrets in the database.
+- Changing Remote Machines, Managed Agents, SSH connection persistence, or plan
+  pricing behavior.
+
+## Acceptance Mapping
+
+- Saved remote clients are loaded from the database rather than
+  `borg_ui_remote_backends` localStorage.
+- Legacy browser-saved clients are imported once for admins and then removed
+  from the legacy localStorage key.
+- The legacy `access_token` key remains the local backend JWT key.
+- Remote target tokens remain scoped to target-specific localStorage keys.
+- Non-admin users cannot call any remote-client persistence endpoint.
+- Non-admin users do not see Remote Clients management and cannot switch to
+  browser-stale remote targets.
+- Storybook covers the updated Remote Clients page state.
+
+## Validation
+
+- Backend unit tests for CRUD, URL normalization, health persistence, and
+  non-admin 403s.
+- Frontend Vitest tests for provider DB hydration, legacy import, JWT key
+  preservation, Remote Clients UI, and target switcher permission gating.
+- Storybook story for the database-backed Remote Clients page state.
+- Standard backend and frontend validation commands for the changed scope.
+- Runtime walkthrough covering admin save/switch from the DB-backed list and
+  non-admin visibility/access denial.

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -16,7 +16,7 @@ For a new setup, follow the sidebar in this order:
 
 1. Open Dashboard to check overall health and spot setup gaps.
 2. Add storage targets from Repositories or Cloud Storage, and register infrastructure endpoints
-   from Remote Clients on Pro/Enterprise plans or from Remote Machines.
+   from Remote Clients with an admin account on Pro/Enterprise plans or from Remote Machines.
 3. Create a plan from Backup Plans.
 4. Configure automatic runs from the plan schedule or the Schedule page.
 5. Watch work in Activity and browse results in Archives.
@@ -28,7 +28,7 @@ For a new setup, follow the sidebar in this order:
 | --- | --- | --- |
 | Main | Dashboard | Check repository health, recent activity, backup freshness, restore-check status, and setup-gap actions for backup plans, cloud storage, remote clients, and verification. |
 | Main | Activity | Review job history, live or recent logs, failures, and completed backup, restore, check, prune, compact, script, or package work. |
-| Infrastructure | Remote Clients | Register other Borg UI client servers, check health and version compatibility, and switch this browser to a remote client. Requires Pro or Enterprise. |
+| Infrastructure | Remote Clients | Register other Borg UI client servers, check health and version compatibility, and switch this browser to a remote client. Requires admin access and Pro or Enterprise. |
 | Infrastructure | Remote Machines | Add SSH-connected machines for remote repositories, remote backup sources, and SSH restore destinations. |
 | Infrastructure | Managed Agents | Enroll and manage Borg UI agents on remote machines. |
 | Infrastructure | Cloud Storage | Configure reusable rclone remotes for Cloud Mirror targets and advanced direct Borg 2 rclone repository URLs. |

--- a/docs/remote-clients.md
+++ b/docs/remote-clients.md
@@ -15,9 +15,13 @@ Open Remote Clients from the Infrastructure navigation group. The global
 server target control near the account menu shows whether the browser is using
 this server or a registered remote client.
 
-Remote Clients require a Pro or Enterprise plan. Community installations keep
-using this server locally, but cannot add remote clients or switch the browser
-to a remote Borg UI server until the instance is upgraded.
+Remote Clients require an admin account and a Pro or Enterprise plan. Community
+installations and non-admin users keep using this server locally, but cannot
+add remote clients or switch the browser to a remote Borg UI server.
+
+Saved remote clients are stored in the Borg UI database so admins can use the
+same saved list from another browser or device after signing in. Authentication
+tokens remain browser-local and are stored separately for each server target.
 
 ## Add a Remote Client
 
@@ -61,7 +65,9 @@ as the local fallback in the same control.
 
 Authentication tokens are stored per server target in the browser. If the
 remote client requires login, Borg UI sends you through that server's normal
-login flow without replacing this server's token.
+login flow without replacing this server's token. Non-admin users cannot switch
+to saved remote clients, even if the browser still has an old remote target
+reference.
 
 ## DNS and Reverse Proxy Notes
 

--- a/frontend/src/components/BackendTargetSwitcher.stories.tsx
+++ b/frontend/src/components/BackendTargetSwitcher.stories.tsx
@@ -1,7 +1,11 @@
+import { useEffect, useState, type ReactNode } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import MockAdapter from 'axios-mock-adapter'
 import { Box } from '@mui/material'
 import { BrowserRouter } from 'react-router-dom'
 import BackendTargetSwitcher from './BackendTargetSwitcher'
+import { AuthProvider } from '../hooks/useAuth'
+import api from '../services/api'
 import { RemoteBackendStoryProvider } from '../services/remoteBackends/storyFixtures'
 import { communitySystemInfo, proSystemInfo } from '../services/remoteBackends/planStoryFixtures'
 
@@ -18,15 +22,76 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-function renderSwitcher(state: 'mixed' | 'activeRemote', props = {}) {
+function installAuthMocks(canManageRemoteClients: boolean): MockAdapter {
+  const mock = new MockAdapter(api)
+  mock.onGet('/auth/config').reply(200, {
+    proxy_auth_enabled: true,
+    insecure_no_auth_enabled: false,
+    authentication_required: true,
+    oidc_enabled: false,
+    oidc_provider_name: null,
+    oidc_disable_local_auth: false,
+    proxy_auth_header: 'x-auth-user',
+    proxy_auth_health: { enabled: true, warnings: [] },
+  })
+  mock.onGet('/auth/me').reply(200, {
+    id: canManageRemoteClients ? 1 : 2,
+    username: canManageRemoteClients ? 'admin' : 'operator',
+    full_name: canManageRemoteClients ? 'Admin User' : 'Operator User',
+    email: canManageRemoteClients ? 'admin@example.com' : 'operator@example.com',
+    is_active: true,
+    role: canManageRemoteClients ? 'admin' : 'operator',
+    deployment_type: 'individual',
+    created_at: '2026-06-06T00:00:00.000Z',
+    global_permissions: canManageRemoteClients ? ['settings.ssh.manage'] : [],
+  })
+  return mock
+}
+
+function SwitcherStoryProviders({
+  children,
+  state,
+  canManageRemoteClients,
+}: {
+  children: ReactNode
+  state: 'mixed' | 'activeRemote'
+  canManageRemoteClients: boolean
+}) {
+  const [isReady, setIsReady] = useState(false)
+
+  useEffect(() => {
+    const mock = installAuthMocks(canManageRemoteClients)
+    setIsReady(true)
+    return () => {
+      mock.restore()
+    }
+  }, [canManageRemoteClients])
+
+  if (!isReady) return null
+
   return (
     <BrowserRouter>
       <RemoteBackendStoryProvider state={state}>
-        <Box sx={{ width: 280 }}>
-          <BackendTargetSwitcher {...props} />
-        </Box>
+        <AuthProvider>{children}</AuthProvider>
       </RemoteBackendStoryProvider>
     </BrowserRouter>
+  )
+}
+
+function renderSwitcher(
+  state: 'mixed' | 'activeRemote',
+  props = {},
+  options: { canManageRemoteClients?: boolean } = {}
+) {
+  return (
+    <SwitcherStoryProviders
+      state={state}
+      canManageRemoteClients={options.canManageRemoteClients ?? true}
+    >
+      <Box sx={{ width: 280 }}>
+        <BackendTargetSwitcher {...props} />
+      </Box>
+    </SwitcherStoryProviders>
   )
 }
 
@@ -50,6 +115,14 @@ export const LockedCommunity: Story = {
     systemInfo: communitySystemInfo,
   },
   render: () => renderSwitcher('mixed'),
+  play: async ({ canvasElement }) => {
+    await new Promise((resolve) => window.setTimeout(resolve, 0))
+    canvasElement.querySelector('button')?.click()
+  },
+}
+
+export const LockedNonAdmin: Story = {
+  render: () => renderSwitcher('mixed', {}, { canManageRemoteClients: false }),
   play: async ({ canvasElement }) => {
     await new Promise((resolve) => window.setTimeout(resolve, 0))
     canvasElement.querySelector('button')?.click()

--- a/frontend/src/components/BackendTargetSwitcher.tsx
+++ b/frontend/src/components/BackendTargetSwitcher.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom'
 import { useRemoteBackends } from '@/services/remoteBackends/context'
 import { LOCAL_BACKEND_ID } from '@/services/remoteBackends/storage'
 import type { BackendTarget } from '@/services/remoteBackends/types'
+import { useAuth } from '@/hooks/useAuth'
 import { usePlan } from '@/hooks/usePlan'
 import {
   buildBackendTargets,
@@ -24,13 +25,17 @@ export default function BackendTargetSwitcher({ compact = false }: BackendTarget
   const muiTheme = useTheme()
   const navigate = useNavigate()
   const { activeTarget, clients, switchTarget } = useRemoteBackends()
+  const { hasGlobalPermission } = useAuth()
   const { can } = usePlan()
-  const canUseRemoteClients = can('remote_clients')
+  const canManageRemoteClients = hasGlobalPermission('settings.ssh.manage')
+  const canUseRemoteClients = canManageRemoteClients && can('remote_clients')
+  const remoteClientsUnavailableReason = canManageRemoteClients ? 'plan' : 'permission'
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const open = Boolean(anchorEl)
   const targets = buildBackendTargets(clients, t)
   const activeStatus = getBackendTargetStatus(activeTarget, t, {
     remoteClientsAvailable: canUseRemoteClients,
+    remoteClientsUnavailableReason,
   })
   const activeName = getBackendTargetName(activeTarget, t)
 
@@ -140,6 +145,7 @@ export default function BackendTargetSwitcher({ compact = false }: BackendTarget
           {targets.map((target) => {
             const status = getBackendTargetStatus(target, t, {
               remoteClientsAvailable: canUseRemoteClients,
+              remoteClientsUnavailableReason,
             })
             const disabled = isBackendTargetDisabled(target, {
               remoteClientsAvailable: canUseRemoteClients,
@@ -208,10 +214,18 @@ export default function BackendTargetSwitcher({ compact = false }: BackendTarget
               <Lock size={14} />
               <Box>
                 <Typography variant="body2" sx={{ fontWeight: 700 }}>
-                  {t('remoteClients.switcher.manageRequiresPlan')}
+                  {t(
+                    canManageRemoteClients
+                      ? 'remoteClients.switcher.manageRequiresPlan'
+                      : 'remoteClients.switcher.manageRequiresAdmin'
+                  )}
                 </Typography>
                 <Typography variant="caption" color="text.secondary">
-                  {t('remoteClients.switcher.remotePlanUnavailable')}
+                  {t(
+                    canManageRemoteClients
+                      ? 'remoteClients.switcher.remotePlanUnavailable'
+                      : 'remoteClients.switcher.remoteAdminUnavailable'
+                  )}
                 </Typography>
               </Box>
             </MenuItem>

--- a/frontend/src/components/__tests__/AppHeader.test.tsx
+++ b/frontend/src/components/__tests__/AppHeader.test.tsx
@@ -64,6 +64,7 @@ vi.mock('../../hooks/useAuth', () => ({
       deployment_type: 'individual',
     },
     logout: logoutMock,
+    hasGlobalPermission: () => true,
   }),
 }))
 

--- a/frontend/src/components/__tests__/BackendTargetSwitcher.test.tsx
+++ b/frontend/src/components/__tests__/BackendTargetSwitcher.test.tsx
@@ -4,13 +4,16 @@ import BackendTargetSwitcher from '../BackendTargetSwitcher'
 import { RemoteBackendProvider } from '../../services/remoteBackends/context'
 import {
   createRemoteBackendClient,
+  listRemoteBackendClients,
   resetRemoteBackendStateForTests,
   setActiveBackendTarget,
   updateRemoteBackendHealth,
 } from '../../services/remoteBackends/storage'
+import type { RemoteBackendClient } from '../../services/remoteBackends/types'
 
 const navigateMock = vi.fn()
-const { mockPlanCan } = vi.hoisted(() => ({
+const { mockHasGlobalPermission, mockPlanCan } = vi.hoisted(() => ({
+  mockHasGlobalPermission: vi.fn((_permission: string) => true),
   mockPlanCan: vi.fn((_feature: string) => true),
 }))
 
@@ -29,9 +32,47 @@ vi.mock('../../hooks/usePlan', () => ({
   }),
 }))
 
+vi.mock('../../hooks/useAuth', () => ({
+  useAuth: () => ({
+    hasGlobalPermission: mockHasGlobalPermission,
+  }),
+}))
+
+function remoteClientResponse(client: RemoteBackendClient) {
+  return {
+    id: client.id,
+    name: client.name,
+    api_base_url: client.apiBaseUrl,
+    web_base_url: client.webBaseUrl,
+    created_at: client.createdAt,
+    updated_at: client.updatedAt,
+    health: {
+      status: client.health.status,
+      checked_at: client.health.checkedAt ?? null,
+      app_version: client.health.appVersion ?? null,
+      borg_version: client.health.borgVersion ?? null,
+      borg2_version: client.health.borg2Version ?? null,
+      error: client.health.error ?? null,
+      compatibility: client.health.compatibility,
+      compatibility_message: client.health.compatibilityMessage ?? null,
+    },
+  }
+}
+
+const switcherFetch: typeof fetch = async (input) => {
+  const url = String(input)
+  if (url.endsWith('/api/remote-clients')) {
+    return new Response(JSON.stringify(listRemoteBackendClients().map(remoteClientResponse)), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+  throw new Error(`Unexpected fetch: ${url}`)
+}
+
 function renderSwitcher() {
   return renderWithProviders(
-    <RemoteBackendProvider>
+    <RemoteBackendProvider fetchImpl={switcherFetch}>
       <BackendTargetSwitcher />
     </RemoteBackendProvider>
   )
@@ -42,6 +83,7 @@ describe('BackendTargetSwitcher', () => {
     vi.clearAllMocks()
     localStorage.clear()
     resetRemoteBackendStateForTests()
+    mockHasGlobalPermission.mockReturnValue(true)
     mockPlanCan.mockReturnValue(true)
   })
 
@@ -160,5 +202,35 @@ describe('BackendTargetSwitcher', () => {
 
     expect(upgradeItem).toHaveAttribute('aria-disabled', 'true')
     expect(navigateMock).not.toHaveBeenCalled()
+  })
+
+  it('blocks stale remote targets when the user lacks remote client admin permission', async () => {
+    mockHasGlobalPermission.mockReturnValue(false)
+    const remote = createRemoteBackendClient({
+      name: 'Studio NAS',
+      backendUrl: 'nas.local:9000',
+    })
+    updateRemoteBackendHealth(remote.id, {
+      status: 'online',
+      checkedAt: '2026-06-05T00:00:00.000Z',
+      appVersion: '2.2.1',
+      compatibility: 'compatible',
+      compatibilityMessage: 'Compatible',
+    })
+    const user = userEvent.setup()
+    renderSwitcher()
+
+    await user.click(screen.getByRole('button', { name: /server target this server/i }))
+    const menu = await screen.findByRole('menu', { name: /server targets/i })
+
+    expect(within(menu).getByRole('menuitem', { name: /studio nas/i })).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    )
+
+    expect(within(menu).getByRole('menuitem', { name: /this server/i })).not.toHaveAttribute(
+      'aria-disabled',
+      'true'
+    )
   })
 })

--- a/frontend/src/components/__tests__/Layout.test.tsx
+++ b/frontend/src/components/__tests__/Layout.test.tsx
@@ -2,8 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { QueryClient } from '@tanstack/react-query'
 import { renderWithProviders, screen, userEvent, waitFor } from '../../test/test-utils'
 import Layout from '../Layout'
-import { RemoteBackendProvider, useRemoteBackends } from '../../services/remoteBackends/context'
-import { resetRemoteBackendStateForTests } from '../../services/remoteBackends/storage'
+import { RemoteBackendProvider } from '../../services/remoteBackends/context'
+import {
+  createRemoteBackendClient,
+  resetRemoteBackendStateForTests,
+  setActiveBackendTarget,
+} from '../../services/remoteBackends/storage'
 
 const {
   logoutMock,
@@ -98,13 +102,14 @@ vi.mock('../AppSidebar', () => ({
 }))
 
 function RemoteBackendSwitchButton() {
-  const { createClient, switchTarget } = useRemoteBackends()
-
   return (
     <button
       onClick={() => {
-        const remote = createClient({ name: 'Remote', backendUrl: 'remote.example.com' })
-        switchTarget(remote.id)
+        const remote = createRemoteBackendClient({
+          name: 'Remote',
+          backendUrl: 'remote.example.com',
+        })
+        setActiveBackendTarget(remote.id)
       }}
     >
       Switch backend
@@ -136,6 +141,7 @@ describe('Layout', () => {
     useAuthMock.mockReturnValue({
       user: { username: 'admin', email: 'admin@example.com', role: 'admin', passkey_count: 0 },
       proxyAuthEnabled: false,
+      hasGlobalPermission: () => true,
       canEnrollPasskeyFromRecentLogin: true,
       clearRecentPasskeyEnrollmentState: vi.fn(),
       refreshUser: refreshUserMock,
@@ -166,7 +172,9 @@ describe('Layout', () => {
       </Layout>
     )
 
-    await user.click(await screen.findByRole('button', { name: 'Dismiss Banner' }))
+    await user.click(
+      await screen.findByRole('button', { name: 'Dismiss Banner' }, { timeout: 5000 })
+    )
 
     await waitFor(() => {
       expect(screen.queryByText('Consent Banner')).not.toBeInTheDocument()
@@ -229,6 +237,7 @@ describe('Layout', () => {
         passkey_count: 0,
       },
       proxyAuthEnabled: false,
+      hasGlobalPermission: () => true,
       canEnrollPasskeyFromRecentLogin: true,
       clearRecentPasskeyEnrollmentState: vi.fn(),
       refreshUser: refreshUserMock,
@@ -263,6 +272,7 @@ describe('Layout', () => {
     useAuthMock.mockReturnValue({
       user: { username: 'admin', email: 'admin@example.com', role: 'admin', passkey_count: 1 },
       proxyAuthEnabled: false,
+      hasGlobalPermission: () => true,
       canEnrollPasskeyFromRecentLogin: true,
       clearRecentPasskeyEnrollmentState: vi.fn(),
       refreshUser: refreshUserMock,

--- a/frontend/src/components/backendTargetPresentation.tsx
+++ b/frontend/src/components/backendTargetPresentation.tsx
@@ -6,6 +6,7 @@ type Translate = (key: string, options?: Record<string, unknown>) => string
 
 interface BackendTargetPresentationOptions {
   remoteClientsAvailable?: boolean
+  remoteClientsUnavailableReason?: 'permission' | 'plan'
 }
 
 export function buildBackendTargets(clients: RemoteBackendClient[], t: Translate): BackendTarget[] {
@@ -44,6 +45,7 @@ export function getBackendTargetStatus(
   options: BackendTargetPresentationOptions = {}
 ) {
   const remoteClientsAvailable = options.remoteClientsAvailable ?? true
+  const unavailableReason = options.remoteClientsUnavailableReason ?? 'plan'
   if (target.kind === 'local') {
     return {
       label: t('remoteClients.labels.local'),
@@ -54,6 +56,15 @@ export function getBackendTargetStatus(
   }
 
   if (!remoteClientsAvailable) {
+    if (unavailableReason === 'permission') {
+      return {
+        label: t('remoteClients.labels.requiresAdmin'),
+        color: 'warning' as const,
+        icon: <Lock size={14} />,
+        helper: t('remoteClients.switcher.remoteAdminUnavailable'),
+      }
+    }
+
     return {
       label: t('remoteClients.labels.requiresPlan'),
       color: 'warning' as const,

--- a/frontend/src/hooks/__tests__/useAuth.test.tsx
+++ b/frontend/src/hooks/__tests__/useAuth.test.tsx
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderWithProviders, screen, userEvent, waitFor } from '../../test/test-utils'
 import { AuthProvider, useAuth } from '../useAuth'
-import { RemoteBackendProvider, useRemoteBackends } from '../../services/remoteBackends/context'
+import { RemoteBackendProvider } from '../../services/remoteBackends/context'
 import {
+  createRemoteBackendClient,
   resetRemoteBackendStateForTests,
+  setActiveBackendTarget,
   setBackendAccessToken,
 } from '../../services/remoteBackends/storage'
 
@@ -95,17 +97,15 @@ function AuthProbe() {
 }
 
 function RemoteSwitchProbe() {
-  const { createClient, switchTarget } = useRemoteBackends()
-
   return (
     <button
       onClick={() => {
-        const remote = createClient({
+        const remote = createRemoteBackendClient({
           name: 'Remote API',
           backendUrl: 'remote.example.com',
         })
         setBackendAccessToken('remote-token', remote.id)
-        switchTarget(remote.id)
+        setActiveBackendTarget(remote.id)
       }}
     >
       Switch backend

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -178,6 +178,7 @@
       "activeTarget": "Aktives Ziel",
       "local": "Lokal",
       "remoteClient": "Remote-Client",
+      "requiresAdmin": "Nur Admin",
       "requiresPlan": "Pro oder Enterprise erforderlich"
     },
     "switcher": {
@@ -192,10 +193,12 @@
       "localCompatibility": "Dieser Browser ist mit diesem Borg-UI-Server verbunden.",
       "remoteHelper": "Remote-Client-Server",
       "remoteUnavailable": "Remote-Client nicht verfügbar",
+      "remoteAdminUnavailable": "Remote-Client-Wechsel erfordert Admin-Zugriff.",
       "remotePlanUnavailable": "Remote-Client-Wechsel erfordert Pro oder Enterprise.",
       "versionMismatch": "Versionskonflikt",
       "versionHelper": "Borg UI {{version}}",
       "manage": "Remote-Clients verwalten",
+      "manageRequiresAdmin": "Remote-Clients erfordern Admin-Zugriff",
       "manageRequiresPlan": "Remote-Clients erfordern Pro oder Enterprise"
     },
     "localBackend": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -178,6 +178,7 @@
       "activeTarget": "Active target",
       "local": "Local",
       "remoteClient": "Remote client",
+      "requiresAdmin": "Admin only",
       "requiresPlan": "Requires Pro or Enterprise"
     },
     "switcher": {
@@ -192,10 +193,12 @@
       "localCompatibility": "This browser is connected to this Borg UI server.",
       "remoteHelper": "Remote client server",
       "remoteUnavailable": "Remote client unavailable",
+      "remoteAdminUnavailable": "Remote client switching requires admin access.",
       "remotePlanUnavailable": "Remote client switching requires Pro or Enterprise.",
       "versionMismatch": "Version mismatch",
       "versionHelper": "Borg UI {{version}}",
       "manage": "Manage remote clients",
+      "manageRequiresAdmin": "Remote Clients require admin access",
       "manageRequiresPlan": "Remote Clients require Pro or Enterprise"
     },
     "localBackend": {

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -178,6 +178,7 @@
       "activeTarget": "Destino activo",
       "local": "Local",
       "remoteClient": "Cliente remoto",
+      "requiresAdmin": "Solo admin",
       "requiresPlan": "Requiere Pro o Enterprise"
     },
     "switcher": {
@@ -192,10 +193,12 @@
       "localCompatibility": "Este navegador está conectado a este servidor Borg UI.",
       "remoteHelper": "Servidor del cliente remoto",
       "remoteUnavailable": "Cliente remoto no disponible",
+      "remoteAdminUnavailable": "Cambiar clientes remotos requiere acceso de administrador.",
       "remotePlanUnavailable": "El cambio a clientes remotos requiere Pro o Enterprise.",
       "versionMismatch": "Conflicto de versión",
       "versionHelper": "Borg UI {{version}}",
       "manage": "Gestionar clientes remotos",
+      "manageRequiresAdmin": "Los clientes remotos requieren acceso de administrador",
       "manageRequiresPlan": "Los clientes remotos requieren Pro o Enterprise"
     },
     "localBackend": {

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -178,6 +178,7 @@
       "activeTarget": "Destinazione attiva",
       "local": "Locale",
       "remoteClient": "Client remoto",
+      "requiresAdmin": "Solo admin",
       "requiresPlan": "Richiede Pro o Enterprise"
     },
     "switcher": {
@@ -192,10 +193,12 @@
       "localCompatibility": "Questo browser è connesso a questo server Borg UI.",
       "remoteHelper": "Server del client remoto",
       "remoteUnavailable": "Client remoto non disponibile",
+      "remoteAdminUnavailable": "Il cambio di client remoto richiede accesso amministratore.",
       "remotePlanUnavailable": "Il passaggio ai client remoti richiede Pro o Enterprise.",
       "versionMismatch": "Conflitto di versione",
       "versionHelper": "Borg UI {{version}}",
       "manage": "Gestisci client remoti",
+      "manageRequiresAdmin": "I client remoti richiedono accesso amministratore",
       "manageRequiresPlan": "I client remoti richiedono Pro o Enterprise"
     },
     "localBackend": {

--- a/frontend/src/pages/RemoteClients.tsx
+++ b/frontend/src/pages/RemoteClients.tsx
@@ -106,6 +106,10 @@ export function RemoteClientsContent() {
   const [formError, setFormError] = useState<string | null>(null)
   const [checkingId, setCheckingId] = useState<string | null>(null)
   const [deletingClient, setDeletingClient] = useState<RemoteBackendClient | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const saveInFlightRef = useRef(false)
+  const deleteInFlightRef = useRef(false)
 
   const openCreateDialog = () => {
     setEditingClient(null)
@@ -122,22 +126,33 @@ export function RemoteClientsContent() {
   }
 
   const closeDialog = () => {
+    if (saveInFlightRef.current) return
     setDialogOpen(false)
     setFormError(null)
   }
 
-  const handleSave = () => {
+  const handleSave = async () => {
+    if (saveInFlightRef.current) return
+    saveInFlightRef.current = true
+    setIsSaving(true)
+    let saved = false
     try {
       if (editingClient) {
-        updateClient(editingClient.id, form)
+        await updateClient(editingClient.id, form)
         toast.success(t('remoteClients.toasts.updated'))
       } else {
-        createClient(form)
+        await createClient(form)
         toast.success(t('remoteClients.toasts.added'))
       }
-      closeDialog()
+      saved = true
     } catch (error) {
       setFormError(error instanceof Error ? error.message : t('remoteClients.errors.saveFailed'))
+    } finally {
+      saveInFlightRef.current = false
+      setIsSaving(false)
+      if (saved) {
+        closeDialog()
+      }
     }
   }
 
@@ -180,14 +195,25 @@ export function RemoteClientsContent() {
   }
 
   const closeDeleteDialog = () => {
+    if (deleteInFlightRef.current) return
     setDeletingClient(null)
   }
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     if (!deletingClient) return
-    deleteClient(deletingClient.id)
-    toast.success(t('remoteClients.toasts.deleted'))
-    closeDeleteDialog()
+    if (deleteInFlightRef.current) return
+    deleteInFlightRef.current = true
+    setIsDeleting(true)
+    try {
+      await deleteClient(deletingClient.id)
+      toast.success(t('remoteClients.toasts.deleted'))
+      setDeletingClient(null)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : t('common.errors.unexpectedError'))
+    } finally {
+      deleteInFlightRef.current = false
+      setIsDeleting(false)
+    }
   }
 
   return (
@@ -448,8 +474,10 @@ export function RemoteClientsContent() {
                 fullWidth
               />
               <Stack direction="row" spacing={1} justifyContent="flex-end">
-                <Button onClick={closeDialog}>{t('common.buttons.cancel')}</Button>
-                <Button variant="contained" onClick={handleSave}>
+                <Button onClick={closeDialog} disabled={isSaving}>
+                  {t('common.buttons.cancel')}
+                </Button>
+                <Button variant="contained" onClick={() => void handleSave()} disabled={isSaving}>
                   {t('remoteClients.dialog.save')}
                 </Button>
               </Stack>
@@ -473,8 +501,15 @@ export function RemoteClientsContent() {
               {t('remoteClients.deleteDialog.description', { name: deletingClient.name })}
             </Typography>
             <Stack direction="row" spacing={1} justifyContent="flex-end" sx={{ mt: 2.5 }}>
-              <Button onClick={closeDeleteDialog}>{t('common.buttons.cancel')}</Button>
-              <Button variant="contained" color="error" onClick={handleDelete}>
+              <Button onClick={closeDeleteDialog} disabled={isDeleting}>
+                {t('common.buttons.cancel')}
+              </Button>
+              <Button
+                variant="contained"
+                color="error"
+                onClick={() => void handleDelete()}
+                disabled={isDeleting}
+              >
                 {t('remoteClients.deleteDialog.confirm')}
               </Button>
             </Stack>

--- a/frontend/src/pages/__tests__/DashboardV3.test.tsx
+++ b/frontend/src/pages/__tests__/DashboardV3.test.tsx
@@ -3,6 +3,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import Dashboard from '../DashboardV3'
 import { formatDateTimeFull } from '../../utils/dateUtils'
+import {
+  createRemoteBackendClient,
+  resetRemoteBackendStateForTests,
+} from '../../services/remoteBackends/storage'
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -184,7 +188,12 @@ beforeEach(() => {
   getOverviewMock.mockResolvedValue({ data: makeOverview() })
   listRemotesMock.mockResolvedValue({ data: { remotes: [] } })
   // Default: suppress localStorage access
-  vi.stubGlobal('localStorage', { getItem: () => 'test-token' })
+  vi.stubGlobal('localStorage', {
+    getItem: () => 'test-token',
+    removeItem: vi.fn(),
+    setItem: vi.fn(),
+  })
+  resetRemoteBackendStateForTests()
 })
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -712,18 +721,12 @@ describe('DashboardV3', () => {
       })
       vi.stubGlobal('localStorage', {
         getItem: (key: string) => {
-          if (key === 'borg_ui_remote_backends') {
-            return JSON.stringify([
-              {
-                id: 'remote-1',
-                name: 'Offsite client',
-                apiBaseUrl: 'https://offsite.example.com/api',
-                webBaseUrl: 'https://offsite.example.com',
-              },
-            ])
-          }
           return key === 'borg_ui_active_backend_target' ? null : 'test-token'
         },
+      })
+      createRemoteBackendClient({
+        name: 'Offsite client',
+        backendUrl: 'https://offsite.example.com',
       })
       mockFetchSuccess(makeOverview())
       renderDashboard()

--- a/frontend/src/pages/__tests__/RemoteClients.test.tsx
+++ b/frontend/src/pages/__tests__/RemoteClients.test.tsx
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, renderWithProviders, screen, userEvent, waitFor } from '../../test/test-utils'
+import { toast } from 'react-hot-toast'
 import RemoteClients from '../RemoteClients'
 import { RemoteBackendProvider } from '../../services/remoteBackends/context'
-import {
-  createRemoteBackendClient,
-  resetRemoteBackendStateForTests,
-} from '../../services/remoteBackends/storage'
+import { resetRemoteBackendStateForTests } from '../../services/remoteBackends/storage'
+import type {
+  RemoteBackendCompatibility,
+  RemoteBackendStatus,
+} from '../../services/remoteBackends/types'
 
 const { mockHasGlobalPermission, mockPlanCan } = vi.hoisted(() => ({
   mockHasGlobalPermission: vi.fn(() => true),
@@ -28,9 +30,173 @@ vi.mock('../../hooks/usePlan', () => ({
   }),
 }))
 
-function renderPage() {
+vi.mock('react-hot-toast', async () => {
+  const actual = await vi.importActual<typeof import('react-hot-toast')>('react-hot-toast')
+  return {
+    ...actual,
+    toast: {
+      success: vi.fn(),
+      error: vi.fn(),
+    },
+  }
+})
+
+let nextDbClientId = 1
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function deriveClientUrls(backendUrl: string): { apiBaseUrl: string; webBaseUrl: string } {
+  const withProtocol = /^https?:\/\//i.test(backendUrl) ? backendUrl : `http://${backendUrl}`
+  const trimmed = withProtocol.replace(/\/+$/, '')
+  if (trimmed.endsWith('/api')) {
+    return {
+      apiBaseUrl: trimmed,
+      webBaseUrl: trimmed.slice(0, -4),
+    }
+  }
+  return {
+    apiBaseUrl: `${trimmed}/api`,
+    webBaseUrl: trimmed,
+  }
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' ? value : null
+}
+
+interface DbClientHealthResponse {
+  status: RemoteBackendStatus
+  checked_at: string | null
+  app_version: string | null
+  borg_version: string | null
+  borg2_version: string | null
+  error: string | null
+  compatibility: RemoteBackendCompatibility
+  compatibility_message: string | null
+}
+
+interface DbClientResponse {
+  id: string
+  name: string
+  api_base_url: string
+  web_base_url: string
+  created_at: string
+  updated_at: string
+  health: DbClientHealthResponse
+}
+
+function makeDbClient(
+  overrides: {
+    id?: string
+    name?: string
+    apiBaseUrl?: string
+    webBaseUrl?: string
+    health?: Partial<DbClientHealthResponse>
+  } = {}
+): DbClientResponse {
+  return {
+    id: overrides.id ?? `db-client-${nextDbClientId++}`,
+    name: overrides.name ?? 'Studio NAS',
+    api_base_url: overrides.apiBaseUrl ?? 'http://nas.local:9000/api',
+    web_base_url: overrides.webBaseUrl ?? 'http://nas.local:9000',
+    created_at: '2026-06-05T00:00:00+00:00',
+    updated_at: '2026-06-05T00:00:00+00:00',
+    health: {
+      status: 'unknown',
+      checked_at: null,
+      app_version: null,
+      borg_version: null,
+      borg2_version: null,
+      error: null,
+      compatibility: 'unknown',
+      compatibility_message: null,
+      ...overrides.health,
+    },
+  }
+}
+
+function createRemoteClientsPageFetch(
+  options: {
+    clients?: ReturnType<typeof makeDbClient>[]
+    deleteStatus?: number
+    handleRemote?: (url: string, init?: RequestInit) => Promise<Response>
+  } = {}
+) {
+  const clients = [...(options.clients ?? [])]
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input)
+    const method = init?.method ?? 'GET'
+
+    if (url.endsWith('/api/remote-clients') && method === 'GET') {
+      return jsonResponse(clients)
+    }
+
+    if (url.endsWith('/api/remote-clients') && method === 'POST') {
+      const body = JSON.parse(String(init?.body ?? '{}')) as {
+        name?: string
+        backend_url?: string
+      }
+      const urls = deriveClientUrls(body.backend_url ?? '')
+      const client = makeDbClient({
+        name: body.name,
+        apiBaseUrl: urls.apiBaseUrl,
+        webBaseUrl: urls.webBaseUrl,
+      })
+      clients.push(client)
+      return jsonResponse(client, 201)
+    }
+
+    if (url.includes('/api/remote-clients/') && method === 'PATCH') {
+      const markerIndex = url.lastIndexOf('/api/remote-clients/')
+      const id = decodeURIComponent(
+        url.slice(markerIndex + '/api/remote-clients/'.length).replace(/\/health$/, '')
+      )
+      const index = clients.findIndex((client) => client.id === id)
+      if (index === -1) return jsonResponse({ detail: 'Not found' }, 404)
+      const body = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
+      clients[index] = {
+        ...clients[index],
+        health: {
+          status: body.status as RemoteBackendStatus,
+          checked_at: stringOrNull(body.checked_at),
+          app_version: stringOrNull(body.app_version),
+          borg_version: stringOrNull(body.borg_version),
+          borg2_version: stringOrNull(body.borg2_version),
+          error: stringOrNull(body.error),
+          compatibility: body.compatibility as RemoteBackendCompatibility,
+          compatibility_message: stringOrNull(body.compatibility_message),
+        },
+      }
+      return jsonResponse(clients[index])
+    }
+
+    if (url.includes('/api/remote-clients/') && method === 'DELETE') {
+      const markerIndex = url.lastIndexOf('/api/remote-clients/')
+      const id = decodeURIComponent(url.slice(markerIndex + '/api/remote-clients/'.length))
+      const index = clients.findIndex((client) => client.id === id)
+      if (options.deleteStatus && options.deleteStatus !== 204) {
+        return jsonResponse({ detail: 'Delete failed' }, options.deleteStatus)
+      }
+      if (index !== -1) clients.splice(index, 1)
+      return new Response(null, { status: 204 })
+    }
+
+    if (options.handleRemote) {
+      return options.handleRemote(url, init)
+    }
+
+    throw new Error(`Unexpected fetch: ${method} ${url}`)
+  })
+}
+
+function renderPage(fetchImpl: typeof fetch = createRemoteClientsPageFetch()) {
   return renderWithProviders(
-    <RemoteBackendProvider frontendVersion="2.2.2-alpha.1">
+    <RemoteBackendProvider frontendVersion="2.2.2-alpha.1" fetchImpl={fetchImpl}>
       <RemoteClients />
     </RemoteBackendProvider>,
     { initialRoute: '/remote-clients' }
@@ -41,8 +207,11 @@ describe('RemoteClients', () => {
   beforeEach(() => {
     localStorage.clear()
     resetRemoteBackendStateForTests()
+    nextDbClientId = 1
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
+    vi.mocked(toast.success).mockClear()
+    vi.mocked(toast.error).mockClear()
     mockHasGlobalPermission.mockReturnValue(true)
     mockPlanCan.mockReturnValue(true)
   })
@@ -52,31 +221,49 @@ describe('RemoteClients', () => {
 
     renderPage()
 
-    expect(
-      await screen.findByText('You do not have permission to open this page')
-    ).toBeInTheDocument()
-
     await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('You do not have permission to open this page', {
+        duration: 4000,
+      })
       expect(window.location.pathname).toBe('/dashboard')
     })
   })
 
   it('adds and lists a remote client with normalized URL details', async () => {
-    const user = userEvent.setup()
     renderPage()
 
     expect(screen.getByRole('heading', { name: 'Remote Clients' })).toBeInTheDocument()
     expect(screen.getByText('No remote clients yet')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /use this server/i })).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: /add remote client/i }))
-    await user.type(screen.getByLabelText('Client name'), 'Studio NAS')
-    await user.type(screen.getByLabelText('Server URL'), 'nas.local:9000')
-    await user.click(screen.getByRole('button', { name: 'Save client' }))
+    fireEvent.click(screen.getByRole('button', { name: /add remote client/i }))
+    fireEvent.change(screen.getByLabelText('Client name'), { target: { value: 'Studio NAS' } })
+    fireEvent.change(screen.getByLabelText('Server URL'), { target: { value: 'nas.local:9000' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save client' }))
 
-    expect(screen.getByText('Studio NAS')).toBeInTheDocument()
+    expect(await screen.findByText('Studio NAS')).toBeInTheDocument()
     expect(screen.getByText('http://nas.local:9000/api')).toBeInTheDocument()
     expect(screen.getByText('Unknown')).toBeInTheDocument()
+  })
+
+  it('prevents duplicate create requests while save is in flight', async () => {
+    const fetchMock = createRemoteClientsPageFetch()
+    renderPage(fetchMock)
+
+    fireEvent.click(screen.getByRole('button', { name: /add remote client/i }))
+    fireEvent.change(screen.getByLabelText('Client name'), { target: { value: 'Studio NAS' } })
+    fireEvent.change(screen.getByLabelText('Server URL'), { target: { value: 'nas.local:9000' } })
+
+    const saveButton = screen.getByRole('button', { name: 'Save client' })
+    fireEvent.click(saveButton)
+    fireEvent.click(saveButton)
+
+    expect(await screen.findByText('Studio NAS')).toBeInTheDocument()
+
+    const createCalls = fetchMock.mock.calls.filter(([input, init]) => {
+      return String(input).endsWith('/api/remote-clients') && (init?.method ?? 'GET') === 'POST'
+    })
+    expect(createCalls).toHaveLength(1)
   })
 
   it('shows the plan gate instead of management controls when remote clients are unavailable', async () => {
@@ -102,29 +289,26 @@ describe('RemoteClients', () => {
   })
 
   it('checks health and switches to an online compatible remote client', async () => {
-    const fetchMock = vi.fn((input: RequestInfo | URL) => {
-      const url = String(input)
-      if (url === 'http://nas.local:9000/health') {
-        return Promise.resolve(new Response(JSON.stringify({ status: 'healthy' }), { status: 200 }))
-      }
-      if (url === 'http://nas.local:9000/api/system/info') {
-        return Promise.resolve(
-          new Response(JSON.stringify({ app_version: '2.2.1', borg_version: 'borg 1.4.0' }), {
-            status: 200,
-          })
-        )
-      }
-      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    const fetchMock = createRemoteClientsPageFetch({
+      handleRemote: async (url) => {
+        if (url === 'http://nas.local:9000/health') {
+          return jsonResponse({ status: 'healthy' })
+        }
+        if (url === 'http://nas.local:9000/api/system/info') {
+          return jsonResponse({ app_version: '2.2.1', borg_version: 'borg 1.4.0' })
+        }
+        throw new Error(`Unexpected fetch: ${url}`)
+      },
     })
-    vi.stubGlobal('fetch', fetchMock)
     const user = userEvent.setup()
-    renderPage()
+    renderPage(fetchMock)
 
     fireEvent.click(screen.getByRole('button', { name: /add remote client/i }))
-    await user.type(screen.getByLabelText('Client name'), 'Studio NAS')
-    await user.type(screen.getByLabelText('Server URL'), 'nas.local:9000')
+    fireEvent.change(screen.getByLabelText('Client name'), { target: { value: 'Studio NAS' } })
+    fireEvent.change(screen.getByLabelText('Server URL'), { target: { value: 'nas.local:9000' } })
     fireEvent.click(screen.getByRole('button', { name: 'Save client' }))
-    await user.click(await screen.findByRole('button', { name: /check studio nas/i }))
+    expect(await screen.findByText('Studio NAS')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /check studio nas/i }))
 
     await waitFor(() => {
       expect(screen.getByText('Online')).toBeInTheDocument()
@@ -137,25 +321,29 @@ describe('RemoteClients', () => {
   })
 
   it('shows validation errors for invalid server URLs', async () => {
-    const user = userEvent.setup()
     renderPage()
 
-    await user.click(screen.getByRole('button', { name: /add remote client/i }))
-    await user.type(screen.getByLabelText('Client name'), 'Broken')
-    await user.type(screen.getByLabelText('Server URL'), 'ftp://example.com')
-    await user.click(screen.getByRole('button', { name: 'Save client' }))
+    fireEvent.click(screen.getByRole('button', { name: /add remote client/i }))
+    fireEvent.change(screen.getByLabelText('Client name'), { target: { value: 'Broken' } })
+    fireEvent.change(screen.getByLabelText('Server URL'), {
+      target: { value: 'ftp://example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save client' }))
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Server URL must use HTTP or HTTPS.')
   })
 
   it('requires confirmation before deleting a remote client', async () => {
-    createRemoteBackendClient({
-      name: 'Studio NAS',
-      backendUrl: 'nas.local:9000',
-    })
-    renderPage()
+    const fetchMock = createRemoteClientsPageFetch()
+    renderPage(fetchMock)
 
-    fireEvent.click(screen.getByRole('button', { name: /delete studio nas/i }))
+    fireEvent.click(screen.getByRole('button', { name: /add remote client/i }))
+    fireEvent.change(screen.getByLabelText('Client name'), { target: { value: 'Studio NAS' } })
+    fireEvent.change(screen.getByLabelText('Server URL'), { target: { value: 'nas.local:9000' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save client' }))
+    expect(await screen.findByText('Studio NAS')).toBeInTheDocument()
+
+    fireEvent.click(await screen.findByRole('button', { name: /delete studio nas/i }))
 
     expect(screen.getByText('Studio NAS')).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Delete remote client?' })).toBeInTheDocument()
@@ -169,8 +357,37 @@ describe('RemoteClients', () => {
     expect(screen.getByText('Studio NAS')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: /delete studio nas/i }))
+    const deleteButton = screen.getByRole('button', { name: 'Delete client' })
+    fireEvent.click(deleteButton)
+    fireEvent.click(deleteButton)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Studio NAS')).not.toBeInTheDocument()
+    })
+
+    const deleteCalls = fetchMock.mock.calls.filter(([input, init]) => {
+      return String(input).includes('/api/remote-clients/') && (init?.method ?? 'GET') === 'DELETE'
+    })
+    expect(deleteCalls).toHaveLength(1)
+  }, 30000)
+
+  it('keeps the delete dialog open and shows an error when delete fails', async () => {
+    const fetchMock = createRemoteClientsPageFetch({ deleteStatus: 500 })
+    renderPage(fetchMock)
+
+    fireEvent.click(screen.getByRole('button', { name: /add remote client/i }))
+    fireEvent.change(screen.getByLabelText('Client name'), { target: { value: 'Studio NAS' } })
+    fireEvent.change(screen.getByLabelText('Server URL'), { target: { value: 'nas.local:9000' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save client' }))
+    expect(await screen.findByText('Studio NAS')).toBeInTheDocument()
+
+    fireEvent.click(await screen.findByRole('button', { name: /delete studio nas/i }))
     fireEvent.click(screen.getByRole('button', { name: 'Delete client' }))
 
-    expect(screen.queryByText('Studio NAS')).not.toBeInTheDocument()
-  })
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Remote client delete failed with HTTP 500.')
+    })
+    expect(screen.getByRole('heading', { name: 'Delete remote client?' })).toBeInTheDocument()
+    expect(screen.getByText('Studio NAS')).toBeInTheDocument()
+  }, 30000)
 })

--- a/frontend/src/services/remoteBackends/context.test.tsx
+++ b/frontend/src/services/remoteBackends/context.test.tsx
@@ -7,8 +7,167 @@ import {
   userEvent,
   waitFor,
 } from '../../test/test-utils'
-import { LOCAL_BACKEND_ID, resetRemoteBackendStateForTests } from './storage'
+import { LOCAL_BACKEND_ID, resetRemoteBackendStateForTests, setBackendAccessToken } from './storage'
 import { RemoteBackendProvider, useRemoteBackends } from './context'
+import type { RemoteBackendCompatibility, RemoteBackendStatus } from './types'
+
+interface DbClientHealthResponse {
+  status: RemoteBackendStatus
+  checked_at: string | null
+  app_version: string | null
+  borg_version: string | null
+  borg2_version: string | null
+  error: string | null
+  compatibility: RemoteBackendCompatibility
+  compatibility_message: string | null
+}
+
+interface DbClientResponse {
+  id: string
+  name: string
+  api_base_url: string
+  web_base_url: string
+  created_at: string
+  updated_at: string
+  health: DbClientHealthResponse
+}
+
+const dbClientResponse: DbClientResponse = {
+  id: 'db-client-1',
+  name: 'Studio NAS',
+  api_base_url: 'https://nas.example.com/api',
+  web_base_url: 'https://nas.example.com',
+  created_at: '2026-06-05T00:00:00+00:00',
+  updated_at: '2026-06-05T00:00:00+00:00',
+  health: {
+    status: 'unknown',
+    checked_at: null,
+    app_version: null,
+    borg_version: null,
+    borg2_version: null,
+    error: null,
+    compatibility: 'unknown',
+    compatibility_message: null,
+  },
+}
+
+let nextDbClientId = 1
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function deriveClientUrls(backendUrl: string): { apiBaseUrl: string; webBaseUrl: string } {
+  const withProtocol = /^https?:\/\//i.test(backendUrl) ? backendUrl : `http://${backendUrl}`
+  const trimmed = withProtocol.replace(/\/+$/, '')
+  if (trimmed.endsWith('/api')) {
+    return {
+      apiBaseUrl: trimmed,
+      webBaseUrl: trimmed.slice(0, -4),
+    }
+  }
+  return {
+    apiBaseUrl: `${trimmed}/api`,
+    webBaseUrl: trimmed,
+  }
+}
+
+function makeDbClient(
+  overrides: {
+    id?: string
+    name?: string
+    apiBaseUrl?: string
+    webBaseUrl?: string
+    health?: Partial<typeof dbClientResponse.health>
+  } = {}
+) {
+  return {
+    ...dbClientResponse,
+    id: overrides.id ?? `db-client-${nextDbClientId++}`,
+    name: overrides.name ?? dbClientResponse.name,
+    api_base_url: overrides.apiBaseUrl ?? dbClientResponse.api_base_url,
+    web_base_url: overrides.webBaseUrl ?? dbClientResponse.web_base_url,
+    health: {
+      ...dbClientResponse.health,
+      ...overrides.health,
+    },
+  }
+}
+
+function createRemoteClientsApiFetch(
+  options: {
+    clients?: ReturnType<typeof makeDbClient>[]
+    handleRemote?: (url: string, init?: RequestInit) => Promise<Response>
+  } = {}
+) {
+  const clients = [...(options.clients ?? [])]
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input)
+    const method = init?.method ?? 'GET'
+
+    if (url.endsWith('/api/remote-clients') && method === 'GET') {
+      return jsonResponse(clients)
+    }
+
+    if (url.endsWith('/api/remote-clients') && method === 'POST') {
+      const body = JSON.parse(String(init?.body ?? '{}')) as {
+        id?: string
+        name?: string
+        backend_url?: string
+      }
+      const urls = deriveClientUrls(body.backend_url ?? '')
+      const client = makeDbClient({
+        id: body.id,
+        name: body.name ?? 'Studio NAS',
+        apiBaseUrl: urls.apiBaseUrl,
+        webBaseUrl: urls.webBaseUrl,
+      })
+      clients.push(client)
+      return jsonResponse(client, 201)
+    }
+
+    if (url.includes('/api/remote-clients/') && method === 'PATCH') {
+      const markerIndex = url.lastIndexOf('/api/remote-clients/')
+      const id = decodeURIComponent(
+        url.slice(markerIndex + '/api/remote-clients/'.length).replace(/\/health$/, '')
+      )
+      const index = clients.findIndex((client) => client.id === id)
+      if (index === -1) return jsonResponse({ detail: 'Not found' }, 404)
+      const body = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
+      clients[index] = {
+        ...clients[index],
+        health: {
+          status: body.status as RemoteBackendStatus,
+          checked_at: body.checked_at as string | null,
+          app_version: body.app_version as string | null,
+          borg_version: body.borg_version as string | null,
+          borg2_version: body.borg2_version as string | null,
+          error: body.error as string | null,
+          compatibility: body.compatibility as RemoteBackendCompatibility,
+          compatibility_message: body.compatibility_message as string | null,
+        },
+      }
+      return jsonResponse(clients[index])
+    }
+
+    if (url.includes('/api/remote-clients/') && method === 'DELETE') {
+      const markerIndex = url.lastIndexOf('/api/remote-clients/')
+      const id = decodeURIComponent(url.slice(markerIndex + '/api/remote-clients/'.length))
+      const index = clients.findIndex((client) => client.id === id)
+      if (index !== -1) clients.splice(index, 1)
+      return new Response(null, { status: 204 })
+    }
+
+    if (options.handleRemote) {
+      return options.handleRemote(url, init)
+    }
+
+    throw new Error(`Unexpected fetch: ${method} ${url}`)
+  })
+}
 
 function RemoteBackendProbe() {
   const { activeTarget, clients, createClient, switchTarget, checkClient, deleteClient } =
@@ -20,23 +179,24 @@ function RemoteBackendProbe() {
       <div>active:{activeTarget.name}</div>
       <div>active-id:{activeTarget.id}</div>
       <div>clients:{clients.length}</div>
+      <div>first:{firstClient?.name ?? 'none'}</div>
       <div>status:{firstClient?.health.status ?? 'none'}</div>
       <div>version:{firstClient?.health.appVersion ?? 'none'}</div>
       <div>compatibility:{firstClient?.health.compatibility ?? 'none'}</div>
       <button
-        onClick={() =>
-          createClient({
+        onClick={() => {
+          void createClient({
             name: 'Studio NAS',
             backendUrl: 'nas.local:9000',
           })
-        }
+        }}
       >
         Add
       </button>
       <button onClick={() => firstClient && switchTarget(firstClient.id)}>SwitchRemote</button>
       <button onClick={() => switchTarget(LOCAL_BACKEND_ID)}>SwitchLocal</button>
       <button onClick={() => firstClient && void checkClient(firstClient.id)}>Check</button>
-      <button onClick={() => firstClient && deleteClient(firstClient.id)}>Delete</button>
+      <button onClick={() => firstClient && void deleteClient(firstClient.id)}>Delete</button>
     </div>
   )
 }
@@ -45,6 +205,7 @@ describe('RemoteBackendProvider', () => {
   beforeEach(() => {
     localStorage.clear()
     resetRemoteBackendStateForTests()
+    nextDbClientId = 1
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
   })
@@ -54,9 +215,10 @@ describe('RemoteBackendProvider', () => {
   })
 
   it('creates clients and switches between local and remote targets', async () => {
+    const fetchMock = createRemoteClientsApiFetch()
     const user = userEvent.setup()
     renderWithProviders(
-      <RemoteBackendProvider>
+      <RemoteBackendProvider fetchImpl={fetchMock}>
         <RemoteBackendProbe />
       </RemoteBackendProvider>
     )
@@ -64,7 +226,7 @@ describe('RemoteBackendProvider', () => {
     expect(screen.getByText('active:This server')).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'Add' }))
-    expect(screen.getByText('clients:1')).toBeInTheDocument()
+    expect(await screen.findByText('clients:1')).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'SwitchRemote' }))
     expect(screen.getByText('active:Studio NAS')).toBeInTheDocument()
@@ -73,36 +235,168 @@ describe('RemoteBackendProvider', () => {
     expect(screen.getByText('active:This server')).toBeInTheDocument()
   })
 
-  it('checks reachability and version compatibility for a remote client', async () => {
-    const fetchMock = vi.fn((input: RequestInfo | URL) => {
-      const url = String(input)
-      if (url === 'http://nas.local:9000/health') {
-        return Promise.resolve(new Response(JSON.stringify({ status: 'healthy' }), { status: 200 }))
-      }
-      if (url === 'http://nas.local:9000/api/system/info') {
+  it('hydrates saved remote clients from the active backend API', async () => {
+    setBackendAccessToken('admin-token')
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === '/api/remote-clients') {
+        expect(new Headers(init?.headers).get('X-Borg-Authorization')).toBe('Bearer admin-token')
         return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              app_version: '2.1.0',
-              borg_version: 'borg 1.4.0',
-              borg2_version: 'borg2 2.0.0',
-            }),
-            { status: 200 }
-          )
+          new Response(JSON.stringify([dbClientResponse]), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
         )
       }
-      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+      return Promise.reject(new Error(`Unexpected fetch: ${String(input)}`))
     })
-    vi.stubGlobal('fetch', fetchMock)
+
+    renderWithProviders(
+      <RemoteBackendProvider fetchImpl={fetchMock}>
+        <RemoteBackendProbe />
+      </RemoteBackendProvider>
+    )
+
+    expect(await screen.findByText('clients:1')).toBeInTheDocument()
+    expect(screen.getByText('active:This server')).toBeInTheDocument()
+  })
+
+  it('imports legacy localStorage clients into the active backend API once', async () => {
+    setBackendAccessToken('admin-token')
+    localStorage.setItem(
+      'borg_ui_remote_backends',
+      JSON.stringify([
+        {
+          id: 'legacy-client-1',
+          kind: 'remote',
+          name: 'Legacy NAS',
+          apiBaseUrl: 'https://legacy.example.com/api',
+          webBaseUrl: 'https://legacy.example.com',
+          createdAt: '2026-06-05T00:00:00.000Z',
+          updatedAt: '2026-06-05T00:00:00.000Z',
+          health: {
+            status: 'unknown',
+            compatibility: 'unknown',
+          },
+        },
+      ])
+    )
+    let getCount = 0
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method ?? 'GET'
+      if (url === '/api/remote-clients' && method === 'GET') {
+        getCount += 1
+        return Promise.resolve(
+          new Response(JSON.stringify(getCount === 1 ? [] : [dbClientResponse]), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        )
+      }
+      if (url === '/api/remote-clients' && method === 'POST') {
+        expect(JSON.parse(String(init?.body))).toMatchObject({
+          id: 'legacy-client-1',
+          name: 'Legacy NAS',
+          backend_url: 'https://legacy.example.com/api',
+        })
+        return Promise.resolve(
+          new Response(JSON.stringify(dbClientResponse), {
+            status: 201,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        )
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${method} ${url}`))
+    })
+
+    renderWithProviders(
+      <RemoteBackendProvider fetchImpl={fetchMock}>
+        <RemoteBackendProbe />
+      </RemoteBackendProvider>
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/remote-clients',
+        expect.objectContaining({ method: 'POST' })
+      )
+      const importCalls = fetchMock.mock.calls.filter(([input, init]) => {
+        return String(input) === '/api/remote-clients' && (init?.method ?? 'GET') === 'POST'
+      })
+      expect(importCalls).toHaveLength(1)
+      expect(localStorage.getItem('borg_ui_remote_backends')).toBeNull()
+    })
+  })
+
+  it('keeps the newest refresh when an older client load resolves late', async () => {
+    const staleClient = makeDbClient({ id: 'stale-client', name: 'Stale NAS' })
+    const freshClient = makeDbClient({ id: 'fresh-client', name: 'Fresh NAS' })
+    let getCount = 0
+    let resolveFirstLoad: (response: Response) => void = () => {}
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method ?? 'GET'
+      if (url === '/api/remote-clients' && method === 'GET') {
+        getCount += 1
+        if (getCount === 1) {
+          return new Promise<Response>((resolve) => {
+            resolveFirstLoad = resolve
+          })
+        }
+        return Promise.resolve(jsonResponse([freshClient]))
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${method} ${url}`))
+    })
+
+    renderWithProviders(
+      <RemoteBackendProvider fetchImpl={fetchMock}>
+        <RemoteBackendProbe />
+      </RemoteBackendProvider>
+    )
+
+    await waitFor(() => {
+      expect(getCount).toBe(1)
+    })
+
+    window.dispatchEvent(new StorageEvent('storage'))
+
+    expect(await screen.findByText('first:Fresh NAS')).toBeInTheDocument()
+
+    await act(async () => {
+      resolveFirstLoad(jsonResponse([staleClient]))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('first:Fresh NAS')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('first:Stale NAS')).not.toBeInTheDocument()
+  })
+
+  it('checks reachability and version compatibility for a remote client', async () => {
+    const fetchMock = createRemoteClientsApiFetch({
+      handleRemote: async (url) => {
+        if (url === 'http://nas.local:9000/health') {
+          return jsonResponse({ status: 'healthy' })
+        }
+        if (url === 'http://nas.local:9000/api/system/info') {
+          return jsonResponse({
+            app_version: '2.1.0',
+            borg_version: 'borg 1.4.0',
+            borg2_version: 'borg2 2.0.0',
+          })
+        }
+        throw new Error(`Unexpected fetch: ${url}`)
+      },
+    })
     const user = userEvent.setup()
     renderWithProviders(
-      <RemoteBackendProvider frontendVersion="2.2.2-alpha.1">
+      <RemoteBackendProvider frontendVersion="2.2.2-alpha.1" fetchImpl={fetchMock}>
         <RemoteBackendProbe />
       </RemoteBackendProvider>
     )
 
     await user.click(screen.getByRole('button', { name: 'Add' }))
-    await user.click(screen.getByRole('button', { name: 'Check' }))
+    await user.click(await screen.findByRole('button', { name: 'Check' }))
 
     await waitFor(() => {
       expect(screen.getByText('status:online')).toBeInTheDocument()
@@ -111,17 +405,66 @@ describe('RemoteBackendProvider', () => {
     })
   })
 
-  it('keeps an unreachable remote client inactive and records the error', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network unavailable')))
+  it('keeps reachable health state when persisting health fails', async () => {
+    const client = makeDbClient({
+      id: 'db-client-1',
+      apiBaseUrl: 'http://nas.local:9000/api',
+      webBaseUrl: 'http://nas.local:9000',
+    })
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method ?? 'GET'
+      if (url === '/api/remote-clients' && method === 'GET') {
+        return Promise.resolve(jsonResponse([client]))
+      }
+      if (url === 'http://nas.local:9000/health') {
+        return Promise.resolve(jsonResponse({ status: 'healthy' }))
+      }
+      if (url === 'http://nas.local:9000/api/system/info') {
+        return Promise.resolve(
+          jsonResponse({
+            app_version: '2.1.0',
+            borg_version: 'borg 1.4.0',
+          })
+        )
+      }
+      if (url.includes('/api/remote-clients/') && method === 'PATCH') {
+        return Promise.reject(new Error('database unavailable'))
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${method} ${url}`))
+    })
     const user = userEvent.setup()
     renderWithProviders(
-      <RemoteBackendProvider>
+      <RemoteBackendProvider frontendVersion="2.2.2-alpha.1" fetchImpl={fetchMock}>
+        <RemoteBackendProbe />
+      </RemoteBackendProvider>
+    )
+
+    await screen.findByText('clients:1')
+    await user.click(screen.getByRole('button', { name: 'Check' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('status:online')).toBeInTheDocument()
+      expect(screen.getByText('compatibility:compatible')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('status:offline')).not.toBeInTheDocument()
+  })
+
+  it('keeps an unreachable remote client inactive and records the error', async () => {
+    const fetchMock = createRemoteClientsApiFetch({
+      handleRemote: async () => {
+        throw new Error('network unavailable')
+      },
+    })
+    const user = userEvent.setup()
+    renderWithProviders(
+      <RemoteBackendProvider fetchImpl={fetchMock}>
         <RemoteBackendProbe />
       </RemoteBackendProvider>
     )
 
     await user.click(screen.getByRole('button', { name: 'Add' }))
-    await user.click(screen.getByRole('button', { name: 'Check' }))
+    await user.click(await screen.findByRole('button', { name: 'Check' }))
 
     await waitFor(() => {
       expect(screen.getByText('status:offline')).toBeInTheDocument()
@@ -131,24 +474,30 @@ describe('RemoteBackendProvider', () => {
   })
 
   it('times out stalled health checks and records the abort error', async () => {
-    vi.useFakeTimers()
-    const fetchMock = vi.fn(
-      (_input: RequestInfo | URL, init?: RequestInit) =>
+    const fetchMock = createRemoteClientsApiFetch({
+      clients: [
+        makeDbClient({
+          apiBaseUrl: 'http://nas.local:9000/api',
+          webBaseUrl: 'http://nas.local:9000',
+        }),
+      ],
+      handleRemote: async (_url, init) =>
         new Promise<Response>((_resolve, reject) => {
           init?.signal?.addEventListener('abort', () => {
             const error = new Error('Aborted')
             error.name = 'AbortError'
             reject(error)
           })
-        })
-    )
+        }),
+    })
     renderWithProviders(
       <RemoteBackendProvider fetchImpl={fetchMock}>
         <RemoteBackendProbe />
       </RemoteBackendProvider>
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    await screen.findByText('clients:1')
+    vi.useFakeTimers()
     fireEvent.click(screen.getByRole('button', { name: 'Check' }))
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -167,28 +516,27 @@ describe('RemoteBackendProvider', () => {
   it('keeps the latest health check result when an older check resolves late', async () => {
     let firstSystemInfoResolve: (value: Record<string, unknown>) => void = () => {}
     let healthCallCount = 0
-    const fetchMock = vi.fn((input: RequestInfo | URL) => {
-      const url = String(input)
-      if (url === 'http://nas.local:9000/health') {
-        healthCallCount += 1
-        if (healthCallCount === 1) {
-          return Promise.resolve(
-            new Response(JSON.stringify({ status: 'healthy' }), { status: 200 })
-          )
+    const fetchMock = createRemoteClientsApiFetch({
+      handleRemote: async (url) => {
+        if (url === 'http://nas.local:9000/health') {
+          healthCallCount += 1
+          if (healthCallCount === 1) {
+            return jsonResponse({ status: 'healthy' })
+          }
+          return jsonResponse({ status: 'down' }, 503)
         }
-        return Promise.resolve(new Response(JSON.stringify({ status: 'down' }), { status: 503 }))
-      }
-      if (url === 'http://nas.local:9000/api/system/info') {
-        return Promise.resolve({
-          ok: true,
-          status: 200,
-          json: () =>
-            new Promise<Record<string, unknown>>((resolve) => {
-              firstSystemInfoResolve = resolve
-            }),
-        } as Response)
-      }
-      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+        if (url === 'http://nas.local:9000/api/system/info') {
+          return {
+            ok: true,
+            status: 200,
+            json: () =>
+              new Promise<Record<string, unknown>>((resolve) => {
+                firstSystemInfoResolve = resolve
+              }),
+          } as Response
+        }
+        throw new Error(`Unexpected fetch: ${url}`)
+      },
     })
     const user = userEvent.setup()
     renderWithProviders(
@@ -198,10 +546,13 @@ describe('RemoteBackendProvider', () => {
     )
 
     await user.click(screen.getByRole('button', { name: 'Add' }))
-    await user.click(screen.getByRole('button', { name: 'Check' }))
+    await user.click(await screen.findByRole('button', { name: 'Check' }))
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://nas.local:9000/api/system/info',
+        expect.anything()
+      )
     })
 
     await user.click(screen.getByRole('button', { name: 'Check' }))

--- a/frontend/src/services/remoteBackends/context.tsx
+++ b/frontend/src/services/remoteBackends/context.tsx
@@ -13,21 +13,24 @@ import type {
   RemoteBackendClient,
   RemoteBackendClientInput,
   RemoteBackendHealth,
+  RemoteBackendStatus,
+  RemoteBackendCompatibility,
   RemoteBackendState,
 } from './types'
 import {
-  createRemoteBackendClient,
+  clearLegacyRemoteBackendClients,
   deleteRemoteBackendClient,
   getActiveBackendTarget,
   getBackendAccessToken,
   listRemoteBackendClients,
   readRemoteBackendState,
+  readLegacyRemoteBackendClients,
+  replaceRemoteBackendClients,
   setActiveBackendTarget,
   subscribeRemoteBackendStorage,
-  updateRemoteBackendClient,
   updateRemoteBackendHealth,
 } from './storage'
-import { compareBackendVersions } from './url'
+import { compareBackendVersions, normalizeRemoteBackendUrl } from './url'
 import { AUTH_TOKEN_HEADER } from '../authHeaders'
 
 const FRONTEND_APP_VERSION = __APP_VERSION__
@@ -37,9 +40,9 @@ interface RemoteBackendContextValue {
   activeTarget: BackendTarget
   clients: RemoteBackendClient[]
   state: RemoteBackendState
-  createClient: (input: RemoteBackendClientInput) => RemoteBackendClient
-  updateClient: (id: string, input: RemoteBackendClientInput) => RemoteBackendClient
-  deleteClient: (id: string) => void
+  createClient: (input: RemoteBackendClientInput) => Promise<RemoteBackendClient>
+  updateClient: (id: string, input: RemoteBackendClientInput) => Promise<RemoteBackendClient>
+  deleteClient: (id: string) => Promise<void>
   switchTarget: (id: string) => void
   checkClient: (id: string) => Promise<RemoteBackendClient>
   refresh: () => void
@@ -76,6 +79,146 @@ async function readJsonResponse(response: Response): Promise<Record<string, unkn
   return (await response.json().catch(() => ({}))) as Record<string, unknown>
 }
 
+interface RemoteClientApiHealth {
+  status: RemoteBackendStatus
+  checked_at?: string | null
+  app_version?: string | null
+  borg_version?: string | null
+  borg2_version?: string | null
+  error?: string | null
+  compatibility: RemoteBackendCompatibility
+  compatibility_message?: string | null
+}
+
+interface RemoteClientApiResponse {
+  id: string
+  name: string
+  api_base_url: string
+  web_base_url: string
+  created_at: string
+  updated_at: string
+  health: RemoteClientApiHealth
+}
+
+type PersistableRemoteBackendHealth = Partial<RemoteBackendHealth> & {
+  status: RemoteBackendStatus
+  compatibility: RemoteBackendCompatibility
+}
+
+function mapApiClient(client: RemoteClientApiResponse): RemoteBackendClient {
+  return {
+    id: client.id,
+    kind: 'remote',
+    name: client.name,
+    apiBaseUrl: client.api_base_url,
+    webBaseUrl: client.web_base_url,
+    createdAt: client.created_at,
+    updatedAt: client.updated_at,
+    health: {
+      status: client.health.status,
+      checkedAt: client.health.checked_at ?? null,
+      appVersion: client.health.app_version ?? null,
+      borgVersion: client.health.borg_version ?? null,
+      borg2Version: client.health.borg2_version ?? null,
+      error: client.health.error ?? null,
+      compatibility: client.health.compatibility,
+      compatibilityMessage: client.health.compatibility_message ?? null,
+    },
+  }
+}
+
+function buildRemoteClientsUrl(target: BackendTarget, path = ''): string {
+  return `${target.apiBaseUrl}/remote-clients${path}`
+}
+
+function buildRemoteClientsHeaders(target: BackendTarget, includeJson = false): Headers {
+  const headers = new Headers({ Accept: 'application/json' })
+  if (includeJson) {
+    headers.set('Content-Type', 'application/json')
+  }
+  const token = getBackendAccessToken(target.id)
+  if (token) {
+    headers.set(AUTH_TOKEN_HEADER, `Bearer ${token}`)
+  }
+  return headers
+}
+
+async function fetchRemoteClientsFromApi(
+  fetchImpl: typeof fetch
+): Promise<{ clients: RemoteBackendClient[]; authorized: boolean }> {
+  const target = getActiveBackendTarget()
+  const response = await fetchImpl(buildRemoteClientsUrl(target), {
+    headers: buildRemoteClientsHeaders(target),
+  })
+
+  if (response.status === 401 || response.status === 403) {
+    return { clients: [], authorized: false }
+  }
+  if (!response.ok) {
+    throw new Error(`Remote clients failed to load with HTTP ${response.status}.`)
+  }
+
+  const body = (await response.json().catch(() => [])) as RemoteClientApiResponse[]
+  return {
+    clients: Array.isArray(body) ? body.map(mapApiClient) : [],
+    authorized: true,
+  }
+}
+
+async function sendRemoteClientApiRequest(
+  fetchImpl: typeof fetch,
+  path: string,
+  init: RequestInit
+): Promise<Response> {
+  const target = getActiveBackendTarget()
+  return fetchImpl(buildRemoteClientsUrl(target, path), {
+    ...init,
+    headers: buildRemoteClientsHeaders(target, Boolean(init.body)),
+  })
+}
+
+async function readRemoteClientApiResponse(response: Response): Promise<RemoteBackendClient> {
+  if (!response.ok) {
+    throw new Error(`Remote client request failed with HTTP ${response.status}.`)
+  }
+  return mapApiClient((await response.json()) as RemoteClientApiResponse)
+}
+
+async function persistRemoteBackendHealth(
+  fetchImpl: typeof fetch,
+  id: string,
+  health: PersistableRemoteBackendHealth
+): Promise<RemoteBackendClient | null> {
+  try {
+    const response = await sendRemoteClientApiRequest(fetchImpl, `/${id}/health`, {
+      method: 'PATCH',
+      body: JSON.stringify({
+        status: health.status,
+        checked_at: health.checkedAt ?? null,
+        app_version: health.appVersion ?? null,
+        borg_version: health.borgVersion ?? null,
+        borg2_version: health.borg2Version ?? null,
+        error: health.error ?? null,
+        compatibility: health.compatibility,
+        compatibility_message: health.compatibilityMessage ?? null,
+      }),
+    })
+    if (!response.ok) {
+      return null
+    }
+    return readRemoteClientApiResponse(response)
+  } catch {
+    return null
+  }
+}
+
+function upsertRemoteBackendClient(client: RemoteBackendClient): void {
+  replaceRemoteBackendClients([
+    ...listRemoteBackendClients().filter((item) => item.id !== client.id),
+    client,
+  ])
+}
+
 export function RemoteBackendProvider({
   children,
   frontendVersion = FRONTEND_APP_VERSION,
@@ -83,20 +226,106 @@ export function RemoteBackendProvider({
 }: RemoteBackendProviderProps) {
   const [snapshot, setSnapshot] = useState(readSnapshot)
   const pendingChecksRef = useRef(new Map<string, AbortController>())
+  const refreshSeqRef = useRef(0)
 
   const refresh = useCallback(() => {
     setSnapshot(readSnapshot())
   }, [])
 
+  const refreshRemoteClients = useCallback(
+    async (options: { importLegacy?: boolean; isCurrent?: () => boolean } = {}) => {
+      const isCurrent = options.isCurrent ?? (() => true)
+      const refreshSeq = ++refreshSeqRef.current
+      const isLatestRefresh = () => isCurrent() && refreshSeq === refreshSeqRef.current
+      try {
+        const result = await fetchRemoteClientsFromApi(fetchImpl)
+        if (!isLatestRefresh()) {
+          return
+        }
+        replaceRemoteBackendClients(result.clients)
+        setSnapshot(readSnapshot())
+
+        const legacyClients = options.importLegacy ? readLegacyRemoteBackendClients() : []
+        if (!result.authorized || legacyClients.length === 0) {
+          return
+        }
+
+        const existingIds = new Set(result.clients.map((client) => client.id))
+        let importSucceeded = true
+        for (const legacyClient of legacyClients) {
+          if (!isLatestRefresh()) {
+            return
+          }
+          if (existingIds.has(legacyClient.id)) {
+            continue
+          }
+          const response = await sendRemoteClientApiRequest(fetchImpl, '', {
+            method: 'POST',
+            body: JSON.stringify({
+              id: legacyClient.id,
+              name: legacyClient.name,
+              backend_url: legacyClient.apiBaseUrl,
+            }),
+          })
+          if (!isLatestRefresh()) {
+            return
+          }
+          if (response.status === 409) {
+            continue
+          }
+          if (!response.ok) {
+            importSucceeded = false
+            break
+          }
+        }
+
+        if (importSucceeded) {
+          if (!isLatestRefresh()) {
+            return
+          }
+          clearLegacyRemoteBackendClients()
+          const refreshed = await fetchRemoteClientsFromApi(fetchImpl)
+          if (!isLatestRefresh()) {
+            return
+          }
+          replaceRemoteBackendClients(refreshed.clients)
+          setSnapshot(readSnapshot())
+        }
+      } catch (error) {
+        console.error('Failed to refresh remote clients:', error)
+      }
+    },
+    [fetchImpl]
+  )
+
   useEffect(() => {
-    const unsubscribe = subscribeRemoteBackendStorage(refresh)
-    const handleStorage = () => refresh()
+    let current = true
+    const isCurrent = () => current
+    const refreshFromApi = () => {
+      if (!current) {
+        return
+      }
+      refresh()
+      void refreshRemoteClients({ importLegacy: true, isCurrent })
+    }
+    const unsubscribe = subscribeRemoteBackendStorage((reason) => {
+      if (!current) {
+        return
+      }
+      refresh()
+      if (reason !== 'clients') {
+        void refreshRemoteClients({ importLegacy: true, isCurrent })
+      }
+    })
+    const handleStorage = () => refreshFromApi()
     window.addEventListener('storage', handleStorage)
+    void refreshRemoteClients({ importLegacy: true, isCurrent })
     return () => {
+      current = false
       unsubscribe()
       window.removeEventListener('storage', handleStorage)
     }
-  }, [refresh])
+  }, [refresh, refreshRemoteClients])
 
   useEffect(() => {
     const pendingChecks = pendingChecksRef.current
@@ -107,16 +336,56 @@ export function RemoteBackendProvider({
   }, [])
 
   const createClient = useCallback(
-    (input: RemoteBackendClientInput) => createRemoteBackendClient(input),
-    []
+    async (input: RemoteBackendClientInput): Promise<RemoteBackendClient> => {
+      const normalized = normalizeRemoteBackendUrl(input.backendUrl)
+      const name = input.name.trim()
+      if (!name) {
+        throw new Error('Enter a client name.')
+      }
+
+      const response = await sendRemoteClientApiRequest(fetchImpl, '', {
+        method: 'POST',
+        body: JSON.stringify({ name, backend_url: normalized.apiBaseUrl }),
+      })
+      const created = await readRemoteClientApiResponse(response)
+      upsertRemoteBackendClient(created)
+      refresh()
+      return created
+    },
+    [fetchImpl, refresh]
   )
 
   const updateClient = useCallback(
-    (id: string, input: RemoteBackendClientInput) => updateRemoteBackendClient(id, input),
-    []
+    async (id: string, input: RemoteBackendClientInput): Promise<RemoteBackendClient> => {
+      const normalized = normalizeRemoteBackendUrl(input.backendUrl)
+      const name = input.name.trim()
+      if (!name) {
+        throw new Error('Enter a client name.')
+      }
+
+      const response = await sendRemoteClientApiRequest(fetchImpl, `/${id}`, {
+        method: 'PUT',
+        body: JSON.stringify({ name, backend_url: normalized.apiBaseUrl }),
+      })
+      const updated = await readRemoteClientApiResponse(response)
+      upsertRemoteBackendClient(updated)
+      refresh()
+      return updated
+    },
+    [fetchImpl, refresh]
   )
 
-  const deleteClient = useCallback((id: string) => deleteRemoteBackendClient(id), [])
+  const deleteClient = useCallback(
+    async (id: string): Promise<void> => {
+      const response = await sendRemoteClientApiRequest(fetchImpl, `/${id}`, { method: 'DELETE' })
+      if (!response.ok) {
+        throw new Error(`Remote client delete failed with HTTP ${response.status}.`)
+      }
+      deleteRemoteBackendClient(id)
+      refresh()
+    },
+    [fetchImpl, refresh]
+  )
 
   const switchTarget = useCallback((id: string) => setActiveBackendTarget(id), [])
 
@@ -182,16 +451,33 @@ export function RemoteBackendProvider({
         }
 
         if (!isLatestCheck()) return readCurrentClient() ?? client
-        return updateRemoteBackendHealth(id, health)
+        updateRemoteBackendHealth(id, health)
+        refresh()
+        const persisted = await persistRemoteBackendHealth(fetchImpl, id, health)
+        if (persisted) {
+          upsertRemoteBackendClient(persisted)
+          refresh()
+          return persisted
+        }
+        return readCurrentClient() ?? client
       } catch (error) {
         if (!isLatestCheck()) return readCurrentClient() ?? client
-        return updateRemoteBackendHealth(id, {
+        const offlineHealth: PersistableRemoteBackendHealth = {
           status: 'offline',
           checkedAt: new Date().toISOString(),
           error: extractErrorMessage(error),
           compatibility: 'unknown',
           compatibilityMessage: 'Remote client server compatibility could not be checked.',
-        })
+        }
+        updateRemoteBackendHealth(id, offlineHealth)
+        refresh()
+        const persisted = await persistRemoteBackendHealth(fetchImpl, id, offlineHealth)
+        if (persisted) {
+          upsertRemoteBackendClient(persisted)
+          refresh()
+          return persisted
+        }
+        return readCurrentClient() ?? client
       } finally {
         window.clearTimeout(timeoutId)
         if (isLatestCheck()) {
@@ -199,7 +485,7 @@ export function RemoteBackendProvider({
         }
       }
     },
-    [fetchImpl, frontendVersion]
+    [fetchImpl, frontendVersion, refresh]
   )
 
   const value = useMemo<RemoteBackendContextValue>(

--- a/frontend/src/services/remoteBackends/storage.test.ts
+++ b/frontend/src/services/remoteBackends/storage.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   clearBackendAccessToken,
+  clearLegacyRemoteBackendClients,
   createRemoteBackendClient,
   deleteRemoteBackendClient,
   getActiveBackendTarget,
@@ -8,6 +9,8 @@ import {
   listRemoteBackendClients,
   LOCAL_BACKEND_ID,
   readRemoteBackendState,
+  readLegacyRemoteBackendClients,
+  replaceRemoteBackendClients,
   resetRemoteBackendStateForTests,
   setActiveBackendTarget,
   setBackendAccessToken,
@@ -66,6 +69,76 @@ describe('remote client storage', () => {
 
     expect(listRemoteBackendClients()).toEqual([])
     expect(getActiveBackendTarget().id).toBe(LOCAL_BACKEND_ID)
+    expect(localStorage.getItem('borg_ui_remote_backends')).toBeNull()
+  })
+
+  it('keeps the remote client cache out of localStorage', () => {
+    createRemoteBackendClient({
+      name: 'Studio NAS',
+      backendUrl: 'nas.local:9000',
+    })
+
+    expect(listRemoteBackendClients()).toHaveLength(1)
+    expect(localStorage.getItem('borg_ui_remote_backends')).toBeNull()
+
+    replaceRemoteBackendClients([])
+
+    expect(listRemoteBackendClients()).toEqual([])
+    expect(localStorage.getItem('borg_ui_remote_backends')).toBeNull()
+  })
+
+  it('returns defensive copies of cached remote clients', () => {
+    const created = createRemoteBackendClient({
+      name: 'Studio NAS',
+      backendUrl: 'nas.local:9000',
+    })
+
+    const listed = listRemoteBackendClients()
+    listed[0].name = 'Mutated NAS'
+    listed[0].health.status = 'offline'
+
+    expect(listRemoteBackendClients()[0]).toMatchObject({
+      id: created.id,
+      name: 'Studio NAS',
+      health: {
+        status: 'unknown',
+      },
+    })
+
+    const state = readRemoteBackendState()
+    state.clients[0].name = 'Mutated again'
+
+    expect(readRemoteBackendState().clients[0].name).toBe('Studio NAS')
+  })
+
+  it('reads and clears legacy localStorage clients for admin migration', () => {
+    const legacyClient = {
+      id: 'legacy-client-1',
+      kind: 'remote',
+      name: 'Legacy NAS',
+      apiBaseUrl: 'https://legacy.example.com/api',
+      webBaseUrl: 'https://legacy.example.com',
+      createdAt: '2026-06-05T00:00:00.000Z',
+      updatedAt: '2026-06-05T00:00:00.000Z',
+      health: {
+        status: 'unknown',
+        checkedAt: null,
+        appVersion: null,
+        borgVersion: null,
+        borg2Version: null,
+        error: null,
+        compatibility: 'unknown',
+        compatibilityMessage: null,
+      },
+    }
+    localStorage.setItem('borg_ui_remote_backends', JSON.stringify([legacyClient]))
+
+    expect(readLegacyRemoteBackendClients()).toEqual([legacyClient])
+
+    clearLegacyRemoteBackendClients()
+
+    expect(readLegacyRemoteBackendClients()).toEqual([])
+    expect(localStorage.getItem('borg_ui_remote_backends')).toBeNull()
   })
 
   it('persists and switches the active remote target', () => {
@@ -134,11 +207,12 @@ describe('remote client storage', () => {
 
     createRemoteBackendClient({ name: 'Lab', backendUrl: 'lab.example.com' })
     setBackendAccessToken('token')
+    replaceRemoteBackendClients([])
 
-    expect(listener).toHaveBeenCalledTimes(2)
+    expect(listener).toHaveBeenCalledTimes(3)
 
     unsubscribe()
     createRemoteBackendClient({ name: 'Office', backendUrl: 'office.example.com' })
-    expect(listener).toHaveBeenCalledTimes(2)
+    expect(listener).toHaveBeenCalledTimes(3)
   })
 })

--- a/frontend/src/services/remoteBackends/storage.ts
+++ b/frontend/src/services/remoteBackends/storage.ts
@@ -14,6 +14,9 @@ const REMOTE_BACKENDS_STORAGE_KEY = 'borg_ui_remote_backends'
 const REMOTE_BACKEND_ACTIVE_KEY = 'borg_ui_active_backend_target'
 const REMOTE_TOKEN_PREFIX = 'borg_ui_access_token'
 const LEGACY_LOCAL_TOKEN_KEY = 'access_token'
+const remoteBackendClientsByStorage = new WeakMap<Storage, RemoteBackendClient[]>()
+let fallbackRemoteBackendClients: RemoteBackendClient[] = []
+export type RemoteBackendStorageChangeReason = 'clients' | 'target' | 'token'
 
 const defaultHealth = (): RemoteBackendHealth => ({
   status: 'unknown',
@@ -26,7 +29,7 @@ const defaultHealth = (): RemoteBackendHealth => ({
   compatibilityMessage: null,
 })
 
-const listeners = new Set<() => void>()
+const listeners = new Set<(reason: RemoteBackendStorageChangeReason) => void>()
 
 function nowIso(): string {
   return new Date().toISOString()
@@ -39,14 +42,53 @@ function createId(): string {
   return `remote-${Date.now()}-${Math.random().toString(36).slice(2)}`
 }
 
-function emitChange(): void {
+function emitChange(reason: RemoteBackendStorageChangeReason = 'clients'): void {
   for (const listener of listeners) {
-    listener()
+    listener(reason)
+  }
+}
+
+function getClientStorage(): Storage | null {
+  return typeof localStorage === 'undefined' ? null : localStorage
+}
+
+function cloneRemoteBackendClient(client: RemoteBackendClient): RemoteBackendClient {
+  return {
+    ...client,
+    health: {
+      ...client.health,
+    },
   }
 }
 
 function readClients(): RemoteBackendClient[] {
-  const raw = localStorage.getItem(REMOTE_BACKENDS_STORAGE_KEY)
+  const storage = getClientStorage()
+  const clients = storage
+    ? (remoteBackendClientsByStorage.get(storage) ?? [])
+    : fallbackRemoteBackendClients
+  return clients.map(cloneRemoteBackendClient)
+}
+
+function writeClients(clients: RemoteBackendClient[]): void {
+  const nextClients = clients.map(cloneRemoteBackendClient)
+  const storage = getClientStorage()
+  if (storage) {
+    remoteBackendClientsByStorage.set(storage, nextClients)
+    return
+  }
+  fallbackRemoteBackendClients = nextClients
+}
+
+export function replaceRemoteBackendClients(clients: RemoteBackendClient[]): void {
+  writeClients(clients)
+  emitChange('clients')
+}
+
+export function readLegacyRemoteBackendClients(): RemoteBackendClient[] {
+  const storage = getClientStorage()
+  if (!storage) return []
+
+  const raw = storage.getItem(REMOTE_BACKENDS_STORAGE_KEY)
   if (!raw) return []
 
   try {
@@ -67,8 +109,8 @@ function readClients(): RemoteBackendClient[] {
   }
 }
 
-function writeClients(clients: RemoteBackendClient[]): void {
-  localStorage.setItem(REMOTE_BACKENDS_STORAGE_KEY, JSON.stringify(clients))
+export function clearLegacyRemoteBackendClients(): void {
+  getClientStorage()?.removeItem(REMOTE_BACKENDS_STORAGE_KEY)
 }
 
 function getStoredActiveTargetId(): string {
@@ -145,7 +187,7 @@ export function createRemoteBackendClient(input: RemoteBackendClientInput): Remo
   }
 
   writeClients([...readClients(), client])
-  emitChange()
+  emitChange('clients')
   return client
 }
 
@@ -175,7 +217,7 @@ export function updateRemoteBackendClient(
   const nextClients = [...clients]
   nextClients[index] = updated
   writeClients(nextClients)
-  emitChange()
+  emitChange('clients')
   return updated
 }
 
@@ -200,7 +242,7 @@ export function updateRemoteBackendHealth(
   const nextClients = [...clients]
   nextClients[index] = updated
   writeClients(nextClients)
-  emitChange()
+  emitChange('clients')
   return updated
 }
 
@@ -211,13 +253,13 @@ export function deleteRemoteBackendClient(id: string): void {
     writeActiveTargetId(LOCAL_BACKEND_ID)
   }
   localStorage.removeItem(getAccessTokenKey(id))
-  emitChange()
+  emitChange('clients')
 }
 
 export function setActiveBackendTarget(targetId: string): void {
   if (targetId === LOCAL_BACKEND_ID) {
     writeActiveTargetId(LOCAL_BACKEND_ID)
-    emitChange()
+    emitChange('target')
     return
   }
 
@@ -231,7 +273,7 @@ export function setActiveBackendTarget(targetId: string): void {
   }
 
   writeActiveTargetId(targetId)
-  emitChange()
+  emitChange('target')
 }
 
 export function getAccessTokenKey(targetId = getActiveBackendTarget().id): string {
@@ -246,15 +288,17 @@ export function getBackendAccessToken(targetId?: string): string | null {
 
 export function setBackendAccessToken(token: string, targetId?: string): void {
   localStorage.setItem(getAccessTokenKey(targetId), token)
-  emitChange()
+  emitChange('token')
 }
 
 export function clearBackendAccessToken(targetId?: string): void {
   localStorage.removeItem(getAccessTokenKey(targetId))
-  emitChange()
+  emitChange('token')
 }
 
-export function subscribeRemoteBackendStorage(listener: () => void): () => void {
+export function subscribeRemoteBackendStorage(
+  listener: (reason: RemoteBackendStorageChangeReason) => void
+): () => void {
   listeners.add(listener)
   return () => {
     listeners.delete(listener)
@@ -262,6 +306,7 @@ export function subscribeRemoteBackendStorage(listener: () => void): () => void 
 }
 
 export function resetRemoteBackendStateForTests(): void {
+  writeClients([])
   localStorage.removeItem(REMOTE_BACKENDS_STORAGE_KEY)
   localStorage.removeItem(REMOTE_BACKEND_ACTIVE_KEY)
   for (const key of Object.keys(localStorage)) {

--- a/frontend/src/services/remoteBackends/storyFixtures.test.tsx
+++ b/frontend/src/services/remoteBackends/storyFixtures.test.tsx
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { renderWithProviders, screen } from '../../test/test-utils'
+import { RemoteBackendStoryProvider } from './storyFixtures'
+import { useRemoteBackends } from './context'
+import { resetRemoteBackendStateForTests } from './storage'
+
+function RemoteBackendStoryProbe() {
+  const { activeTarget, clients } = useRemoteBackends()
+
+  return (
+    <div>
+      <div>active:{activeTarget.name}</div>
+      <div>clients:{clients.map((client) => client.name).join(',')}</div>
+    </div>
+  )
+}
+
+describe('RemoteBackendStoryProvider', () => {
+  beforeEach(() => {
+    resetRemoteBackendStateForTests()
+  })
+
+  it('hydrates mixed story clients on initial render', async () => {
+    renderWithProviders(
+      <RemoteBackendStoryProvider state="mixed">
+        <RemoteBackendStoryProbe />
+      </RemoteBackendStoryProvider>
+    )
+
+    expect(await screen.findByText(/clients:.*Studio NAS/)).toBeInTheDocument()
+    expect(screen.getByText(/Workshop Mini PC/)).toBeInTheDocument()
+    expect(screen.getByText(/Legacy Server/)).toBeInTheDocument()
+  })
+
+  it('selects the active remote story client on initial render', async () => {
+    renderWithProviders(
+      <RemoteBackendStoryProvider state="activeRemote">
+        <RemoteBackendStoryProbe />
+      </RemoteBackendStoryProvider>
+    )
+
+    expect(await screen.findByText('active:Studio NAS')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/services/remoteBackends/storyFixtures.tsx
+++ b/frontend/src/services/remoteBackends/storyFixtures.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactNode } from 'react'
+import { useState, type ReactNode } from 'react'
 import { RemoteBackendProvider } from './context'
 import {
   createRemoteBackendClient,
@@ -183,13 +183,26 @@ export function RemoteBackendStoryProvider({
   children,
   state = 'mixed',
 }: RemoteBackendStoryProviderProps) {
-  const seededRef = useRef(false)
+  return (
+    <SeededRemoteBackendStoryProvider key={state} state={state}>
+      {children}
+    </SeededRemoteBackendStoryProvider>
+  )
+}
 
-  useEffect(() => {
-    if (seededRef.current) return
-    seededRef.current = true
+function SeededRemoteBackendStoryProvider({
+  children,
+  state,
+}: Required<RemoteBackendStoryProviderProps>) {
+  const [seededState] = useState(() => {
+    // Storybook fixtures must exist before RemoteBackendProvider reads its initial snapshot.
     seedRemoteBackends(state)
-  }, [state])
+    return state
+  })
 
-  return <RemoteBackendProvider fetchImpl={storyFetch}>{children}</RemoteBackendProvider>
+  return (
+    <RemoteBackendProvider key={seededState} fetchImpl={storyFetch}>
+      {children}
+    </RemoteBackendProvider>
+  )
 }

--- a/frontend/src/services/remoteBackends/storyFixtures.tsx
+++ b/frontend/src/services/remoteBackends/storyFixtures.tsx
@@ -2,10 +2,14 @@ import { useEffect, useRef, type ReactNode } from 'react'
 import { RemoteBackendProvider } from './context'
 import {
   createRemoteBackendClient,
+  deleteRemoteBackendClient,
+  listRemoteBackendClients,
   resetRemoteBackendStateForTests,
   setActiveBackendTarget,
+  updateRemoteBackendClient,
   updateRemoteBackendHealth,
 } from './storage'
+import type { RemoteBackendClient } from './types'
 
 type RemoteBackendStoryState = 'empty' | 'mixed' | 'activeRemote'
 
@@ -14,9 +18,98 @@ interface RemoteBackendStoryProviderProps {
   state?: RemoteBackendStoryState
 }
 
-const storyFetch: typeof fetch = async (input) => {
+function storyClientResponse(client: RemoteBackendClient) {
+  return {
+    id: client.id,
+    name: client.name,
+    api_base_url: client.apiBaseUrl,
+    web_base_url: client.webBaseUrl,
+    created_at: client.createdAt,
+    updated_at: client.updatedAt,
+    health: {
+      status: client.health.status,
+      checked_at: client.health.checkedAt ?? null,
+      app_version: client.health.appVersion ?? null,
+      borg_version: client.health.borgVersion ?? null,
+      borg2_version: client.health.borg2Version ?? null,
+      error: client.health.error ?? null,
+      compatibility: client.health.compatibility,
+      compatibility_message: client.health.compatibilityMessage ?? null,
+    },
+  }
+}
+
+const storyFetch: typeof fetch = async (input, init) => {
   const url =
     typeof input === 'string' ? input : input instanceof Request ? input.url : String(input)
+  const path = new URL(url, window.location.origin).pathname
+  const remoteClientsIndex = path.lastIndexOf('/api/remote-clients')
+
+  if (remoteClientsIndex !== -1) {
+    const method = init?.method ?? 'GET'
+    const tail = path.slice(remoteClientsIndex + '/api/remote-clients'.length)
+
+    if (tail === '' && method === 'GET') {
+      return new Response(JSON.stringify(listRemoteBackendClients().map(storyClientResponse)), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    if (tail === '' && method === 'POST') {
+      const body = JSON.parse(String(init?.body ?? '{}')) as {
+        name?: string
+        backend_url?: string
+      }
+      const client = createRemoteBackendClient({
+        name: body.name ?? 'Remote client',
+        backendUrl: body.backend_url ?? '',
+      })
+      return new Response(JSON.stringify(storyClientResponse(client)), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    const id = decodeURIComponent(tail.replace(/^\//, '').replace(/\/health$/, ''))
+    if (id && method === 'PUT') {
+      const body = JSON.parse(String(init?.body ?? '{}')) as {
+        name?: string
+        backend_url?: string
+      }
+      const client = updateRemoteBackendClient(id, {
+        name: body.name ?? 'Remote client',
+        backendUrl: body.backend_url ?? '',
+      })
+      return new Response(JSON.stringify(storyClientResponse(client)), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    if (id && method === 'PATCH' && tail.endsWith('/health')) {
+      const body = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
+      const client = updateRemoteBackendHealth(id, {
+        status: body.status as RemoteBackendClient['health']['status'],
+        checkedAt: body.checked_at as string | null,
+        appVersion: body.app_version as string | null,
+        borgVersion: body.borg_version as string | null,
+        borg2Version: body.borg2_version as string | null,
+        error: body.error as string | null,
+        compatibility: body.compatibility as RemoteBackendClient['health']['compatibility'],
+        compatibilityMessage: body.compatibility_message as string | null,
+      })
+      return new Response(JSON.stringify(storyClientResponse(client)), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    if (id && method === 'DELETE') {
+      deleteRemoteBackendClient(id)
+      return new Response(null, { status: 204 })
+    }
+  }
 
   if (url.endsWith('/health')) {
     return new Response(JSON.stringify({ status: 'ok' }), {

--- a/tests/unit/test_api_remote_clients.py
+++ b/tests/unit/test_api_remote_clients.py
@@ -1,0 +1,159 @@
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.unit
+class TestRemoteClientsApi:
+    def test_admin_can_manage_remote_clients(
+        self, test_client: TestClient, admin_headers
+    ):
+        create_response = test_client.post(
+            "/api/remote-clients",
+            json={
+                "id": "legacy-client-1",
+                "name": "Studio NAS",
+                "backend_url": "nas.local:9000",
+            },
+            headers=admin_headers,
+        )
+
+        assert create_response.status_code == 201
+        created = create_response.json()
+        assert created["id"] == "legacy-client-1"
+        assert created["name"] == "Studio NAS"
+        assert created["api_base_url"] == "http://nas.local:9000/api"
+        assert created["web_base_url"] == "http://nas.local:9000"
+        assert created["health"]["status"] == "unknown"
+        assert created["health"]["compatibility"] == "unknown"
+        assert created["created_at"].endswith("+00:00")
+        assert created["updated_at"].endswith("+00:00")
+
+        list_response = test_client.get("/api/remote-clients", headers=admin_headers)
+        assert list_response.status_code == 200
+        assert [client["id"] for client in list_response.json()] == ["legacy-client-1"]
+
+        update_response = test_client.put(
+            "/api/remote-clients/legacy-client-1",
+            json={
+                "name": "Studio NAS 2",
+                "backend_url": "https://nas.example.com/borg/api",
+            },
+            headers=admin_headers,
+        )
+
+        assert update_response.status_code == 200
+        updated = update_response.json()
+        assert updated["id"] == "legacy-client-1"
+        assert updated["name"] == "Studio NAS 2"
+        assert updated["api_base_url"] == "https://nas.example.com/borg/api"
+        assert updated["web_base_url"] == "https://nas.example.com/borg"
+
+        health_response = test_client.patch(
+            "/api/remote-clients/legacy-client-1/health",
+            json={
+                "status": "online",
+                "checked_at": "2026-06-06T12:34:56+00:00",
+                "app_version": "2.2.2-alpha.1",
+                "borg_version": "borg 1.4.0",
+                "borg2_version": "borg2 2.0.0",
+                "error": None,
+                "compatibility": "compatible",
+                "compatibility_message": "Compatible",
+            },
+            headers=admin_headers,
+        )
+
+        assert health_response.status_code == 200
+        health = health_response.json()["health"]
+        assert health["status"] == "online"
+        assert health["checked_at"] == "2026-06-06T12:34:56+00:00"
+        assert health["app_version"] == "2.2.2-alpha.1"
+        assert health["borg_version"] == "borg 1.4.0"
+        assert health["borg2_version"] == "borg2 2.0.0"
+        assert health["compatibility"] == "compatible"
+        assert health["compatibility_message"] == "Compatible"
+
+        delete_response = test_client.delete(
+            "/api/remote-clients/legacy-client-1", headers=admin_headers
+        )
+        assert delete_response.status_code == 204
+
+        final_list = test_client.get("/api/remote-clients", headers=admin_headers)
+        assert final_list.status_code == 200
+        assert final_list.json() == []
+
+    @pytest.mark.parametrize(
+        ("method", "path", "json"),
+        [
+            ("get", "/api/remote-clients", None),
+            (
+                "post",
+                "/api/remote-clients",
+                {"name": "Office", "backend_url": "office.example.com"},
+            ),
+            (
+                "put",
+                "/api/remote-clients/client-1",
+                {"name": "Office", "backend_url": "office.example.com"},
+            ),
+            (
+                "patch",
+                "/api/remote-clients/client-1/health",
+                {"status": "offline", "compatibility": "unknown"},
+            ),
+            ("delete", "/api/remote-clients/client-1", None),
+        ],
+    )
+    def test_non_admin_cannot_manage_remote_clients(
+        self,
+        test_client: TestClient,
+        auth_headers,
+        method: str,
+        path: str,
+        json: dict | None,
+    ):
+        request = getattr(test_client, method)
+        if json is None:
+            response = request(path, headers=auth_headers)
+        else:
+            response = request(path, json=json, headers=auth_headers)
+
+        assert response.status_code == 403
+
+    def test_rejects_invalid_remote_client_url(
+        self, test_client: TestClient, admin_headers
+    ):
+        response = test_client.post(
+            "/api/remote-clients",
+            json={"name": "Broken", "backend_url": "ftp://example.com"},
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 422
+        assert (
+            response.json()["detail"]["key"]
+            == "backend.errors.remoteClients.invalidUrl"
+        )
+
+    def test_rejects_duplicate_remote_client_id(
+        self, test_client: TestClient, admin_headers
+    ):
+        payload = {
+            "id": "legacy-client-1",
+            "name": "Studio NAS",
+            "backend_url": "nas.local:9000",
+        }
+        first_response = test_client.post(
+            "/api/remote-clients", json=payload, headers=admin_headers
+        )
+        assert first_response.status_code == 201
+
+        duplicate_response = test_client.post(
+            "/api/remote-clients", json=payload, headers=admin_headers
+        )
+
+        assert duplicate_response.status_code == 409
+        assert (
+            duplicate_response.json()["detail"]["key"]
+            == "backend.errors.remoteClients.alreadyExists"
+        )


### PR DESCRIPTION
## Description
Persist saved remote clients in the database instead of browser localStorage. Adds an admin-only backend API and migration for remote client CRUD and health state, updates the frontend provider to hydrate and mutate saved clients through that API, keeps JWT and per-target tokens browser-local, imports legacy localStorage clients once for admins, and gates remote client management and switching to admin users.

The Code Review Reply update restores seeded remote client Storybook states after the provider moved to server-backed hydration, so switcher and remote-client page stories render populated clients again.

## Related Issue
Fixes BOR-155

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands and walkthroughs run:

- `git diff --check`
- `ruff check app tests`
- `ruff format --check app tests`
- `pytest tests/unit/test_api_remote_clients.py -q`
- `cd frontend && npm run check:locales`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `cd frontend && npm run test -- --run src/services/remoteBackends/storage.test.ts src/services/remoteBackends/context.test.tsx src/components/__tests__/BackendTargetSwitcher.test.tsx src/pages/__tests__/RemoteClients.test.tsx src/components/__tests__/Layout.test.tsx src/hooks/__tests__/useAuth.test.tsx`
- `cd frontend && npm run test -- --run src/services/remoteBackends/storyFixtures.test.tsx src/services/remoteBackends/context.test.tsx src/components/__tests__/BackendTargetSwitcher.test.tsx src/pages/__tests__/RemoteClients.test.tsx --reporter=dot`
- `cd frontend && npx prettier --check src/services/remoteBackends/storyFixtures.tsx src/services/remoteBackends/storyFixtures.test.tsx`
- `cd frontend && npm run snapshots` built Storybook successfully; Chromium screenshot capture could not launch because this host is missing Playwright system libraries and passwordless sudo is unavailable for `npx playwright install-deps chromium`.
- `./scripts/dev.sh` runtime walkthrough covering admin login, remote client create/list/delete, health persistence, viewer 403 list/delete checks, and `/remote-clients` frontend route load.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Storybook coverage includes backend target switcher states, the non-admin locked state, and remote client page states. The latest CI Storybook Visual Report passed and recorded 10 changed snapshots plus 2 added non-admin locked snapshots: https://docs.borgui.com/visual/reports/pr-639/

## Additional Context
The login JWT and per-target access tokens intentionally remain in browser localStorage. Only the saved remote client list and health metadata move into the database, enforced by admin-only backend routes.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
