### PR TITLE
Show repository initialization error details

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -4651,7 +4651,7 @@
         "sshUrlWithoutConnectionId": "Der Pfad scheint eine SSH-URL zu sein, aber es wurde keine connection_id angegeben. Bitte wählen Sie eine SSH-Verbindung aus.",
         "failedToRetrieveRepositories": "Repositories konnten nicht abgerufen werden",
         "failedToCreateParentDirectory": "Übergeordnetes Verzeichnis konnte nicht erstellt werden",
-        "failedToInitializeRepository": "Repository konnte nicht initialisiert werden",
+        "failedToInitializeRepository": "Repository konnte nicht initialisiert werden: {{error}}",
         "initFailed": "Repository konnte nicht initialisiert werden: {{error}}",
         "verificationFailed": "Repository konnte nicht verifiziert werden: {{error}}",
         "infoFailed": "Repository-Informationen konnten nicht geladen werden: {{error}}",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -4651,7 +4651,7 @@
         "sshUrlWithoutConnectionId": "Path appears to be an SSH URL but no connection_id provided. Please select an SSH connection.",
         "failedToRetrieveRepositories": "Failed to retrieve repositories",
         "failedToCreateParentDirectory": "Failed to create parent directory",
-        "failedToInitializeRepository": "Failed to initialize repository",
+        "failedToInitializeRepository": "Failed to initialize repository: {{error}}",
         "initFailed": "Failed to initialize repository: {{error}}",
         "verificationFailed": "Failed to verify repository: {{error}}",
         "infoFailed": "Failed to load repository information: {{error}}",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -4651,7 +4651,7 @@
         "sshUrlWithoutConnectionId": "La ruta parece ser una URL SSH pero no se proporcionó connection_id. Seleccione una conexión SSH.",
         "failedToRetrieveRepositories": "Error al recuperar los repositorios",
         "failedToCreateParentDirectory": "Error al crear el directorio padre",
-        "failedToInitializeRepository": "Error al inicializar el repositorio",
+        "failedToInitializeRepository": "Error al inicializar el repositorio: {{error}}",
         "initFailed": "Error al inicializar el repositorio: {{error}}",
         "verificationFailed": "Error al verificar el repositorio: {{error}}",
         "infoFailed": "Error al cargar la información del repositorio: {{error}}",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -4651,7 +4651,7 @@
         "sshUrlWithoutConnectionId": "Il percorso sembra essere un URL SSH ma non è stato fornito connection_id. Seleziona una connessione SSH.",
         "failedToRetrieveRepositories": "Impossibile recuperare i repository",
         "failedToCreateParentDirectory": "Impossibile creare la directory padre",
-        "failedToInitializeRepository": "Impossibile inizializzare il repository",
+        "failedToInitializeRepository": "Impossibile inizializzare il repository: {{error}}",
         "initFailed": "Impossibile inizializzare il repository: {{error}}",
         "verificationFailed": "Impossibile verificare il repository: {{error}}",
         "infoFailed": "Impossibile caricare le informazioni del repository: {{error}}",

--- a/frontend/src/utils/__tests__/backendRepoTranslations.test.ts
+++ b/frontend/src/utils/__tests__/backendRepoTranslations.test.ts
@@ -9,13 +9,14 @@ import { translateBackendKey } from '../translateBackendKey'
 
 const locales = { de, en, es, it: itLocale }
 
-const borg2RepoErrorKeys = [
+const repositoryErrorKeys = [
   'backend.errors.repo.nameExists',
   'backend.errors.repo.pathExists',
   'backend.errors.repo.initFailed',
   'backend.errors.repo.verificationFailed',
   'backend.errors.repo.infoFailed',
   'backend.errors.repo.listFailed',
+  'backend.errors.repo.failedToInitializeRepository',
   'backend.errors.repo.remoteBorg2Incompatible',
 ] as const
 
@@ -29,9 +30,9 @@ function lookup(locale: unknown, key: string): unknown {
 }
 
 describe('backend repository translations', () => {
-  it('defines Borg 2 repository error keys in every bundled locale', () => {
+  it('defines repository error keys in every bundled locale', () => {
     for (const [localeName, locale] of Object.entries(locales)) {
-      for (const key of borg2RepoErrorKeys) {
+      for (const key of repositoryErrorKeys) {
         const value = lookup(locale, key)
 
         expect(value, `${localeName}:${key}`).toEqual(expect.any(String))
@@ -46,6 +47,17 @@ describe('backend repository translations', () => {
     expect(
       translateBackendKey({
         key: 'backend.errors.repo.initFailed',
+        params: { error: 'remote: borg: command not found' },
+      })
+    ).toBe('Failed to initialize repository: remote: borg: command not found')
+  })
+
+  it('translates legacy repository initialization failures with backend error params', async () => {
+    await i18n.changeLanguage('en')
+
+    expect(
+      translateBackendKey({
+        key: 'backend.errors.repo.failedToInitializeRepository',
         params: { error: 'remote: borg: command not found' },
       })
     ).toBe('Failed to initialize repository: remote: borg: command not found')


### PR DESCRIPTION
## Description
Repository initialization failures now include the backend-provided Borg error detail in every bundled locale. The backend already sends `params.error` for `backend.errors.repo.failedToInitializeRepository`; this makes the repository wizard toast show the actual stderr instead of a generic message.

## Related Issue
https://linear.app/nullcodeai/issue/BOR-165/show-repository-initialization-error-details

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `cd frontend && npm test -- backendRepoTranslations.test.ts`
- `cd frontend && npm run check:locales`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable. This changes localized error text used by existing repository wizard error handling; no layout or component state changed.

## Additional Context
The Discord thread included a user seeing `backend.errors.repo.failedToInitializeRepository` while trying to initialize a repository on a connected Hetzner Storage Box. Existing code already sends Borg stderr in the error params, so this keeps the UI from hiding the actionable detail.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- visual-regression:start -->
## Visual regression report
No visual changes detected: 0 changed, 0 added, 0 removed, 412 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-662/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/27191921500
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- None
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->