### PR TITLE
Support Borg prune keep-within retention

### DIFF
--- a/agent/borg_ui_agent/repository_ops.py
+++ b/agent/borg_ui_agent/repository_ops.py
@@ -240,6 +240,9 @@ class RepositoryOperationPayload:
                 value = operation.get(key)
                 if value is not None:
                     cmd.extend([flag, str(int(value))])
+            keep_within = operation.get("keep_within")
+            if keep_within is not None and str(keep_within).strip():
+                cmd.append(f"--keep-within={str(keep_within).strip()}")
             if dry_run:
                 cmd.append("--dry-run")
             if self.borg_version == 1:

--- a/app/api/backup_plans.py
+++ b/app/api/backup_plans.py
@@ -155,6 +155,7 @@ class BackupPlanPayload(BaseModel):
     prune_keep_monthly: int = 6
     prune_keep_quarterly: int = 0
     prune_keep_yearly: int = 1
+    prune_keep_within: Optional[str] = None
     repositories: list[BackupPlanRepositoryPayload]
     clear_legacy_source_repository_ids: list[int] = Field(default_factory=list)
 
@@ -176,6 +177,13 @@ def _decode_json_list(value: Optional[str]) -> list[str]:
     except (TypeError, json.JSONDecodeError):
         return []
     return decoded if isinstance(decoded, list) else []
