### PR TITLE
fix(agent): keep idle agents live via a WS heartbeat message

### DIFF
--- a/agent/borg_ui_agent/session.py
+++ b/agent/borg_ui_agent/session.py
@@ -233,11 +233,20 @@ class AgentSessionRuntime:
                 try:
                     raw_message = socket.recv()
                 except (TimeoutError, WebSocketTimeoutException):
-                    # Idle keep-alive ping. The key property of this loop is that
-                    # it stays in recv() *even while a job runs in a worker
-                    # thread*, so websocket-client keeps auto-ponging the server's
-                    # pings and the session survives long backups/checks.
+                    # Idle keep-alive. The key property of this loop is that it
+                    # stays in recv() *even while a job runs in a worker thread*,
+                    # so websocket-client keeps auto-ponging the server's pings
+                    # and the session survives long backups/checks.
+                    #
+                    # The protocol ping keeps the socket alive but never reaches
+                    # application code, so it cannot refresh the server's
+                    # last_seen_at. Send an application-level heartbeat too so an
+                    # idle-but-healthy agent stays "live" server-side.
                     with self._send_lock:
+                        try:
+                            socket.send(json.dumps({"type": "heartbeat"}))
+                        except Exception:
+                            pass
                         ping = getattr(socket, "ping", None)
                         if callable(ping):
                             ping()

