### PR TITLE
fix(agent): list borg2 archives with repo-list, not list

### DIFF
--- a/agent/borg_ui_agent/repository_ops.py
+++ b/agent/borg_ui_agent/repository_ops.py
@@ -143,7 +143,7 @@ class RepositoryOperationPayload:
 
         if self.job_kind == "repository.list_archives":
             if self.borg_version == 2:
-                return [*self._base_borg2("list"), "--json"]
+                return [*self._base_borg2("repo-list"), "--json"]
             return [*self._base_borg1("list"), "--json", self.repository_path]
 
         if self.job_kind == "repository.list_archive_contents":


### PR DESCRIPTION
## Description

`borg1` and `borg2` differ in command syntax and archive handling. To list the
archives in a repository, `borg2` needs **`repo-list`** — `borg2 list` instead
lists the *contents of a single archive* and requires an additional
archive-name argument.

The managed agent built `borg2 -r <repo> list --json` for
`repository.list_archives`, so listing archives on a borg2 managed-agent
repository failed (`list` demands a `NAME`). This switches the borg2 branch to
`repo-list`.

There is more of this sort (other borg2 subcommand renames, e.g. `info` →
`repo-info`) still to reconcile, but we are focusing on borg1 for the time
being.

## Change

`agent/borg_ui_agent/repository_ops.py`: `repository.list_archives` for
`borg_version == 2` now builds `repo-list` instead of `list`.

## Type of Change

- [x] Bug fix (non-breaking)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive listing compatibility for repository operations.
  * Preserved existing JSON output and legacy behavior while making the command work correctly across Borg versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->