### PR TITLE
fix(auth): don't 500 on password login for users without a local password

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -43,11 +43,22 @@ LOGIN_CHALLENGE_EXPIRE_MINUTES = 10
 TOTP_SETUP_EXPIRE_MINUTES = 15
 
 
-def verify_password(plain_password: str, hashed_password: str) -> bool:
-    """Verify a password against its hash"""
-    return bcrypt.checkpw(
-        plain_password.encode("utf-8"), hashed_password.encode("utf-8")
-    )
+def verify_password(plain_password: str, hashed_password: Optional[str]) -> bool:
+    """Verify a password against its bcrypt hash.
+
+    Returns False (instead of raising) when the stored hash is missing or not a
+    valid bcrypt hash — e.g. OIDC-only users have no local password. bcrypt would
+    otherwise raise ``ValueError: Invalid salt``, which surfaced as a 500 on a
+    password login attempt; a clean False lets it fail with the normal 401.
+    """
+    if not hashed_password:
+        return False
+    try:
+        return bcrypt.checkpw(
+            plain_password.encode("utf-8"), hashed_password.encode("utf-8")
+        )
+    except ValueError:
+        return False
 
 
 def get_password_hash(password: str) -> str:

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -37,6 +37,24 @@ def test_password_verification():
 
 
 @pytest.mark.unit
+def test_verify_password_rejects_invalid_or_missing_hash():
+    """A missing/non-bcrypt stored hash fails cleanly instead of raising.
+
+    OIDC-only users have no local bcrypt password_hash; bcrypt.checkpw would
+    raise ValueError('Invalid salt'), which previously surfaced as a 500 on a
+    password login attempt. verify_password must return False for these.
+    """
+    assert verify_password("anything", "") is False
+    assert verify_password("anything", None) is False
+    assert verify_password("anything", "not-a-bcrypt-hash") is False
+
+    # A real hash still verifies correctly.
+    hashed = get_password_hash("realpassword")
+    assert verify_password("realpassword", hashed) is True
+    assert verify_password("wrong", hashed) is False
+
+
+@pytest.mark.unit
 def test_different_passwords_different_hashes():
     """Test that different passwords produce different hashes"""
     password1 = "password123"


### PR DESCRIPTION
`verify_password` raised `ValueError: Invalid salt` when a user's stored `password_hash` is missing or not a valid bcrypt hash — e.g. OIDC-only users have no local password — surfacing as a **500** on `POST /api/auth/login` instead of a clean 401. This returns False for a missing/invalid hash so the login fails normally. Adds unit coverage for empty/None/invalid hashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password verification so missing, empty, or invalid stored hashes now safely fail instead of causing login errors.
  * Prevented invalid password hash formats from surfacing as server-side failures during sign-in.

* **Tests**
  * Added coverage for missing, empty, malformed, and valid password hash cases to confirm login behaves correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->