### PR TITLE
Fix repository source removal clearing all sources

### DIFF
--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -4531,9 +4531,24 @@ async def update_repository(
         )
         if source_settings_changed:
             if "source_locations" in update_data:
-                source_locations_input = repo_data.source_locations or []
-                source_directories_input = None
-                source_connection_id_input = None
+                if repo_data.source_locations:
+                    source_locations_input = repo_data.source_locations
+                    source_directories_input = None
+                    source_connection_id_input = None
+                elif "source_directories" in update_data and any(
+                    str(path).strip() for path in repo_data.source_directories or []
+                ):
+                    source_locations_input = None
+                    source_directories_input = repo_data.source_directories
+                    source_connection_id_input = (
+                        repo_data.source_connection_id
+                        if "source_connection_id" in update_data
+                        else repository.source_ssh_connection_id
+                    )
+                else:
+                    source_locations_input = []
+                    source_directories_input = None
+                    source_connection_id_input = None
             else:
                 source_locations_input = None
                 source_directories_input = (

--- a/tests/unit/test_api_repositories.py
+++ b/tests/unit/test_api_repositories.py
@@ -1764,6 +1764,95 @@ class TestRepositoriesUpdate:
         assert repo.source_directories is None
         assert repo.exclude_patterns is None
 
+    def test_update_repository_empty_source_locations_preserves_legacy_remaining_sources(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """A stale empty source_locations field must not clear non-empty source_directories."""
+        repo = Repository(
+            name="Source Removal Repo",
+            path="/tmp/source-removal-repo",
+            encryption="none",
+            compression="lz4",
+            repository_type="local",
+            source_directories=json.dumps(["/srv/old", "/srv/keep"]),
+            source_locations=json.dumps(
+                [
+                    {
+                        "source_type": "local",
+                        "source_ssh_connection_id": None,
+                        "agent_machine_id": None,
+                        "paths": ["/srv/old", "/srv/keep"],
+                    }
+                ]
+            ),
+        )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+
+        response = test_client.put(
+            f"/api/repositories/{repo.id}",
+            json={
+                "source_directories": ["/srv/keep"],
+                "source_locations": [],
+            },
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        test_db.refresh(repo)
+        assert json.loads(repo.source_directories) == ["/srv/keep"]
+        assert json.loads(repo.source_locations) == [
+            {
+                "source_type": "local",
+                "source_ssh_connection_id": None,
+                "agent_machine_id": None,
+                "paths": ["/srv/keep"],
+            }
+        ]
+
+    def test_update_repository_empty_source_locations_and_directories_clear_connection(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """Empty source fields clear stale remote source connection metadata."""
+        repo = Repository(
+            name="Remote Source Clear Repo",
+            path="/tmp/remote-source-clear-repo",
+            encryption="none",
+            compression="lz4",
+            repository_type="local",
+            source_ssh_connection_id=42,
+            source_directories=json.dumps(["/remote/old"]),
+            source_locations=json.dumps(
+                [
+                    {
+                        "source_type": "remote",
+                        "source_ssh_connection_id": 42,
+                        "agent_machine_id": None,
+                        "paths": ["/remote/old"],
+                    }
+                ]
+            ),
+        )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+
+        response = test_client.put(
+            f"/api/repositories/{repo.id}",
+            json={
+                "source_directories": [],
+                "source_locations": [],
+            },
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        test_db.refresh(repo)
+        assert repo.source_directories is None
+        assert repo.source_locations is None
+        assert repo.source_ssh_connection_id is None
+
     def test_update_repository_type_local_to_ssh(
         self, test_client: TestClient, admin_headers, test_db
     ):


### PR DESCRIPTION
## Description
Fixes the repository update path so removing one source path does not clear every source when the payload contains an empty stale `source_locations` list alongside the intended remaining `source_directories`.

The backend now falls back to `source_directories` in that stale-empty case and rebuilds compatible `source_locations` only when at least one source path remains. Explicit empty source lists still clear source settings, including legacy source connection metadata.

## Related Issue
Fixes #683

Linear: BOR-179

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing targeted tests pass

Commands and proof:

- `pytest tests/unit/test_api_repositories.py::TestRepositoriesUpdate::test_update_repository_empty_source_locations_preserves_legacy_remaining_sources tests/unit/test_api_repositories.py::TestRepositoriesUpdate::test_update_repository_empty_source_locations_and_directories_clear_connection -q`
- `pytest tests/unit/test_api_repositories.py::TestRepositoriesUpdate -q`
- `ruff==0.15.16 check app tests`
- `ruff==0.15.16 format --check app tests`
- Runtime API proof with `docker compose -p borg-ui-dev -f docker-compose.dev.yml up -d --build --force-recreate app`: create a repository with two source paths, submit an update with one remaining `source_directories` path and `source_locations: []`, then confirm GET `/api/repositories/{id}` returns only the remaining source and rebuilt local `source_locations`.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Comments were not required for this small branch-local control-flow change
- [x] Documentation changes are not required for this backend bug fix
- [x] My changes generate no new warnings
- [x] New and existing targeted unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; this is a backend repository update fix.

## Additional Context
Local validation used the repo-pinned `ruff==0.15.16` so formatter output matches GitHub Actions.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository source configuration updates now correctly interpret partial source changes. When `source_locations` is provided (including as an empty list), legacy source directories and related connection details are updated appropriately instead of being incorrectly cleared.

* **Tests**
  * Added unit test coverage for `source_locations` + legacy `source_directories` update interactions, including cases where empty lists should preserve remaining sources and where empty inputs should clear connection metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->