### PR TITLE
Fix direct Borg 2 rclone config handling

### DIFF
--- a/app/core/borg2.py
+++ b/app/core/borg2.py
@@ -31,10 +31,12 @@ Key command differences from Borg 1:
 """
 
 import asyncio
-import subprocess
 import os
-import structlog
+import subprocess
+from pathlib import Path
 from typing import Dict, List, Optional
+
+import structlog
 
 from app.config import settings
 
@@ -125,6 +127,7 @@ class Borg2Interface:
             "LogLevel=ERROR",
         ]
         env["BORG_RSH"] = f"ssh {' '.join(ssh_opts)}"
+        env["RCLONE_CONFIG"] = str(Path(settings.rclone_config_root) / "rclone.conf")
         if extra:
             env.update(extra)
         return env

--- a/docs/engineering/plans/2026-06-12-direct-borg2-rclone-config.md
+++ b/docs/engineering/plans/2026-06-12-direct-borg2-rclone-config.md
@@ -1,40 +1,61 @@
 # Direct Borg 2 Rclone Config Implementation Plan
 
-**Goal:** Ensure Direct Borg 2 rclone repositories use Borg UI's managed rclone configuration for repository creation, verification, backup, and maintenance commands.
+**Goal:** Ensure Direct Borg 2 rclone repositories use Borg UI's managed
+rclone configuration for repository creation, verification, backup, and
+maintenance commands.
 
-**Architecture:** Borg UI stores rclone remotes in the managed config at `settings.rclone_config_root/rclone.conf`. Cloud Mirror passes that config to the `rclone` CLI explicitly, while Borg 2 direct rclone commands run through `app/core/borg2.py`. The fix belongs in the Borg 2 command environment so every Borg 2 subprocess can resolve Borg UI-managed rclone remotes without per-call special cases.
+**Architecture:** Borg UI stores rclone remotes in the managed config at
+`settings.rclone_config_root/rclone.conf`. Cloud Mirror passes that config to
+the `rclone` CLI explicitly, while Borg 2 direct rclone commands run through
+`app/core/borg2.py`. The fix belongs in the Borg 2 command environment so every
+Borg 2 subprocess can resolve Borg UI-managed rclone remotes without per-call
+special cases.
 
 **Tech Stack:** Python, FastAPI service layer, Borg 2 command wrapper, pytest.
 
 ---
 
+## Tasks
+
 ### Task 1: Reproduce Missing Rclone Config in Borg 2 Process Env
 
 **Files:**
+
 - Modify: `tests/unit/test_borg2.py`
 
-- [x] Add a failing pytest that calls `borg2.rcreate("rclone://prod-s3/borg-ui/direct", encryption="none")` with `asyncio.create_subprocess_exec` patched.
-- [x] Capture the subprocess `env` argument and assert `RCLONE_CONFIG` equals `<settings.rclone_config_root>/rclone.conf`.
-- [x] Run `pytest tests/unit/test_borg2.py::test_rcreate_injects_managed_rclone_config_into_process_env -q` and confirm it fails because `RCLONE_CONFIG` is missing.
+- [x] Add a failing pytest that calls `borg2.rcreate(...)` for a
+  `rclone://prod-s3/borg-ui/direct` repository with
+  `asyncio.create_subprocess_exec` patched.
+- [x] Capture the subprocess `env` argument and assert `RCLONE_CONFIG` equals
+  `<settings.rclone_config_root>/rclone.conf`.
+- [x] Run the focused `test_rcreate_injects_managed_rclone_config_into_process_env`
+  test and confirm it fails because `RCLONE_CONFIG` is missing.
 
 ### Task 2: Inject Managed Rclone Config Centrally
 
 **Files:**
+
 - Modify: `app/core/borg2.py`
 
-- [x] Update `Borg2Interface._base_env` to set `RCLONE_CONFIG` to `Path(settings.rclone_config_root) / "rclone.conf"` before merging explicit per-call env overrides.
-- [x] Preserve explicit per-call `env["RCLONE_CONFIG"]` overrides by keeping the existing final `env.update(extra)` merge.
+- [x] Update `Borg2Interface._base_env` to set `RCLONE_CONFIG` to
+  `Path(settings.rclone_config_root) / "rclone.conf"` before merging explicit
+  per-call env overrides.
+- [x] Preserve explicit per-call `env["RCLONE_CONFIG"]` overrides by keeping
+  the existing final `env.update(extra)` merge.
 - [x] Run the targeted pytest from Task 1 and confirm it passes.
 
 ### Task 3: Validate Direct Rclone Regression Surface
 
 **Files:**
+
 - Test: `tests/unit/test_borg2.py`
 - Test: `tests/unit/test_api_rclone.py`
 - Test: `tests/unit/test_v2_backup_service.py`
 
-- [x] Run `pytest tests/unit/test_borg2.py tests/unit/test_api_rclone.py::test_create_direct_borg2_rclone_repository_uses_url_without_storage_row tests/unit/test_api_rclone.py::test_import_direct_borg2_rclone_repository_verifies_url_without_hydrate tests/unit/test_api_rclone.py::test_get_direct_borg2_rclone_repository_reports_direct_storage_backend tests/unit/test_api_rclone.py::test_update_direct_borg2_rclone_repository_accepts_noop_form_fields tests/unit/test_v2_backup_service.py -q`.
+- [x] Run the targeted backend pytest batch for Borg 2, direct rclone
+  repository API handling, and v2 backup service behavior.
 - [x] Run `ruff check app tests`.
 - [x] Run `ruff format --check app tests`.
-- [x] Run a dev-stack smoke check that creates a Borg 2 Direct rclone repository through the API, reloads it, and runs a backup through Borg 2.
+- [x] Run a dev-stack smoke check that creates a Borg 2 Direct rclone
+  repository through the API, reloads it, and runs a backup through Borg 2.
 - [x] Record validation results in the Linear workpad.

--- a/docs/engineering/plans/2026-06-12-direct-borg2-rclone-config.md
+++ b/docs/engineering/plans/2026-06-12-direct-borg2-rclone-config.md
@@ -1,0 +1,40 @@
+# Direct Borg 2 Rclone Config Implementation Plan
+
+**Goal:** Ensure Direct Borg 2 rclone repositories use Borg UI's managed rclone configuration for repository creation, verification, backup, and maintenance commands.
+
+**Architecture:** Borg UI stores rclone remotes in the managed config at `settings.rclone_config_root/rclone.conf`. Cloud Mirror passes that config to the `rclone` CLI explicitly, while Borg 2 direct rclone commands run through `app/core/borg2.py`. The fix belongs in the Borg 2 command environment so every Borg 2 subprocess can resolve Borg UI-managed rclone remotes without per-call special cases.
+
+**Tech Stack:** Python, FastAPI service layer, Borg 2 command wrapper, pytest.
+
+---
+
+### Task 1: Reproduce Missing Rclone Config in Borg 2 Process Env
+
+**Files:**
+- Modify: `tests/unit/test_borg2.py`
+
+- [x] Add a failing pytest that calls `borg2.rcreate("rclone://prod-s3/borg-ui/direct", encryption="none")` with `asyncio.create_subprocess_exec` patched.
+- [x] Capture the subprocess `env` argument and assert `RCLONE_CONFIG` equals `<settings.rclone_config_root>/rclone.conf`.
+- [x] Run `pytest tests/unit/test_borg2.py::test_rcreate_injects_managed_rclone_config_into_process_env -q` and confirm it fails because `RCLONE_CONFIG` is missing.
+
+### Task 2: Inject Managed Rclone Config Centrally
+
+**Files:**
+- Modify: `app/core/borg2.py`
+
+- [x] Update `Borg2Interface._base_env` to set `RCLONE_CONFIG` to `Path(settings.rclone_config_root) / "rclone.conf"` before merging explicit per-call env overrides.
+- [x] Preserve explicit per-call `env["RCLONE_CONFIG"]` overrides by keeping the existing final `env.update(extra)` merge.
+- [x] Run the targeted pytest from Task 1 and confirm it passes.
+
+### Task 3: Validate Direct Rclone Regression Surface
+
+**Files:**
+- Test: `tests/unit/test_borg2.py`
+- Test: `tests/unit/test_api_rclone.py`
+- Test: `tests/unit/test_v2_backup_service.py`
+
+- [x] Run `pytest tests/unit/test_borg2.py tests/unit/test_api_rclone.py::test_create_direct_borg2_rclone_repository_uses_url_without_storage_row tests/unit/test_api_rclone.py::test_import_direct_borg2_rclone_repository_verifies_url_without_hydrate tests/unit/test_api_rclone.py::test_get_direct_borg2_rclone_repository_reports_direct_storage_backend tests/unit/test_api_rclone.py::test_update_direct_borg2_rclone_repository_accepts_noop_form_fields tests/unit/test_v2_backup_service.py -q`.
+- [x] Run `ruff check app tests`.
+- [x] Run `ruff format --check app tests`.
+- [x] Run a dev-stack smoke check that creates a Borg 2 Direct rclone repository through the API, reloads it, and runs a backup through Borg 2.
+- [x] Record validation results in the Linear workpad.

--- a/tests/unit/test_borg2.py
+++ b/tests/unit/test_borg2.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from app.config import settings
 from app.core.borg2 import borg2
 
 
@@ -88,3 +89,45 @@ async def test_extract_archive_uses_restore_umask():
         cwd="/restore",
         env=None,
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rcreate_injects_managed_rclone_config_into_process_env(
+    monkeypatch, tmp_path
+):
+    rclone_root = tmp_path / "rclone"
+    monkeypatch.setattr(settings, "rclone_config_root", str(rclone_root))
+    captured: dict[str, object] = {}
+
+    class Process:
+        returncode = 0
+
+        async def communicate(self):
+            return b"", b""
+
+    async def create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return Process()
+
+    monkeypatch.setattr(
+        "app.core.borg2.asyncio.create_subprocess_exec",
+        create_subprocess_exec,
+    )
+
+    result = await borg2.rcreate(
+        repository="rclone://prod-s3/borg-ui/direct",
+        encryption="none",
+    )
+
+    assert result["success"] is True
+    assert captured["cmd"] == (
+        borg2.borg_cmd,
+        "-r",
+        "rclone://prod-s3/borg-ui/direct",
+        "repo-create",
+        "--encryption",
+        "none",
+    )
+    assert captured["env"]["RCLONE_CONFIG"] == str(rclone_root / "rclone.conf")


### PR DESCRIPTION
## Description
Fixes direct Borg 2 rclone repositories by passing Borg UI's managed rclone config into every Borg 2 subprocess environment. This lets Borg's rclone transport resolve remotes that Borg UI created in `/data/rclone/rclone.conf` instead of failing as an unknown or missing repository.

The change also adds regression coverage for Borg 2 repository creation and records the BOR-174 implementation plan.

## Related Issue
Fixes #672

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands and walkthroughs run:

- `pytest tests/unit/test_borg2.py tests/unit/test_api_rclone.py::test_create_direct_borg2_rclone_repository_uses_url_without_storage_row tests/unit/test_api_rclone.py::test_import_direct_borg2_rclone_repository_verifies_url_without_hydrate tests/unit/test_api_rclone.py::test_get_direct_borg2_rclone_repository_reports_direct_storage_backend tests/unit/test_api_rclone.py::test_update_direct_borg2_rclone_repository_accepts_noop_form_fields tests/unit/test_v2_backup_service.py -q`
- `ruff==0.15.16 check app tests`
- `ruff==0.15.16 format --check app tests`
- `cd frontend && npm test -- --run src/components/__tests__/RepositoryWizard.test.tsx -t "direct Borg 2 rclone"`
- Dev stack smoke: created a managed local rclone remote through the API, created a Borg 2 `rclone_direct` repository, reloaded it with `storage_backend: rclone_direct`, and completed a backup job with one file.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; this is a backend direct-rclone command environment fix.

## Additional Context
Direct Borg 2 rclone repositories rely on Borg's rclone subprocess support. Cloud Mirror already passes the managed rclone config directly to the rclone CLI; direct Borg 2 mode needed the equivalent config path in the Borg subprocess environment.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Borg 2 now uses the application's managed rclone configuration for direct rclone-backed repositories, improving remote storage reliability.

* **Tests**
  * Added a unit test that verifies the managed rclone configuration is provided to Borg 2 subprocesses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->