### PR TITLE
Prevent false repository check failure notifications

### DIFF
--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -129,6 +129,7 @@ AGENT_REPOSITORY_INIT_CAPABILITY = "repository.init"
 DIRECT_RCLONE_STORAGE_BACKEND = "rclone_direct"
 RCLONE_FEATURE = "rclone"
 MANAGED_AGENTS_FEATURE = "managed_agents"
+ACTIVE_MAINTENANCE_JOB_STATUSES = ("pending", "running")
 
 # Initialize Borg interface
 borg = BorgInterface()
@@ -6314,19 +6315,28 @@ async def get_running_jobs(
 
         check_job = (
             db.query(CheckJob)
-            .filter(CheckJob.repository_id == repo_id, CheckJob.status == "running")
+            .filter(
+                CheckJob.repository_id == repo_id,
+                CheckJob.status.in_(ACTIVE_MAINTENANCE_JOB_STATUSES),
+            )
             .first()
         )
 
         compact_job = (
             db.query(CompactJob)
-            .filter(CompactJob.repository_id == repo_id, CompactJob.status == "running")
+            .filter(
+                CompactJob.repository_id == repo_id,
+                CompactJob.status.in_(ACTIVE_MAINTENANCE_JOB_STATUSES),
+            )
             .first()
         )
 
         prune_job = (
             db.query(PruneJob)
-            .filter(PruneJob.repository_id == repo_id, PruneJob.status == "running")
+            .filter(
+                PruneJob.repository_id == repo_id,
+                PruneJob.status.in_(ACTIVE_MAINTENANCE_JOB_STATUSES),
+            )
             .first()
         )
 
@@ -6334,7 +6344,7 @@ async def get_running_jobs(
             db.query(RestoreCheckJob)
             .filter(
                 RestoreCheckJob.repository_id == repo_id,
-                RestoreCheckJob.status == "running",
+                RestoreCheckJob.status.in_(ACTIVE_MAINTENANCE_JOB_STATUSES),
             )
             .first()
         )
@@ -6354,6 +6364,7 @@ async def get_running_jobs(
             ),
             "check_job": {
                 "id": check_job.id,
+                "status": check_job.status,
                 "progress": check_job.progress,
                 "progress_message": check_job.progress_message,
                 "started_at": serialize_datetime(check_job.started_at),
@@ -6362,6 +6373,7 @@ async def get_running_jobs(
             else None,
             "compact_job": {
                 "id": compact_job.id,
+                "status": compact_job.status,
                 "progress": compact_job.progress,
                 "progress_message": compact_job.progress_message,
                 "started_at": serialize_datetime(compact_job.started_at),
@@ -6370,12 +6382,14 @@ async def get_running_jobs(
             else None,
             "prune_job": {
                 "id": prune_job.id,
+                "status": prune_job.status,
                 "started_at": serialize_datetime(prune_job.started_at),
             }
             if prune_job
             else None,
             "restore_check_job": {
                 "id": restore_check_job.id,
+                "status": restore_check_job.status,
                 "progress": restore_check_job.progress,
                 "progress_message": restore_check_job.progress_message,
                 "started_at": serialize_datetime(restore_check_job.started_at),

--- a/frontend/src/components/RepositoryCard.tsx
+++ b/frontend/src/components/RepositoryCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Box, Typography, Button, IconButton, Tooltip, Chip, useTheme, alpha } from '@mui/material'
 import { format, isTomorrow, isToday, isThisYear } from 'date-fns'
@@ -112,6 +112,7 @@ export default function RepositoryCard({
     repository.id,
     true
   )
+  const hasObservedTrackedJobRef = useRef(false)
   const isMaintenanceRunning = hasRunningJobs
   const hasManualBackupSources = Boolean(repository.source_directories?.length)
   const canCreatePlan = Boolean(onCreateBackupPlan) && canDo('backup') && repository.mode === 'full'
@@ -181,7 +182,18 @@ export default function RepositoryCard({
   ])
 
   useEffect(() => {
-    if (!hasRunningJobs && isInJobsSet) {
+    if (!isInJobsSet) {
+      hasObservedTrackedJobRef.current = false
+      return
+    }
+
+    if (hasRunningJobs) {
+      hasObservedTrackedJobRef.current = true
+      return
+    }
+
+    if (hasObservedTrackedJobRef.current) {
+      hasObservedTrackedJobRef.current = false
       onJobCompleted?.(repository.id)
       queryClient.invalidateQueries({ queryKey: ['repositories'] })
     }

--- a/frontend/src/components/__tests__/RepositoryCard.test.tsx
+++ b/frontend/src/components/__tests__/RepositoryCard.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { QueryClient } from '@tanstack/react-query'
 import { renderWithProviders } from '../../test/test-utils'
 import RepositoryCard from '../RepositoryCard'
 import * as useMaintenanceJobsModule from '../../hooks/useMaintenanceJobs'
@@ -842,6 +843,25 @@ describe('RepositoryCard', () => {
   })
 
   describe('Maintenance Jobs', () => {
+    it('waits to observe a running job before announcing completion', () => {
+      vi.spyOn(useMaintenanceJobsModule, 'useMaintenanceJobs').mockReturnValue({
+        ...mockMaintenanceJobs,
+        hasRunningJobs: false,
+      })
+
+      renderWithProviders(
+        <RepositoryCard
+          repository={mockRepository}
+          isInJobsSet={true}
+          canManageRepository={true}
+          getCompressionLabel={mockGetCompressionLabel}
+          {...mockCallbacks}
+        />
+      )
+
+      expect(mockCallbacks.onJobCompleted).not.toHaveBeenCalled()
+    })
+
     it('disables all action buttons when maintenance is running', () => {
       vi.spyOn(useMaintenanceJobsModule, 'useMaintenanceJobs').mockReturnValue({
         ...mockMaintenanceJobs,
@@ -948,7 +968,16 @@ describe('RepositoryCard', () => {
     })
 
     it('calls onJobCompleted and invalidates queries when jobs complete', async () => {
-      // Start with running jobs
+      const invalidateQueriesSpy = vi
+        .spyOn(QueryClient.prototype, 'invalidateQueries')
+        .mockResolvedValue()
+      const maintenanceJobsSpy = vi
+        .spyOn(useMaintenanceJobsModule, 'useMaintenanceJobs')
+        .mockReturnValue({
+          ...mockMaintenanceJobs,
+          hasRunningJobs: true,
+        })
+
       const { rerender } = renderWithProviders(
         <RepositoryCard
           repository={mockRepository}
@@ -959,14 +988,7 @@ describe('RepositoryCard', () => {
         />
       )
 
-      // Initial state: jobs running
-      vi.spyOn(useMaintenanceJobsModule, 'useMaintenanceJobs').mockReturnValue({
-        ...mockMaintenanceJobs,
-        hasRunningJobs: true,
-      })
-
-      // Jobs complete
-      vi.spyOn(useMaintenanceJobsModule, 'useMaintenanceJobs').mockReturnValue({
+      maintenanceJobsSpy.mockReturnValue({
         ...mockMaintenanceJobs,
         hasRunningJobs: false,
       })
@@ -984,6 +1006,7 @@ describe('RepositoryCard', () => {
 
       await waitFor(() => {
         expect(mockCallbacks.onJobCompleted).toHaveBeenCalledWith(mockRepository.id)
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ['repositories'] })
       })
     })
   })

--- a/tests/unit/test_api_repositories.py
+++ b/tests/unit/test_api_repositories.py
@@ -2912,6 +2912,47 @@ class TestRepositoriesJobStatus:
 
         assert response.status_code == 200
 
+    @pytest.mark.parametrize(
+        "job_model,response_key",
+        [
+            (CheckJob, "check_job"),
+            (CompactJob, "compact_job"),
+            (PruneJob, "prune_job"),
+            (RestoreCheckJob, "restore_check_job"),
+        ],
+    )
+    def test_get_repository_running_jobs_includes_pending_maintenance_job(
+        self, test_client: TestClient, admin_headers, test_db, job_model, response_key
+    ):
+        """Pending maintenance jobs should be active while startup is settling."""
+        repo = Repository(
+            name=f"Pending {response_key} Repo",
+            path=f"/job/pending-{response_key}-repo",
+            encryption="none",
+            repository_type="local",
+        )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+
+        job = job_model(
+            repository_id=repo.id,
+            repository_path=repo.path,
+            status="pending",
+        )
+        test_db.add(job)
+        test_db.commit()
+
+        response = test_client.get(
+            f"/api/repositories/{repo.id}/running-jobs", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["has_running_jobs"] is True
+        assert data[response_key]["id"] == job.id
+        assert data[response_key]["status"] == "pending"
+
     def test_get_check_jobs_repository_not_found(
         self, test_client: TestClient, admin_headers
     ):


### PR DESCRIPTION
## Description
Fixes a race in repository check startup notifications. Borg v1 check starts return a pending maintenance job, but the repositories page could see `hasRunningJobs=false` before the polling endpoint observed the job and then announce completion/failure against older check history. This PR treats pending maintenance jobs as active in `/running-jobs` and makes `RepositoryCard` wait until it has observed an active tracked job before firing completion handling.

## Related Issue
Fixes #673

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing relevant tests pass locally

Commands run:
- `npm run test -- RepositoryCard.test.tsx -t "waits to observe a running job before announcing completion"`
- `npm run test -- RepositoryCard.test.tsx -t "calls onJobCompleted and invalidates queries when jobs complete"`
- `pytest tests/unit/test_api_repositories.py::TestRepositoriesJobStatus::test_get_repository_running_jobs_includes_pending_maintenance_job -q`
- `npm run test -- RepositoryCard.test.tsx Repositories.test.tsx`
- `pipx run --spec ruff==0.15.16 ruff check app tests && pipx run --spec ruff==0.15.16 ruff format --check app tests && pytest tests/unit/test_api_repositories.py::TestRepositoriesJobStatus -q && git diff --check`
- `npm run test -- RepositoryCard.test.tsx Repositories.test.tsx && npm run check:locales && npm run typecheck && npm run lint && npm run build`
- Targeted live smoke against a dev backend on `:8083`: created a Borg v1 repository, started a check, verified `/running-jobs` reported the check as active, and waited for the check job to complete.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, or verified no new comments were needed
- [x] I have made corresponding changes to the documentation, or verified none were needed
- [x] My changes generate no new warnings
- [x] New and existing relevant unit tests pass locally with my changes

Documentation and comments note: this is a state synchronization bug fix with no navigation, user-doc, visual, or Storybook surface change. No new code comments were needed because the guard and tests document the behavior.

## Screenshots (if applicable)
Not applicable. This fixes notification timing/state synchronization and is covered by regression tests plus live API smoke evidence.

## Additional Context
Local `ruff` on PATH is older than CI; backend validation was run with pinned `ruff==0.15.16` from `requirements.txt`. The Vite build emits the existing `webauthn.ts` dynamic/static import and large chunk warnings; no new warning class was introduced by this change.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- visual-regression:start -->
## Visual regression report
No visual changes detected: 0 changed, 0 added, 0 removed, 422 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-675/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/27403354811
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- None
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented premature job-completion notifications by only triggering callbacks after a tracked job has been observed.

* **New Features**
  * Maintenance jobs in "pending" are treated as active (not just "running").
  * Maintenance job responses now include each job's status.

* **Tests**
  * Added tests verifying "pending" jobs are reported as active and status fields are returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->