--- a/app/api/agents.py
+++ b/app/api/agents.py
@@ -648,6 +648,21 @@ async def _handle_agent_session_message(
     command_id = str(message.get("command_id") or "")
     job_id = message.get("job_id")
 
+    if message_type == "heartbeat":
+        # Idle-liveness signal. The agent stays in recv() and sends this on a
+        # timer (even while a job runs in a worker thread), so it is the one
+        # signal that keeps last_seen_at fresh when the agent is not actively
+        # POSTing /heartbeat during a job. Protocol-level WS pings keep the
+        # socket alive but never reach here, so without this an idle-but-healthy
+        # agent looks stale.
+        now = _now_utc()
+        db.query(AgentMachine).filter(AgentMachine.id == agent_machine_id).update(
+            {"last_seen_at": now, "status": "online", "updated_at": now},
+            synchronize_session=False,
+        )
+        db.commit()
+        return
+
     job = _load_session_job(db, agent_machine_id, job_id)
 
     if message_type == "command_ack":

--- a/tests/unit/test_agent_heartbeat.py
+++ b/tests/unit/test_agent_heartbeat.py
@@ -1,0 +1,55 @@
+"""Idle agents stay live server-side.
+
+An agent keeps its WebSocket alive with protocol-level pings, but those never
+reach application code, so `last_seen_at` used to only advance while a job was
+running (via POST /heartbeat). An idle-but-healthy agent therefore looked
+stale. The agent now sends an application-level `heartbeat` message on its idle
+timer; the session handler must refresh `last_seen_at` (and mark the agent
+online) when it arrives.
+"""
+
+import pytest
+
+from app.api.agents import _handle_agent_session_message
+from app.core.security import get_password_hash
+from app.database.models import AgentMachine
+
+
+def _create_agent(test_db, *, status="offline"):
+    agent = AgentMachine(
+        name="HB Agent",
+        agent_id="agt_hb",
+        token_hash=get_password_hash("secret"),
+        token_prefix="secret"[:20],
+        status=status,
+        last_seen_at=None,
+        capabilities=[],
+    )
+    test_db.add(agent)
+    test_db.commit()
+    test_db.refresh(agent)
+    return agent
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_heartbeat_message_refreshes_last_seen(test_db):
+    agent = _create_agent(test_db, status="offline")
+    assert agent.last_seen_at is None
+
+    await _handle_agent_session_message(test_db, agent.id, {"type": "heartbeat"})
+
+    test_db.refresh(agent)
+    assert agent.last_seen_at is not None
+    assert agent.status == "online"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_non_heartbeat_message_does_not_require_a_job(test_db):
+    # A heartbeat carries no job_id; the early return must not touch job state.
+    agent = _create_agent(test_db)
+    # Should not raise even though there is no matching agent job.
+    await _handle_agent_session_message(test_db, agent.id, {"type": "heartbeat"})
+    test_db.refresh(agent)
+    assert agent.status == "online"

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -571,6 +571,32 @@ def test_session_runtime_connects_with_websocket_url_and_sends_hello(monkeypatch
 
 
 @pytest.mark.unit
+def test_session_runtime_sends_app_heartbeat_while_idle(monkeypatch):
+    from agent.borg_ui_agent.session import AgentSessionRuntime
+
+    # recv() raises a timeout first (idle) then yields a harmless message so the
+    # bounded loop can exit; the idle branch must emit an app-level heartbeat.
+    socket = FakeWebSocket([TimeoutError(), {"type": "noop"}])
+
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.detect_platform",
+        lambda: {"hostname": "host.local", "os": "linux", "arch": "amd64"},
+    )
+    monkeypatch.setattr("agent.borg_ui_agent.session.detect_borg_binaries", lambda: [])
+
+    runtime = AgentSessionRuntime(
+        AgentConfig("https://borgui.example.com", "agt_123", "secret"),
+        connect=lambda url, *, header, timeout: socket,
+    )
+    runtime.run_session(max_messages=1)
+
+    # hello first, then the idle heartbeat; the protocol ping is also sent.
+    assert socket.sent[0]["type"] == "hello"
+    assert {"type": "heartbeat"} in socket.sent
+    assert socket.pings >= 1
+
+
+@pytest.mark.unit
 def test_session_runtime_handles_ephemeral_filesystem_browse(monkeypatch):
     from agent.borg_ui_agent.session import AgentSessionRuntime
 
@@ -898,8 +924,12 @@ def test_session_runtime_sends_ping_on_idle_recv_timeout(monkeypatch):
     runtime.run_session(max_messages=1)
 
     assert socket.pings == 1
-    assert socket.sent[1]["type"] == "command_ack"
-    assert socket.sent[2]["type"] == "command_result"
+    # Idle recv timeout now emits an app-level heartbeat before the ping, so the
+    # command handshake follows it.
+    assert socket.sent[0]["type"] == "hello"
+    assert socket.sent[1] == {"type": "heartbeat"}
+    assert socket.sent[2]["type"] == "command_ack"
+    assert socket.sent[3]["type"] == "command_result"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

Managed agents keep their WebSocket alive with **protocol-level** pings, which the server library auto-pongs. But those pings never reach application code, so the server's `last_seen_at` only advances when the agent is actively `POST /heartbeat`-ing during a job (the 5s `should_cancel` check).

An **idle-but-healthy** agent therefore freezes at "time of last job" and looks stale — even though its WS is connected and fine. On a busy cluster, every agent's `last_seen_at` sat hours in the past while all were online.

## Fix

- **Agent** (`session.py`): the idle recv-timeout branch — which fires every ~30s and keeps running even while a job runs in a worker thread — now also sends an application-level `{"type": "heartbeat"}` frame, alongside the existing protocol ping.
- **Server** (`agents.py` `_handle_agent_session_message`): handles `heartbeat` by refreshing `last_seen_at` and marking the agent `online`.

`last_seen_at` now reflects real "last contact" instead of "last job", which is a prerequisite for liveness-based orphaned-job handling.

## Tests

- `test_agent_heartbeat.py`: the session handler refreshes `last_seen_at` / status on a `heartbeat` message.
- `test_agent_runtime.py`: the session emits an app heartbeat on an idle recv timeout (existing idle-ping test updated for the new frame).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent sessions now send a lightweight heartbeat during idle periods, helping keep connections alive more reliably.
  * Heartbeat messages are now recognized by the backend and update agent status and last-seen time correctly.
  * Improved idle-session handling so agents stay marked online instead of being treated as inactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->