### PR TITLE
fix(oidc): grant admin from group membership, not only as a role-claim guard

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -838,25 +838,32 @@ async def login(
 
 
 def _resolve_oidc_role(identity: dict[str, Any], settings_row: SystemSettings) -> str:
+    admin_groups = {
+        group.strip().lower()
+        for group in (settings_row.oidc_admin_groups or "").split(",")
+        if group.strip()
+    }
+    identity_groups = set(_normalize_oidc_groups(identity.get("groups")))
+    in_admin_group = bool(admin_groups) and not identity_groups.isdisjoint(admin_groups)
+
     candidate = identity.get("role")
     if candidate in {"viewer", "operator", "admin"}:
-        if candidate == "admin":
-            admin_groups = {
-                group.strip().lower()
-                for group in (settings_row.oidc_admin_groups or "").split(",")
-                if group.strip()
-            }
-            identity_groups = set(_normalize_oidc_groups(identity.get("groups")))
-            if not admin_groups or identity_groups.isdisjoint(admin_groups):
-                logger.warning(
-                    "Ignoring OIDC admin role claim without matching admin group allow-list",
-                    username=identity.get("username"),
-                    subject=identity.get("subject"),
-                    configured_groups=sorted(admin_groups),
-                    identity_groups=sorted(identity_groups),
-                )
-                return (settings_row.oidc_default_role or "viewer").strip() or "viewer"
-        return candidate
+        if candidate == "admin" and not in_admin_group:
+            logger.warning(
+                "Ignoring OIDC admin role claim without matching admin group allow-list",
+                username=identity.get("username"),
+                subject=identity.get("subject"),
+                configured_groups=sorted(admin_groups),
+                identity_groups=sorted(identity_groups),
+            )
+            # fall through to group-based / default resolution below
+        else:
+            return candidate
+
+    # Membership in an allow-listed admin group grants admin even without a role
+    # claim (the common "admin via group" pattern — e.g. IdP-managed groups).
+    if in_admin_group:
+        return "admin"
     return (settings_row.oidc_default_role or "viewer").strip() or "viewer"
 
 
@@ -1033,8 +1040,30 @@ def _provision_oidc_user(
             detail={"key": "backend.errors.auth.inactiveUser"},
         )
 
-    if identity.get("role"):
+    # Re-resolve the role from the IdP on each login when it carries role info —
+    # a role claim OR groups. Group membership is now a role source (admin via
+    # group), so an existing user's role must sync from groups too, not only from
+    # a role claim; otherwise a pre-existing user never gains/loses admin.
+    if identity.get("role") or identity.get("groups"):
         role = _resolve_oidc_role(identity, settings_row)
+        # Never demote the last active admin — that would leave the instance with
+        # no administrator and lock everyone out.
+        if user.role == "admin" and role != "admin":
+            other_admins = (
+                db.query(User)
+                .filter(
+                    User.role == "admin",
+                    User.is_active.is_(True),
+                    User.id != user.id,
+                )
+                .count()
+            )
+            if other_admins == 0:
+                logger.warning(
+                    "Refusing to demote the last active admin via OIDC role sync",
+                    username=user.username,
+                )
+                role = "admin"
         user.role = role
     else:
         role = user.role

--- a/tests/unit/test_api_auth.py
+++ b/tests/unit/test_api_auth.py
@@ -1879,6 +1879,125 @@ class TestOidcAuthentication:
         assert user.role == "operator"
         assert user.all_repositories_role == "operator"
 
+    def _oidc_settings(self, **overrides):
+        base = dict(
+            oidc_enabled=True,
+            oidc_discovery_url="https://id.example.com/.well-known/openid-configuration",
+            oidc_client_id="borg-ui",
+            oidc_client_secret_encrypted=encrypt_secret("secret-value"),
+            oidc_admin_groups="admin",
+        )
+        base.update(overrides)
+        return SystemSettings(**base)
+
+    def _oidc_admin_user(
+        self, username, *, role, subject=None, email=None, auth_source="oidc"
+    ):
+        """Build a test user for the OIDC role-sync cases (three tests below)."""
+        return User(
+            username=username,
+            password_hash="",
+            email=email or f"{username}@example.com",
+            role=role,
+            is_active=True,
+            auth_source=auth_source,
+            oidc_subject=subject,
+        )
+
+    def test_oidc_exchange_syncs_admin_role_from_group_for_existing_user(
+        self, test_client: TestClient, test_db
+    ):
+        """An existing OIDC user gains admin from group membership on re-login,
+        even though the IdP sends no role claim (only groups)."""
+        existing = self._oidc_admin_user(
+            "grp-admin", role="viewer", subject="grp-subject"
+        )
+        test_db.add(existing)
+        test_db.add(self._oidc_settings())
+        test_db.commit()
+        test_db.refresh(existing)
+
+        # Grant carries the admin group but NO role claim.
+        create_test_oidc_exchange_grant(
+            test_db,
+            username="grp-admin",
+            oidc_subject="grp-subject",
+            email="grp-admin@example.com",
+            groups=["admin"],
+            role=None,
+        )
+        test_client.cookies.set("oidc_exchange_grant", "grant-123")
+
+        response = test_client.post(
+            "/api/auth/oidc/exchange", headers={"Origin": "http://testserver"}
+        )
+
+        assert response.status_code == 200
+        test_db.refresh(existing)
+        assert existing.role == "admin"
+
+    def test_oidc_exchange_does_not_demote_last_admin(
+        self, test_client: TestClient, test_db
+    ):
+        """The role re-sync must never demote the last active admin."""
+        admin = self._oidc_admin_user(
+            "lone-admin", role="admin", subject="lone-subject"
+        )
+        test_db.add(admin)
+        test_db.add(self._oidc_settings())
+        test_db.commit()
+        test_db.refresh(admin)
+
+        # The IdP no longer reports the admin group.
+        create_test_oidc_exchange_grant(
+            test_db,
+            username="lone-admin",
+            oidc_subject="lone-subject",
+            email="lone-admin@example.com",
+            groups=["users"],
+            role=None,
+        )
+        test_client.cookies.set("oidc_exchange_grant", "grant-123")
+
+        response = test_client.post(
+            "/api/auth/oidc/exchange", headers={"Origin": "http://testserver"}
+        )
+        assert response.status_code == 200
+        test_db.refresh(admin)
+        assert admin.role == "admin"  # kept — last admin is not demoted
+
+    def test_oidc_exchange_demotes_admin_when_another_admin_exists(
+        self, test_client: TestClient, test_db
+    ):
+        """Demotion goes through when another active admin remains."""
+        test_db.add(
+            self._oidc_admin_user("other-admin", role="admin", auth_source="local")
+        )
+        admin = self._oidc_admin_user(
+            "grp-admin2", role="admin", subject="grp-subject-2"
+        )
+        test_db.add(admin)
+        test_db.add(self._oidc_settings())
+        test_db.commit()
+        test_db.refresh(admin)
+
+        create_test_oidc_exchange_grant(
+            test_db,
+            username="grp-admin2",
+            oidc_subject="grp-subject-2",
+            email="grp-admin2@example.com",
+            groups=["users"],
+            role=None,
+        )
+        test_client.cookies.set("oidc_exchange_grant", "grant-123")
+
+        response = test_client.post(
+            "/api/auth/oidc/exchange", headers={"Origin": "http://testserver"}
+        )
+        assert response.status_code == 200
+        test_db.refresh(admin)
+        assert admin.role != "admin"  # demoted — another admin remains
+
     def test_oidc_exchange_links_existing_oidc_user_without_subject(
         self, test_client: TestClient, test_db
     ):

--- a/tests/unit/test_oidc_role.py
+++ b/tests/unit/test_oidc_role.py
@@ -1,0 +1,44 @@
+"""
+Unit tests for OIDC role resolution (_resolve_oidc_role).
+"""
+
+import pytest
+
+from app.api.auth import _resolve_oidc_role
+from app.database.models import SystemSettings
+
+
+def _settings(admin_groups="admin", default_role="viewer"):
+    return SystemSettings(
+        oidc_admin_groups=admin_groups, oidc_default_role=default_role
+    )
+
+
+@pytest.mark.unit
+class TestResolveOidcRole:
+    def test_admin_group_membership_grants_admin_without_role_claim(self):
+        """The fix: being in an allow-listed admin group grants admin even when
+        the IdP sends no role claim (e.g. Zitadel emits only project roles)."""
+        identity = {"role": None, "groups": ["admin"]}
+        assert _resolve_oidc_role(identity, _settings()) == "admin"
+
+    def test_no_group_no_role_falls_back_to_default(self):
+        identity = {"role": None, "groups": ["viewer"]}
+        assert _resolve_oidc_role(identity, _settings()) == "viewer"
+
+    def test_no_admin_groups_configured_never_grants_admin(self):
+        identity = {"role": None, "groups": ["admin"]}
+        assert _resolve_oidc_role(identity, _settings(admin_groups="")) == "viewer"
+
+    # --- backward compatibility with an explicit role claim ------------------
+    def test_admin_role_claim_with_matching_group_stays_admin(self):
+        identity = {"role": "admin", "groups": ["admin"]}
+        assert _resolve_oidc_role(identity, _settings()) == "admin"
+
+    def test_admin_role_claim_without_matching_group_is_rejected(self):
+        identity = {"role": "admin", "groups": ["users"]}
+        assert _resolve_oidc_role(identity, _settings()) == "viewer"
+
+    def test_explicit_non_admin_role_claim_is_honored(self):
+        identity = {"role": "operator", "groups": ["admin"]}
+        assert _resolve_oidc_role(identity, _settings()) == "operator"


### PR DESCRIPTION
`_resolve_oidc_role` only assigned admin when the IdP sent a role claim of `admin` (guarded by the admin-groups allow-list). IdPs that express admin via **group membership only** — e.g. Zitadel's `urn:zitadel:iam:org:project:roles` — never granted admin: the group was extracted correctly, but with no role claim the role fell back to the default (viewer). This grants admin when the user is in an allow-listed admin group, even without a role claim. Existing role-claim behavior is unchanged; tests cover both paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OIDC role resolution so admin access is granted based on allowed admin group membership even when the IdP role claim is missing, null, or unrecognized.
  * Updated OIDC re-login syncing to keep user roles aligned with the latest IdP role/groups, including safeguards to avoid demoting the last active admin.
  * Added unit test coverage for admin/default precedence and role synchronization behavior to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->