### PR TITLE
Filter activity by completed-with-warnings jobs

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1523,6 +1523,7 @@
       },
       "statuses": {
         "completed": "Abgeschlossen",
+        "completedWithWarnings": "Abgeschlossen mit Warnungen",
         "needsBackup": "Backup erforderlich",
         "failed": "Fehlgeschlagen",
         "running": "Läuft",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1504,6 +1504,9 @@
   "activity": {
     "title": "Aktivität",
     "subtitle": "Alle Vorgänge und ihre Protokolle anzeigen",
+    "actions": {
+      "refresh": "Aktivität aktualisieren"
+    },
     "filters": {
       "type": "Typ",
       "status": "Status",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1504,6 +1504,9 @@
   "activity": {
     "title": "Activity",
     "subtitle": "View all operations and their logs",
+    "actions": {
+      "refresh": "Refresh activity"
+    },
     "filters": {
       "type": "Type",
       "status": "Status",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1523,6 +1523,7 @@
       },
       "statuses": {
         "completed": "Completed",
+        "completedWithWarnings": "Completed with Warnings",
         "needsBackup": "Needs backup",
         "failed": "Failed",
         "running": "Running",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -1523,6 +1523,7 @@
       },
       "statuses": {
         "completed": "Completado",
+        "completedWithWarnings": "Completado con advertencias",
         "needsBackup": "Necesita copia",
         "failed": "Fallido",
         "running": "En ejecución",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -1504,6 +1504,9 @@
   "activity": {
     "title": "Actividad",
     "subtitle": "Ver todas las operaciones y sus registros",
+    "actions": {
+      "refresh": "Actualizar actividad"
+    },
     "filters": {
       "type": "Tipo",
       "status": "Estado",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -1504,6 +1504,9 @@
   "activity": {
     "title": "Attività",
     "subtitle": "Visualizza tutte le operazioni e i relativi log",
+    "actions": {
+      "refresh": "Aggiorna attività"
+    },
     "filters": {
       "type": "Tipo",
       "status": "Stato",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -1523,6 +1523,7 @@
       },
       "statuses": {
         "completed": "Completato",
+        "completedWithWarnings": "Completato con avvisi",
         "needsBackup": "Backup richiesto",
         "failed": "Fallito",
         "running": "In Esecuzione",

--- a/frontend/src/pages/Activity.tsx
+++ b/frontend/src/pages/Activity.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useQuery } from '@tanstack/react-query'
-import { Box, IconButton, MenuItem, Select, Typography } from '@mui/material'
+import { Box, IconButton, Typography } from '@mui/material'
 import { History, Info, RefreshCw } from 'lucide-react'
 import { activityAPI, repositoriesAPI } from '../services/api'
 import { useAnalytics } from '../hooks/useAnalytics'
@@ -10,8 +10,9 @@ import { useLockBreakPermissions } from '../hooks/useLockBreakPermissions'
 import BackupJobsTable from '../components/BackupJobsTable'
 import LogViewerDialog from '../components/LogViewerDialog'
 import RunningCloudStorageJobsSection from '../components/RunningCloudStorageJobsSection'
+import { ActivityFilters } from './activity/ActivityFilters'
 
-interface ActivityItem {
+export interface ActivityItem {
   id: number
   type: string
   status: string
@@ -33,62 +34,34 @@ interface ActivityItem {
   has_logs?: boolean
 }
 
-const Activity: React.FC = () => {
+interface ActivityContentProps {
+  activities?: ActivityItem[]
+  isLoading: boolean
+  typeFilter: string
+  statusFilter: string
+  onTypeFilterChange: (value: string) => void
+  onStatusFilterChange: (value: string) => void
+  onRefresh: () => void
+  canManageActivityJobs: boolean
+  canBreakLockForActivity: (job: ActivityItem) => boolean
+  lockBreakingEnabled: boolean
+}
+
+export function ActivityContent({
+  activities,
+  isLoading,
+  typeFilter,
+  statusFilter,
+  onTypeFilterChange,
+  onStatusFilterChange,
+  onRefresh,
+  canManageActivityJobs,
+  canBreakLockForActivity,
+  lockBreakingEnabled,
+}: ActivityContentProps) {
   const { t } = useTranslation()
-  const { track, EventCategory, EventAction } = useAnalytics()
-  const { hasGlobalPermission } = useAuth()
-  const canManageActivityJobs = hasGlobalPermission('repositories.manage_all')
-  const [typeFilter, setTypeFilter] = useState<string>('all')
-  const [statusFilter, setStatusFilter] = useState<string>('all')
   const [logJob, setLogJob] = useState<ActivityItem | null>(null)
 
-  // Fetch activity data
-  const {
-    data: activities,
-    isLoading,
-    refetch,
-  } = useQuery({
-    queryKey: ['activity', typeFilter, statusFilter],
-    queryFn: async () => {
-      const params: Record<string, unknown> = { limit: 200 }
-      if (typeFilter !== 'all') params.job_type = typeFilter
-      if (statusFilter !== 'all') params.status = statusFilter
-
-      const response = await activityAPI.list(params)
-      return response.data
-    },
-    refetchInterval: 3000, // Refresh every 3 seconds
-  })
-
-  const { data: repositoriesData } = useQuery({
-    queryKey: ['repositories'],
-    queryFn: repositoriesAPI.getRepositories,
-  })
-  const repositories = React.useMemo(
-    () => repositoriesData?.data?.repositories ?? [],
-    [repositoriesData?.data?.repositories]
-  )
-  const { canBreakLock: canBreakLockForActivity, lockBreakingEnabled } = useLockBreakPermissions({
-    repositories,
-  })
-
-  const handleTypeFilterChange = (value: string) => {
-    setTypeFilter(value)
-    track(EventCategory.NAVIGATION, EventAction.FILTER, {
-      filter_kind: 'type',
-      filter_value: value,
-    })
-  }
-
-  const handleStatusFilterChange = (value: string) => {
-    setStatusFilter(value)
-    track(EventCategory.NAVIGATION, EventAction.FILTER, {
-      filter_kind: 'status',
-      filter_value: value,
-    })
-  }
-
-  // Just return all activities without grouping
   const processedActivities = React.useMemo(() => {
     if (!activities) return { grouped: [], individual: [] }
     return { grouped: [], individual: activities }
@@ -126,7 +99,7 @@ const Activity: React.FC = () => {
           </Box>
         </Box>
         <IconButton
-          onClick={() => refetch()}
+          onClick={onRefresh}
           title="Refresh"
           sx={{ alignSelf: { xs: 'flex-end', sm: 'auto' } }}
         >
@@ -134,43 +107,12 @@ const Activity: React.FC = () => {
         </IconButton>
       </Box>
 
-      {/* Filters */}
-      <Box sx={{ mb: 3, display: 'flex', flexWrap: 'wrap', gap: 1.5, alignItems: 'center' }}>
-        <Select
-          size="small"
-          value={typeFilter}
-          onChange={(e) => handleTypeFilterChange(e.target.value)}
-          sx={{ minWidth: 160, fontSize: '0.8rem', fontWeight: 600, borderRadius: 1.5 }}
-        >
-          <MenuItem value="all">{t('activity.filters.allTypes')}</MenuItem>
-          <MenuItem value="backup">{t('activity.filters.types.backup')}</MenuItem>
-          <MenuItem value="restore">{t('activity.filters.types.restore')}</MenuItem>
-          <MenuItem value="restore_check">{t('activity.filters.types.restoreCheck')}</MenuItem>
-          <MenuItem value="check">{t('activity.filters.types.check')}</MenuItem>
-          <MenuItem value="compact">{t('activity.filters.types.compact')}</MenuItem>
-          <MenuItem value="prune">{t('activity.filters.types.prune')}</MenuItem>
-          <MenuItem value="package">{t('activity.filters.types.package')}</MenuItem>
-          <MenuItem value="rclone_sync">{t('activity.filters.types.rcloneSync')}</MenuItem>
-          <MenuItem value="rclone_hydrate">{t('activity.filters.types.rcloneHydrate')}</MenuItem>
-          <MenuItem value="script_execution">
-            {t('activity.filters.types.scriptExecution')}
-          </MenuItem>
-        </Select>
-
-        <Select
-          size="small"
-          value={statusFilter}
-          onChange={(e) => handleStatusFilterChange(e.target.value)}
-          sx={{ minWidth: 140, fontSize: '0.8rem', fontWeight: 600, borderRadius: 1.5 }}
-        >
-          <MenuItem value="all">{t('activity.filters.allStatus')}</MenuItem>
-          <MenuItem value="completed">{t('activity.filters.statuses.completed')}</MenuItem>
-          <MenuItem value="needs_backup">{t('activity.filters.statuses.needsBackup')}</MenuItem>
-          <MenuItem value="failed">{t('activity.filters.statuses.failed')}</MenuItem>
-          <MenuItem value="running">{t('activity.filters.statuses.running')}</MenuItem>
-          <MenuItem value="pending">{t('activity.filters.statuses.pending')}</MenuItem>
-        </Select>
-      </Box>
+      <ActivityFilters
+        typeFilter={typeFilter}
+        statusFilter={statusFilter}
+        onTypeFilterChange={onTypeFilterChange}
+        onStatusFilterChange={onStatusFilterChange}
+      />
 
       <RunningCloudStorageJobsSection
         jobs={activeCloudStorageJobs}
@@ -228,6 +170,75 @@ const Activity: React.FC = () => {
       )}
       <LogViewerDialog job={logJob} open={Boolean(logJob)} onClose={() => setLogJob(null)} />
     </Box>
+  )
+}
+
+const Activity: React.FC = () => {
+  const { track, EventCategory, EventAction } = useAnalytics()
+  const { hasGlobalPermission } = useAuth()
+  const canManageActivityJobs = hasGlobalPermission('repositories.manage_all')
+  const [typeFilter, setTypeFilter] = useState<string>('all')
+  const [statusFilter, setStatusFilter] = useState<string>('all')
+
+  // Fetch activity data
+  const {
+    data: activities,
+    isLoading,
+    refetch,
+  } = useQuery({
+    queryKey: ['activity', typeFilter, statusFilter],
+    queryFn: async () => {
+      const params: Record<string, unknown> = { limit: 200 }
+      if (typeFilter !== 'all') params.job_type = typeFilter
+      if (statusFilter !== 'all') params.status = statusFilter
+
+      const response = await activityAPI.list(params)
+      return response.data
+    },
+    refetchInterval: 3000, // Refresh every 3 seconds
+  })
+
+  const { data: repositoriesData } = useQuery({
+    queryKey: ['repositories'],
+    queryFn: repositoriesAPI.getRepositories,
+  })
+  const repositories = React.useMemo(
+    () => repositoriesData?.data?.repositories ?? [],
+    [repositoriesData?.data?.repositories]
+  )
+  const { canBreakLock: canBreakLockForActivity, lockBreakingEnabled } = useLockBreakPermissions({
+    repositories,
+  })
+
+  const handleTypeFilterChange = (value: string) => {
+    setTypeFilter(value)
+    track(EventCategory.NAVIGATION, EventAction.FILTER, {
+      filter_kind: 'type',
+      filter_value: value,
+    })
+  }
+
+  const handleStatusFilterChange = (value: string) => {
+    setStatusFilter(value)
+    track(EventCategory.NAVIGATION, EventAction.FILTER, {
+      filter_kind: 'status',
+      filter_value: value,
+    })
+  }
+
+  return (
+    <ActivityContent
+      activities={activities}
+      isLoading={isLoading}
+      typeFilter={typeFilter}
+      statusFilter={statusFilter}
+      onTypeFilterChange={handleTypeFilterChange}
+      onStatusFilterChange={handleStatusFilterChange}
+      onRefresh={() => refetch()}
+      canManageActivityJobs={canManageActivityJobs}
+      canBreakLockForActivity={canBreakLockForActivity}
+      lockBreakingEnabled={lockBreakingEnabled}
+    />
   )
 }
 

--- a/frontend/src/pages/Activity.tsx
+++ b/frontend/src/pages/Activity.tsx
@@ -75,6 +75,7 @@ export function ActivityContent({
       ),
     [activities]
   )
+  const refreshLabel = t('activity.actions.refresh')
 
   return (
     <Box>
@@ -100,7 +101,8 @@ export function ActivityContent({
         </Box>
         <IconButton
           onClick={onRefresh}
-          title="Refresh"
+          aria-label={refreshLabel}
+          title={refreshLabel}
           sx={{ alignSelf: { xs: 'flex-end', sm: 'auto' } }}
         >
           <RefreshCw size={20} />

--- a/frontend/src/pages/__tests__/Activity.test.tsx
+++ b/frontend/src/pages/__tests__/Activity.test.tsx
@@ -144,6 +144,21 @@ describe('Activity page', () => {
       filter_value: 'failed',
     })
 
+    fireEvent.mouseDown(screen.getAllByRole('combobox')[1])
+    await user.click(await screen.findByRole('option', { name: /completed with warnings/i }))
+
+    await waitFor(() => {
+      expect(activityAPI.list).toHaveBeenLastCalledWith({
+        limit: 200,
+        job_type: 'restore_check',
+        status: 'completed_with_warnings',
+      })
+    })
+    expect(track).toHaveBeenCalledWith('Navigation', 'Filter', {
+      filter_kind: 'status',
+      filter_value: 'completed_with_warnings',
+    })
+
     await user.click(screen.getByRole('button', { name: /refresh/i }))
     expect(refetchSpy).toHaveBeenCalled()
   })

--- a/frontend/src/pages/__tests__/Activity.test.tsx
+++ b/frontend/src/pages/__tests__/Activity.test.tsx
@@ -103,6 +103,12 @@ describe('Activity page', () => {
     renderWithProviders(<Activity />)
 
     expect(await screen.findByText('Jobs Table')).toBeInTheDocument()
+    const getTypeFilter = () => screen.getByRole('combobox', { name: /^type$/i })
+    const getStatusFilter = () => screen.getByRole('combobox', { name: /^status$/i })
+    const refreshButton = screen.getByRole('button', { name: /^refresh activity$/i })
+    expect(getTypeFilter()).toBeInTheDocument()
+    expect(getStatusFilter()).toBeInTheDocument()
+    expect(refreshButton).toHaveAttribute('title', 'Refresh activity')
     expect(activityAPI.list).toHaveBeenCalledWith({ limit: 200 })
     expect(jobsTablePropsSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -115,7 +121,7 @@ describe('Activity page', () => {
       })
     )
 
-    fireEvent.mouseDown(screen.getAllByRole('combobox')[0])
+    fireEvent.mouseDown(getTypeFilter())
     await user.click(await screen.findByRole('option', { name: /^Restore Check$/i }))
 
     await waitFor(() => {
@@ -129,7 +135,7 @@ describe('Activity page', () => {
       filter_value: 'restore_check',
     })
 
-    fireEvent.mouseDown(screen.getAllByRole('combobox')[1])
+    fireEvent.mouseDown(getStatusFilter())
     await user.click(await screen.findByRole('option', { name: /failed/i }))
 
     await waitFor(() => {
@@ -144,7 +150,7 @@ describe('Activity page', () => {
       filter_value: 'failed',
     })
 
-    fireEvent.mouseDown(screen.getAllByRole('combobox')[1])
+    fireEvent.mouseDown(getStatusFilter())
     await user.click(await screen.findByRole('option', { name: /completed with warnings/i }))
 
     await waitFor(() => {
@@ -159,7 +165,7 @@ describe('Activity page', () => {
       filter_value: 'completed_with_warnings',
     })
 
-    await user.click(screen.getByRole('button', { name: /refresh/i }))
+    await user.click(refreshButton)
     expect(refetchSpy).toHaveBeenCalled()
   })
 
@@ -204,7 +210,7 @@ describe('Activity page', () => {
     expect(screen.getByText('Cloud Mirror Repo')).toBeInTheDocument()
     expect(screen.getByText('Cloud Hydrate Repo')).toBeInTheDocument()
 
-    fireEvent.mouseDown(screen.getAllByRole('combobox')[0])
+    fireEvent.mouseDown(screen.getByRole('combobox', { name: /^type$/i }))
     await user.click(await screen.findByRole('option', { name: /^Cloud Sync$/i }))
 
     await waitFor(() => {

--- a/frontend/src/pages/activity/ActivityFilters.stories.tsx
+++ b/frontend/src/pages/activity/ActivityFilters.stories.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box } from '@mui/material'
+import { ActivityFilters } from './ActivityFilters'
+
+function ActivityFiltersStory({ initialStatusFilter = 'all' }: { initialStatusFilter?: string }) {
+  const [typeFilter, setTypeFilter] = useState('all')
+  const [statusFilter, setStatusFilter] = useState(initialStatusFilter)
+
+  return (
+    <Box sx={{ maxWidth: 1120, mx: 'auto', p: 3 }}>
+      <ActivityFilters
+        typeFilter={typeFilter}
+        statusFilter={statusFilter}
+        onTypeFilterChange={setTypeFilter}
+        onStatusFilterChange={setStatusFilter}
+      />
+    </Box>
+  )
+}
+
+const meta = {
+  title: 'Pages/Activity/ActivityFilters',
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const AllActivity: Story = {
+  render: () => <ActivityFiltersStory />,
+}
+
+export const CompletedWithWarningsFilter: Story = {
+  render: () => <ActivityFiltersStory initialStatusFilter="completed_with_warnings" />,
+}

--- a/frontend/src/pages/activity/ActivityFilters.tsx
+++ b/frontend/src/pages/activity/ActivityFilters.tsx
@@ -22,6 +22,7 @@ export function ActivityFilters({
         size="small"
         value={typeFilter}
         onChange={(event) => onTypeFilterChange(event.target.value)}
+        inputProps={{ 'aria-label': t('activity.filters.type') }}
         sx={{ minWidth: 160, fontSize: '0.8rem', fontWeight: 600, borderRadius: 1.5 }}
       >
         <MenuItem value="all">{t('activity.filters.allTypes')}</MenuItem>
@@ -41,6 +42,7 @@ export function ActivityFilters({
         size="small"
         value={statusFilter}
         onChange={(event) => onStatusFilterChange(event.target.value)}
+        inputProps={{ 'aria-label': t('activity.filters.status') }}
         sx={{ minWidth: 210, fontSize: '0.8rem', fontWeight: 600, borderRadius: 1.5 }}
       >
         <MenuItem value="all">{t('activity.filters.allStatus')}</MenuItem>

--- a/frontend/src/pages/activity/ActivityFilters.tsx
+++ b/frontend/src/pages/activity/ActivityFilters.tsx
@@ -1,0 +1,58 @@
+import { useTranslation } from 'react-i18next'
+import { Box, MenuItem, Select } from '@mui/material'
+
+interface ActivityFiltersProps {
+  typeFilter: string
+  statusFilter: string
+  onTypeFilterChange: (value: string) => void
+  onStatusFilterChange: (value: string) => void
+}
+
+export function ActivityFilters({
+  typeFilter,
+  statusFilter,
+  onTypeFilterChange,
+  onStatusFilterChange,
+}: ActivityFiltersProps) {
+  const { t } = useTranslation()
+
+  return (
+    <Box sx={{ mb: 3, display: 'flex', flexWrap: 'wrap', gap: 1.5, alignItems: 'center' }}>
+      <Select
+        size="small"
+        value={typeFilter}
+        onChange={(event) => onTypeFilterChange(event.target.value)}
+        sx={{ minWidth: 160, fontSize: '0.8rem', fontWeight: 600, borderRadius: 1.5 }}
+      >
+        <MenuItem value="all">{t('activity.filters.allTypes')}</MenuItem>
+        <MenuItem value="backup">{t('activity.filters.types.backup')}</MenuItem>
+        <MenuItem value="restore">{t('activity.filters.types.restore')}</MenuItem>
+        <MenuItem value="restore_check">{t('activity.filters.types.restoreCheck')}</MenuItem>
+        <MenuItem value="check">{t('activity.filters.types.check')}</MenuItem>
+        <MenuItem value="compact">{t('activity.filters.types.compact')}</MenuItem>
+        <MenuItem value="prune">{t('activity.filters.types.prune')}</MenuItem>
+        <MenuItem value="package">{t('activity.filters.types.package')}</MenuItem>
+        <MenuItem value="rclone_sync">{t('activity.filters.types.rcloneSync')}</MenuItem>
+        <MenuItem value="rclone_hydrate">{t('activity.filters.types.rcloneHydrate')}</MenuItem>
+        <MenuItem value="script_execution">{t('activity.filters.types.scriptExecution')}</MenuItem>
+      </Select>
+
+      <Select
+        size="small"
+        value={statusFilter}
+        onChange={(event) => onStatusFilterChange(event.target.value)}
+        sx={{ minWidth: 210, fontSize: '0.8rem', fontWeight: 600, borderRadius: 1.5 }}
+      >
+        <MenuItem value="all">{t('activity.filters.allStatus')}</MenuItem>
+        <MenuItem value="completed">{t('activity.filters.statuses.completed')}</MenuItem>
+        <MenuItem value="completed_with_warnings">
+          {t('activity.filters.statuses.completedWithWarnings')}
+        </MenuItem>
+        <MenuItem value="needs_backup">{t('activity.filters.statuses.needsBackup')}</MenuItem>
+        <MenuItem value="failed">{t('activity.filters.statuses.failed')}</MenuItem>
+        <MenuItem value="running">{t('activity.filters.statuses.running')}</MenuItem>
+        <MenuItem value="pending">{t('activity.filters.statuses.pending')}</MenuItem>
+      </Select>
+    </Box>
+  )
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ fastapi==0.136.3
 gunicorn==26.0.0
 httpx==0.28.1
 psutil==7.2.2
-pydantic-settings==2.14.1
+pydantic-settings==2.14.2
 pydantic==2.13.4
 pre-commit==4.6.0
 pytest-asyncio==1.4.0


### PR DESCRIPTION
## Description
Adds `Completed with Warnings` to the Activity status filter so users can isolate jobs whose backend status is `completed_with_warnings`. The Activity filter controls are extracted into a focused component for Storybook coverage, and locale/test coverage now includes the new option.

The Activity filter controls now expose localized accessible names, and the Activity refresh button uses a localized label for both `title` and `aria-label`.

This also bumps `pydantic-settings` from 2.14.1 to 2.14.2 to clear the fixable GHSA-4xgf-cpjx-pc3j finding reported by the required pip-audit PR check.

## Related Issue
Fixes #705

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [x] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Validation run:
- `cd frontend && npm run test -- src/pages/__tests__/Activity.test.tsx`
- `cd frontend && npm run check:locales`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `cd frontend && npm run build-storybook`
- `ruff check app tests`
- `ruff format --check app tests`
- `pytest tests/unit/test_api_activity.py -q`
- `git diff --check`

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No hard-to-understand code required additional comments
- [x] Documentation changes were not required because navigation and user flows did not change
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
No screenshot artifact is committed. The new Storybook state is available as `Pages/Activity/ActivityFilters/CompletedWithWarningsFilter`, and `npm run build-storybook` completed successfully.

## Additional Context
Headless Playwright visual inspection could not run on this host because required system browser libraries are missing (`libnspr4`, `libnss3`, `libatk1.0-0`, `libxdamage1`, `libxkbcommon0`, `libatspi2.0-0`). The Activity DOM interaction test opens the status dropdown, selects `Completed with Warnings`, verifies the API request uses `status: completed_with_warnings`, and now targets the filter controls and refresh button by localized accessible names.

Local pip-audit could not be run because neither `python3 -m pip_audit` nor `pip-audit` is installed in this workspace; the PR security workflow is the audit confirmation for the dependency pin.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 0 changed, 4 added, 0 removed, 422 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-710/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/28341553039
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- `pages-activity-activityfilters--all-activity--mobile.png`
- `pages-activity-activityfilters--all-activity.png`
- `pages-activity-activityfilters--completed-with-warnings-filter--mobile.png`
- `pages-activity-activityfilters--completed-with-warnings-filter.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->