### PR TITLE
feat(repositories): allow ssh:// repositories for managed agents

### DIFF
--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -2006,11 +2006,16 @@ def _reject_agent_repository_ssh_target(
     connection_id: Optional[int],
     execution_target: Optional[str],
 ) -> None:
-    if (
-        connection_id
-        or (path or "").strip().startswith("ssh://")
-        or (execution_target or "").strip().lower() == "ssh"
-    ):
+    """Reject only a server-managed SSH connection for an agent repository.
+
+    An agent reaches its repository over its OWN SSH setup (mounted key /
+    known_hosts), so ``ssh://`` paths and ``execution_target="ssh"`` are fully
+    supported: the agent backup/operation payload already carries the path +
+    remote_path and the agent runs ``borg ... --remote-path`` itself. Only a
+    server-managed ``connection_id`` (an ``ssh_connections`` row that only the
+    Borg UI server can use, not the agent) stays unsupported.
+    """
+    if connection_id:
         raise HTTPException(
             status_code=400,
             detail={"key": "backend.errors.repo.agentRepositorySshUnsupported"},

--- a/tests/unit/test_api_repositories.py
+++ b/tests/unit/test_api_repositories.py
@@ -904,6 +904,60 @@ class TestRepositoriesCreate:
         assert repo.connection_id is None
         assert repo.repository_type == "local"
 
+    def test_create_agent_repository_accepts_ssh_path(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """Agent repos may target ssh:// with an explicit ``execution_target=ssh``;
+        the agent uses its own SSH credentials, so the server accepts it."""
+        agent = AgentMachine(
+            name="SSH Owner",
+            agent_id="agt_ssh_owner",
+            token_hash=get_password_hash("borgui_agent_secret"),
+            token_prefix="borgui_agent_secret"[:20],
+            status="online",
+            capabilities=["repository.init"],
+        )
+        test_db.add(agent)
+        test_db.commit()
+        test_db.refresh(agent)
+
+        with (
+            patch(
+                "app.api.repositories.initialize_borg_repository",
+                new=AsyncMock(return_value={"success": True}),
+            ),
+            patch(
+                "app.api.repositories.wait_for_agent_repository_operation_job",
+                new=AsyncMock(return_value={"status": "completed"}),
+            ),
+            patch("app.api.repositories.mqtt_service.sync_state_with_db"),
+        ):
+            response = test_client.post(
+                "/api/repositories/",
+                json={
+                    "name": "Agent SSH Repo",
+                    "path": "ssh://u123456@u123456.your-storagebox.de:23/./repo",
+                    "encryption": "none",
+                    "compression": "lz4",
+                    "source_directories": ["/data"],
+                    "executor_type": "agent",
+                    "execution_target": "ssh",
+                    "agent_machine_id": agent.id,
+                    "borg_version": 1,
+                    "remote_path": "borg-1.4",
+                },
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        repo = test_db.query(Repository).filter_by(name="Agent SSH Repo").one()
+        assert repo.executor_type == "agent"
+        assert repo.execution_target == "agent"
+        assert repo.path == "ssh://u123456@u123456.your-storagebox.de:23/./repo"
+        assert repo.borg_version == 1
+        assert repo.remote_path == "borg-1.4"
+        assert repo.connection_id is None
+
     def test_update_agent_repository_rejects_ssh_target(
         self, test_client: TestClient, admin_headers, test_db
     ):


### PR DESCRIPTION
## Description

Agent-owned repositories are rejected for any `ssh://` path, a
`connection_id`, or `execution_target=ssh`
(`_reject_agent_repository_ssh_target`). However, the **execution path
already fully supports ssh:// for agents**:

- `agent/borg_ui_agent/backup.py` (`BackupCreatePayload.build_command`)
  uses the `borg` (v1) binary for `borg_version == 1`, passes the
  repository path verbatim, and appends `--remote-path` when set.
- `app/services/repository_executor.py` puts `path`, `borg_version` and
  `remote_path` into both the backup and repository-operation payloads.
- The runtime gate `validate_agent_backup_repository` does not inspect the
  path scheme at all.

So an agent can already run `borg -r ssh://… --remote-path=borg-1.4
create/check` over its own mounted SSH key — only the create/import
**validation guard** prevented configuring it. In practice this blocks the
common, fast setup of backing up node-local data to a **Hetzner Storage
Box via server-side borg-1.4** (ssh), forcing borg2+sftp (dumb storage,
much slower) instead.

### Change
Narrow the guard to reject only a **server-managed `connection_id`** (an
`ssh_connections` row that only the server can use). `ssh://` paths and
`execution_target=ssh` are now accepted for agent repositories; the agent
supplies its own SSH credentials.

### Notes
- The two existing tests assert `connection_id` rejection and remain green.
- Added `test_create_agent_repository_accepts_ssh_path`.
- `_create_agent_repository_record` still records `repository_type="local"`
  for agent repos; that's metadata (the agent backs up via `path`), so it's
  left unchanged — happy to derive it from the scheme if you'd prefer.

## Type of Change
- [x] New feature (non-breaking)

## Testing
- `tests/unit/test_api_repositories.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent-managed repository creation now supports `ssh://...` paths with `execution_target="ssh"` when no server-side connection is specified.
  * Repository details are now persisted correctly for agent-based SSH setups, including the SSH URL and related remote/Borg information.
* **Tests**
  * Added a unit test covering agent-managed `ssh://...` repository creation and verifying the saved execution/executor settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->