### PR TITLE
Restore prune dry-run archive preview

### DIFF
--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -5028,9 +5028,10 @@ async def check_repository(
             repository,
             CheckJob,
             error_key="backend.errors.repo.checkAlreadyRunning",
-            dispatcher=lambda job, router_repo=SimpleNamespace(id=repository.id, borg_version=repository.borg_version): (
-                BorgRouter(router_repo).check(job.id)
-            ),
+            dispatcher=lambda job,
+            router_repo=SimpleNamespace(
+                id=repository.id, borg_version=repository.borg_version
+            ): (BorgRouter(router_repo).check(job.id)),
             extra_fields={
                 "max_duration": max_duration,
                 "extra_flags": check_extra_flags,
@@ -5179,9 +5180,10 @@ async def compact_repository(
             repository,
             CompactJob,
             error_key="backend.errors.repo.compactAlreadyRunning",
-            dispatcher=lambda job, router_repo=SimpleNamespace(id=repository.id, borg_version=repository.borg_version): (
-                BorgRouter(router_repo).compact(job.id)
-            ),
+            dispatcher=lambda job,
+            router_repo=SimpleNamespace(
+                id=repository.id, borg_version=repository.borg_version
+            ): (BorgRouter(router_repo).compact(job.id)),
             extra_fields={"scheduled_compact": False},
         )
 
@@ -5274,7 +5276,9 @@ async def prune_repository(
                 prune_job.completed_at = datetime.utcnow()
                 db.commit()
                 db.refresh(prune_job)
-            stdout_output = read_job_logs(prune_job, fallback_to_logs=True)
+            stdout_output = read_job_logs(
+                prune_job, fallback_to_logs=True, log_save_policy="all_jobs"
+            )
             if not stdout_output:
                 stdout_output = str(result.get("stdout") or "")
             return {
@@ -5295,7 +5299,10 @@ async def prune_repository(
                 repository,
                 PruneJob,
                 error_key="backend.errors.repo.pruneAlreadyRunning",
-                dispatcher=lambda job, router_repo=SimpleNamespace(id=repository.id, borg_version=repository.borg_version): (
+                dispatcher=lambda job,
+                router_repo=SimpleNamespace(
+                    id=repository.id, borg_version=repository.borg_version
+                ): (
                     BorgRouter(router_repo).prune(
                         job.id,
                         keep_hourly,
@@ -5356,7 +5363,9 @@ async def prune_repository(
         db.refresh(prune_job)
 
         # Read log file if it exists
-        stdout_output = read_job_logs(prune_job, fallback_to_logs=True)
+        stdout_output = read_job_logs(
+            prune_job, fallback_to_logs=True, log_save_policy="all_jobs"
+        )
         stderr_output = ""
 
         # Return results in format expected by frontend

--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -5028,10 +5028,9 @@ async def check_repository(
             repository,
             CheckJob,
             error_key="backend.errors.repo.checkAlreadyRunning",
-            dispatcher=lambda job,
-            router_repo=SimpleNamespace(
-                id=repository.id, borg_version=repository.borg_version
-            ): (BorgRouter(router_repo).check(job.id)),
+            dispatcher=lambda job, router_repo=SimpleNamespace(id=repository.id, borg_version=repository.borg_version): (
+                BorgRouter(router_repo).check(job.id)
+            ),
             extra_fields={
                 "max_duration": max_duration,
                 "extra_flags": check_extra_flags,
@@ -5180,10 +5179,9 @@ async def compact_repository(
             repository,
             CompactJob,
             error_key="backend.errors.repo.compactAlreadyRunning",
-            dispatcher=lambda job,
-            router_repo=SimpleNamespace(
-                id=repository.id, borg_version=repository.borg_version
-            ): (BorgRouter(router_repo).compact(job.id)),
+            dispatcher=lambda job, router_repo=SimpleNamespace(id=repository.id, borg_version=repository.borg_version): (
+                BorgRouter(router_repo).compact(job.id)
+            ),
             extra_fields={"scheduled_compact": False},
         )
 
@@ -5299,10 +5297,7 @@ async def prune_repository(
                 repository,
                 PruneJob,
                 error_key="backend.errors.repo.pruneAlreadyRunning",
-                dispatcher=lambda job,
-                router_repo=SimpleNamespace(
-                    id=repository.id, borg_version=repository.borg_version
-                ): (
+                dispatcher=lambda job, router_repo=SimpleNamespace(id=repository.id, borg_version=repository.borg_version): (
                     BorgRouter(router_repo).prune(
                         job.id,
                         keep_hourly,

--- a/app/services/check_scheduler.py
+++ b/app/services/check_scheduler.py
@@ -166,9 +166,10 @@ async def run_due_scheduled_checks(db: Session, now: Optional[datetime] = None) 
                 repo,
                 CheckJob,
                 error_key="backend.errors.repo.checkAlreadyRunning",
-                dispatcher=lambda job, router_repo=SimpleNamespace(id=repo.id, borg_version=repo.borg_version): (
-                    BorgRouter(router_repo).check(job.id)
-                ),
+                dispatcher=lambda job,
+                router_repo=SimpleNamespace(
+                    id=repo.id, borg_version=repo.borg_version
+                ): (BorgRouter(router_repo).check(job.id)),
                 extra_fields={
                     "max_duration": (
                         repo.check_max_duration

--- a/app/services/check_scheduler.py
+++ b/app/services/check_scheduler.py
@@ -166,10 +166,9 @@ async def run_due_scheduled_checks(db: Session, now: Optional[datetime] = None) 
                 repo,
                 CheckJob,
                 error_key="backend.errors.repo.checkAlreadyRunning",
-                dispatcher=lambda job,
-                router_repo=SimpleNamespace(
-                    id=repo.id, borg_version=repo.borg_version
-                ): (BorgRouter(router_repo).check(job.id)),
+                dispatcher=lambda job, router_repo=SimpleNamespace(id=repo.id, borg_version=repo.borg_version): (
+                    BorgRouter(router_repo).check(job.id)
+                ),
                 extra_fields={
                     "max_duration": (
                         repo.check_max_duration

--- a/frontend/src/components/PruneRepositoryDialog.stories.tsx
+++ b/frontend/src/components/PruneRepositoryDialog.stories.tsx
@@ -20,6 +20,13 @@ const repository = {
   path: '/mnt/borg/production',
 }
 
+const borgV1DryRunOutput = [
+  '[stderr] {"type": "log_message", "message": "Keeping archive (rule: daily #1):            production-2026-06-09      Tue, 2026-06-09 04:00:42 [abcdef0123456789]", "levelname": "INFO", "name": "borg.output.list"}',
+  '[stderr] {"type": "log_message", "message": "Would prune:                                 production-2026-06-08      Mon, 2026-06-08 22:24:37 [1234567890abcdef]", "levelname": "INFO", "name": "borg.output.list"}',
+  '[stderr] {"type": "log_message", "message": "Keeping archive (rule: weekly #1):           production-2026-06-07      Sun, 2026-06-07 22:16:20 [fedcba0987654321]", "levelname": "INFO", "name": "borg.output.list"}',
+  '[stderr] {"type": "log_message", "message": "Would prune:                                 production-2026-06-06      Sat, 2026-06-06 04:00:19 [0011223344556677]", "levelname": "INFO", "name": "borg.output.list"}',
+].join('\n')
+
 export const RetentionPreview: Story = {
   args: {
     open: true,
@@ -38,6 +45,35 @@ export const RetentionPreview: Story = {
   },
   render: (args) => (
     <Box sx={{ width: 560, minHeight: 520 }}>
+      <PruneRepositoryDialog {...args} />
+    </Box>
+  ),
+}
+
+export const DryRunLogMessages: Story = {
+  args: {
+    open: true,
+    repository,
+    initialForm: {
+      keep_daily: 1,
+      keep_weekly: 1,
+      keep_monthly: 1,
+      keep_yearly: 0,
+    },
+    isLoading: false,
+    results: {
+      dry_run: true,
+      prune_result: {
+        success: true,
+        stdout: borgV1DryRunOutput,
+      },
+    },
+    onClose: () => {},
+    onDryRun: async () => {},
+    onConfirmPrune: async () => {},
+  },
+  render: (args) => (
+    <Box sx={{ width: 760, minHeight: 620 }}>
       <PruneRepositoryDialog {...args} />
     </Box>
   ),

--- a/frontend/src/components/PruneRepositoryDialog.tsx
+++ b/frontend/src/components/PruneRepositoryDialog.tsx
@@ -139,7 +139,10 @@ function segmentArchiveLine(line: string) {
   // Pattern: <Verb> archive <rule?>: <spaces><name> <date> [<hash>]
   const ruleMatch = line.match(/(\(rule:[^)]+\))/)
   const hashMatch = line.match(/\[([a-f0-9]{16,})\]/)
-  const colonIdx = line.indexOf(':')
+  const colonIdx =
+    ruleMatch && ruleMatch.index !== undefined
+      ? line.indexOf(':', ruleMatch.index + ruleMatch[1].length)
+      : line.indexOf(':')
 
   if (colonIdx === -1) return [{ text: line, kind: 'verb' as const }]
 

--- a/frontend/src/components/__tests__/PruneRepositoryDialog.test.tsx
+++ b/frontend/src/components/__tests__/PruneRepositoryDialog.test.tsx
@@ -376,6 +376,37 @@ describe('PruneRepositoryDialog', () => {
       expect(screen.getByRole('dialog')).toHaveTextContent('Would prune: archive-2023-01-01')
     })
 
+    it('shows Borg v1 dry run log messages from prune output', async () => {
+      render(
+        <PruneRepositoryDialog
+          open={true}
+          repository={mockRepository}
+          onClose={vi.fn()}
+          onDryRun={vi.fn()}
+          onConfirmPrune={vi.fn()}
+          isLoading={false}
+          results={{
+            dry_run: true,
+            prune_result: {
+              success: true,
+              stdout: [
+                '[stderr] {"type": "log_message", "message": "Keeping archive (rule: daily #1):            repo-2026-06-09      Tue, 2026-06-09 04:00:42 [abcdef0123456789]", "levelname": "INFO", "name": "borg.output.list"}',
+                '[stderr] {"type": "log_message", "message": "Would prune:                                 repo-2026-06-08      Mon, 2026-06-08 22:24:37 [1234567890abcdef]", "levelname": "INFO", "name": "borg.output.list"}',
+              ].join('\n'),
+            },
+          }}
+        />
+      )
+
+      await screen.findByText('Dry Run Results (Preview)')
+      const dialogs = screen.getAllByRole('dialog')
+      const resultsDialog = dialogs[dialogs.length - 1]
+      expect(resultsDialog).toHaveTextContent(
+        /Keeping archive \(rule: daily #1\):\s+repo-2026-06-09/
+      )
+      expect(resultsDialog).toHaveTextContent(/Would prune:\s+repo-2026-06-08/)
+    })
+
     it('shows error state for failed operation', async () => {
       render(
         <PruneRepositoryDialog

--- a/tests/unit/test_api_repositories_dispatch.py
+++ b/tests/unit/test_api_repositories_dispatch.py
@@ -184,6 +184,52 @@ class TestRepositoryApiDispatch:
         mock_router.assert_called_once()
         fake_router.prune.assert_awaited_once()
 
+    def test_prune_dry_run_response_includes_successful_log_output(
+        self, test_client: TestClient, admin_headers, test_db, tmp_path
+    ):
+        repo = Repository(
+            name="Repo Dry Run Logs",
+            path="/tmp/repo-dry-run-logs",
+            encryption="none",
+            repository_type="local",
+            borg_version=1,
+        )
+        settings = SystemSettings(log_save_policy="failed_and_warnings")
+        test_db.add_all([repo, settings])
+        test_db.commit()
+        test_db.refresh(repo)
+
+        dry_run_logs = "\n".join(
+            [
+                '[stderr] {"type": "log_message", "message": "Keeping archive (rule: daily #1):            repo-2026-06-09      Tue, 2026-06-09 04:00:42 [abcdef0123456789]", "levelname": "INFO", "name": "borg.output.list"}',
+                '[stderr] {"type": "log_message", "message": "Would prune:                                 repo-2026-06-08      Mon, 2026-06-08 22:24:37 [1234567890abcdef]", "levelname": "INFO", "name": "borg.output.list"}',
+            ]
+        )
+
+        async def complete_prune_with_logs(job_id, *_args, **_kwargs):
+            log_path = tmp_path / "prune-dry-run.log"
+            log_path.write_text(dry_run_logs, encoding="utf-8")
+            job = test_db.query(PruneJob).filter(PruneJob.id == job_id).one()
+            job.status = "completed"
+            job.log_file_path = str(log_path)
+            job.has_logs = True
+            test_db.commit()
+
+        fake_router = Mock(prune=AsyncMock(side_effect=complete_prune_with_logs))
+        with patch("app.api.repositories.BorgRouter", return_value=fake_router):
+            response = test_client.post(
+                f"/api/repositories/{repo.id}/prune",
+                json={"keep_daily": 3, "dry_run": True},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["dry_run"] is True
+        assert body["prune_result"]["success"] is True
+        assert "Keeping archive (rule: daily #1)" in body["prune_result"]["stdout"]
+        assert "Would prune:" in body["prune_result"]["stdout"]
+
     @pytest.mark.asyncio
     async def test_prune_route_starts_background_job_for_actual_prune(
         self, test_client: TestClient, admin_headers, test_db


### PR DESCRIPTION
## Description
Restores prune dry-run preview output for Borg v1 repositories when Borg emits dry-run list entries as `log_message` lines. The immediate dry-run API response now reads the completed job log with `all_jobs` visibility so successful preview output is returned even when the saved activity-log policy hides completed job logs.

Also fixes the prune result renderer so archive lines containing `(rule: ...)` split on the delimiter after the rule instead of the colon inside the rule metadata, and adds a Storybook state for Borg v1 dry-run log output.

## Related Issue
Fixes #667

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass

Commands run:
- `pytest tests/unit/test_api_repositories_dispatch.py::TestRepositoryApiDispatch::test_prune_route_dispatches_through_borg_router tests/unit/test_api_repositories_dispatch.py::TestRepositoryApiDispatch::test_prune_dry_run_response_includes_successful_log_output tests/unit/test_api_repositories_dispatch.py::TestRepositoryApiDispatch::test_prune_route_starts_background_job_for_actual_prune -q`
- `cd frontend && npm test -- PruneRepositoryDialog --run`
- `ruff check app tests`
- `ruff format --check app tests`
- `cd frontend && npm run check:locales`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `cd frontend && npm run snapshots` built Storybook successfully, but screenshot capture could not run because this host is missing Chromium shared library `libnspr4.so`. Retried after local Playwright Chromium install and with host validation skipped; Chromium still failed to launch due the missing shared library.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
No screenshots captured locally. The prune dry-run Storybook state builds successfully, but Playwright screenshot capture is blocked on this host by missing Chromium runtime library `libnspr4.so`.

## Additional Context
The saved activity-log policy is unchanged. The `all_jobs` read is limited to the immediate dry-run preview response so the UI can show the operation output the user just requested.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dry-run log collection during prune operations to ensure log output is properly captured and displayed in the results dialog.
  * Enhanced parsing of dry-run log messages to correctly display archive retention decisions and pruning actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 0 changed, 2 added, 0 removed, 418 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-668/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/27257794043
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- `components-prunerepositorydialog--dry-run-log-messages--mobile.png`
- `components-prunerepositorydialog--dry-run-log-messages.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->