### PR TITLE
fix(oidc): accept dict-shaped group/role claims (e.g. Zitadel)

### DIFF
--- a/app/core/oidc.py
+++ b/app/core/oidc.py
@@ -389,6 +389,16 @@ def normalize_role_claim(value: Any) -> Optional[str]:
 
 
 def normalize_groups_claim(value: Any) -> list[str]:
+    if isinstance(value, dict):
+        # Some IdPs express roles/groups as an object keyed by the group name
+        # rather than a list — notably Zitadel's
+        # "urn:zitadel:iam:org:project:roles": {"admin": {"<projId>": "<org>"}, …}.
+        # The keys are the group names.
+        return [
+            normalized
+            for key in value
+            if (normalized := normalize_string_claim(key)) is not None
+        ]
     if isinstance(value, list):
         return [
             normalized

--- a/tests/unit/test_oidc.py
+++ b/tests/unit/test_oidc.py
@@ -1,0 +1,33 @@
+"""
+Unit tests for OIDC claim normalization.
+"""
+
+import pytest
+
+from app.core.oidc import normalize_groups_claim
+
+
+@pytest.mark.unit
+class TestNormalizeGroupsClaim:
+    def test_list_of_strings(self):
+        assert normalize_groups_claim(["admin", "viewer"]) == ["admin", "viewer"]
+
+    def test_single_string(self):
+        assert normalize_groups_claim("admin") == ["admin"]
+
+    def test_zitadel_role_dict_uses_keys(self):
+        """Zitadel emits project roles as an object keyed by role name."""
+        claim = {
+            "admin": {"310049588908064772": "myorg.zitadel.cloud"},
+            "viewer": {"310049588908064772": "myorg.zitadel.cloud"},
+        }
+        assert normalize_groups_claim(claim) == ["admin", "viewer"]
+
+    def test_empty_and_none(self):
+        assert normalize_groups_claim({}) == []
+        assert normalize_groups_claim([]) == []
+        assert normalize_groups_claim(None) == []
+        assert normalize_groups_claim("") == []
+
+    def test_list_drops_non_strings_and_blanks(self):
+        assert normalize_groups_claim(["admin", None, "  ", 123]) == ["admin", "123"]


### PR DESCRIPTION
`normalize_groups_claim` only handled list/string claims; a **dict** claim fell through to `[]`. Zitadel emits project roles as `urn:zitadel:iam:org:project:roles: {"admin": {...}, ...}` (role names as keys), so the admin allow-list never matched and OIDC admins were mapped as viewers. This treats a dict claim's keys as the group names (list/string paths unchanged). Adds unit tests incl. the Zitadel shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for OIDC group and role claims coming in as dictionary-shaped data, so group names are now recognized correctly.
  * Fixed claim normalization so empty, blank, and unsupported values are ignored consistently, while valid entries are preserved.
  * Added coverage to ensure common claim formats are handled reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->