### PR TITLE
feat(repositories): UI support for agent-owned ssh:// repositories (follow-up to #708)

### DIFF
--- a/agent/borg_ui_agent/session.py
+++ b/agent/borg_ui_agent/session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import socket as socket_module
 import threading
 import time
@@ -333,6 +334,10 @@ class AgentSessionRuntime:
             self._handle_diagnostics(client, payload)
             return
 
+        if command == "agent.repository_defaults":
+            self._handle_repository_defaults(client, payload)
+            return
+
         if command == "cancel":
             # Signal the worker running this job so it actually stops; the worker
             # emits the job_canceled frame itself as it unwinds.
@@ -405,6 +410,21 @@ class AgentSessionRuntime:
         with self._registry_lock:
             self._cancel_events.pop(job_id, None)
             self._pending_cancels.discard(job_id)
+
+    def _handle_repository_defaults(
+        self, client: SessionCommandClient, payload: dict[str, Any]
+    ) -> None:
+        """Report the agent's own environment-configured repository target
+        (``$BORG_REPO`` / ``$BORG_REMOTE_PATH``) so the UI can pre-fill the
+        repository form, plus whether a ``$BORG_PASSPHRASE`` is set — a boolean,
+        never the passphrase value itself."""
+        client.send_result(
+            {
+                "repo": os.environ.get("BORG_REPO"),
+                "remote_path": os.environ.get("BORG_REMOTE_PATH"),
+                "has_passphrase": bool(os.environ.get("BORG_PASSPHRASE")),
+            }
+        )
 
     def _handle_filesystem_browse(
         self, client: SessionCommandClient, payload: dict[str, Any]

--- a/app/api/managed_machines.py
+++ b/app/api/managed_machines.py
@@ -544,6 +544,48 @@ async def browse_agent_machine_filesystem(
     )
 
 
+@router.get("/agents/{agent_machine_id}/repository-defaults")
+async def get_agent_machine_repository_defaults(
+    agent_machine_id: int,
+    _: User = Depends(require_managed_agents_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Ask a connected managed agent for its environment-configured repository
+    target (``$BORG_REPO`` / ``$BORG_REMOTE_PATH``) so the repository wizard can
+    pre-fill the form. Returns nulls when the agent is offline or does not set
+    them; no secrets are requested."""
+    agent = (
+        db.query(AgentMachine)
+        .filter(
+            AgentMachine.id == agent_machine_id,
+            AgentMachine.status != "deleted",
+        )
+        .first()
+    )
+    if not agent:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"key": "backend.errors.agents.agentNotFound"},
+        )
+    try:
+        result = await agent_connection_manager.send_command(
+            agent.id,
+            command="agent.repository_defaults",
+            payload={},
+            timeout_seconds=AGENT_FILESYSTEM_BROWSE_TIMEOUT_SECONDS,
+            wait_for_result=True,
+        )
+    except (AgentConnectionUnavailable, AgentCommandTimeout, AgentCommandError):
+        return {"repo": None, "remote_path": None, "has_passphrase": False}
+    if not isinstance(result, dict):
+        return {"repo": None, "remote_path": None, "has_passphrase": False}
+    return {
+        "repo": result.get("repo"),
+        "remote_path": result.get("remote_path"),
+        "has_passphrase": bool(result.get("has_passphrase")),
+    }
+
+
 @router.post("/agents/{agent_machine_id}/diagnostics")
 async def run_agent_machine_diagnostics(
     agent_machine_id: int,

--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -74,6 +74,13 @@ from app.services.check_flag_validation import (
     validate_check_flags_for_max_duration,
 )
 from app.services.agent_job_dispatcher import dispatch_agent_job_best_effort
+from app.services.agent_connection_manager import (
+    agent_connection_manager,
+    AgentConnectionUnavailable,
+    AgentCommandTimeout,
+    AgentCommandError,
+)
+from app.core.agent_constants import AGENT_FILESYSTEM_BROWSE_TIMEOUT_SECONDS
 from app.services.job_admission import (
     OPERATION_CHECK,
     OPERATION_COMPACT,
@@ -2039,7 +2046,7 @@ def _reject_agent_repository_ssh_target(
         )
 
 
-def _validate_agent_repository_payload(
+async def _validate_agent_repository_payload(
     repo_data: Union[RepositoryCreate, RepositoryImport], db: Session
 ) -> AgentMachine:
     _reject_agent_repository_ssh_target(
@@ -2047,8 +2054,9 @@ def _validate_agent_repository_payload(
         connection_id=repo_data.connection_id,
         execution_target=repo_data.execution_target,
     )
+    agent = _require_queueable_agent(repo_data.agent_machine_id, db)
 
-    if repo_data.encryption in [
+    encrypted = repo_data.encryption in [
         "repokey",
         "keyfile",
         "repokey-blake2",
@@ -2057,17 +2065,48 @@ def _validate_agent_repository_payload(
         "repokey-chacha20-poly1305",
         "keyfile-aes-ocb",
         "keyfile-chacha20-poly1305",
-    ]:
-        if not repo_data.passphrase or repo_data.passphrase.strip() == "":
+    ]
+    if encrypted and not (repo_data.passphrase or "").strip():
+        # Agent repos run every borg op on the agent, so the server never needs
+        # the passphrase — but confirm the agent has one, or the repo would be
+        # openable by neither. The agent returns a boolean, never the value.
+        if not await _agent_has_passphrase(agent):
             raise HTTPException(
                 status_code=400,
                 detail={
-                    "key": "backend.errors.repo.encryptedPassphraseRequired",
+                    "key": "backend.errors.repo.agentPassphraseUnavailable",
                     "params": {"mode": repo_data.encryption},
                 },
             )
 
-    return _require_queueable_agent(repo_data.agent_machine_id, db)
+    return agent
+
+
+async def _agent_has_passphrase(agent: AgentMachine) -> bool:
+    """Ask the agent whether it has a ``$BORG_PASSPHRASE`` of its own — a
+    boolean, never the passphrase value. False when the agent is offline or does
+    not set one."""
+    try:
+        result = await agent_connection_manager.send_command(
+            agent.id,
+            command="agent.repository_defaults",
+            payload={},
+            timeout_seconds=AGENT_FILESYSTEM_BROWSE_TIMEOUT_SECONDS,
+            wait_for_result=True,
+        )
+    except (AgentConnectionUnavailable, AgentCommandTimeout, AgentCommandError):
+        return False
+    except Exception:
+        # Fail closed: any unexpected error reaching the agent (e.g. the websocket
+        # layer re-raising a connection reset) must not surface as a 500 — treat it
+        # as "passphrase not confirmed" so the caller asks for one instead.
+        logger.warning(
+            "Failed to confirm agent passphrase; treating as unavailable",
+            agent_id=agent.id,
+            exc_info=True,
+        )
+        return False
+    return bool(isinstance(result, dict) and result.get("has_passphrase"))
 
 
 async def _create_agent_repository_record(
@@ -2079,7 +2118,7 @@ async def _create_agent_repository_record(
 ):
     cloud_mirror_remote = _validate_cloud_mirror_payload(repo_data, db)
     await _preflight_cloud_mirror_path(repo_data, cloud_mirror_remote)
-    agent = _validate_agent_repository_payload(repo_data, db)
+    agent = await _validate_agent_repository_payload(repo_data, db)
     if not imported:
         _require_agent_capability(agent, AGENT_REPOSITORY_INIT_CAPABILITY)
     if cloud_mirror_remote:

--- a/app/services/backup_route_planner.py
+++ b/app/services/backup_route_planner.py
@@ -109,7 +109,7 @@ def plan_repository_route(
         )
 
     if executor_type == EXECUTOR_AGENT:
-        if _is_ssh_repository(repository):
+        if getattr(repository, "connection_id", None):
             return _unsupported(
                 repository,
                 reason_key="backend.errors.backupPlans.agentRepoSshTargetUnsupported",

--- a/frontend/src/components/RepositoryWizard.tsx
+++ b/frontend/src/components/RepositoryWizard.tsx
@@ -217,6 +217,7 @@ const RepositoryWizard = ({
   const [wizardState, setWizardState] = useState<WizardState>(() => createInitialState())
   const [sshConnections, setSshConnections] = useState<SSHConnection[]>([])
   const [agentMachines, setAgentMachines] = useState<AgentMachineResponse[]>([])
+  const [agentRepoAdvertised, setAgentRepoAdvertised] = useState<boolean | null>(null)
   const [rcloneStatus, setRcloneStatus] = useState<RcloneStatus | null>(null)
   const [rcloneRemotes, setRcloneRemotes] = useState<RcloneRemote[]>([])
   const [rcloneProviders, setRcloneProviders] = useState<RcloneProvider[]>([])
@@ -556,6 +557,11 @@ const RepositoryWizard = ({
       return
     }
 
+    if (wizardState.executionTarget === 'agent') {
+      handleStateChange({ path: newPath })
+      return
+    }
+
     if (newPath.startsWith('ssh://')) {
       const matchWithPort = newPath.match(/^ssh:\/\/([^@]+)@([^:/]+):(\d+)(\/.*)$/)
       const matchWithoutPort = newPath.match(/^ssh:\/\/([^@]+)@([^/]+)(\/.*)$/)
@@ -675,6 +681,38 @@ const RepositoryWizard = ({
     }
   }, [open, mode, repository, populateEditData, loadWizardData])
 
+  // Auto-fill the repository target from the selected agent's own $BORG_REPO
+  useEffect(() => {
+    if (mode === 'edit' || wizardState.executionTarget !== 'agent' || !wizardState.agentMachineId) {
+      setAgentRepoAdvertised(null)
+      return
+    }
+    let cancelled = false
+    setAgentRepoAdvertised(null)
+    managedAgentsAPI
+      .getRepositoryDefaults(Number(wizardState.agentMachineId))
+      .then((res) => {
+        if (cancelled) return
+        // Only fill fields the user hasn't already started editing while the
+        // request was in flight (evaluated at apply-time in the functional update).
+        setWizardState((prev) => {
+          const updates: Partial<WizardState> = {}
+          if (res.data.repo && !(prev.path || '').trim()) updates.path = res.data.repo
+          if (res.data.remote_path && !(prev.remotePath || '').trim()) {
+            updates.remotePath = res.data.remote_path
+          }
+          return Object.keys(updates).length ? { ...prev, ...updates } : prev
+        })
+        setAgentRepoAdvertised(Boolean(res.data.repo))
+      })
+      .catch(() => {
+        if (!cancelled) setAgentRepoAdvertised(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [mode, wizardState.executionTarget, wizardState.agentMachineId])
+
   // Auto-select SSH connection for edit mode
   useEffect(() => {
     if (mode === 'edit' && repository && sshConnections.length > 0) {
@@ -759,7 +797,12 @@ const RepositoryWizard = ({
       case 'security':
         if (mode === 'edit') return true
         if (mode === 'import') return true
-        if (wizardState.encryption !== 'none' && !wizardState.passphrase.trim()) return false
+        if (
+          wizardState.encryption !== 'none' &&
+          !wizardState.passphrase.trim() &&
+          wizardState.executionTarget !== 'agent'
+        )
+          return false
         return true
 
       case 'config':
@@ -1023,52 +1066,61 @@ const RepositoryWizard = ({
     switch (currentStepKey) {
       case 'location':
         return (
-          <WizardStepLocation
-            mode={mode}
-            data={{
-              name: wizardState.name,
-              borgVersion: wizardState.borgVersion,
-              repositoryMode: wizardState.repositoryMode,
-              repositoryLocation: wizardState.repositoryLocation,
-              executionTarget: wizardState.executionTarget,
-              agentMachineId: wizardState.agentMachineId,
-              path: wizardState.path,
-              repoSshConnectionId: wizardState.repoSshConnectionId,
-              rcloneRemoteId: wizardState.rcloneRemoteId || selectedDirectRcloneRemote?.id || '',
-              rcloneRemotePath: directRcloneRemotePath,
-              bypassLock: wizardState.bypassLock,
-            }}
-            sshConnections={sshConnections}
-            agentMachines={agentMachines}
-            rcloneStatus={rcloneStatus}
-            rcloneRemotes={rcloneRemotes}
-            canUseManagedAgents={canUseManagedAgents}
-            canUseRclone={canUseRclone}
-            dataSource={wizardState.dataSource}
-            sourceSshConnectionId={wizardState.sourceSshConnectionId}
-            onChange={(updates) => {
-              if (typeof updates.path === 'string' && updates.repositoryLocation === undefined) {
-                if (wizardState.repositoryLocation === 'rclone') {
-                  handleStateChange(updates)
+          <>
+            {wizardState.executionTarget === 'agent' &&
+              wizardState.agentMachineId &&
+              agentRepoAdvertised === false && (
+                <div className="mb-4 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-400">
+                  {t('repositoryWizard.agentRepoUnknownWarning')}
+                </div>
+              )}
+            <WizardStepLocation
+              mode={mode}
+              data={{
+                name: wizardState.name,
+                borgVersion: wizardState.borgVersion,
+                repositoryMode: wizardState.repositoryMode,
+                repositoryLocation: wizardState.repositoryLocation,
+                executionTarget: wizardState.executionTarget,
+                agentMachineId: wizardState.agentMachineId,
+                path: wizardState.path,
+                repoSshConnectionId: wizardState.repoSshConnectionId,
+                rcloneRemoteId: wizardState.rcloneRemoteId || selectedDirectRcloneRemote?.id || '',
+                rcloneRemotePath: directRcloneRemotePath,
+                bypassLock: wizardState.bypassLock,
+              }}
+              sshConnections={sshConnections}
+              agentMachines={agentMachines}
+              rcloneStatus={rcloneStatus}
+              rcloneRemotes={rcloneRemotes}
+              canUseManagedAgents={canUseManagedAgents}
+              canUseRclone={canUseRclone}
+              dataSource={wizardState.dataSource}
+              sourceSshConnectionId={wizardState.sourceSshConnectionId}
+              onChange={(updates) => {
+                if (typeof updates.path === 'string' && updates.repositoryLocation === undefined) {
+                  if (wizardState.repositoryLocation === 'rclone') {
+                    handleStateChange(updates)
+                    return
+                  }
+                  handlePathChange(updates.path)
                   return
                 }
-                handlePathChange(updates.path)
-                return
-              }
 
-              // Handle SSH connection selection
-              if (
-                updates.repoSshConnectionId &&
-                updates.repoSshConnectionId !== wizardState.repoSshConnectionId
-              ) {
-                handleRepoSshConnectionSelect(updates.repoSshConnectionId as number)
-              } else {
-                handleStateChange(updates)
-              }
-            }}
-            onBrowsePath={() => setShowPathExplorer(true)}
-            onBrowseDirectRclonePath={() => setShowRcloneRemoteExplorer(true)}
-          />
+                // Handle SSH connection selection
+                if (
+                  updates.repoSshConnectionId &&
+                  updates.repoSshConnectionId !== wizardState.repoSshConnectionId
+                ) {
+                  handleRepoSshConnectionSelect(updates.repoSshConnectionId as number)
+                } else {
+                  handleStateChange(updates)
+                }
+              }}
+              onBrowsePath={() => setShowPathExplorer(true)}
+              onBrowseDirectRclonePath={() => setShowRcloneRemoteExplorer(true)}
+            />
+          </>
         )
 
       case 'cloudMirror':

--- a/frontend/src/components/RepositoryWizard.tsx
+++ b/frontend/src/components/RepositoryWizard.tsx
@@ -387,10 +387,17 @@ const RepositoryWizard = ({
   const populateEditData = React.useCallback(() => {
     if (!repository) return
 
+    const isAgentRepo =
+      repository.executor_type === 'agent' || repository.execution_target === 'agent'
+
     let repoPath = repository.path || ''
 
-    // Extract plain path from SSH URL if needed
-    if (repoPath.startsWith('ssh://')) {
+    // A non-agent SSH repo keeps host/user/port in a separate SSH connection, so
+    // the path field holds only the path portion. An agent repo's path IS the
+    // agent's full $BORG_REPO ssh URL (there is no separate connection) — keep it
+    // intact; chopping it here would drop ssh://user@host:port and a subsequent
+    // save would overwrite the agent's repository URL with just the path.
+    if (!isAgentRepo && repoPath.startsWith('ssh://')) {
       const sshUrlMatch = repoPath.match(/^ssh:\/\/[^@]+@[^:/]+(?::\d+)?(.*)$/)
       if (sshUrlMatch) {
         repoPath = sshUrlMatch[1]
@@ -681,9 +688,12 @@ const RepositoryWizard = ({
     }
   }, [open, mode, repository, populateEditData, loadWizardData])
 
-  // Auto-fill the repository target from the selected agent's own $BORG_REPO
+  // Reflect the selected agent's own $BORG_REPO: advertise it (drives the "agent
+  // has no repo" warning) and auto-fill the path. Runs in edit too so agent repos
+  // behave the same as on import; the "only fill an empty field" guard below means
+  // it never overwrites the existing repository URL.
   useEffect(() => {
-    if (mode === 'edit' || wizardState.executionTarget !== 'agent' || !wizardState.agentMachineId) {
+    if (wizardState.executionTarget !== 'agent' || !wizardState.agentMachineId) {
       setAgentRepoAdvertised(null)
       return
     }
@@ -711,7 +721,7 @@ const RepositoryWizard = ({
     return () => {
       cancelled = true
     }
-  }, [mode, wizardState.executionTarget, wizardState.agentMachineId])
+  }, [wizardState.executionTarget, wizardState.agentMachineId])
 
   // Auto-select SSH connection for edit mode
   useEffect(() => {

--- a/frontend/src/components/__tests__/RepositoryWizard.test.tsx
+++ b/frontend/src/components/__tests__/RepositoryWizard.test.tsx
@@ -19,6 +19,7 @@ vi.mock('../../services/api', () => ({
   },
   managedAgentsAPI: {
     listAgents: vi.fn(),
+    getRepositoryDefaults: vi.fn(),
   },
   rcloneAPI: {
     getStatus: vi.fn(),
@@ -357,6 +358,9 @@ describe('RepositoryWizard', () => {
     })
     ;(managedAgentsAPI.listAgents as Mock).mockResolvedValue({
       data: mockManagedAgents,
+    })
+    ;(managedAgentsAPI.getRepositoryDefaults as Mock).mockResolvedValue({
+      data: { repo: null, remote_path: null, has_passphrase: false },
     })
     ;(rcloneAPI.getStatus as Mock).mockResolvedValue({
       data: { available: true, version: 'rclone v1.66.0', error: null },

--- a/frontend/src/components/__tests__/RepositoryWizard.test.tsx
+++ b/frontend/src/components/__tests__/RepositoryWizard.test.tsx
@@ -428,6 +428,31 @@ describe('RepositoryWizard', () => {
       ).toBeTruthy()
     })
 
+    it('preserves an agent repository ssh:// URL in edit mode (does not chop it to the path)', async () => {
+      const agentRepoUrl = 'ssh://u209739@borg01.ioanalytica.com:23/./m3s/k8s-borg-m3s'
+      // The agent still advertises the same repo; edit must show the full URL and
+      // must not overwrite it with the advertised value (only-fill-if-empty guard).
+      ;(managedAgentsAPI.getRepositoryDefaults as Mock).mockResolvedValue({
+        data: { repo: agentRepoUrl, remote_path: null, has_passphrase: false },
+      })
+
+      renderWizard('edit', {
+        id: 7,
+        name: 'Agent Repo',
+        path: agentRepoUrl,
+        executor_type: 'agent',
+        agent_machine_id: 101,
+        encryption: 'repokey',
+        compression: 'lz4',
+        mode: 'full',
+      })
+
+      await waitForLocationStep()
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Repository Path/i)).toHaveValue(agentRepoUrl)
+      })
+    })
+
     it('requires repository name and path before continuing', async () => {
       renderWizard('create')
       await waitForLocationStep()

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -4270,6 +4270,7 @@
     "none": "Keine"
   },
   "repositoryWizard": {
+    "agentRepoUnknownWarning": "Dieser Managed Agent scheint sein eigenes Borg-Repository nicht zu kennen. Wenn du hier eine ssh://- oder sftp://-URL eingibst, stelle sicher, dass dieser Managed Agent das Repository auch wirklich erreichen kann.",
     "titleCreate": "Repository erstellen",
     "titleEdit": "Repository bearbeiten",
     "titleImport": "Repository importieren",
@@ -4662,6 +4663,7 @@
         "permissionDeniedCreateDirectory": "Zugriff verweigert: Verzeichnis kann nicht unter '{{path}}' erstellt werden. Um Repositories auf Ihrem Host-Rechner zu speichern, verwenden Sie Pfade, die mit '/local/' beginnen.",
         "permissionDeniedCreateParentDirectory": "Zugriff verweigert: Übergeordnetes Verzeichnis '{{path}}' kann nicht erstellt werden. Stellen Sie sicher, dass das Verzeichnis auf Ihrem Host-Rechner mit den entsprechenden Berechtigungen vorhanden ist.",
         "encryptedPassphraseRequired": "Passphrase ist für den Verschlüsselungsmodus '{{mode}}' erforderlich",
+        "agentPassphraseUnavailable": "Dieser Managed Agent hat keine BORG_PASSPHRASE gemeldet, daher kann er ein verschlüsseltes Repository nicht öffnen. Setze BORG_PASSPHRASE in der Umgebung des Agents oder gib hier eine Passphrase ein.",
         "encryptedPassphraseIncorrect": "Das Repository ist verschlüsselt, aber die Passphrase ist falsch oder fehlt. Bitte geben Sie die korrekte Passphrase an.",
         "encryptionKeyfileNotRequired": "Das Repository verwendet die Verschlüsselung '{{mode}}', für die keine Schlüsseldatei erforderlich ist. Der Upload einer Schlüsseldatei ist nur für die Verschlüsselungsmodi 'keyfile' oder 'keyfile-blake2' erforderlich.",
         "adminAccessRequired": "Administratorzugriff erforderlich",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -4270,6 +4270,7 @@
     "none": "None"
   },
   "repositoryWizard": {
+    "agentRepoUnknownWarning": "This managed agent doesn't seem to know its own Borg repository. If you enter an ssh:// or sftp:// URL here, make sure this managed agent can actually reach that repository.",
     "titleCreate": "Create Repository",
     "titleEdit": "Edit Repository",
     "titleImport": "Import Repository",
@@ -4662,6 +4663,7 @@
         "permissionDeniedCreateDirectory": "Permission denied: cannot create directory at '{{path}}'. To store repositories on your host machine, use paths starting with '/local/'.",
         "permissionDeniedCreateParentDirectory": "Permission denied: cannot create parent directory '{{path}}'. Please ensure the directory exists on your host machine with proper permissions.",
         "encryptedPassphraseRequired": "Passphrase is required for encryption mode '{{mode}}'",
+        "agentPassphraseUnavailable": "This managed agent didn't report a BORG_PASSPHRASE, so an encrypted repository can't be opened by it. Set BORG_PASSPHRASE in the agent's environment, or enter a passphrase here.",
         "encryptedPassphraseIncorrect": "Repository is encrypted but the passphrase is incorrect or missing. Please provide the correct passphrase.",
         "encryptionKeyfileNotRequired": "Repository uses '{{mode}}' encryption, which does not require a keyfile. Keyfile upload is only needed for 'keyfile' or 'keyfile-blake2' encryption modes.",
         "adminAccessRequired": "Admin access required",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -4270,6 +4270,7 @@
     "none": "Ninguno"
   },
   "repositoryWizard": {
+    "agentRepoUnknownWarning": "Este agente administrado no parece conocer su propio repositorio Borg. Si introduces aquí una URL ssh:// o sftp://, asegúrate de que este agente administrado pueda acceder realmente a ese repositorio.",
     "titleCreate": "Crear repositorio",
     "titleEdit": "Editar repositorio",
     "titleImport": "Importar repositorio",
@@ -4662,6 +4663,7 @@
         "permissionDeniedCreateDirectory": "Permiso denegado: no se puede crear el directorio en '{{path}}'. Para almacenar repositorios en su máquina anfitriona, use rutas que comiencen con '/local/'.",
         "permissionDeniedCreateParentDirectory": "Permiso denegado: no se puede crear el directorio padre '{{path}}'. Asegúrese de que el directorio exista en su máquina anfitriona con los permisos correctos.",
         "encryptedPassphraseRequired": "Se requiere contraseña para el modo de cifrado '{{mode}}'",
+        "agentPassphraseUnavailable": "Este agente administrado no proporcionó una BORG_PASSPHRASE, por lo que no puede abrir un repositorio cifrado. Define BORG_PASSPHRASE en el entorno del agente o introduce aquí una contraseña.",
         "encryptedPassphraseIncorrect": "El repositorio está cifrado pero la contraseña es incorrecta o falta. Proporcione la contraseña correcta.",
         "encryptionKeyfileNotRequired": "El repositorio usa cifrado '{{mode}}', que no requiere un archivo de clave. La carga del archivo de clave solo es necesaria para los modos de cifrado 'keyfile' o 'keyfile-blake2'.",
         "adminAccessRequired": "Se requiere acceso de administrador",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -4270,6 +4270,7 @@
     "none": "Nessuno"
   },
   "repositoryWizard": {
+    "agentRepoUnknownWarning": "Questo agent gestito non sembra conoscere il proprio repository Borg. Se inserisci qui un URL ssh:// o sftp://, assicurati che questo agent gestito possa effettivamente raggiungere quel repository.",
     "titleCreate": "Crea Repository",
     "titleEdit": "Modifica Repository",
     "titleImport": "Importa Repository",
@@ -4662,6 +4663,7 @@
         "permissionDeniedCreateDirectory": "Permesso negato: impossibile creare la directory in '{{path}}'. Per archiviare repository sulla tua macchina host, usa percorsi che iniziano con '/local/'.",
         "permissionDeniedCreateParentDirectory": "Permesso negato: impossibile creare la directory padre '{{path}}'. Assicurati che la directory esista sulla tua macchina host con i permessi corretti.",
         "encryptedPassphraseRequired": "La passphrase è richiesta per la modalità di crittografia '{{mode}}'",
+        "agentPassphraseUnavailable": "Questo agent gestito non ha segnalato una BORG_PASSPHRASE, quindi non può aprire un repository crittografato. Imposta BORG_PASSPHRASE nell'ambiente dell'agent oppure inserisci qui una passphrase.",
         "encryptedPassphraseIncorrect": "Il repository è crittografato ma la passphrase non è corretta o mancante. Fornisci la passphrase corretta.",
         "encryptionKeyfileNotRequired": "Il repository usa la crittografia '{{mode}}', che non richiede un file chiave. Il caricamento del file chiave è necessario solo per le modalità di crittografia 'keyfile' o 'keyfile-blake2'.",
         "adminAccessRequired": "Accesso amministratore richiesto",

--- a/frontend/src/pages/backup-plans/routePreview.ts
+++ b/frontend/src/pages/backup-plans/routePreview.ts
@@ -93,8 +93,7 @@ export function buildRoutePreviews(
     }
 
     if (isAgentRepo) {
-      const repositoryPath = String(repository.path || '')
-      if (repository.connection_id || repositoryPath.startsWith('ssh://')) {
+      if (repository.connection_id) {
         return unsupported(repository, 'agent', 'backupPlans.routePreview.agentRepoSshUnsupported')
       }
       if (!firstLocation || firstLocation.source_type === 'local') {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1267,6 +1267,10 @@ export const managedAgentsAPI = {
     ),
   runDiagnostics: (agentId: number, data: AgentDiagnosticsRequest) =>
     api.post<AgentDiagnosticsResponse>(`/managed-machines/agents/${agentId}/diagnostics`, data),
+  getRepositoryDefaults: (agentId: number) =>
+    api.get<{ repo: string | null; remote_path: string | null; has_passphrase: boolean }>(
+      `/managed-machines/agents/${agentId}/repository-defaults`
+    ),
 }
 
 // Schedule API


### PR DESCRIPTION
## Context

Follow-up to #708. That PR let the backend accept `ssh://` repositories owned by
a managed agent; this PR adds the UI and the agent-side plumbing so the flow
works end-to-end. It also opens a design question I'd rather think through
**together with you** than settle unilaterally — see *Architecture* below.

## The idea

There are hosts that are already prepared — by other means (Ansible, Kubernetes
pods, …) — to run Borg backups:

* they **know** the repository assigned to them,
* they hold SSH keys registered at the repository target,
* they have a `BORG_PASSPHRASE` ready.

In short: such a host can already operate its own repository with no further
configuration. That makes it an **ideal managed agent** — it can simply *tell*
borg-ui what the UI needs to know, instead of the UI having to provision SSH
connections and secrets for it.

The one thing deliberately **not** sent to the server is the secret
(`BORG_PASSPHRASE`) — the server doesn't need it, so it never learns it.

## What this PR does

* **The agent advertises its own repository.** New WS command
  `agent.repository_defaults` (+ endpoint
  `GET /managed-machines/agents/{id}/repository-defaults`): the agent reports its
  `$BORG_REPO` / `$BORG_REMOTE_PATH`, and whether a `$BORG_PASSPHRASE` is set —
  as a **boolean, never the value**.
* **The wizard auto-fills from that.** For an agent-owned repo the wizard keeps
  the full `ssh://` URL (instead of splitting it into a server SSH connection +
  path) and pre-fills repo path / remote-path from what the agent advertised; it
  warns when the agent reports nothing of its own.
* **Passphrase optional, with a server-side safeguard.** Since the agent runs
  every Borg operation itself, the server never needs the passphrase. The field
  becomes optional for agent repos — but only if the agent confirmed (via the
  boolean above) that it *has* one; otherwise create is refused, so you can't end
  up with an encrypted repo nobody can open.
* **Guards narrowed.** The remaining "agent repos can't use `ssh://` targets"
  guards now reject only a *server-managed* `connection_id` (repository create +
  backup-plan routing, front and back end).

**Security invariant:** every Borg operation for an agent-owned repo runs on the
agent with its own `$BORG_PASSPHRASE`. No secret ever reaches the server.

## Architecture — worth discussing together

This works and I'm running it, but it introduces a *model*: **a managed agent
that owns, and is self-sufficient about, its repository.** That's a slightly
different mental model from the current "server provisions everything" one, and I'd
rather align on it with you than push a shape you may want different. Points I'd
value your take on:

* Is "the agent advertises its repo defaults on demand" the right mechanism, or
  would you prefer the agent to register its repository explicitly at enrolment?
* Is a `has_passphrase` **boolean** the right amount for the server to know about
  the secret, or would you model that trust boundary differently?
* Browse / download / restore for a repo whose passphrase the server never holds
  all dispatch to the agent today — is that how you'd want it surfaced in the UI?

Treat this as a proposal to refine, not a fait accompli — happy to iterate.

## Notes

* Restore for agent-owned repos still has a permissions issue that's being scoped
  separately; it's not part of this PR. Backup, listing and browse work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only endpoint for managed agents to report repository defaults (repo, remote path, and passphrase availability).
  * Repository wizard now fetches and uses these defaults for agent-managed setups.

* **Bug Fixes**
  * Encrypted repository checks now rely on whether the agent reports passphrase availability.
  * Improved handling of managed-agent SSH repository URLs in route planning/preview and wizard edit mode.
  * Passphrase validation rules were refined for agent vs non-agent targets; added user warnings when agent repo info is unknown.

* **Tests**
  * Updated and extended repository wizard tests for repository-defaults retrieval and URL preservation.

* **Documentation**
  * Added new user-facing translations for the new warning/error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->