### PR TITLE
Clarify AGPL contribution license language

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -161,7 +161,7 @@ We welcome contributions for:
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
+By contributing, you agree that your contributions will be licensed under the GNU Affero General Public License v3.0 (AGPL-3.0), the same license as this project.
 
 All contributions become part of the project and are subject to the terms in the [LICENSE](../LICENSE) file.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,4 +48,4 @@ Fixes #
 
 ---
 
-**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU General Public License v3.0, the same license as this project.
+**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU Affero General Public License v3.0 (AGPL-3.0), the same license as this project.


### PR DESCRIPTION
## Description
Clarifies contributor-facing license language so Borg UI PR contributions are described as licensed under the GNU Affero General Public License v3.0 (AGPL-3.0), matching README and LICENSE.

Updates both the pull request template and the nearby GitHub contributing guide.

## Related Issue
Fixes BOR-186

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally with `git diff --check`
- [ ] I have added tests that prove my fix is effective or that my feature works (documentation-only; not applicable)
- [ ] All existing tests pass (not run; documentation-only change)

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (no code comments required; documentation-only change)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes (not run; documentation-only change)

## Screenshots (if applicable)
Not applicable; documentation-only change.

## Additional Context
During review, `.github/COPYRIGHT_NOTICE.md` was found to contain broader proprietary-license language that conflicts with the AGPL repository license. That broader cleanup is tracked separately in Linear as BOR-187 to keep this PR focused on contribution-license language.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor and pull request guidance to reflect the current license notice.
  * The licensing reference shown to contributors now points to AGPL-3.0 instead of GPL-3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->