### PR TITLE
Show correct backup plan count on dashboard

### DIFF
--- a/app/api/dashboard.py
+++ b/app/api/dashboard.py
@@ -12,6 +12,8 @@ from app.database.database import get_db
 from app.database.models import (
     User,
     BackupJob,
+    BackupPlan,
+    BackupPlanRepository,
     Repository,
     ScheduledJob,
     ScheduledJobRepository,
@@ -85,6 +87,24 @@ def resolve_schedule_next_run(
             schedule.cron_expression,
             now_utc,
             schedule.timezone or DEFAULT_SCHEDULE_TIMEZONE,
+        )
+    except Exception:
+        return None
+
+
+def resolve_backup_plan_next_run(plan: BackupPlan, now: datetime) -> Optional[datetime]:
+    """Resolve the next due time for a backup plan, preferring stored future values."""
+    now_utc = to_utc_naive(now)
+    if plan.next_run and to_utc_naive(plan.next_run) > now_utc:
+        return to_utc_naive(plan.next_run)
+    if not plan.cron_expression:
+        return None
+
+    try:
+        return calculate_next_cron_run(
+            plan.cron_expression,
+            now_utc,
+            plan.timezone or DEFAULT_SCHEDULE_TIMEZONE,
         )
     except Exception:
         return None
@@ -441,6 +461,24 @@ def build_observe_repository_health(
     }
 
 
+def build_backup_plan_summary(plans: list[BackupPlan], now: datetime) -> Dict[str, Any]:
+    """Build repository-level backup plan counts and next scheduled run metadata."""
+    scheduled_plans = [plan for plan in plans if plan.enabled and plan.schedule_enabled]
+    scheduled_next_runs = [
+        next_run
+        for plan in scheduled_plans
+        if (next_run := resolve_backup_plan_next_run(plan, now)) is not None
+    ]
+    return {
+        "backup_plan_count": len(plans),
+        "backup_plan_scheduled_count": len(scheduled_plans),
+        "backup_plan_names": [plan.name for plan in plans],
+        "backup_plan_next_run": serialize_datetime(
+            min(scheduled_next_runs) if scheduled_next_runs else None
+        ),
+    }
+
+
 def get_system_metrics() -> SystemMetrics:
     """Get system resource metrics"""
     try:
@@ -665,6 +703,26 @@ async def get_dashboard_overview(
 
         # Get all schedules
         schedules = db.query(ScheduledJob).all()
+        active_schedules = [s for s in schedules if s.enabled]
+
+        # Get all backup plans so the dashboard can report the plan-native
+        # automation counts separately from legacy schedules.
+        backup_plans = db.query(BackupPlan).all()
+        active_backup_plans = [p for p in backup_plans if p.enabled]
+        backup_plan_links = (
+            db.query(BackupPlanRepository, BackupPlan)
+            .join(BackupPlan, BackupPlan.id == BackupPlanRepository.backup_plan_id)
+            .filter(BackupPlanRepository.enabled.is_(True))
+            .order_by(
+                BackupPlanRepository.repository_id.asc(),
+                BackupPlanRepository.execution_order.asc(),
+                BackupPlan.name.asc(),
+            )
+            .all()
+        )
+        backup_plans_by_repo: dict[int, list[BackupPlan]] = {}
+        for link, plan in backup_plan_links:
+            backup_plans_by_repo.setdefault(link.repository_id, []).append(plan)
 
         # Get SSH connections
         ssh_connections = db.query(SSHConnection).all()
@@ -737,6 +795,7 @@ async def get_dashboard_overview(
                         fallback_schedule = schedule  # keep first disabled as fallback
             if repo_schedule is None:
                 repo_schedule = fallback_schedule
+            repo_backup_plans = backup_plans_by_repo.get(repo.id, [])
 
             # Calculate dedup ratio (if we have the data)
             dedup_ratio = None
@@ -785,6 +844,7 @@ async def get_dashboard_overview(
                         and repo_schedule.next_run
                     )
                     else None,
+                    **build_backup_plan_summary(repo_backup_plans, now),
                     "dimension_health": health["dimension_health"],
                 }
             )
@@ -795,6 +855,7 @@ async def get_dashboard_overview(
             health = build_observe_repository_health(
                 repo, now, latest_restore_check, health_thresholds
             )
+            repo_backup_plans = backup_plans_by_repo.get(repo.id, [])
 
             repo_health.append(
                 {
@@ -823,6 +884,7 @@ async def get_dashboard_overview(
                     "schedule_enabled": False,
                     "schedule_name": None,
                     "next_run": None,
+                    **build_backup_plan_summary(repo_backup_plans, now),
                     "dimension_health": health["dimension_health"],
                 }
             )
@@ -864,7 +926,6 @@ async def get_dashboard_overview(
 
         # Get upcoming schedules (next 24 hours)
         end_time = now + timedelta(hours=24)
-        active_schedules = [s for s in schedules if s.enabled]
         upcoming_tasks = []
         for schedule in active_schedules:
             next_run_dt = resolve_schedule_next_run(schedule, now)
@@ -1151,8 +1212,12 @@ async def get_dashboard_overview(
                 "ssh_repositories": len(
                     [r for r in repositories if r.repository_type == "ssh"]
                 ),
-                "active_schedules": len([s for s in schedules if s.enabled]),
+                "active_schedules": len(active_schedules),
                 "total_schedules": len(schedules),
+                "active_backup_plans": len(active_backup_plans),
+                "total_backup_plans": len(backup_plans),
+                "active_automations": len(active_schedules) + len(active_backup_plans),
+                "total_automations": len(schedules) + len(backup_plans),
                 "ssh_connections_active": ssh_active,
                 "ssh_connections_total": ssh_total,
                 "success_rate_30d": round(success_rate, 1),

--- a/tests/unit/test_api_dashboard.py
+++ b/tests/unit/test_api_dashboard.py
@@ -19,6 +19,8 @@ from app.api.dashboard import (
 )
 from app.database.models import (
     BackupJob,
+    BackupPlan,
+    BackupPlanRepository,
     CheckJob,
     CompactJob,
     Repository,
@@ -745,6 +747,44 @@ class TestDashboardScheduleAndOverview:
         test_db.refresh(far_schedule)
         test_db.refresh(ssh_connection)
 
+        stale_plan_next_run = now - timedelta(hours=1)
+        enabled_plan = BackupPlan(
+            name="Z Scheduled Documents",
+            enabled=True,
+            source_directories='["/srv/data"]',
+            schedule_enabled=True,
+            cron_expression="0 3 * * *",
+            next_run=stale_plan_next_run,
+        )
+        disabled_plan = BackupPlan(
+            name="A Paused Media",
+            enabled=False,
+            source_directories='["/srv/media"]',
+            schedule_enabled=False,
+        )
+        test_db.add_all([enabled_plan, disabled_plan])
+        test_db.commit()
+        test_db.refresh(enabled_plan)
+        test_db.refresh(disabled_plan)
+
+        test_db.add_all(
+            [
+                BackupPlanRepository(
+                    backup_plan_id=enabled_plan.id,
+                    repository_id=full_repo.id,
+                    enabled=True,
+                    execution_order=1,
+                ),
+                BackupPlanRepository(
+                    backup_plan_id=disabled_plan.id,
+                    repository_id=full_repo.id,
+                    enabled=True,
+                    execution_order=2,
+                ),
+            ]
+        )
+        test_db.commit()
+
         test_db.add_all(
             [
                 BackupJob(
@@ -813,6 +853,10 @@ class TestDashboardScheduleAndOverview:
             "ssh_repositories": 1,
             "active_schedules": 2,
             "total_schedules": 2,
+            "active_backup_plans": 1,
+            "total_backup_plans": 2,
+            "active_automations": 3,
+            "total_automations": 4,
             "ssh_connections_active": 1,
             "ssh_connections_total": 1,
             "success_rate_30d": 50.0,
@@ -826,6 +870,17 @@ class TestDashboardScheduleAndOverview:
         repo_health = {item["name"]: item for item in data["repository_health"]}
         assert repo_health["Full Repo"]["health_status"] == "critical"
         assert repo_health["Full Repo"]["schedule_name"] == "Nightly Full Repo"
+        assert repo_health["Full Repo"]["backup_plan_count"] == 2
+        assert repo_health["Full Repo"]["backup_plan_scheduled_count"] == 1
+        assert repo_health["Full Repo"]["backup_plan_names"] == [
+            "Z Scheduled Documents",
+            "A Paused Media",
+        ]
+        backup_plan_next_run = datetime.fromisoformat(
+            repo_health["Full Repo"]["backup_plan_next_run"]
+        )
+        assert backup_plan_next_run > now
+        assert backup_plan_next_run != stale_plan_next_run
         assert repo_health["Full Repo"]["dimension_health"]["restore"] == "critical"
         assert repo_health["Full Repo"]["latest_restore_check_status"] == "failed"
         assert (


### PR DESCRIPTION
## Description
The dashboard overview API now reports backup-plan-native counts instead of only legacy schedule counts. The summary includes total/enabled backup plans plus combined automation totals, and repository health rows include linked plan count/name/next-run metadata used by dashboard plan coverage UI.

This also resolves review feedback by recalculating stale backup-plan `next_run` values before serialization and preserving per-repository backup plan execution order when building repository health metadata.

## Related Issue
Linear: [BOR-161](https://linear.app/nullcodeai/issue/BOR-161/new-dashboard-widget-shows-incorrect-values)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [x] Test addition/improvement
- [ ] Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass

Commands run:
- `ruff check app tests`
- `ruff format --check app tests` using CI ruff `0.15.15`
- `pytest tests/unit/test_api_dashboard.py::TestDashboardScheduleAndOverview -q`
- `cd frontend && npm run check:locales`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm test -- --run src/pages/__tests__/DashboardV3.test.tsx`
- `cd frontend && npm run build`

`npm run build` passed with existing Vite warnings about `webauthn.ts` chunking and large production chunks.

## Checklist
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable. This is a backend dashboard overview contract fix; the existing DashboardV3 and CapabilityLaunchpad frontend coverage exercises the non-zero backup-plan count rendering path.

## Additional Context
The root cause was that `DashboardV3` and `CapabilityLaunchpad` already read `summary.total_backup_plans` and `summary.active_backup_plans`, but `/api/dashboard/overview` never emitted those fields. That made the widget fall back to legacy schedule counts and show zero when backup plans existed without legacy schedules.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
