### PR TITLE
feat(auth): accept personal access tokens as Bearer credentials

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -20,7 +20,13 @@ from app.core.permissions import (
     normalize_repository_role_for_global_role,
 )
 from app.database.database import get_db
-from app.database.models import Repository, User, UserRepositoryPermission
+from app.database.models import (
+    ApiToken,
+    Repository,
+    User,
+    UserRepositoryPermission,
+    utc_now,
+)
 
 logger = structlog.get_logger()
 
@@ -36,6 +42,12 @@ FALLBACK_PROXY_AUTH_HEADERS = (
 
 # JWT token security
 security = HTTPBearer()
+
+# Personal access tokens are minted as "borgui_<random>" (see app/api/tokens.py)
+# and stored by their 12-char prefix + bcrypt hash. A JWT never starts with this
+# prefix, so it cleanly disambiguates a PAT from a JWT on the same Bearer header.
+API_TOKEN_PREFIX = "borgui_"
+API_TOKEN_PREFIX_LENGTH = 12
 
 LOGIN_CHALLENGE_TOKEN_TYPE = "login_challenge"
 TOTP_SETUP_TOKEN_TYPE = "totp_setup"
@@ -403,18 +415,47 @@ def _proxy_email_is_available(
     return query.first() is None
 
 
+def _resolve_api_token_user(token: str, db: Session) -> Optional[User]:
+    """Resolve the user behind a personal access token ("borgui_…").
+
+    Mirrors the agent-token scheme (see app/core/agent_auth.py): narrow by the
+    stored prefix, then bcrypt-verify the full value. Stamps last_used_at on a
+    match. Returns None when no active token matches.
+    """
+    prefix = token[:API_TOKEN_PREFIX_LENGTH]
+    candidates = db.query(ApiToken).filter(ApiToken.prefix == prefix).all()
+    for api_token in candidates:
+        if verify_password(token, api_token.token_hash):
+            user = db.query(User).filter(User.id == api_token.user_id).first()
+            if user is None:
+                return None
+            api_token.last_used_at = utc_now()
+            try:
+                db.commit()
+            except Exception:
+                db.rollback()
+                logger.warning("Failed to update API token last_used_at", exc_info=True)
+            return user
+    return None
+
+
 def _get_active_user_from_token(
     token: Optional[str], db: Session, invalid_exception: HTTPException
 ) -> User:
-    """Resolve an active user from a JWT token."""
+    """Resolve an active user from a JWT access token or a personal access token."""
     if not token:
         raise invalid_exception
 
-    username = verify_token(token)
-    if username is None:
-        raise invalid_exception
+    # Personal access token ("borgui_…") — a JWT never carries this prefix, so we
+    # can route on it without ambiguity. Anything else is treated as a JWT.
+    if token.startswith(API_TOKEN_PREFIX):
+        user = _resolve_api_token_user(token, db)
+    else:
+        username = verify_token(token)
+        if username is None:
+            raise invalid_exception
+        user = db.query(User).filter(User.username == username).first()
 
-    user = db.query(User).filter(User.username == username).first()
     if user is None:
         raise invalid_exception
 

--- a/tests/unit/test_api_tokens.py
+++ b/tests/unit/test_api_tokens.py
@@ -119,3 +119,66 @@ class TestApiTokens:
     def test_unauthenticated_returns_401(self, test_client: TestClient):
         """Token endpoints require authentication"""
         assert test_client.get("/api/settings/tokens").status_code == 401
+
+
+@pytest.mark.unit
+class TestApiTokenAuth:
+    """A personal access token ("borgui_…") authenticates API requests as a Bearer."""
+
+    def _make_pat(
+        self, test_client: TestClient, admin_headers, name="auth-test"
+    ) -> str:
+        resp = test_client.post(
+            "/api/settings/tokens", json={"name": name}, headers=admin_headers
+        )
+        assert resp.status_code == 201
+        return resp.json()["token"]
+
+    def test_pat_authenticates_via_authorization_header(
+        self, test_client: TestClient, admin_headers
+    ):
+        """The raw PAT works as its own Bearer credential on a protected endpoint."""
+        pat = self._make_pat(test_client, admin_headers)
+        resp = test_client.get(
+            "/api/settings/tokens", headers={"Authorization": f"Bearer {pat}"}
+        )
+        assert resp.status_code == 200
+        # Authenticated as the same (admin) user -> sees the token it just created.
+        assert any(t["name"] == "auth-test" for t in resp.json())
+
+    def test_pat_authenticates_via_x_borg_authorization_header(
+        self, test_client: TestClient, admin_headers
+    ):
+        """The PAT also works on the X-Borg-Authorization header (proxy-friendly)."""
+        pat = self._make_pat(test_client, admin_headers, name="proxy-header")
+        resp = test_client.get(
+            "/api/settings/tokens", headers={"X-Borg-Authorization": f"Bearer {pat}"}
+        )
+        assert resp.status_code == 200
+
+    def test_bogus_pat_is_rejected(self, test_client: TestClient):
+        """A well-formed but unknown borgui_ token is rejected."""
+        resp = test_client.get(
+            "/api/settings/tokens",
+            headers={"Authorization": "Bearer borgui_thisisnotarealtoken"},
+        )
+        assert resp.status_code == 401
+
+    def test_revoked_pat_is_rejected(self, test_client: TestClient, admin_headers):
+        """A revoked PAT no longer authenticates."""
+        create = test_client.post(
+            "/api/settings/tokens", json={"name": "to-revoke"}, headers=admin_headers
+        )
+        pat = create.json()["token"]
+        token_id = create.json()["id"]
+
+        auth = {"Authorization": f"Bearer {pat}"}
+        assert test_client.get("/api/settings/tokens", headers=auth).status_code == 200
+
+        assert (
+            test_client.delete(
+                f"/api/settings/tokens/{token_id}", headers=admin_headers
+            ).status_code
+            == 204
+        )
+        assert test_client.get("/api/settings/tokens", headers=auth).status_code == 401


### PR DESCRIPTION
PATs (`POST /api/settings/tokens`) were created + revocable but never accepted for auth — `get_current_user` only validated JWTs. This wires `ApiToken` into token resolution (prefix lookup + bcrypt verify, same scheme as agent tokens), stamping `last_used_at`. JWT path unchanged. Adds tests for both auth headers + bogus/revoked rejection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for personal access tokens (PATs) alongside JWTs for bearer authentication.
  * Requests can now authenticate with valid PATs using either the standard authorization header or the custom Borg authorization header.
* **Bug Fixes**
  * Improved token validation so unknown or revoked PATs are rejected with unauthorized responses.
  * Ensures only active users can authenticate successfully. 
* **Tests**
  * Added unit tests covering PAT authentication, including header variants and rejection of bogus/revoked tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->