### PR TITLE
Fix repository edits blocked by unused rclone gate

### DIFF
--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -1441,7 +1441,7 @@ def _rclone_feature_gate_updates(
     update_data: dict[str, Any],
     requested_rclone_updates: set[str],
 ) -> set[str]:
-    if repo_data.cloud_mirror_enabled is not False:
+    if repo_data.cloud_mirror_enabled is True:
         return requested_rclone_updates
 
     exempt_updates = {"cloud_mirror_enabled"}

--- a/tests/unit/test_api_repositories.py
+++ b/tests/unit/test_api_repositories.py
@@ -33,6 +33,7 @@ from app.database.models import (
     LicensingState,
     PruneJob,
     Repository,
+    RepositoryStorage,
     RestoreCheckJob,
     ScheduledJob,
     SSHConnection,
@@ -1504,6 +1505,72 @@ class TestRepositoriesUpdate:
         )
 
         assert response.status_code == 200
+
+    def test_update_repository_allows_local_storage_noop_on_community_plan(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        _set_plan(test_db, "community")
+        repo = Repository(
+            name="Community Local Repo",
+            path="/tmp/community-local-repo",
+            encryption="none",
+            compression="lz4",
+            repository_type="local",
+        )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+
+        response = test_client.put(
+            f"/api/repositories/{repo.id}",
+            json={
+                "exclude_patterns": ["*.tmp"],
+                "storage_backend": "local",
+            },
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200, response.json()
+        test_db.refresh(repo)
+        assert repo.exclude_patterns == '["*.tmp"]'
+        assert (
+            test_db.query(RepositoryStorage)
+            .filter(RepositoryStorage.repository_id == repo.id)
+            .first()
+            is None
+        )
+
+    def test_update_repository_requires_rclone_feature_to_enable_cloud_mirror(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        _set_plan(test_db, "community")
+        repo = Repository(
+            name="Community Mirror Repo",
+            path="/tmp/community-mirror-repo",
+            encryption="none",
+            compression="lz4",
+            repository_type="local",
+        )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+
+        response = test_client.put(
+            f"/api/repositories/{repo.id}",
+            json={
+                "storage_backend": "local",
+                "cloud_mirror_enabled": True,
+            },
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == {
+            "key": "backend.errors.plan.featureNotAvailable",
+            "feature": "rclone",
+            "required": "pro",
+            "current": "community",
+        }
 
     def test_update_repository_compression(
         self, test_client: TestClient, admin_headers, test_db


### PR DESCRIPTION
## Description
- Fix repository update feature gating so community-plan users can save local repository edits when the form sends `storage_backend: "local"` and does not enable cloud mirror storage.
- Preserve the rclone feature gate when a request explicitly enables cloud mirror storage.

## Related Issue
Fixes #678
Linear: BOR-176

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [x] Test addition/improvement
- [ ] Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Relevant existing tests pass locally

Commands run:
- `pytest tests/unit/test_api_repositories.py::TestRepositoriesUpdate -q`
- `ruff 0.15.16: ruff check app tests`
- `ruff 0.15.16: ruff format --check app tests`
- `git diff --check`

## Checklist
- [ ] No `CONTRIBUTING.md` file is present in this checkout to review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No hard-to-understand code paths were introduced
- [x] Documentation changes are not needed for this backend regression fix
- [x] No new Ruff warnings are introduced
- [x] New and relevant existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable: backend-only API fix.

## Additional Context
Local shell `ruff` was version 0.14.0, while CI installs `ruff==0.15.16` from `requirements.txt`. The branch was validated with the CI-pinned Ruff version before the final push.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