+
+
+def _normalize_prune_keep_within(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
 
 
 def _unique_backup_plan_name(db: Session, base_name: str) -> str:
@@ -333,6 +341,7 @@ def _payload_from_repository(
         prune_keep_monthly=schedule.prune_keep_monthly if schedule else 6,
         prune_keep_quarterly=schedule.prune_keep_quarterly if schedule else 0,
         prune_keep_yearly=schedule.prune_keep_yearly if schedule else 1,
+        prune_keep_within=schedule.prune_keep_within if schedule else None,
         repositories=[
             BackupPlanRepositoryPayload(
                 repository_id=repository.id,
@@ -609,6 +618,7 @@ def _serialize_plan(plan: BackupPlan, *, detail: bool = False) -> dict[str, Any]
                 "prune_keep_monthly": plan.prune_keep_monthly,
                 "prune_keep_quarterly": plan.prune_keep_quarterly,
                 "prune_keep_yearly": plan.prune_keep_yearly,
+                "prune_keep_within": plan.prune_keep_within,
                 "repositories": [
                     _serialize_repository_link(link) for link in plan.repositories
                 ],
@@ -1218,6 +1228,7 @@ def _apply_payload(plan: BackupPlan, payload: BackupPlanPayload) -> None:
     plan.prune_keep_monthly = payload.prune_keep_monthly
     plan.prune_keep_quarterly = payload.prune_keep_quarterly
     plan.prune_keep_yearly = payload.prune_keep_yearly
+    plan.prune_keep_within = _normalize_prune_keep_within(payload.prune_keep_within)
     plan.updated_at = datetime.utcnow()
 
 

--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -147,6 +147,7 @@ def _dispatch_router_prune(
     keep_monthly: int,
     keep_quarterly: int,
     keep_yearly: int,
+    keep_within: str | None,
     job: PruneJob,
 ):
     return BorgRouter(router_repo).prune(
@@ -157,7 +158,8 @@ def _dispatch_router_prune(
         keep_monthly,
         keep_quarterly,
         keep_yearly,
-        False,
+        dry_run=False,
+        keep_within=keep_within,
     )
 
 
@@ -708,6 +710,7 @@ def _parse_agent_json_result(result: dict[str, Any]) -> dict[str, Any]:
 
 
 def _agent_prune_operation_payload(request: dict) -> dict[str, Any]:
+    keep_within = _normalize_prune_keep_within(request.get("keep_within"))
     return {
         "keep_hourly": request.get("keep_hourly", 0),
         "keep_daily": request.get("keep_daily", 7),
@@ -715,8 +718,16 @@ def _agent_prune_operation_payload(request: dict) -> dict[str, Any]:
         "keep_monthly": request.get("keep_monthly", 6),
         "keep_quarterly": request.get("keep_quarterly", 0),
         "keep_yearly": request.get("keep_yearly", 1),
+        "keep_within": keep_within,
         "dry_run": request.get("dry_run", False),
     }
+
+
+def _normalize_prune_keep_within(value: Any) -> str | None:
+    if value is None:
+        return None
+    value = str(value).strip()
+    return value or None
 
 
 # Helper function to get operation timeouts from DB settings (with fallback to config)
@@ -5287,6 +5298,7 @@ async def prune_repository(
         keep_monthly = request.get("keep_monthly", 6)
         keep_quarterly = request.get("keep_quarterly", 0)
         keep_yearly = request.get("keep_yearly", 1)
+        keep_within = _normalize_prune_keep_within(request.get("keep_within"))
         dry_run = request.get("dry_run", False)
 
         if is_agent_executor(repository):
@@ -5361,6 +5373,7 @@ async def prune_repository(
                     keep_monthly,
                     keep_quarterly,
                     keep_yearly,
+                    keep_within,
                 ),
                 extra_fields={"scheduled_prune": False},
             )
@@ -5404,7 +5417,8 @@ async def prune_repository(
             keep_monthly,
             keep_quarterly,
             keep_yearly,
-            dry_run,
+            dry_run=dry_run,
+            keep_within=keep_within,
         )
 
         # Refresh job to get updated status and logs

--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -727,7 +727,12 @@ def _agent_prune_operation_payload(request: dict) -> dict[str, Any]:
 def _normalize_prune_keep_within(value: Any) -> str | None:
     if value is None:
         return None
-    value = str(value).strip()
+    if not isinstance(value, str):
+        raise HTTPException(
+            status_code=422,
+            detail={"key": "backend.errors.repo.invalidPruneKeepWithin"},
+        )
+    value = value.strip()
     return value or None
 
 

--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -150,7 +150,7 @@ def _dispatch_router_prune(
     keep_within: str | None,
     job: PruneJob,
 ):
-    return BorgRouter(router_repo).prune(
+    args = (
         job.id,
         keep_hourly,
         keep_daily,
@@ -158,9 +158,10 @@ def _dispatch_router_prune(
         keep_monthly,
         keep_quarterly,
         keep_yearly,
-        dry_run=False,
-        keep_within=keep_within,
+        False,
     )
+    kwargs = {"keep_within": keep_within} if keep_within is not None else {}
+    return BorgRouter(router_repo).prune(*args, **kwargs)
 
 
 AGENT_RCLONE_SYNC_CAPABILITY = "repository.rclone_sync"
@@ -5409,6 +5410,7 @@ async def prune_repository(
         )
 
         # Wait for prune to complete and get logs
+        prune_kwargs = {"keep_within": keep_within} if keep_within is not None else {}
         await BorgRouter(repository).prune(
             prune_job.id,
             keep_hourly,
@@ -5417,8 +5419,8 @@ async def prune_repository(
             keep_monthly,
             keep_quarterly,
             keep_yearly,
-            dry_run=dry_run,
-            keep_within=keep_within,
+            dry_run,
+            **prune_kwargs,
         )
 
         # Refresh job to get updated status and logs

--- a/app/api/schedule.py
+++ b/app/api/schedule.py
@@ -89,6 +89,7 @@ class ScheduledJobCreate(BaseModel):
     prune_keep_monthly: int = 6
     prune_keep_quarterly: int = 0
     prune_keep_yearly: int = 1
+    prune_keep_within: Optional[str] = None
 
 
 class ScheduledJobUpdate(BaseModel):
@@ -122,6 +123,7 @@ class ScheduledJobUpdate(BaseModel):
     prune_keep_monthly: Optional[int] = None
     prune_keep_quarterly: Optional[int] = None
     prune_keep_yearly: Optional[int] = None
+    prune_keep_within: Optional[str] = None
 
 
 class CronExpression(BaseModel):
@@ -131,6 +133,13 @@ class CronExpression(BaseModel):
     month: str = "*"
     day_of_week: str = "*"
     timezone: Optional[str] = None
+
+
+def _normalize_prune_keep_within(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
 
 
 def _calculate_next_schedule_run(
@@ -439,6 +448,7 @@ async def get_scheduled_jobs(
                     "prune_keep_monthly": job.prune_keep_monthly,
                     "prune_keep_quarterly": job.prune_keep_quarterly,
                     "prune_keep_yearly": job.prune_keep_yearly,
+                    "prune_keep_within": job.prune_keep_within,
                     "last_prune": serialize_datetime(job.last_prune),
                     "last_compact": serialize_datetime(job.last_compact),
                 }
@@ -646,6 +656,7 @@ async def create_scheduled_job(
             prune_keep_monthly=job_data.prune_keep_monthly,
             prune_keep_quarterly=job_data.prune_keep_quarterly,
             prune_keep_yearly=job_data.prune_keep_yearly,
+            prune_keep_within=_normalize_prune_keep_within(job_data.prune_keep_within),
         )
 
         logger.info(
@@ -1048,6 +1059,7 @@ async def get_scheduled_job(
                 "prune_keep_monthly": job.prune_keep_monthly,
                 "prune_keep_quarterly": job.prune_keep_quarterly,
                 "prune_keep_yearly": job.prune_keep_yearly,
+                "prune_keep_within": job.prune_keep_within,
                 "last_prune": serialize_datetime(job.last_prune),
                 "last_compact": serialize_datetime(job.last_compact),
             },
@@ -1195,6 +1207,11 @@ async def update_scheduled_job(
 
         if job_data.prune_keep_yearly is not None:
             job.prune_keep_yearly = job_data.prune_keep_yearly
+
+        if "prune_keep_within" in job_data.model_fields_set:
+            job.prune_keep_within = _normalize_prune_keep_within(
+                job_data.prune_keep_within
+            )
 
         # Update multi-repo settings
         if job_data.repository_id is not None:
@@ -1449,6 +1466,7 @@ async def duplicate_scheduled_job(
             prune_keep_monthly=original_job.prune_keep_monthly,
             prune_keep_quarterly=original_job.prune_keep_quarterly,
             prune_keep_yearly=original_job.prune_keep_yearly,
+            prune_keep_within=original_job.prune_keep_within,
         )
 
         db.add(duplicated_job)
@@ -2220,6 +2238,7 @@ async def execute_multi_repo_schedule(scheduled_job: ScheduledJob, db: Session):
                             keep_quarterly=scheduled_job.prune_keep_quarterly,
                             keep_yearly=scheduled_job.prune_keep_yearly,
                             dry_run=False,
+                            keep_within=scheduled_job.prune_keep_within,
                         )
 
                         # Refresh job to get updated status
@@ -2474,6 +2493,7 @@ async def execute_scheduled_backup_with_maintenance(
                     keep_quarterly=scheduled_job.prune_keep_quarterly,
                     keep_yearly=scheduled_job.prune_keep_yearly,
                     dry_run=False,
+                    keep_within=scheduled_job.prune_keep_within,
                 )
 
                 # Refresh job to get updated status

--- a/app/api/v2/backups.py
+++ b/app/api/v2/backups.py
@@ -68,6 +68,7 @@ class PruneV2Request(BaseModel):
     keep_monthly: int = 6
     keep_quarterly: int = 0
     keep_yearly: int = 1
+    keep_within: Optional[str] = None
     dry_run: bool = False
 
 
@@ -99,6 +100,13 @@ def _get_v2_repo_by_id(repo_id: int, db: Session, current_user: User) -> Reposit
 def _source_dirs(repo: Repository) -> list:
     if not repo.source_directories:
         return []
+
+
+def _normalize_keep_within(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
     try:
         return json.loads(repo.source_directories)
     except (json.JSONDecodeError, TypeError):
@@ -178,6 +186,7 @@ async def prune_archives(
         )
 
     repo = _get_v2_repo_by_id(data.repository_id, db, current_user)
+    keep_within = _normalize_keep_within(data.keep_within)
     if not data.dry_run:
         prune_job = start_background_maintenance_job(
             db,
@@ -194,6 +203,7 @@ async def prune_archives(
                 data.keep_quarterly,
                 data.keep_yearly,
                 False,
+                keep_within=keep_within,
             ),
             status="running",
             extra_fields={"scheduled_prune": False},
@@ -221,6 +231,7 @@ async def prune_archives(
         keep_quarterly=data.keep_quarterly,
         keep_yearly=data.keep_yearly,
         dry_run=data.dry_run,
+        keep_within=keep_within,
     )
 
     if not result["success"]:

--- a/app/api/v2/backups.py
+++ b/app/api/v2/backups.py
@@ -100,6 +100,10 @@ def _get_v2_repo_by_id(repo_id: int, db: Session, current_user: User) -> Reposit
 def _source_dirs(repo: Repository) -> list:
     if not repo.source_directories:
         return []
+    try:
+        return json.loads(repo.source_directories)
+    except (json.JSONDecodeError, TypeError):
+        return []
 
 
 def _normalize_keep_within(value: Optional[str]) -> Optional[str]:
@@ -107,10 +111,6 @@ def _normalize_keep_within(value: Optional[str]) -> Optional[str]:
         return None
     value = value.strip()
     return value or None
-    try:
-        return json.loads(repo.source_directories)
-    except (json.JSONDecodeError, TypeError):
-        return []
 
 
 # ── Routes ─────────────────────────────────────────────────────────────────────
@@ -187,6 +187,7 @@ async def prune_archives(
 
     repo = _get_v2_repo_by_id(data.repository_id, db, current_user)
     keep_within = _normalize_keep_within(data.keep_within)
+    prune_kwargs = {"keep_within": keep_within} if keep_within is not None else {}
     if not data.dry_run:
         prune_job = start_background_maintenance_job(
             db,
@@ -203,7 +204,7 @@ async def prune_archives(
                 data.keep_quarterly,
                 data.keep_yearly,
                 False,
-                keep_within=keep_within,
+                **prune_kwargs,
             ),
             status="running",
             extra_fields={"scheduled_prune": False},
@@ -231,7 +232,7 @@ async def prune_archives(
         keep_quarterly=data.keep_quarterly,
         keep_yearly=data.keep_yearly,
         dry_run=data.dry_run,
-        keep_within=keep_within,
+        **prune_kwargs,
     )
 
     if not result["success"]:

--- a/app/core/borg.py
+++ b/app/core/borg.py
@@ -682,6 +682,7 @@ class BorgInterface:
         dry_run: bool = False,
         remote_path: str = None,
         passphrase: str = None,
+        keep_within: str | None = None,
     ) -> Dict:
         """Prune old archives
 
@@ -696,6 +697,7 @@ class BorgInterface:
             dry_run: Run in dry-run mode
             remote_path: Path to remote borg binary
             passphrase: Repository passphrase
+            keep_within: Keep all archives within Borg interval
         """
         cmd = [self.borg_cmd, "prune"]
         if remote_path:
@@ -717,6 +719,8 @@ class BorgInterface:
             cmd.extend(["--keep-3monthly", str(keep_quarterly)])
         if keep_yearly > 0:
             cmd.extend(["--keep-yearly", str(keep_yearly)])
+        if keep_within and keep_within.strip():
+            cmd.append(f"--keep-within={keep_within.strip()}")
 
         cmd.append("--list")
 

--- a/app/core/borg2.py
+++ b/app/core/borg2.py
@@ -530,6 +530,7 @@ class Borg2Interface:
         dry_run: bool = False,
         passphrase: Optional[str] = None,
         remote_path: Optional[str] = None,
+        keep_within: Optional[str] = None,
     ) -> Dict:
         """Prune old archives.
 
@@ -551,6 +552,8 @@ class Borg2Interface:
             cmd.extend(["--keep-3monthly", str(keep_quarterly)])
         if keep_yearly > 0:
             cmd.extend(["--keep-yearly", str(keep_yearly)])
+        if keep_within and keep_within.strip():
+            cmd.append(f"--keep-within={keep_within.strip()}")
         cmd.append("--list")
         if dry_run:
             cmd.append("--dry-run")

--- a/app/core/borg_router.py
+++ b/app/core/borg_router.py
@@ -463,36 +463,31 @@ class BorgRouter:
         keep_quarterly: int,
         keep_yearly: int,
         dry_run: bool = False,
+        keep_within: str | None = None,
     ) -> None:
         """Run repository pruning through the version-aware service layer."""
+        kwargs = {
+            "job_id": job_id,
+            "repository_id": self.repo.id,
+            "keep_hourly": keep_hourly,
+            "keep_daily": keep_daily,
+            "keep_weekly": keep_weekly,
+            "keep_monthly": keep_monthly,
+            "keep_quarterly": keep_quarterly,
+            "keep_yearly": keep_yearly,
+            "dry_run": dry_run,
+        }
+        if keep_within is not None:
+            kwargs["keep_within"] = keep_within
+
         if self.is_v2:
             from app.services.v2.prune_service import prune_v2_service
 
-            await prune_v2_service.execute_prune(
-                job_id=job_id,
-                repository_id=self.repo.id,
-                keep_hourly=keep_hourly,
-                keep_daily=keep_daily,
-                keep_weekly=keep_weekly,
-                keep_monthly=keep_monthly,
-                keep_quarterly=keep_quarterly,
-                keep_yearly=keep_yearly,
-                dry_run=dry_run,
-            )
+            await prune_v2_service.execute_prune(**kwargs)
         else:
             from app.services.prune_service import prune_service
 
-            await prune_service.execute_prune(
-                job_id=job_id,
-                repository_id=self.repo.id,
-                keep_hourly=keep_hourly,
-                keep_daily=keep_daily,
-                keep_weekly=keep_weekly,
-                keep_monthly=keep_monthly,
-                keep_quarterly=keep_quarterly,
-                keep_yearly=keep_yearly,
-                dry_run=dry_run,
-            )
+            await prune_service.execute_prune(**kwargs)
 
     async def delete_archive(self, job_id: int, archive_name: str) -> None:
         """Delete an archive through the version-aware service layer."""

--- a/app/database/migrations/125_add_prune_keep_within.py
+++ b/app/database/migrations/125_add_prune_keep_within.py
@@ -1,0 +1,46 @@
+"""Add Borg prune keep-within retention fields."""
+
+from sqlalchemy import inspect, text
+
+
+def _bind(db):
+    return db.get_bind() if hasattr(db, "get_bind") else db
+
+
+def _columns(db, table_name: str) -> set[str]:
+    return {column["name"] for column in inspect(_bind(db)).get_columns(table_name)}
+
+
+def _add_column_if_missing(db, table_name: str, column_name: str) -> None:
+    if column_name not in _columns(db, table_name):
+        db.execute(text(f"ALTER TABLE {table_name} ADD COLUMN {column_name} VARCHAR"))
+
+
+def _drop_column_if_present(db, table_name: str, column_name: str) -> None:
+    if column_name not in _columns(db, table_name):
+        return
+    if _bind(db).dialect.name == "sqlite":
+        version = db.execute(text("SELECT sqlite_version()")).scalar() or "0.0.0"
+        supports_drop = tuple(int(part) for part in version.split(".")[:3]) >= (
+            3,
+            35,
+            0,
+        )
+        if not supports_drop:
+            raise RuntimeError(
+                "SQLite does not support DROP COLUMN; "
+                f"{table_name}.{column_name} was not removed"
+            )
+    db.execute(text(f"ALTER TABLE {table_name} DROP COLUMN {column_name}"))
+
+
+def upgrade(db):
+    _add_column_if_missing(db, "scheduled_jobs", "prune_keep_within")
+    _add_column_if_missing(db, "backup_plans", "prune_keep_within")
+    db.commit()
+
+
+def downgrade(db):
+    _drop_column_if_present(db, "scheduled_jobs", "prune_keep_within")
+    _drop_column_if_present(db, "backup_plans", "prune_keep_within")
+    db.commit()

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -797,6 +797,9 @@ class ScheduledJob(Base):
         Integer, default=0
     )  # Keep N quarterly backups (0 = disabled)
     prune_keep_yearly = Column(Integer, default=1)  # Keep N yearly backups
+    prune_keep_within = Column(
+        String, nullable=True
+    )  # Keep all archives within interval
     last_prune = Column(DateTime, nullable=True)  # Last prune execution time
     last_compact = Column(DateTime, nullable=True)  # Last compact execution time
 
@@ -899,6 +902,7 @@ class BackupPlan(Base):
     prune_keep_monthly = Column(Integer, default=6, nullable=False)
     prune_keep_quarterly = Column(Integer, default=0, nullable=False)
     prune_keep_yearly = Column(Integer, default=1, nullable=False)
+    prune_keep_within = Column(String, nullable=True)
 
     created_at = Column(DateTime, default=utc_now, nullable=False)
     updated_at = Column(DateTime, default=utc_now, onupdate=utc_now)

--- a/app/services/backup_plan_execution_service.py
+++ b/app/services/backup_plan_execution_service.py
@@ -108,6 +108,7 @@ class PlanRunContext:
     prune_keep_monthly: int
     prune_keep_quarterly: int
     prune_keep_yearly: int
+    prune_keep_within: Optional[str]
     repository_count: int
     timestamp: str
     date: str
@@ -1069,6 +1070,7 @@ class BackupPlanExecutionService:
                 prune_keep_monthly=plan.prune_keep_monthly,
                 prune_keep_quarterly=plan.prune_keep_quarterly,
                 prune_keep_yearly=plan.prune_keep_yearly,
+                prune_keep_within=plan.prune_keep_within,
                 repository_count=len(enabled_links),
                 timestamp=now.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3],
                 date=now.strftime("%Y-%m-%d"),
@@ -1765,6 +1767,7 @@ class BackupPlanExecutionService:
                 keep_quarterly=context.prune_keep_quarterly,
                 keep_yearly=context.prune_keep_yearly,
                 dry_run=False,
+                keep_within=context.prune_keep_within,
             )
             db.refresh(prune_job)
             if self._is_run_cancelled(run_id):

--- a/app/services/borgmatic_service.py
+++ b/app/services/borgmatic_service.py
@@ -39,6 +39,14 @@ def _safe_export_name(name: str, fallback: str) -> str:
     return safe_name or fallback
 
 
+def _normalize_import_keep_within(value: Any) -> tuple[str | None, str | None]:
+    if value is None:
+        return None, None
+    if not isinstance(value, str):
+        return None, f"Ignored invalid keep_within value for schedule: {value!r}"
+    return value.strip() or None, None
+
+
 def _unique_yaml_filename(base_name: str, used_names: set[str]) -> str:
     filename = f"{base_name}.yaml"
     if filename not in used_names:
@@ -909,7 +917,12 @@ class BorgmaticImportService:
         scheduled_job.prune_keep_weekly = retention.get("keep_weekly", 4)
         scheduled_job.prune_keep_monthly = retention.get("keep_monthly", 6)
         scheduled_job.prune_keep_yearly = retention.get("keep_yearly", 1)
-        scheduled_job.prune_keep_within = retention.get("keep_within")
+        keep_within, keep_within_warning = _normalize_import_keep_within(
+            retention.get("keep_within")
+        )
+        scheduled_job.prune_keep_within = keep_within
+        if keep_within_warning:
+            result["warnings"].append(keep_within_warning)
         try:
             scheduled_job.next_run = calculate_next_cron_run(
                 scheduled_job.cron_expression,

--- a/app/services/borgmatic_service.py
+++ b/app/services/borgmatic_service.py
@@ -289,6 +289,8 @@ class BorgmaticExportService:
             retention["keep_monthly"] = scheduled_job.prune_keep_monthly
         if scheduled_job.prune_keep_yearly is not None:
             retention["keep_yearly"] = scheduled_job.prune_keep_yearly
+        if scheduled_job.prune_keep_within:
+            retention["keep_within"] = scheduled_job.prune_keep_within
 
         return retention
 
@@ -615,6 +617,7 @@ class BorgmaticImportService:
                         "keep_monthly",
                         "keep_quarterly",
                         "keep_yearly",
+                        "keep_within",
                     ]:
                         if key in data:
                             retention[key] = data[key]
@@ -906,6 +909,7 @@ class BorgmaticImportService:
         scheduled_job.prune_keep_weekly = retention.get("keep_weekly", 4)
         scheduled_job.prune_keep_monthly = retention.get("keep_monthly", 6)
         scheduled_job.prune_keep_yearly = retention.get("keep_yearly", 1)
+        scheduled_job.prune_keep_within = retention.get("keep_within")
         try:
             scheduled_job.next_run = calculate_next_cron_run(
                 scheduled_job.cron_expression,

--- a/app/services/prune_service.py
+++ b/app/services/prune_service.py
@@ -58,6 +58,7 @@ class PruneService:
         keep_yearly: int,
         dry_run: bool = False,
         db: Session = None,
+        keep_within: str | None = None,
     ):
         """Execute repository prune operation with job tracking"""
 
@@ -154,6 +155,8 @@ class PruneService:
                 cmd.extend(["--keep-3monthly", str(keep_quarterly)])
             if keep_yearly > 0:
                 cmd.extend(["--keep-yearly", str(keep_yearly)])
+            if keep_within and keep_within.strip():
+                cmd.append(f"--keep-within={keep_within.strip()}")
 
             # Add remote path if specified
             if repository.remote_path:

--- a/app/services/v2/prune_service.py
+++ b/app/services/v2/prune_service.py
@@ -59,6 +59,7 @@ class PruneV2Service:
         keep_quarterly: int,
         keep_yearly: int,
         dry_run: bool = False,
+        keep_within: str | None = None,
     ) -> dict:
         """Execute a Borg 2 prune command and return the raw result."""
         return await borg2.prune_archives(
@@ -70,6 +71,7 @@ class PruneV2Service:
             keep_quarterly=keep_quarterly,
             keep_yearly=keep_yearly,
             dry_run=dry_run,
+            keep_within=keep_within,
             passphrase=repo.passphrase,
             remote_path=repo.remote_path,
         )
@@ -86,6 +88,7 @@ class PruneV2Service:
         keep_yearly: int,
         dry_run: bool = False,
         _db=None,
+        keep_within: str | None = None,
     ):
         """Execute borg2 prune and persist results to the shared PruneJob model."""
         db = SessionLocal()
@@ -149,6 +152,8 @@ class PruneV2Service:
                 cmd.extend(["--keep-3monthly", str(keep_quarterly)])
             if keep_yearly > 0:
                 cmd.extend(["--keep-yearly", str(keep_yearly)])
+            if keep_within and keep_within.strip():
+                cmd.append(f"--keep-within={keep_within.strip()}")
             if dry_run:
                 cmd.append("--dry-run")
 

--- a/docs/engineering/plans/2026-06-29-borg-prune-keep-within.md
+++ b/docs/engineering/plans/2026-06-29-borg-prune-keep-within.md
@@ -1,0 +1,63 @@
+# Borg Prune Keep-Within Implementation Plan
+
+## Goal
+
+Add optional Borg prune keep-within support across manual prune, scheduled
+maintenance, backup plan maintenance, agent execution, and borgmatic
+import/export.
+
+## Architecture
+
+Treat keep-within as an optional string. Normalize user input by trimming
+whitespace and converting empty strings to null/undefined at API and payload
+boundaries. Thread the value through existing prune call chains and append
+`--keep-within=<value>` near the other retention flags only when present.
+
+## Tasks
+
+- [x] Backend red tests
+  - Add tests that expect Borg v1/v2/router/agent prune commands to include
+    `--keep-within=1d` when set and omit it when blank.
+  - Add API/persistence tests for backup plan create/copy/execute and borgmatic
+    export/import carrying `prune_keep_within`.
+  - Run the focused pytest paths and confirm the new tests fail for missing
+    fields/arguments.
+
+- [x] Backend implementation
+  - Add migration `125_add_prune_keep_within.py`.
+  - Add `prune_keep_within` to `ScheduledJob` and `BackupPlan` models.
+  - Extend schedule and backup plan Pydantic payloads, create/update/list/copy
+    serializers, backup plan run context, legacy schedule execution, and manual
+    repository prune request parsing.
+  - Extend `BorgRouter.prune`, v1/v2 prune services, `app.core.borg`,
+    `app.core.borg2`, repository executor payloads, and agent command building.
+  - Extend borgmatic retention export/import with `keep_within`.
+
+- [x] Frontend red tests
+  - Add `PruneSettingsInput` tests for rendering, editing, and disabling the
+    keep-within text field.
+  - Add manual `PruneRepositoryDialog` tests for initial values, submission
+    payloads, and preview copy including keep-within.
+  - Add backup plan payload/state/review tests for `pruneKeepWithin`.
+  - Run focused Vitest commands and confirm the new tests fail before UI code.
+
+- [x] Frontend implementation
+  - Add `keepWithin` to `PruneSettings`, schedule wizard state/types,
+    backup-plan payload state/types, API client `PruneOptions`, and response
+    types.
+  - Add localized labels/helper copy in all locale files and update tests/stories
+    that use local translation maps.
+  - Add the text field to `PruneSettingsInput` and manual
+    `PruneRepositoryDialog`, preserving stable layout and compact controls.
+  - Include the interval in retention summaries/review pills/schedule cards when
+    configured.
+  - Update Storybook stories for `PruneRepositoryDialog` and backup-plan
+    `ScheduleStep`.
+
+- [x] Validation and handoff
+  - Run targeted backend/frontend tests.
+  - Run required backend and frontend checks for touched code.
+  - Run an app walkthrough or smoke proof for the prune retention UI path.
+  - Commit, push, open/update PR with the Borg UI template, attach it to Linear,
+    ensure the `symphony` label, sweep feedback/checks, and move to Human Review
+    only when green.

--- a/docs/engineering/specs/2026-06-29-borg-prune-keep-within.md
+++ b/docs/engineering/specs/2026-06-29-borg-prune-keep-within.md
@@ -56,9 +56,9 @@ and empty strings both mean disabled.
 
 ## Validation
 
-- Backend targeted tests:
+- Backend-targeted tests:
   `pytest tests/unit/test_borg_router.py tests/unit/test_v2_prune_service.py tests/unit/test_agent_runtime.py tests/unit/test_api_backup_plans.py tests/unit/test_borgmatic_service.py`
-- Frontend targeted tests:
+- Frontend-targeted tests:
   `cd frontend && npm run test -- PruneSettingsInput PruneRepositoryDialog ScheduleStep ReviewStep borgApi/client backupPlanPayload`
 - Required backend checks:
   `ruff check app tests`, `ruff format --check app tests`

--- a/docs/engineering/specs/2026-06-29-borg-prune-keep-within.md
+++ b/docs/engineering/specs/2026-06-29-borg-prune-keep-within.md
@@ -1,0 +1,75 @@
+# Borg Prune Keep-Within Support
+
+## Problem
+
+Borg UI prune settings only support count-based retention rules such as hourly,
+daily, weekly, monthly, quarterly, and yearly. Users running frequent backups,
+for example every five minutes, cannot keep every recent archive for a time
+window before older archives are thinned. Borg supports this directly with
+`--keep-within=<interval>`.
+
+## Desired Outcome
+
+Manual repository prune, scheduled post-backup prune, backup plan maintenance,
+agent-executed prune jobs, and borgmatic import/export all understand an
+optional keep-within interval. When present, Borg UI passes it through to Borg as
+`--keep-within=<interval>` without changing existing count-based retention
+defaults.
+
+## UX
+
+The existing prune retention UI keeps its count-based controls and adds a text
+field for the recent archive window. The field accepts Borg interval strings
+such as `12H`, `1d`, `2w`, `1m`, and `1y`. Empty means disabled. The helper text
+explains that archives inside the interval are kept before the count rules apply.
+
+The shared `PruneSettingsInput` covers scheduled jobs and backup plans. The
+manual `PruneRepositoryDialog` keeps its compact row layout and adds a matching
+first row for keep-within. Review/status summaries include the interval when it
+is set.
+
+## Data Model
+
+Add nullable string columns:
+
+- `scheduled_jobs.prune_keep_within`
+- `backup_plans.prune_keep_within`
+
+Manual prune requests do not persist repository defaults; they carry the
+optional interval in the request body. Existing rows remain valid because null
+and empty strings both mean disabled.
+
+## Acceptance Criteria
+
+- Manual prune dry-run and execution include `--keep-within=<interval>` when the
+  dialog submits a non-empty interval.
+- Scheduled jobs and backup plans persist `prune_keep_within`, return it in API
+  responses, duplicate/copy it, and pass it into post-backup prune execution.
+- Borg v1, Borg v2, and agent prune command builders include the flag when set
+  and omit it when blank.
+- Existing count-based retention defaults and behavior are unchanged when
+  keep-within is blank.
+- Storybook coverage demonstrates the new manual prune field and backup plan
+  schedule state.
+- Focused backend and frontend tests cover payload plumbing and command
+  generation.
+
+## Validation
+
+- Backend targeted tests:
+  `pytest tests/unit/test_borg_router.py tests/unit/test_v2_prune_service.py tests/unit/test_agent_runtime.py tests/unit/test_api_backup_plans.py tests/unit/test_borgmatic_service.py`
+- Frontend targeted tests:
+  `cd frontend && npm run test -- PruneSettingsInput PruneRepositoryDialog ScheduleStep ReviewStep borgApi/client backupPlanPayload`
+- Required backend checks:
+  `ruff check app tests`, `ruff format --check app tests`
+- Required frontend checks:
+  `cd frontend && npm run check:locales && npm run typecheck && npm run lint && npm run build`
+- Runtime/UI proof: launch or smoke-test Borg UI enough to open the prune
+  retention path and verify the new interval field is visible and usable.
+
+## Notes
+
+- Borg docs define `--keep-within INTERVAL` as keeping all archives within the
+  interval, and those archives do not count toward other retention totals.
+- Borg interval examples from the docs use `<int><char>` with chars such as
+  `H`, `d`, `w`, `m`, and `y`.

--- a/frontend/src/components/BackupHistorySection.tsx
+++ b/frontend/src/components/BackupHistorySection.tsx
@@ -31,6 +31,7 @@ interface ScheduledJob {
   prune_keep_monthly: number
   prune_keep_quarterly: number
   prune_keep_yearly: number
+  prune_keep_within?: string | null
   last_prune: string | null
   last_compact: string | null
 }

--- a/frontend/src/components/DeleteScheduleDialog.tsx
+++ b/frontend/src/components/DeleteScheduleDialog.tsx
@@ -38,6 +38,7 @@ interface ScheduledJob {
   prune_keep_monthly: number
   prune_keep_quarterly: number
   prune_keep_yearly: number
+  prune_keep_within?: string | null
   last_prune: string | null
   last_compact: string | null
 }

--- a/frontend/src/components/PruneRepositoryDialog.stories.tsx
+++ b/frontend/src/components/PruneRepositoryDialog.stories.tsx
@@ -32,6 +32,7 @@ export const RetentionPreview: Story = {
     open: true,
     repository,
     initialForm: {
+      keep_within: '1d',
       keep_daily: 14,
       keep_weekly: 2,
       keep_monthly: 6,
@@ -55,6 +56,7 @@ export const DryRunLogMessages: Story = {
     open: true,
     repository,
     initialForm: {
+      keep_within: '12H',
       keep_daily: 1,
       keep_weekly: 1,
       keep_monthly: 1,

--- a/frontend/src/components/PruneRepositoryDialog.tsx
+++ b/frontend/src/components/PruneRepositoryDialog.tsx
@@ -33,6 +33,7 @@ import {
 import { Repository } from '../types'
 
 interface PruneForm {
+  keep_within: string
   keep_hourly: number
   keep_daily: number
   keep_weekly: number
@@ -59,6 +60,7 @@ interface PruneRepositoryDialogProps {
 }
 
 const defaultPruneForm: PruneForm = {
+  keep_within: '',
   keep_hourly: 0,
   keep_daily: 7,
   keep_weekly: 4,
@@ -649,12 +651,18 @@ export default function PruneRepositoryDialog({
       unit: t('dialogs.prune.retentionUnits.yearly'),
     },
   ]
+  const keepWithinValue = pruneForm.keep_within.trim()
 
   const borderColor = isDark ? alpha('#fff', 0.08) : alpha('#000', 0.09)
   const retentionSummary = formatRetentionList(
-    retentionFields
-      .filter((field) => pruneForm[field.key] > 0)
-      .map((field) => `${pruneForm[field.key]} ${field.unit}`),
+    [
+      ...(keepWithinValue
+        ? [t('dialogs.prune.keepWithinSummary', { interval: keepWithinValue })]
+        : []),
+      ...retentionFields
+        .filter((field) => pruneForm[field.key] > 0)
+        .map((field) => `${pruneForm[field.key]} ${field.unit}`),
+    ],
     i18n.resolvedLanguage || i18n.language
   )
 
@@ -753,6 +761,63 @@ export default function PruneRepositoryDialog({
               mb: 0.75,
             }}
           >
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1.5,
+                px: 1.75,
+                py: 0.9,
+                borderBottom: '1px solid',
+                borderColor,
+                bgcolor: isDark ? alpha('#fff', 0.015) : alpha('#000', 0.012),
+                '&:hover': {
+                  bgcolor: isDark ? alpha('#fff', 0.03) : alpha('#000', 0.025),
+                },
+                transition: 'background-color 150ms',
+              }}
+            >
+              <Box sx={{ color: 'text.disabled', display: 'flex', flexShrink: 0 }}>
+                <Clock size={14} />
+              </Box>
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography variant="body2" sx={{ fontSize: '0.8rem' }}>
+                  {t('dialogs.prune.keepWithin')}
+                </Typography>
+                <Typography variant="caption" color="text.disabled">
+                  {t('dialogs.prune.keepWithinHelper')}
+                </Typography>
+              </Box>
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  border: '1px solid',
+                  borderColor,
+                  borderRadius: 1,
+                  px: 1,
+                  py: 0.35,
+                  bgcolor: 'background.paper',
+                  width: 96,
+                }}
+              >
+                <InputBase
+                  value={pruneForm.keep_within}
+                  onChange={(e) => setPruneForm({ ...pruneForm, keep_within: e.target.value })}
+                  inputProps={{
+                    'aria-label': t('dialogs.prune.keepWithin'),
+                    style: { textAlign: 'center', padding: 0 },
+                  }}
+                  placeholder={t('dialogs.prune.keepWithinPlaceholder')}
+                  sx={{
+                    fontSize: '0.85rem',
+                    fontWeight: 600,
+                    fontVariantNumeric: 'tabular-nums',
+                    flex: 1,
+                  }}
+                />
+              </Box>
+            </Box>
             {retentionFields.map((field, i) => (
               <Box
                 key={field.key}
@@ -796,7 +861,11 @@ export default function PruneRepositoryDialog({
                     onChange={(e) =>
                       setPruneForm({ ...pruneForm, [field.key]: parseInt(e.target.value) || 0 })
                     }
-                    inputProps={{ min: 0, style: { textAlign: 'center', padding: 0 } }}
+                    inputProps={{
+                      min: 0,
+                      'aria-label': field.label,
+                      style: { textAlign: 'center', padding: 0 },
+                    }}
                     sx={{
                       fontSize: '0.85rem',
                       fontWeight: 600,

--- a/frontend/src/components/PruneSettingsInput.tsx
+++ b/frontend/src/components/PruneSettingsInput.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Box, TextField } from '@mui/material'
 
 export interface PruneSettings {
+  keepWithin: string
   keepHourly: number
   keepDaily: number
   keepWeekly: number
@@ -23,12 +24,18 @@ const PruneSettingsInput: React.FC<PruneSettingsInputProps> = ({
   disabled = false,
 }) => {
   const { t } = useTranslation()
-  const handleChange = (field: keyof PruneSettings, value: string) => {
+  const handleCountChange = (field: Exclude<keyof PruneSettings, 'keepWithin'>, value: string) => {
     const parsedValue = parseInt(value, 10)
     const finalValue = isNaN(parsedValue) ? 0 : Math.max(0, parsedValue)
     onChange({
       ...values,
       [field]: finalValue,
+    })
+  }
+  const handleKeepWithinChange = (value: string) => {
+    onChange({
+      ...values,
+      keepWithin: value,
     })
   }
 
@@ -41,10 +48,20 @@ const PruneSettingsInput: React.FC<PruneSettingsInputProps> = ({
       }}
     >
       <TextField
+        label={t('pruneSettings.keepWithin')}
+        value={values.keepWithin}
+        onChange={(e) => handleKeepWithinChange(e.target.value)}
+        size="small"
+        helperText={t('pruneSettings.keepWithinHint')}
+        disabled={disabled}
+        placeholder={t('pruneSettings.keepWithinPlaceholder')}
+        sx={{ gridColumn: { xs: 'auto', sm: '1 / -1' } }}
+      />
+      <TextField
         label={t('pruneSettings.keepHourly')}
         type="number"
         value={values.keepHourly}
-        onChange={(e) => handleChange('keepHourly', e.target.value)}
+        onChange={(e) => handleCountChange('keepHourly', e.target.value)}
         inputProps={{ min: 0 }}
         size="small"
         helperText={t('pruneSettings.keepHourlyHint')}
@@ -54,7 +71,7 @@ const PruneSettingsInput: React.FC<PruneSettingsInputProps> = ({
         label={t('pruneSettings.keepDaily')}
         type="number"
         value={values.keepDaily}
-        onChange={(e) => handleChange('keepDaily', e.target.value)}
+        onChange={(e) => handleCountChange('keepDaily', e.target.value)}
         inputProps={{ min: 0 }}
         size="small"
         helperText={t('pruneSettings.keepDailyHint')}
@@ -64,7 +81,7 @@ const PruneSettingsInput: React.FC<PruneSettingsInputProps> = ({
         label={t('pruneSettings.keepWeekly')}
         type="number"
         value={values.keepWeekly}
-        onChange={(e) => handleChange('keepWeekly', e.target.value)}
+        onChange={(e) => handleCountChange('keepWeekly', e.target.value)}
         inputProps={{ min: 0 }}
         size="small"
         helperText={t('pruneSettings.keepWeeklyHint')}
@@ -74,7 +91,7 @@ const PruneSettingsInput: React.FC<PruneSettingsInputProps> = ({
         label={t('pruneSettings.keepMonthly')}
         type="number"
         value={values.keepMonthly}
-        onChange={(e) => handleChange('keepMonthly', e.target.value)}
+        onChange={(e) => handleCountChange('keepMonthly', e.target.value)}
         inputProps={{ min: 0 }}
         size="small"
         helperText={t('pruneSettings.keepMonthlyHint')}
@@ -84,7 +101,7 @@ const PruneSettingsInput: React.FC<PruneSettingsInputProps> = ({
         label={t('pruneSettings.keepQuarterly')}
         type="number"
         value={values.keepQuarterly}
-        onChange={(e) => handleChange('keepQuarterly', e.target.value)}
+        onChange={(e) => handleCountChange('keepQuarterly', e.target.value)}
         inputProps={{ min: 0 }}
         size="small"
         helperText={t('pruneSettings.keepQuarterlyHint')}
@@ -94,7 +111,7 @@ const PruneSettingsInput: React.FC<PruneSettingsInputProps> = ({
         label={t('pruneSettings.keepYearly')}
         type="number"
         value={values.keepYearly}
-        onChange={(e) => handleChange('keepYearly', e.target.value)}
+        onChange={(e) => handleCountChange('keepYearly', e.target.value)}
         inputProps={{ min: 0 }}
         size="small"
         helperText={t('pruneSettings.keepYearlyHint')}

--- a/frontend/src/components/ScheduleJobCard.tsx
+++ b/frontend/src/components/ScheduleJobCard.tsx
@@ -134,6 +134,28 @@ export default function ScheduleJobCard({
   ]
 
   const meta: MetaItem[] = []
+  const keepWithinSummary = job.prune_keep_within
+    ? t('schedule.card.meta.keepWithin', { interval: job.prune_keep_within })
+    : null
+  const keepWithinTooltip = job.prune_keep_within
+    ? t('schedule.card.meta.keepWithinTooltip', { interval: job.prune_keep_within })
+    : null
+  const pruneRetentionParts = [
+    job.prune_keep_hourly > 0 ? `${job.prune_keep_hourly}h` : null,
+    `${job.prune_keep_daily}d`,
+    `${job.prune_keep_weekly}w`,
+    `${job.prune_keep_monthly}m`,
+    job.prune_keep_quarterly > 0 ? `${job.prune_keep_quarterly}q` : null,
+    `${job.prune_keep_yearly}y`,
+  ].filter(Boolean)
+  const pruneTooltipParts = [
+    job.prune_keep_hourly > 0 ? `hourly=${job.prune_keep_hourly}` : null,
+    `daily=${job.prune_keep_daily}`,
+    `weekly=${job.prune_keep_weekly}`,
+    `monthly=${job.prune_keep_monthly}`,
+    job.prune_keep_quarterly > 0 ? `quarterly=${job.prune_keep_quarterly}` : null,
+    `yearly=${job.prune_keep_yearly}`,
+  ].filter(Boolean)
   meta.push({
     label: t('common.timezone', { defaultValue: 'Timezone' }),
     value: scheduleTimezone,
@@ -142,16 +164,8 @@ export default function ScheduleJobCard({
   if (job.run_prune_after)
     meta.push({
       label: t('schedule.card.meta.prune'),
-      value: [
-        job.prune_keep_within ? `within ${job.prune_keep_within}` : null,
-        `${job.prune_keep_daily}d/${job.prune_keep_weekly}w/${job.prune_keep_monthly}m/${job.prune_keep_yearly}y`,
-      ]
-        .filter(Boolean)
-        .join(' · '),
-      tooltip: [
-        `Keep: daily=${job.prune_keep_daily} weekly=${job.prune_keep_weekly} monthly=${job.prune_keep_monthly} yearly=${job.prune_keep_yearly}`,
-        job.prune_keep_within ? `within=${job.prune_keep_within}` : null,
-      ]
+      value: [keepWithinSummary, pruneRetentionParts.join('/')].filter(Boolean).join(' · '),
+      tooltip: [`Keep: ${pruneTooltipParts.join(' ')}`, keepWithinTooltip]
         .filter(Boolean)
         .join(' '),
     })

--- a/frontend/src/components/ScheduleJobCard.tsx
+++ b/frontend/src/components/ScheduleJobCard.tsx
@@ -45,6 +45,7 @@ interface ScheduledJob {
   prune_keep_monthly: number
   prune_keep_quarterly: number
   prune_keep_yearly: number
+  prune_keep_within?: string | null
   last_prune: string | null
   last_compact: string | null
 }
@@ -141,8 +142,18 @@ export default function ScheduleJobCard({
   if (job.run_prune_after)
     meta.push({
       label: t('schedule.card.meta.prune'),
-      value: `${job.prune_keep_daily}d/${job.prune_keep_weekly}w/${job.prune_keep_monthly}m/${job.prune_keep_yearly}y`,
-      tooltip: `Keep: daily=${job.prune_keep_daily} weekly=${job.prune_keep_weekly} monthly=${job.prune_keep_monthly} yearly=${job.prune_keep_yearly}`,
+      value: [
+        job.prune_keep_within ? `within ${job.prune_keep_within}` : null,
+        `${job.prune_keep_daily}d/${job.prune_keep_weekly}w/${job.prune_keep_monthly}m/${job.prune_keep_yearly}y`,
+      ]
+        .filter(Boolean)
+        .join(' · '),
+      tooltip: [
+        `Keep: daily=${job.prune_keep_daily} weekly=${job.prune_keep_weekly} monthly=${job.prune_keep_monthly} yearly=${job.prune_keep_yearly}`,
+        job.prune_keep_within ? `within=${job.prune_keep_within}` : null,
+      ]
+        .filter(Boolean)
+        .join(' '),
     })
   if (job.last_prune)
     meta.push({

--- a/frontend/src/components/ScheduleWizard.tsx
+++ b/frontend/src/components/ScheduleWizard.tsx
@@ -39,6 +39,7 @@ export interface ScheduledJob {
   prune_keep_monthly: number
   prune_keep_quarterly: number
   prune_keep_yearly: number
+  prune_keep_within?: string | null
 }
 
 export interface Script {
@@ -78,6 +79,7 @@ export interface ScheduleData {
   prune_keep_monthly: number
   prune_keep_quarterly: number
   prune_keep_yearly: number
+  prune_keep_within: string | null
   [key: string]: unknown
 }
 
@@ -108,6 +110,7 @@ interface WizardState {
   pruneKeepMonthly: number
   pruneKeepQuarterly: number
   pruneKeepYearly: number
+  pruneKeepWithin: string
 }
 
 const createInitialState = (): WizardState => ({
@@ -130,6 +133,7 @@ const createInitialState = (): WizardState => ({
   pruneKeepMonthly: 6,
   pruneKeepQuarterly: 0,
   pruneKeepYearly: 1,
+  pruneKeepWithin: '',
 })
 
 const ScheduleWizard: React.FC<ScheduleWizardProps> = ({
@@ -200,6 +204,7 @@ const ScheduleWizard: React.FC<ScheduleWizardProps> = ({
       pruneKeepMonthly: scheduledJob.prune_keep_monthly ?? 6,
       pruneKeepQuarterly: scheduledJob.prune_keep_quarterly ?? 0,
       pruneKeepYearly: scheduledJob.prune_keep_yearly ?? 1,
+      pruneKeepWithin: scheduledJob.prune_keep_within || '',
     })
   }, [scheduledJob, repositories])
 
@@ -285,6 +290,7 @@ const ScheduleWizard: React.FC<ScheduleWizardProps> = ({
       prune_keep_monthly: wizardState.pruneKeepMonthly,
       prune_keep_quarterly: wizardState.pruneKeepQuarterly,
       prune_keep_yearly: wizardState.pruneKeepYearly,
+      prune_keep_within: wizardState.pruneKeepWithin.trim() || null,
     }
 
     track(EventCategory.BACKUP, mode === 'create' ? EventAction.CREATE : EventAction.EDIT, {
@@ -357,6 +363,7 @@ const ScheduleWizard: React.FC<ScheduleWizardProps> = ({
               pruneKeepMonthly: wizardState.pruneKeepMonthly,
               pruneKeepQuarterly: wizardState.pruneKeepQuarterly,
               pruneKeepYearly: wizardState.pruneKeepYearly,
+              pruneKeepWithin: wizardState.pruneKeepWithin,
             }}
             onChange={handleStateChange}
           />

--- a/frontend/src/components/ScheduledJobsTable.tsx
+++ b/frontend/src/components/ScheduledJobsTable.tsx
@@ -29,6 +29,7 @@ interface ScheduledJob {
   prune_keep_monthly: number
   prune_keep_quarterly: number
   prune_keep_yearly: number
+  prune_keep_within?: string | null
   last_prune: string | null
   last_compact: string | null
 }

--- a/frontend/src/components/__tests__/PruneRepositoryDialog.test.tsx
+++ b/frontend/src/components/__tests__/PruneRepositoryDialog.test.tsx
@@ -98,6 +98,7 @@ describe('PruneRepositoryDialog', () => {
       )
 
       expect(screen.getByText(/Keep Hourly/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/Keep Within/i)).toBeInTheDocument()
       expect(screen.getByText(/Keep Daily/i)).toBeInTheDocument()
       expect(screen.getByText(/Keep Weekly/i)).toBeInTheDocument()
       expect(screen.getByText(/Keep Monthly/i)).toBeInTheDocument()
@@ -242,12 +243,39 @@ describe('PruneRepositoryDialog', () => {
 
       expect(onDryRun).toHaveBeenCalledWith(
         expect.objectContaining({
+          keep_within: '',
           keep_hourly: 0,
           keep_daily: 7,
           keep_weekly: 4,
           keep_monthly: 6,
           keep_quarterly: 0,
           keep_yearly: 1,
+        })
+      )
+    })
+
+    it('submits keep-within when set before dry run', async () => {
+      const user = userEvent.setup()
+      const onDryRun = vi.fn()
+
+      render(
+        <PruneRepositoryDialog
+          open={true}
+          repository={mockRepository}
+          onClose={vi.fn()}
+          onDryRun={onDryRun}
+          onConfirmPrune={vi.fn()}
+          isLoading={false}
+          results={null}
+        />
+      )
+
+      await user.type(screen.getByLabelText(/Keep Within/i), '1d')
+      await user.click(screen.getByRole('button', { name: /Dry Run/i }))
+
+      expect(onDryRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          keep_within: '1d',
         })
       )
     })

--- a/frontend/src/components/__tests__/PruneSettingsInput.test.tsx
+++ b/frontend/src/components/__tests__/PruneSettingsInput.test.tsx
@@ -10,12 +10,14 @@ describe('PruneSettingsInput', () => {
     keepMonthly: 6,
     keepQuarterly: 0,
     keepYearly: 1,
+    keepWithin: '',
   }
 
-  it('renders all six input fields', () => {
+  it('renders all retention input fields', () => {
     const onChange = vi.fn()
     render(<PruneSettingsInput values={defaultValues} onChange={onChange} />)
 
+    expect(screen.getByLabelText(/Keep Within/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/Keep Hourly/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/Keep Daily/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/Keep Weekly/i)).toBeInTheDocument()
@@ -28,6 +30,7 @@ describe('PruneSettingsInput', () => {
     const onChange = vi.fn()
     render(<PruneSettingsInput values={defaultValues} onChange={onChange} />)
 
+    expect(screen.getByLabelText(/Keep Within/i)).toHaveValue('')
     expect(screen.getByLabelText(/Keep Hourly/i)).toHaveValue(0)
     expect(screen.getByLabelText(/Keep Daily/i)).toHaveValue(7)
     expect(screen.getByLabelText(/Keep Weekly/i)).toHaveValue(4)
@@ -46,6 +49,19 @@ describe('PruneSettingsInput', () => {
     expect(onChange).toHaveBeenCalledWith({
       ...defaultValues,
       keepHourly: 24,
+    })
+  })
+
+  it('calls onChange when keep-within value changes', () => {
+    const onChange = vi.fn()
+    render(<PruneSettingsInput values={defaultValues} onChange={onChange} />)
+
+    const keepWithinInput = screen.getByLabelText(/Keep Within/i)
+    fireEvent.change(keepWithinInput, { target: { value: '1d' } })
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...defaultValues,
+      keepWithin: '1d',
     })
   })
 
@@ -121,11 +137,12 @@ describe('PruneSettingsInput', () => {
       keepMonthly: 0,
       keepQuarterly: 0,
       keepYearly: 0,
+      keepWithin: '',
     }
 
     render(<PruneSettingsInput values={allZeroValues} onChange={onChange} />)
 
-    Object.values(screen.getAllByRole('spinbutton')).forEach((input) => {
+    screen.getAllByRole('spinbutton').forEach((input) => {
       expect(input).toHaveValue(0)
     })
   })

--- a/frontend/src/components/wizard/schedule/WizardStepMaintenance.tsx
+++ b/frontend/src/components/wizard/schedule/WizardStepMaintenance.tsx
@@ -22,6 +22,7 @@ interface WizardStepMaintenanceData {
   pruneKeepMonthly: number
   pruneKeepQuarterly: number
   pruneKeepYearly: number
+  pruneKeepWithin: string
 }
 
 interface WizardStepMaintenanceProps {
@@ -40,6 +41,7 @@ const WizardStepMaintenance: React.FC<WizardStepMaintenanceProps> = ({ data, onC
       pruneKeepMonthly: values.keepMonthly,
       pruneKeepQuarterly: values.keepQuarterly,
       pruneKeepYearly: values.keepYearly,
+      pruneKeepWithin: values.keepWithin,
     })
   }
 
@@ -106,6 +108,7 @@ const WizardStepMaintenance: React.FC<WizardStepMaintenanceProps> = ({ data, onC
                 keepMonthly: data.pruneKeepMonthly,
                 keepQuarterly: data.pruneKeepQuarterly,
                 keepYearly: data.pruneKeepYearly,
+                keepWithin: data.pruneKeepWithin,
               }}
               onChange={handlePruneSettingsChange}
             />

--- a/frontend/src/components/wizard/schedule/WizardStepScheduleReview.tsx
+++ b/frontend/src/components/wizard/schedule/WizardStepScheduleReview.tsx
@@ -24,6 +24,7 @@ interface WizardStepScheduleReviewProps {
     pruneKeepMonthly: number
     pruneKeepQuarterly: number
     pruneKeepYearly: number
+    pruneKeepWithin: string
   }
   repositories: Repository[]
   scripts: Script[]
@@ -181,6 +182,7 @@ const WizardStepScheduleReview: React.FC<WizardStepScheduleReviewProps> = ({
     `${data.pruneKeepMonthly}m`,
     data.pruneKeepQuarterly > 0 && `${data.pruneKeepQuarterly}q`,
     `${data.pruneKeepYearly}y`,
+    data.pruneKeepWithin && `within ${data.pruneKeepWithin}`,
   ]
     .filter(Boolean)
     .join(' · ')

--- a/frontend/src/components/wizard/schedule/WizardStepScheduleReview.tsx
+++ b/frontend/src/components/wizard/schedule/WizardStepScheduleReview.tsx
@@ -182,7 +182,10 @@ const WizardStepScheduleReview: React.FC<WizardStepScheduleReviewProps> = ({
     `${data.pruneKeepMonthly}m`,
     data.pruneKeepQuarterly > 0 && `${data.pruneKeepQuarterly}q`,
     `${data.pruneKeepYearly}y`,
-    data.pruneKeepWithin && `within ${data.pruneKeepWithin}`,
+    data.pruneKeepWithin &&
+      t('wizard.scheduleWizard.review.keepWithin', {
+        interval: data.pruneKeepWithin,
+      }),
   ]
     .filter(Boolean)
     .join(' · ')

--- a/frontend/src/components/wizard/schedule/__tests__/WizardStepMaintenance.test.tsx
+++ b/frontend/src/components/wizard/schedule/__tests__/WizardStepMaintenance.test.tsx
@@ -12,6 +12,7 @@ describe('WizardStepMaintenance', () => {
     pruneKeepMonthly: 6,
     pruneKeepQuarterly: 0,
     pruneKeepYearly: 1,
+    pruneKeepWithin: '',
   }
 
   const defaultProps = {
@@ -88,6 +89,7 @@ describe('WizardStepMaintenance', () => {
     render(<WizardStepMaintenance {...defaultProps} data={dataWithPrune} />)
 
     expect(screen.getByLabelText(/Keep Hourly/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Keep Within/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/Keep Daily/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/Keep Weekly/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/Keep Monthly/i)).toBeInTheDocument()
@@ -134,6 +136,30 @@ describe('WizardStepMaintenance', () => {
       pruneKeepMonthly: 6,
       pruneKeepQuarterly: 0,
       pruneKeepYearly: 1,
+      pruneKeepWithin: '',
+    })
+  })
+
+  it('calls onChange with keep-within when the interval changes', () => {
+    const onChange = vi.fn()
+    const dataWithPrune = {
+      ...defaultData,
+      runPruneAfter: true,
+    }
+
+    render(<WizardStepMaintenance {...defaultProps} data={dataWithPrune} onChange={onChange} />)
+
+    const keepWithinInput = screen.getByLabelText(/Keep Within/i)
+    fireEvent.change(keepWithinInput, { target: { value: '1d' } })
+
+    expect(onChange).toHaveBeenCalledWith({
+      pruneKeepHourly: 0,
+      pruneKeepDaily: 7,
+      pruneKeepWeekly: 4,
+      pruneKeepMonthly: 6,
+      pruneKeepQuarterly: 0,
+      pruneKeepYearly: 1,
+      pruneKeepWithin: '1d',
     })
   })
 

--- a/frontend/src/components/wizard/schedule/__tests__/WizardStepScheduleReview.test.tsx
+++ b/frontend/src/components/wizard/schedule/__tests__/WizardStepScheduleReview.test.tsx
@@ -32,6 +32,7 @@ describe('WizardStepScheduleReview', () => {
     pruneKeepMonthly: 6,
     pruneKeepQuarterly: 2,
     pruneKeepYearly: 1,
+    pruneKeepWithin: '',
   }
 
   const defaultProps = {

--- a/frontend/src/components/wizard/schedule/__tests__/WizardStepScheduleReview.test.tsx
+++ b/frontend/src/components/wizard/schedule/__tests__/WizardStepScheduleReview.test.tsx
@@ -216,6 +216,17 @@ describe('WizardStepScheduleReview', () => {
     expect(screen.getByText(/1y/i)).toBeInTheDocument()
   })
 
+  it('displays keep-within prune interval when configured', () => {
+    render(
+      <WizardStepScheduleReview
+        {...defaultProps}
+        data={{ ...defaultData, pruneKeepWithin: '1d' }}
+      />
+    )
+
+    expect(screen.getByText(/within 1d/i)).toBeInTheDocument()
+  })
+
   it('does not display prune keep format when prune is disabled', () => {
     const dataNoPrune = {
       ...defaultData,

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -742,6 +742,8 @@
       "meta": {
         "note": "Note",
         "prune": "Prune",
+        "keepWithin": "innerhalb {{interval}}",
+        "keepWithinTooltip": "innerhalb={{interval}}",
         "lastPruned": "Last Pruned",
         "compact": "Compact",
         "lastCompact": "Last Compact",
@@ -1290,7 +1292,8 @@
         "schedule": "Zeitplan",
         "prune": "Prune",
         "retention": "Aufbewahrung",
-        "retentionValue": "Innerhalb {{within}} / H {{hourly}} / T {{daily}} / W {{weekly}} / M {{monthly}} / Q {{quarterly}} / J {{yearly}}",
+        "retentionValue": "H {{hourly}} / T {{daily}} / W {{weekly}} / M {{monthly}} / Q {{quarterly}} / J {{yearly}}",
+        "retentionValueWithWithin": "Innerhalb {{within}} / H {{hourly}} / T {{daily}} / W {{weekly}} / M {{monthly}} / Q {{quarterly}} / J {{yearly}}",
         "compact": "Compact",
         "check": "Check",
         "checkExtraFlags": "Check-Flags",
@@ -4005,6 +4008,7 @@
         "pruneAfterBackup": "Bereinigung nach Sicherung",
         "enabled": "Aktiviert",
         "disabled": "Deaktiviert",
+        "keepWithin": "innerhalb {{interval}}",
         "compactAfterPrune": "Komprimierung nach Bereinigung",
         "none": "Keine"
       },

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1290,7 +1290,7 @@
         "schedule": "Zeitplan",
         "prune": "Prune",
         "retention": "Aufbewahrung",
-        "retentionValue": "H {{hourly}} / T {{daily}} / W {{weekly}} / M {{monthly}} / Q {{quarterly}} / J {{yearly}}",
+        "retentionValue": "Innerhalb {{within}} / H {{hourly}} / T {{daily}} / W {{weekly}} / M {{monthly}} / Q {{quarterly}} / J {{yearly}}",
         "compact": "Compact",
         "check": "Check",
         "checkExtraFlags": "Check-Flags",
@@ -2463,6 +2463,10 @@
       "dryRunTip": "Tipp: Immer zuerst 'Testlauf' ausführen, um eine Vorschau der zu löschenden Elemente zu sehen!",
       "retentionPolicy": "Aufbewahrungsrichtlinie",
       "retentionDescription": "Angeben, wie viele Sicherungen für jeden Zeitraum behalten werden sollen",
+      "keepWithin": "Innerhalb behalten",
+      "keepWithinHelper": "Alle Archive behalten, die innerhalb dieses aktuellen Intervalls erstellt wurden",
+      "keepWithinPlaceholder": "1d",
+      "keepWithinSummary": "alle Archive innerhalb von {{interval}}",
       "keepHourly": "Stündlich behalten",
       "keepHourlyHelper": "Letzte N stündliche Sicherungen (0 = deaktiviert)",
       "keepDaily": "Täglich behalten",
@@ -3269,7 +3273,10 @@
     "keepQuarterly": "Vierteljährlich behalten",
     "keepQuarterlyHint": "Vierteljährliche Sicherungen zum Behalten (0 = deaktiviert)",
     "keepYearly": "Jährlich behalten",
-    "keepYearlyHint": "Jährliche Sicherungen zum Behalten"
+    "keepYearlyHint": "Jährliche Sicherungen zum Behalten",
+    "keepWithin": "Innerhalb behalten",
+    "keepWithinHint": "Alle Archive innerhalb dieses aktuellen Intervalls behalten, z. B. 1d oder 12H",
+    "keepWithinPlaceholder": "1d"
   },
   "compressionSettings": {
     "title": "Komprimierungseinstellungen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -756,6 +756,8 @@
       "meta": {
         "note": "Note",
         "prune": "Prune",
+        "keepWithin": "within {{interval}}",
+        "keepWithinTooltip": "within={{interval}}",
         "lastPruned": "Last Pruned",
         "compact": "Compact",
         "lastCompact": "Last Compact",
@@ -1290,7 +1292,8 @@
         "schedule": "Schedule",
         "prune": "Prune",
         "retention": "Retention",
-        "retentionValue": "Within {{within}} / H {{hourly}} / D {{daily}} / W {{weekly}} / M {{monthly}} / Q {{quarterly}} / Y {{yearly}}",
+        "retentionValue": "H {{hourly}} / D {{daily}} / W {{weekly}} / M {{monthly}} / Q {{quarterly}} / Y {{yearly}}",
+        "retentionValueWithWithin": "Within {{within}} / H {{hourly}} / D {{daily}} / W {{weekly}} / M {{monthly}} / Q {{quarterly}} / Y {{yearly}}",
         "compact": "Compact",
         "check": "Check",
         "checkExtraFlags": "Check flags",
@@ -4005,6 +4008,7 @@
         "pruneAfterBackup": "Prune After Backup",
         "enabled": "Enabled",
         "disabled": "Disabled",
+        "keepWithin": "within {{interval}}",
         "compactAfterPrune": "Compact After Prune",
         "none": "None"
       },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1290,7 +1290,7 @@
         "schedule": "Schedule",
         "prune": "Prune",
         "retention": "Retention",
-        "retentionValue": "H {{hourly}} / D {{daily}} / W {{weekly}} / M {{monthly}} / Q {{quarterly}} / Y {{yearly}}",
+        "retentionValue": "Within {{within}} / H {{hourly}} / D {{daily}} / W {{weekly}} / M {{monthly}} / Q {{quarterly}} / Y {{yearly}}",
         "compact": "Compact",
         "check": "Check",
         "checkExtraFlags": "Check flags",
@@ -2463,6 +2463,10 @@
       "dryRunTip": "Tip: Always run \"Dry Run\" first to preview what will be deleted!",
       "retentionPolicy": "Retention Policy",
       "retentionDescription": "Specify how many backups to keep for each time period",
+      "keepWithin": "Keep Within",
+      "keepWithinHelper": "Keep all archives created within this recent interval",
+      "keepWithinPlaceholder": "1d",
+      "keepWithinSummary": "all archives within {{interval}}",
       "keepHourly": "Keep Hourly",
       "keepHourlyHelper": "Last N hourly backups (0 = disabled)",
       "keepDaily": "Keep Daily",
@@ -3269,7 +3273,10 @@
     "keepQuarterly": "Keep Quarterly",
     "keepQuarterlyHint": "Quarterly backups to keep (0 = disabled)",
     "keepYearly": "Keep Yearly",
-    "keepYearlyHint": "Yearly backups to keep"
+    "keepYearlyHint": "Yearly backups to keep",
+    "keepWithin": "Keep Within",
+    "keepWithinHint": "Keep all archives within this recent interval, for example 1d or 12H",
+    "keepWithinPlaceholder": "1d"
   },
   "compressionSettings": {
     "title": "Compression Settings",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -1290,7 +1290,7 @@
         "schedule": "Programación",
         "prune": "Prune",
         "retention": "Retención",
-        "retentionValue": "H {{hourly}} / D {{daily}} / S {{weekly}} / M {{monthly}} / T {{quarterly}} / A {{yearly}}",
+        "retentionValue": "Dentro de {{within}} / H {{hourly}} / D {{daily}} / S {{weekly}} / M {{monthly}} / T {{quarterly}} / A {{yearly}}",
         "compact": "Compact",
         "check": "Check",
         "checkExtraFlags": "Flags de check",
@@ -2463,6 +2463,10 @@
       "dryRunTip": "Consejo: ¡Ejecuta siempre el \"Simulacro\" primero para ver qué se eliminará!",
       "retentionPolicy": "Política de retención",
       "retentionDescription": "Especifica cuántas copias conservar para cada período de tiempo",
+      "keepWithin": "Mantener dentro de",
+      "keepWithinHelper": "Conserva todos los archivos creados dentro de este intervalo reciente",
+      "keepWithinPlaceholder": "1d",
+      "keepWithinSummary": "todos los archivos dentro de {{interval}}",
       "keepHourly": "Mantener por hora",
       "keepHourlyHelper": "Últimas N copias horarias (0 = deshabilitado)",
       "keepDaily": "Mantener por día",
@@ -3269,7 +3273,10 @@
     "keepQuarterly": "Mantener por trimestre",
     "keepQuarterlyHint": "Copias de seguridad trimestrales a mantener (0 = deshabilitado)",
     "keepYearly": "Mantener por año",
-    "keepYearlyHint": "Copias de seguridad anuales a mantener"
+    "keepYearlyHint": "Copias de seguridad anuales a mantener",
+    "keepWithin": "Mantener dentro de",
+    "keepWithinHint": "Conserva todos los archivos dentro de este intervalo reciente, por ejemplo 1d o 12H",
+    "keepWithinPlaceholder": "1d"
   },
   "compressionSettings": {
     "title": "Configuración de compresión",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -742,6 +742,8 @@
       "meta": {
         "note": "Note",
         "prune": "Prune",
+        "keepWithin": "dentro de {{interval}}",
+        "keepWithinTooltip": "dentro={{interval}}",
         "lastPruned": "Last Pruned",
         "compact": "Compact",
         "lastCompact": "Last Compact",
@@ -1290,7 +1292,8 @@
         "schedule": "Programación",
         "prune": "Prune",
         "retention": "Retención",
-        "retentionValue": "Dentro de {{within}} / H {{hourly}} / D {{daily}} / S {{weekly}} / M {{monthly}} / T {{quarterly}} / A {{yearly}}",
+        "retentionValue": "H {{hourly}} / D {{daily}} / S {{weekly}} / M {{monthly}} / T {{quarterly}} / A {{yearly}}",
+        "retentionValueWithWithin": "Dentro de {{within}} / H {{hourly}} / D {{daily}} / S {{weekly}} / M {{monthly}} / T {{quarterly}} / A {{yearly}}",
         "compact": "Compact",
         "check": "Check",
         "checkExtraFlags": "Flags de check",
@@ -4005,6 +4008,7 @@
         "pruneAfterBackup": "Poda tras la copia de seguridad",
         "enabled": "Habilitado",
         "disabled": "Deshabilitado",
+        "keepWithin": "dentro de {{interval}}",
         "compactAfterPrune": "Compactación tras la poda",
         "none": "Ninguno"
       },

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -742,6 +742,8 @@
       "meta": {
         "note": "Note",
         "prune": "Prune",
+        "keepWithin": "entro {{interval}}",
+        "keepWithinTooltip": "entro={{interval}}",
         "lastPruned": "Last Pruned",
         "compact": "Compact",
         "lastCompact": "Last Compact",
@@ -1290,7 +1292,8 @@
         "schedule": "Pianificazione",
         "prune": "Prune",
         "retention": "Conservazione",
-        "retentionValue": "Entro {{within}} / H {{hourly}} / G {{daily}} / S {{weekly}} / M {{monthly}} / T {{quarterly}} / A {{yearly}}",
+        "retentionValue": "H {{hourly}} / G {{daily}} / S {{weekly}} / M {{monthly}} / T {{quarterly}} / A {{yearly}}",
+        "retentionValueWithWithin": "Entro {{within}} / H {{hourly}} / G {{daily}} / S {{weekly}} / M {{monthly}} / T {{quarterly}} / A {{yearly}}",
         "compact": "Compact",
         "check": "Check",
         "checkExtraFlags": "Flag di check",
@@ -4005,6 +4008,7 @@
         "pruneAfterBackup": "Pulizia dopo Backup",
         "enabled": "Abilitato",
         "disabled": "Disabilitato",
+        "keepWithin": "entro {{interval}}",
         "compactAfterPrune": "Compattazione dopo Pulizia",
         "none": "Nessuno"
       },

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -1290,7 +1290,7 @@
         "schedule": "Pianificazione",
         "prune": "Prune",
         "retention": "Conservazione",
-        "retentionValue": "H {{hourly}} / G {{daily}} / S {{weekly}} / M {{monthly}} / T {{quarterly}} / A {{yearly}}",
+        "retentionValue": "Entro {{within}} / H {{hourly}} / G {{daily}} / S {{weekly}} / M {{monthly}} / T {{quarterly}} / A {{yearly}}",
         "compact": "Compact",
         "check": "Check",
         "checkExtraFlags": "Flag di check",
@@ -2463,6 +2463,10 @@
       "dryRunTip": "Suggerimento: Esegui sempre prima una \"Prova Simulata\" per vedere cosa verrà eliminato!",
       "retentionPolicy": "Politica di Conservazione",
       "retentionDescription": "Specifica quanti backup mantenere per ogni periodo di tempo",
+      "keepWithin": "Mantieni entro",
+      "keepWithinHelper": "Mantieni tutti gli archivi creati entro questo intervallo recente",
+      "keepWithinPlaceholder": "1d",
+      "keepWithinSummary": "tutti gli archivi entro {{interval}}",
       "keepHourly": "Mantieni Orari",
       "keepHourlyHelper": "Ultimi N backup orari (0 = disabilitato)",
       "keepDaily": "Mantieni Giornalieri",
@@ -3269,7 +3273,10 @@
     "keepQuarterly": "Mantieni Trimestrali",
     "keepQuarterlyHint": "Backup trimestrali da mantenere (0 = disabilitato)",
     "keepYearly": "Mantieni Annuali",
-    "keepYearlyHint": "Backup annuali da mantenere"
+    "keepYearlyHint": "Backup annuali da mantenere",
+    "keepWithin": "Mantieni entro",
+    "keepWithinHint": "Mantieni tutti gli archivi entro questo intervallo recente, ad esempio 1d o 12H",
+    "keepWithinPlaceholder": "1d"
   },
   "compressionSettings": {
     "title": "Impostazioni Compressione",

--- a/frontend/src/pages/BackupPlans.tsx
+++ b/frontend/src/pages/BackupPlans.tsx
@@ -645,6 +645,7 @@ export default function BackupPlans() {
       pruneKeepMonthly: values.keepMonthly,
       pruneKeepQuarterly: values.keepQuarterly,
       pruneKeepYearly: values.keepYearly,
+      pruneKeepWithin: values.keepWithin,
     })
   }
 

--- a/frontend/src/pages/Schedule.tsx
+++ b/frontend/src/pages/Schedule.tsx
@@ -65,6 +65,7 @@ interface ScheduledJob {
   prune_keep_monthly: number
   prune_keep_quarterly: number
   prune_keep_yearly: number
+  prune_keep_within?: string | null
   last_prune: string | null
   last_compact: string | null
 }

--- a/frontend/src/pages/backup-plans/__tests__/ReviewStep.test.tsx
+++ b/frontend/src/pages/backup-plans/__tests__/ReviewStep.test.tsx
@@ -193,14 +193,14 @@ describe('ReviewStep', () => {
     expect(screen.getByText(/within 1d/)).toBeInTheDocument()
   })
 
-  it('omits keep-within retention when the interval is blank', () => {
+  it('omits keep-within retention when the interval is whitespace', () => {
     renderReview({
       ...createInitialState(),
       name: 'Frequent backup',
       sourceDirectories: ['/data'],
       repositoryIds: [10],
       runPruneAfter: true,
-      pruneKeepWithin: '',
+      pruneKeepWithin: '   ',
     })
 
     expect(screen.getByText('Prune')).toBeInTheDocument()

--- a/frontend/src/pages/backup-plans/__tests__/ReviewStep.test.tsx
+++ b/frontend/src/pages/backup-plans/__tests__/ReviewStep.test.tsx
@@ -34,7 +34,8 @@ const translations: Record<string, string> = {
   'backupPlans.wizard.review.prune': 'Prune',
   'backupPlans.wizard.review.repositories': 'Repositories',
   'backupPlans.wizard.review.repositoryScripts': 'Repository scripts',
-  'backupPlans.wizard.review.retentionValue': 'daily {{daily}}, weekly {{weekly}}',
+  'backupPlans.wizard.review.retentionValue':
+    'daily {{daily}}, weekly {{weekly}}, within {{within}}',
   'backupPlans.wizard.review.runMode': 'Run mode',
   'backupPlans.wizard.review.sourceLocation': 'Source location',
   'backupPlans.wizard.review.sources': 'Sources',
@@ -54,6 +55,7 @@ const t = (key: string, options?: Record<string, unknown>) => {
     .replace('{{count}}', String(options?.count ?? ''))
     .replace('{{daily}}', String(options?.daily ?? ''))
     .replace('{{weekly}}', String(options?.weekly ?? ''))
+    .replace('{{within}}', String(options?.within ?? ''))
     .replace('{{seconds}}', String(options?.seconds ?? ''))
     .replace('{{limit}}', String(options?.limit ?? ''))
 }
@@ -174,5 +176,19 @@ describe('ReviewStep', () => {
     expect(screen.getByText('postgres:17')).toBeInTheDocument()
     expect(screen.getByText('Export staging path')).toBeInTheDocument()
     expect(screen.getByText('/var/tmp/borg-ui/container-exports/postgres')).toBeInTheDocument()
+  })
+
+  it('shows keep-within retention in the prune review', () => {
+    renderReview({
+      ...createInitialState(),
+      name: 'Frequent backup',
+      sourceDirectories: ['/data'],
+      repositoryIds: [10],
+      runPruneAfter: true,
+      pruneKeepWithin: '1d',
+    })
+
+    expect(screen.getByText('Prune')).toBeInTheDocument()
+    expect(screen.getByText(/within 1d/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/backup-plans/__tests__/ReviewStep.test.tsx
+++ b/frontend/src/pages/backup-plans/__tests__/ReviewStep.test.tsx
@@ -34,8 +34,7 @@ const translations: Record<string, string> = {
   'backupPlans.wizard.review.prune': 'Prune',
   'backupPlans.wizard.review.repositories': 'Repositories',
   'backupPlans.wizard.review.repositoryScripts': 'Repository scripts',
-  'backupPlans.wizard.review.retentionValue':
-    'daily {{daily}}, weekly {{weekly}}',
+  'backupPlans.wizard.review.retentionValue': 'daily {{daily}}, weekly {{weekly}}',
   'backupPlans.wizard.review.retentionValueWithWithin':
     'daily {{daily}}, weekly {{weekly}}, within {{within}}',
   'backupPlans.wizard.review.runMode': 'Run mode',

--- a/frontend/src/pages/backup-plans/__tests__/ReviewStep.test.tsx
+++ b/frontend/src/pages/backup-plans/__tests__/ReviewStep.test.tsx
@@ -35,6 +35,8 @@ const translations: Record<string, string> = {
   'backupPlans.wizard.review.repositories': 'Repositories',
   'backupPlans.wizard.review.repositoryScripts': 'Repository scripts',
   'backupPlans.wizard.review.retentionValue':
+    'daily {{daily}}, weekly {{weekly}}',
+  'backupPlans.wizard.review.retentionValueWithWithin':
     'daily {{daily}}, weekly {{weekly}}, within {{within}}',
   'backupPlans.wizard.review.runMode': 'Run mode',
   'backupPlans.wizard.review.sourceLocation': 'Source location',
@@ -190,5 +192,19 @@ describe('ReviewStep', () => {
 
     expect(screen.getByText('Prune')).toBeInTheDocument()
     expect(screen.getByText(/within 1d/)).toBeInTheDocument()
+  })
+
+  it('omits keep-within retention when the interval is blank', () => {
+    renderReview({
+      ...createInitialState(),
+      name: 'Frequent backup',
+      sourceDirectories: ['/data'],
+      repositoryIds: [10],
+      runPruneAfter: true,
+      pruneKeepWithin: '',
+    })
+
+    expect(screen.getByText('Prune')).toBeInTheDocument()
+    expect(screen.queryByText(/within/i)).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/backup-plans/state.ts
+++ b/frontend/src/pages/backup-plans/state.ts
@@ -49,6 +49,7 @@ export const createInitialState = (): WizardState => ({
   pruneKeepMonthly: 6,
   pruneKeepQuarterly: 0,
   pruneKeepYearly: 1,
+  pruneKeepWithin: '',
   databaseTemplateId: null,
 })
 
@@ -359,6 +360,7 @@ export function planToState(plan: BackupPlan): WizardState {
     pruneKeepMonthly: plan.prune_keep_monthly ?? 6,
     pruneKeepQuarterly: plan.prune_keep_quarterly ?? 0,
     pruneKeepYearly: plan.prune_keep_yearly ?? 1,
+    pruneKeepWithin: plan.prune_keep_within || '',
     databaseTemplateId: plan.database_template_id ?? null,
   }
 }

--- a/frontend/src/pages/backup-plans/wizard-step/ReviewStep.tsx
+++ b/frontend/src/pages/backup-plans/wizard-step/ReviewStep.tsx
@@ -113,6 +113,7 @@ export function ReviewStep({
     monthly: wizardState.pruneKeepMonthly,
     quarterly: wizardState.pruneKeepQuarterly,
     yearly: wizardState.pruneKeepYearly,
+    within: wizardState.pruneKeepWithin || t('common.disabled'),
   })
 
   return (

--- a/frontend/src/pages/backup-plans/wizard-step/ReviewStep.tsx
+++ b/frontend/src/pages/backup-plans/wizard-step/ReviewStep.tsx
@@ -106,8 +106,9 @@ export function ReviewStep({
     0
   )
   const uploadPolicies = wizardState.uploadRatelimitSchedulePolicies || []
+  const pruneKeepWithin = wizardState.pruneKeepWithin?.trim() ?? ''
   const retentionLabel = t(
-    wizardState.pruneKeepWithin
+    pruneKeepWithin
       ? 'backupPlans.wizard.review.retentionValueWithWithin'
       : 'backupPlans.wizard.review.retentionValue',
     {
@@ -117,7 +118,7 @@ export function ReviewStep({
       monthly: wizardState.pruneKeepMonthly,
       quarterly: wizardState.pruneKeepQuarterly,
       yearly: wizardState.pruneKeepYearly,
-      within: wizardState.pruneKeepWithin,
+      within: pruneKeepWithin,
     }
   )
 

--- a/frontend/src/pages/backup-plans/wizard-step/ReviewStep.tsx
+++ b/frontend/src/pages/backup-plans/wizard-step/ReviewStep.tsx
@@ -106,15 +106,20 @@ export function ReviewStep({
     0
   )
   const uploadPolicies = wizardState.uploadRatelimitSchedulePolicies || []
-  const retentionLabel = t('backupPlans.wizard.review.retentionValue', {
-    hourly: wizardState.pruneKeepHourly,
-    daily: wizardState.pruneKeepDaily,
-    weekly: wizardState.pruneKeepWeekly,
-    monthly: wizardState.pruneKeepMonthly,
-    quarterly: wizardState.pruneKeepQuarterly,
-    yearly: wizardState.pruneKeepYearly,
-    within: wizardState.pruneKeepWithin || t('common.disabled'),
-  })
+  const retentionLabel = t(
+    wizardState.pruneKeepWithin
+      ? 'backupPlans.wizard.review.retentionValueWithWithin'
+      : 'backupPlans.wizard.review.retentionValue',
+    {
+      hourly: wizardState.pruneKeepHourly,
+      daily: wizardState.pruneKeepDaily,
+      weekly: wizardState.pruneKeepWeekly,
+      monthly: wizardState.pruneKeepMonthly,
+      quarterly: wizardState.pruneKeepQuarterly,
+      yearly: wizardState.pruneKeepYearly,
+      within: wizardState.pruneKeepWithin,
+    }
+  )
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>

--- a/frontend/src/pages/backup-plans/wizard-step/ScheduleStep.stories.tsx
+++ b/frontend/src/pages/backup-plans/wizard-step/ScheduleStep.stories.tsx
@@ -31,6 +31,8 @@ const t = ((key: string, params?: Record<string, unknown>) =>
 
 const conflictState = {
   ...createInitialState(),
+  runPruneAfter: true,
+  pruneKeepWithin: '1d',
   runCheckAfter: true,
   checkMaxDuration: 3600,
   checkExtraFlags: '--archives-only',

--- a/frontend/src/pages/backup-plans/wizard-step/ScheduleStep.tsx
+++ b/frontend/src/pages/backup-plans/wizard-step/ScheduleStep.tsx
@@ -116,6 +116,7 @@ export function ScheduleStep({
                   keepMonthly: wizardState.pruneKeepMonthly,
                   keepQuarterly: wizardState.pruneKeepQuarterly,
                   keepYearly: wizardState.pruneKeepYearly,
+                  keepWithin: wizardState.pruneKeepWithin || '',
                 }}
                 onChange={handlePruneSettingsChange}
               />

--- a/frontend/src/services/borgApi/client.test.ts
+++ b/frontend/src/services/borgApi/client.test.ts
@@ -81,7 +81,7 @@ describe('BorgApiClient', () => {
     client.deleteArchive('archive-1')
     client.getDeleteJobStatus(12)
     client.runBackup({ archive_name: 'nightly' })
-    client.pruneArchives({ keep_daily: 7 })
+    client.pruneArchives({ keep_daily: 7, keep_within: '1d' })
     client.compact()
     client.checkRepository(30)
     const downloadUrl = client.getDownloadUrl('archive-1', '/etc/hosts')
@@ -102,7 +102,10 @@ describe('BorgApiClient', () => {
       repository: '/repo-v1',
       archive_name: 'nightly',
     })
-    expect(postMock).toHaveBeenCalledWith('/repositories/7/prune', { keep_daily: 7 })
+    expect(postMock).toHaveBeenCalledWith('/repositories/7/prune', {
+      keep_daily: 7,
+      keep_within: '1d',
+    })
     expect(postMock).toHaveBeenCalledWith('/repositories/7/compact')
     expect(postMock).toHaveBeenCalledWith('/repositories/7/check', { max_duration: 30 })
     expect(downloadUrl).toContain('/api/archives/download?')
@@ -120,7 +123,7 @@ describe('BorgApiClient', () => {
 
     client.runBackup({ archive_name: 'manual-v2' })
     client.getArchiveContents('archive-id', 'ignored-name', '/srv')
-    client.pruneArchives({ keep_weekly: 4 })
+    client.pruneArchives({ keep_weekly: 4, keep_within: '1d' })
     client.compact()
     client.checkRepository()
     const downloadUrl = client.getDownloadUrl('archive-2', '/srv/data.txt')
@@ -135,6 +138,7 @@ describe('BorgApiClient', () => {
     expect(postMock).toHaveBeenCalledWith('/v2/backup/prune', {
       repository_id: 9,
       keep_weekly: 4,
+      keep_within: '1d',
     })
     expect(postMock).toHaveBeenCalledWith('/v2/backup/compact', { repository_id: 9 })
     expect(postMock).toHaveBeenCalledWith('/v2/backup/check', {

--- a/frontend/src/services/borgApi/client.ts
+++ b/frontend/src/services/borgApi/client.ts
@@ -75,6 +75,7 @@ export interface PruneOptions {
   keep_monthly?: number
   keep_quarterly?: number
   keep_yearly?: number
+  keep_within?: string
   dry_run?: boolean
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -338,6 +338,7 @@ export interface BackupPlan {
   prune_keep_monthly?: number
   prune_keep_quarterly?: number
   prune_keep_yearly?: number
+  prune_keep_within?: string | null
   created_at?: string | null
   updated_at?: string | null
 }
@@ -423,6 +424,7 @@ export interface BackupPlanData {
   prune_keep_monthly: number
   prune_keep_quarterly: number
   prune_keep_yearly: number
+  prune_keep_within?: string | null
   repositories: BackupPlanRepositoryLink[]
   clear_legacy_source_repository_ids?: number[]
 }

--- a/frontend/src/utils/backupPlanPayload.test.ts
+++ b/frontend/src/utils/backupPlanPayload.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { createInitialState, planToState } from '../pages/backup-plans/state'
+import { buildBackupPlanPayload } from './backupPlanPayload'
+import type { BackupPlan } from '../types'
+
+describe('backupPlanPayload prune keep-within', () => {
+  it('includes a trimmed keep-within interval in backup plan payloads', () => {
+    const payload = buildBackupPlanPayload({
+      ...createInitialState(),
+      name: 'Frequent backup',
+      sourceDirectories: ['/data'],
+      repositoryIds: [10],
+      runPruneAfter: true,
+      pruneKeepWithin: ' 1d ',
+    })
+
+    expect(payload.prune_keep_within).toBe('1d')
+  })
+
+  it('hydrates keep-within from an existing backup plan', () => {
+    const state = planToState({
+      id: 1,
+      name: 'Frequent backup',
+      enabled: true,
+      source_type: 'local',
+      source_directories: ['/data'],
+      source_locations: [],
+      exclude_patterns: [],
+      repository_run_mode: 'series',
+      max_parallel_repositories: 1,
+      failure_behavior: 'continue',
+      schedule_enabled: false,
+      timezone: 'UTC',
+      archive_name_template: '{plan_name}-{repo_name}-{now}',
+      compression: 'lz4',
+      run_repository_scripts: true,
+      run_prune_after: true,
+      run_compact_after: false,
+      run_check_after: false,
+      repository_count: 1,
+      check_max_duration: 3600,
+      prune_keep_hourly: 0,
+      prune_keep_daily: 7,
+      prune_keep_weekly: 4,
+      prune_keep_monthly: 6,
+      prune_keep_quarterly: 0,
+      prune_keep_yearly: 1,
+      prune_keep_within: '1d',
+      repositories: [{ repository_id: 10, enabled: true, execution_order: 1 }],
+    } as BackupPlan)
+
+    expect(state.pruneKeepWithin).toBe('1d')
+  })
+})

--- a/frontend/src/utils/backupPlanPayload.test.ts
+++ b/frontend/src/utils/backupPlanPayload.test.ts
@@ -18,6 +18,19 @@ describe('backupPlanPayload prune keep-within', () => {
     expect(payload.prune_keep_within).toBe('1d')
   })
 
+  it('normalizes a cleared keep-within interval to null in backup plan payloads', () => {
+    const payload = buildBackupPlanPayload({
+      ...createInitialState(),
+      name: 'Frequent backup',
+      sourceDirectories: ['/data'],
+      repositoryIds: [10],
+      runPruneAfter: true,
+      pruneKeepWithin: '   ',
+    })
+
+    expect(payload.prune_keep_within).toBeNull()
+  })
+
   it('hydrates keep-within from an existing backup plan', () => {
     const state = planToState({
       id: 1,

--- a/frontend/src/utils/backupPlanPayload.ts
+++ b/frontend/src/utils/backupPlanPayload.ts
@@ -54,6 +54,7 @@ export interface BackupPlanPayloadState {
   pruneKeepMonthly: number
   pruneKeepQuarterly: number
   pruneKeepYearly: number
+  pruneKeepWithin?: string
   // Set when the plan source came in via the Database tab (detected DB or
   // template pick). Lets the dialog open on the right tab on edit and the
   // backend remember the template choice across reloads. Null/undefined for
@@ -116,6 +117,11 @@ function mbToKib(value: string): number | null {
   const parsed = Number(value)
   if (!Number.isFinite(parsed) || parsed <= 0) return null
   return Math.round(parsed * 1024)
+}
+
+function normalizeOptionalString(value?: string): string | null {
+  const trimmed = value?.trim() || ''
+  return trimmed || null
 }
 
 function normalizeUploadRatelimitSchedulePolicies(
@@ -402,6 +408,7 @@ export function buildBackupPlanPayload(
     prune_keep_monthly: state.pruneKeepMonthly,
     prune_keep_quarterly: state.pruneKeepQuarterly,
     prune_keep_yearly: state.pruneKeepYearly,
+    prune_keep_within: normalizeOptionalString(state.pruneKeepWithin),
     repositories: state.repositoryIds.map((repositoryId, index) => ({
       repository_id: repositoryId,
       enabled: true,

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ fastapi==0.136.3
 gunicorn==26.0.0
 httpx==0.28.1
 psutil==7.2.2
-pydantic-settings==2.14.1
+pydantic-settings==2.14.2
 pydantic==2.13.4
 pre-commit==4.6.0
 pytest-asyncio==1.4.0

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -1216,7 +1216,7 @@ def test_repository_operation_payload_builds_agent_local_commands():
         {
             "job_kind": "repository.prune",
             "repository": {"path": "/agent/repo", "borg_version": 2},
-            "operation": {"keep_daily": 7, "dry_run": True},
+            "operation": {"keep_daily": 7, "keep_within": "1d", "dry_run": True},
         }
     )
 
@@ -1232,6 +1232,7 @@ def test_repository_operation_payload_builds_agent_local_commands():
         "--log-json",
         "--keep-daily",
         "7",
+        "--keep-within=1d",
         "--dry-run",
     ]
 

--- a/tests/unit/test_api_backup_plans.py
+++ b/tests/unit/test_api_backup_plans.py
@@ -398,6 +398,28 @@ class TestBackupPlanRoutes:
             == created["upload_ratelimit_schedule_policies"]
         )
 
+    def test_create_plan_persists_prune_keep_within(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        repo = _create_repo(test_db, "Primary", "/repos/primary")
+
+        create_response = test_client.post(
+            "/api/backup-plans/",
+            json=_payload(
+                [repo.id],
+                run_prune_after=True,
+                prune_keep_within="1d",
+            ),
+            headers=admin_headers,
+        )
+
+        assert create_response.status_code == 201
+        created = create_response.json()
+        assert created["prune_keep_within"] == "1d"
+
+        plan = test_db.query(BackupPlan).filter_by(id=created["id"]).one()
+        assert plan.prune_keep_within == "1d"
+
     def test_update_plan_replaces_upload_ratelimit_schedule_policies(
         self, test_client: TestClient, admin_headers, test_db
     ):
@@ -4344,6 +4366,7 @@ class TestBackupPlanRoutes:
             run_check_after=True,
             check_extra_flags="--verify-data",
             run_prune_after=True,
+            prune_keep_within="1d",
             run_compact_after=True,
         )
 
@@ -4370,6 +4393,7 @@ class TestBackupPlanRoutes:
 
             async def prune(self, job_id, **kwargs):
                 maintenance_calls.append("prune")
+                assert kwargs["keep_within"] == "1d"
                 job = test_db.query(PruneJob).filter_by(id=job_id).one()
                 assert job.repository_id == repo.id
                 job.status = "completed"

--- a/tests/unit/test_api_repositories.py
+++ b/tests/unit/test_api_repositories.py
@@ -1455,6 +1455,26 @@ class TestRepositoriesCreate:
             routed_keep_within = args[8]
         assert routed_keep_within == "1d"
 
+    def test_legacy_prune_route_rejects_non_string_keep_within(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        repo = Repository(**_base_repository_payload(name="Invalid Keep Within"))
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+
+        response = test_client.post(
+            f"/api/repositories/{repo.id}/prune",
+            json={"keep_within": ["1d"], "dry_run": True},
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 422
+        assert (
+            response.json()["detail"]["key"]
+            == "backend.errors.repo.invalidPruneKeepWithin"
+        )
+
     def test_create_repository_duplicate_path(
         self, test_client: TestClient, admin_headers, test_db
     ):

--- a/tests/unit/test_api_repositories.py
+++ b/tests/unit/test_api_repositories.py
@@ -1442,12 +1442,18 @@ class TestRepositoriesCreate:
         ) as mock_prune:
             response = test_client.post(
                 f"/api/repositories/{repo.id}/prune",
-                json={"keep_daily": 7, "dry_run": True},
+                json={"keep_daily": 7, "keep_within": "1d", "dry_run": True},
                 headers=admin_headers,
             )
 
         assert response.status_code == 200
         mock_prune.assert_awaited_once()
+        args = mock_prune.await_args.args
+        kwargs = mock_prune.await_args.kwargs
+        routed_keep_within = kwargs.get("keep_within")
+        if routed_keep_within is None and len(args) >= 9:
+            routed_keep_within = args[8]
+        assert routed_keep_within == "1d"
 
     def test_create_repository_duplicate_path(
         self, test_client: TestClient, admin_headers, test_db

--- a/tests/unit/test_api_schedule_routes.py
+++ b/tests/unit/test_api_schedule_routes.py
@@ -188,6 +188,27 @@ class TestScheduleRouteContracts:
             response.json()["detail"]["key"] == "backend.errors.schedule.jobNameExists"
         )
 
+    def test_update_schedule_clears_prune_keep_within(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        schedule = _create_schedule(
+            test_db,
+            "Keep Within",
+            repository="/repos/keep-within",
+            prune_keep_within="1d",
+        )
+
+        response = test_client.put(
+            f"/api/schedule/{schedule.id}",
+            json={"prune_keep_within": None},
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+        test_db.refresh(schedule)
+        assert schedule.prune_keep_within is None
+
     def test_toggle_schedule_enable_recomputes_stale_next_run(
         self, test_client: TestClient, admin_headers, test_db
     ):

--- a/tests/unit/test_borg_router.py
+++ b/tests/unit/test_borg_router.py
@@ -177,6 +177,41 @@ async def test_prune_delegates_to_v2_service():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_prune_delegates_keep_within_to_v2_service():
+    repo = SimpleNamespace(borg_version=2, id=41)
+
+    with patch(
+        "app.services.v2.prune_service.prune_v2_service.execute_prune",
+        new=AsyncMock(),
+    ) as mock_prune:
+        await BorgRouter(repo).prune(
+            job_id=7,
+            keep_hourly=1,
+            keep_daily=2,
+            keep_weekly=3,
+            keep_monthly=4,
+            keep_quarterly=5,
+            keep_yearly=6,
+            dry_run=True,
+            keep_within="1d",
+        )
+
+    mock_prune.assert_awaited_once_with(
+        job_id=7,
+        repository_id=41,
+        keep_hourly=1,
+        keep_daily=2,
+        keep_weekly=3,
+        keep_monthly=4,
+        keep_quarterly=5,
+        keep_yearly=6,
+        dry_run=True,
+        keep_within="1d",
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_prune_delegates_to_v1_service():
     repo = SimpleNamespace(borg_version=1, id=19)
 

--- a/tests/unit/test_borgmatic_service.py
+++ b/tests/unit/test_borgmatic_service.py
@@ -238,6 +238,60 @@ retention:
         schedule = db_session.query(ScheduledJob).filter_by(repository=repo.path).one()
         assert schedule.prune_keep_within == "1d"
 
+    def test_import_trims_keep_within_retention(self, db_session):
+        """Test importing borgmatic retention trims keep_within."""
+        yaml_content = """
+location:
+  source_directories:
+    - /home/user
+  repositories:
+    - /backup/trimmed.borg
+
+retention:
+  keep_within: " 1d "
+"""
+
+        import_service = BorgmaticImportService(db_session)
+        result = import_service.import_from_yaml(
+            yaml_content, merge_strategy="skip_duplicates", dry_run=False
+        )
+
+        assert result["success"]
+        repo = (
+            db_session.query(Repository)
+            .filter(Repository.path == "/backup/trimmed.borg")
+            .one()
+        )
+        schedule = db_session.query(ScheduledJob).filter_by(repository=repo.path).one()
+        assert schedule.prune_keep_within == "1d"
+
+    def test_import_clears_blank_keep_within_retention(self, db_session):
+        """Test importing borgmatic retention clears blank keep_within."""
+        yaml_content = """
+location:
+  source_directories:
+    - /home/user
+  repositories:
+    - /backup/blank.borg
+
+retention:
+  keep_within: "   "
+"""
+
+        import_service = BorgmaticImportService(db_session)
+        result = import_service.import_from_yaml(
+            yaml_content, merge_strategy="skip_duplicates", dry_run=False
+        )
+
+        assert result["success"]
+        repo = (
+            db_session.query(Repository)
+            .filter(Repository.path == "/backup/blank.borg")
+            .one()
+        )
+        schedule = db_session.query(ScheduledJob).filter_by(repository=repo.path).one()
+        assert schedule.prune_keep_within is None
+
     def test_import_with_hooks(self, db_session):
         """Test importing configuration with hooks."""
         yaml_content = """

--- a/tests/unit/test_borgmatic_service.py
+++ b/tests/unit/test_borgmatic_service.py
@@ -91,6 +91,7 @@ class TestBorgmaticExportService:
         # New flat format - retention keys at top level
         assert "keep_daily" in config
         assert config["keep_daily"] == sample_scheduled_job.prune_keep_daily
+        assert config["keep_within"] == "1d"
 
     def test_export_to_yaml(self, db_session, sample_repository):
         """Test exporting to YAML string."""
@@ -216,6 +217,7 @@ storage:
   compression: lz4
 
 retention:
+  keep_within: 1d
   keep_daily: 7
   keep_weekly: 4
 """
@@ -233,6 +235,8 @@ retention:
         assert repo is not None
         assert repo.path == "/backup/repo.borg"
         assert repo.compression == "lz4"
+        schedule = db_session.query(ScheduledJob).filter_by(repository=repo.path).one()
+        assert schedule.prune_keep_within == "1d"
 
     def test_import_with_hooks(self, db_session):
         """Test importing configuration with hooks."""
@@ -425,6 +429,7 @@ def sample_scheduled_job(db_session, sample_repository):
         prune_keep_weekly=4,
         prune_keep_monthly=6,
         prune_keep_yearly=1,
+        prune_keep_within="1d",
         run_prune_after=True,
         run_compact_after=False,
     )

--- a/tests/unit/test_prune_service.py
+++ b/tests/unit/test_prune_service.py
@@ -1,0 +1,80 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+
+from app.database.models import PruneJob, Repository
+from app.services.prune_service import PruneService
+
+
+class EmptyAsyncStream:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+class FakeProcess:
+    def __init__(self, returncode=0):
+        self.returncode = returncode
+        self.pid = 123
+        self.stdout = EmptyAsyncStream()
+        self.stderr = EmptyAsyncStream()
+
+    async def wait(self):
+        return self.returncode
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_prune_command_includes_keep_within(db_engine):
+    testing_session_local = sessionmaker(bind=db_engine)
+    session = testing_session_local()
+    repo = Repository(
+        name="V1 Repo",
+        path="/tmp/v1-repo",
+        encryption="repokey",
+        repository_type="local",
+        borg_version=1,
+    )
+    session.add(repo)
+    session.commit()
+    session.refresh(repo)
+
+    job = PruneJob(repository_id=repo.id, repository_path=repo.path, status="pending")
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    repo_id = repo.id
+    job_id = job.id
+    session.close()
+
+    service = PruneService()
+
+    with (
+        patch("app.services.prune_service.SessionLocal", testing_session_local),
+        patch(
+            "app.services.prune_service.build_repository_borg_env",
+            return_value=({}, None),
+        ),
+        patch(
+            "app.services.prune_service.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=FakeProcess(0)),
+        ) as create_subprocess,
+    ):
+        await service.execute_prune(
+            job_id,
+            repo_id,
+            0,
+            7,
+            4,
+            6,
+            0,
+            1,
+            dry_run=True,
+            keep_within="1d",
+        )
+
+    cmd = list(create_subprocess.await_args.args)
+    assert "--keep-within=1d" in cmd

--- a/tests/unit/test_v2_prune_service.py
+++ b/tests/unit/test_v2_prune_service.py
@@ -153,3 +153,21 @@ async def test_borg2_prune_command_omits_stats_flag():
     assert "prune" in cmd
     assert "--stats" not in cmd
     assert "--list" in cmd
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_borg2_prune_command_includes_keep_within():
+    with patch(
+        "app.core.borg2.borg2._run",
+        new=AsyncMock(return_value={"success": True, "stdout": "", "stderr": ""}),
+    ) as mock_run:
+        await borg2.prune_archives(
+            repository="/tmp/v2-repo",
+            keep_daily=7,
+            keep_within="1d",
+            dry_run=True,
+        )
+
+    cmd = mock_run.await_args.args[0]
+    assert "--keep-within=1d" in cmd


### PR DESCRIPTION
## Description
Adds Borg prune keep-within support across Borg UI so users can preserve every recent archive within an interval such as `1d` before the existing hourly/daily/weekly/monthly/yearly count rules thin older archives.

This includes:
- backend persistence for scheduled jobs and backup plans
- command generation for Borg v1, Borg v2, manual prune, scheduled maintenance, backup plan maintenance, borgmatic import/export, and agent prune execution
- UI controls, summaries, localized copy, and Storybook states for keep-within retention
- regression coverage for blank/cleared keep-within behavior and generated `--keep-within=<interval>` arguments

## Related Issue
Fixes #704
Linear: BOR-184

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Validation run:
- `ruff check app tests`
- `ruff format --check app tests`
- `pytest tests/unit/test_prune_service.py tests/unit/test_borg_router.py tests/unit/test_v2_prune_service.py tests/unit/test_agent_runtime.py tests/unit/test_api_repositories.py::TestRepositoriesCreate::test_legacy_prune_route_dispatches_v2_repo_via_router tests/unit/test_api_backup_plans.py::TestBackupPlanRoutes::test_create_plan_persists_prune_keep_within tests/unit/test_api_backup_plans.py::TestBackupPlanRoutes::test_plan_maintenance_jobs_are_attributed_to_repository tests/unit/test_borgmatic_service.py`
- `pytest tests/unit/test_api_schedule_routes.py::TestScheduleRouteContracts::test_update_schedule_clears_prune_keep_within`
- `cd frontend && npm run test -- --run PruneSettingsInput PruneRepositoryDialog WizardStepMaintenance ReviewStep borgApi/client backupPlanPayload`
- `cd frontend && npm run check:locales`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `./scripts/dev.sh` frontend probe served `HTTP/1.1 200 OK` at `http://localhost:7879/`

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Storybook coverage was updated for the manual prune dialog and backup-plan schedule step. Local screenshot capture via `npm run snapshots` built Storybook, but browser launch is unavailable in this environment because Playwright host libraries are missing.

## Additional Context
Blank keep-within values are normalized to disabled behavior, so existing retention configurations keep their current count-based behavior. The schedule update path explicitly handles `prune_keep_within: null` so users can clear an existing interval.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Keep Within” prune retention support across manual repository pruning, scheduled jobs, backup plans, and agent pruning (including Borg v1/v2).
  * The “Keep Within” value is configurable in the UI, included in prune requests, persisted on plans/jobs, and preserved through schedule and borgmatic export/import.
  * Prune retention previews and review screens now display a `within <interval>` segment when set.
* **Bug Fixes**
  * Whitespace-only values are treated as empty and cleared.
  * `--keep-within` is sent only for non-empty values, and non-string inputs are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 6 changed, 0 added, 0 removed, 416 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-711/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/28344904808
<details>
<summary>Changed files</summary>
- `backup-plans-schedulestep--check-flag-conflict--mobile.png` (21.75%)
- `backup-plans-schedulestep--check-flag-conflict.png` (9.94%)
- `components-prunerepositorydialog--dry-run-log-messages--mobile.png` (22.67%)
- `components-prunerepositorydialog--dry-run-log-messages.png` (13.70%)
- `components-prunerepositorydialog--retention-preview--mobile.png` (22.27%)
- `components-prunerepositorydialog--retention-preview.png` (20.66%)
</details>
<details>
<summary>New screenshots</summary>
- None
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->