### PR TITLE
fix(agent): deliver terminal job outcomes over REST, not the WebSocket

### DIFF
--- a/agent/borg_ui_agent/session.py
+++ b/agent/borg_ui_agent/session.py
@@ -69,6 +69,8 @@ class SessionCommandClient:
         send_lock: Optional[threading.Lock] = None,
         closing: Optional[threading.Event] = None,
         artifact_uploader: Optional[Callable[[int, Any], dict[str, Any]]] = None,
+        http_client: Optional[AgentClient] = None,
+        http_lock: Optional[threading.Lock] = None,
     ):
         self.socket = socket
         self.command_id = command_id
@@ -78,6 +80,12 @@ class SessionCommandClient:
         self._send_lock = send_lock or threading.Lock()
         self._closing = closing
         self._artifact_uploader = artifact_uploader
+        # Terminal job outcomes (result/error/canceled) are delivered over the
+        # REST job API, not the WebSocket — see _deliver_terminal. The client
+        # wraps one requests.Session shared by all worker threads, so calls are
+        # serialized under http_lock.
+        self._http_client = http_client
+        self._http_lock = http_lock or threading.Lock()
 
     def upload_artifact(self, job_id: int, data: Any) -> dict[str, Any]:
         """Stream a binary job artifact to the server over HTTP (not the WS)."""
@@ -118,12 +126,9 @@ class SessionCommandClient:
     def complete_job(self, job_id: int, *, result: dict[str, Any]) -> dict[str, Any]:
         self._ensure_started(job_id)
         self.finished = True
-        self._send(
-            {
-                "type": "command_result",
-                "job_id": job_id,
-                "result": result,
-            }
+        self._deliver_terminal(
+            {"type": "command_result", "job_id": job_id, "result": result},
+            lambda c: c.complete_job(job_id, result=result),
         )
         return {"id": job_id, "status": "completed"}
 
@@ -135,18 +140,28 @@ class SessionCommandClient:
         error: dict[str, Any] = {"message": error_message}
         if return_code is not None:
             error["return_code"] = return_code
-        self._send({"type": "command_error", "job_id": job_id, "error": error})
+        self._deliver_terminal(
+            {"type": "command_error", "job_id": job_id, "error": error},
+            lambda c: c.fail_job(
+                job_id, error_message=error_message, return_code=return_code
+            ),
+        )
         return {"id": job_id, "status": "failed"}
 
     def cancel_job(self, job_id: int) -> dict[str, Any]:
-        self._ensure_started(job_id)
         self.finished = True
-        self._send({"type": "job_canceled", "job_id": job_id})
+        self._deliver_terminal(
+            {"type": "job_canceled", "job_id": job_id},
+            lambda c: c.cancel_job(job_id),
+        )
         return {"id": job_id, "status": "canceled"}
 
     def send_result(self, result: dict[str, Any]) -> None:
         self.finished = True
-        self._send({"type": "command_result", "job_id": self.job_id, "result": result})
+        self._deliver_terminal(
+            {"type": "command_result", "job_id": self.job_id, "result": result},
+            lambda c: c.complete_job(self.job_id, result=result),
+        )
 
     def send_error(
         self,
@@ -159,19 +174,73 @@ class SessionCommandClient:
         error: dict[str, Any] = {"code": code, "message": message}
         if return_code is not None:
             error["return_code"] = return_code
-        self._send({"type": "command_error", "job_id": self.job_id, "error": error})
+        self._deliver_terminal(
+            {"type": "command_error", "job_id": self.job_id, "error": error},
+            lambda c: c.fail_job(
+                self.job_id, error_message=message, return_code=return_code
+            ),
+        )
+
+    def _deliver_terminal(
+        self,
+        ws_payload: dict[str, Any],
+        http_call: Callable[[AgentClient], Any],
+    ) -> None:
+        """Deliver a terminal outcome (result/error/canceled).
+
+        A **persisted** job (``job_id`` set) is reported over the REST job API,
+        NOT the WebSocket. A job result can be large (an archive listing is
+        hundreds of KB); sending it as one WebSocket frame holds websocket-client's
+        per-connection send lock for the whole write, which starves the keepalive
+        pong the recv loop must emit. The server then hits its ws-ping timeout and
+        tears the session down mid-send — the result is lost and the job orphaned
+        (empty browse dialogs) until the reaper cleans it up 15 minutes later.
+        REST keeps the socket free for small control frames + keepalive, and
+        /complete, /fail and /cancel are idempotent so a retry/late delivery is a
+        no-op. The client wraps one requests.Session shared by all worker threads,
+        so calls are serialized under _http_lock.
+
+        An **ephemeral** command (``job_id`` is None, e.g. an interactive
+        filesystem browse) has no job row, so its result is correlated by
+        command_id and returned over the WebSocket. These payloads are small
+        directory listings, not large archive results.
+        """
+        if self.job_id is not None and self._http_client is not None:
+            with self._http_lock:
+                try:
+                    http_call(self._http_client)
+                except Exception:
+                    # Outcome is dropped until the server-side reaper reconciles
+                    # it (~15 min); log the job id + traceback so that window is
+                    # diagnosable.
+                    logger.warning(
+                        "Failed to deliver terminal job outcome over REST for job %s",
+                        self.job_id,
+                        exc_info=True,
+                    )
+            return
+        self._try_ws_send(ws_payload)
 
     def _send(self, payload: dict[str, Any]) -> None:
-        """Serialize one frame onto the socket under the shared send lock, but
-        skip the write once the session is closing, so a worker never touches a
-        connection the drop handler has already torn down."""
+        """Best-effort telemetry send (job_started/progress/log/cancel). Losing
+        one is harmless; terminal results go through _deliver_terminal instead."""
+        self._try_ws_send(payload)
+
+    def _try_ws_send(self, payload: dict[str, Any]) -> bool:
+        """Serialize one frame onto the socket under the shared send lock. Skip
+        (reporting failure) once the session is closing, so a worker never
+        touches a connection the drop handler has already torn down."""
         if self._closing is not None and self._closing.is_set():
-            return
+            return False
         message = json.dumps({"command_id": self.command_id, **payload})
         with self._send_lock:
             if self._closing is not None and self._closing.is_set():
-                return
-            self.socket.send(message)
+                return False
+            try:
+                self.socket.send(message)
+                return True
+            except Exception:
+                return False
 
     def _ensure_started(self, job_id: int) -> None:
         if not self.started:
@@ -186,6 +255,7 @@ class AgentSessionRuntime:
         connect: Optional[Callable[..., Any]] = None,
         sleep: Callable[[float], None] = time.sleep,
         timeout_seconds: int = 30,
+        http_client: Optional[AgentClient] = None,
     ):
         self.config = config
         self.connect = connect or _default_connect
@@ -194,6 +264,12 @@ class AgentSessionRuntime:
         # HTTP client used to stream binary artifacts (e.g. extracted files) to
         # the server out-of-band, so they never go through the WebSocket.
         self._artifact_client = AgentClient.from_config(config)
+        # REST client used to re-deliver terminal job frames if the WebSocket
+        # drops mid-command (see SessionCommandClient._deliver_terminal).
+        self._http_client = http_client or AgentClient.from_config(config)
+        # Serializes REST terminal deliveries across worker threads (the client
+        # wraps one requests.Session).
+        self._http_lock = threading.Lock()
         self._send_lock = threading.Lock()
         self._registry_lock = threading.Lock()
         self._cancel_events: dict[int, threading.Event] = {}
@@ -334,6 +410,8 @@ class AgentSessionRuntime:
             send_lock=self._send_lock,
             closing=closing,
             artifact_uploader=self._artifact_client.upload_artifact,
+            http_client=self._http_client,
+            http_lock=self._http_lock,
         )
 
         ack = json.dumps(
@@ -360,11 +438,16 @@ class AgentSessionRuntime:
             return
 
         if command == "cancel":
-            # Signal the worker running this job so it actually stops; the worker
-            # emits the job_canceled frame itself as it unwinds.
+            # Signal the worker running this job so it actually stops; it emits
+            # its own job_canceled as it unwinds. Also record the cancel here via
+            # the cancel path (idempotent /cancel) so the outcome is captured even
+            # if no worker is running. NOT send_result — that routes through
+            # complete_job and would wrongly finalize the target job as completed,
+            # racing the worker's cancel. The server dispatches cancel
+            # fire-and-forget (wait_for_result=False), so no response is expected.
             if job_id is not None:
                 self._signal_cancel(job_id)
-            client.send_result({"success": True})
+                client.cancel_job(job_id)
             return
 
         handler = get_job_handler(command)

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -47,6 +47,28 @@ class FakeWebSocket:
         self.closed = True
 
 
+class RecordingHttpClient:
+    """Records the REST terminal-delivery calls the session makes (results,
+    errors and cancels now go over the job API instead of the WebSocket)."""
+
+    def __init__(self):
+        self.completed = []
+        self.failed = []
+        self.canceled = []
+
+    def complete_job(self, job_id, *, result):
+        self.completed.append((job_id, result))
+        return {"id": job_id, "status": "completed"}
+
+    def fail_job(self, job_id, *, error_message, return_code=None):
+        self.failed.append((job_id, error_message, return_code))
+        return {"id": job_id, "status": "failed"}
+
+    def cancel_job(self, job_id):
+        self.canceled.append(job_id)
+        return {"id": job_id, "status": "canceled"}
+
+
 class FakeResponse:
     def __init__(self, payload=None, status_code=200, text=""):
         self.payload = payload or {}
@@ -74,6 +96,16 @@ class FakeSession:
             }
         )
         return self.responses.pop(0)
+
+
+@pytest.fixture
+def patch_session_platform(monkeypatch):
+    """Stub the platform / borg detection the session runtime runs on hello."""
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.detect_platform",
+        lambda: {"hostname": "host.local", "os": "linux", "arch": "amd64"},
+    )
+    monkeypatch.setattr("agent.borg_ui_agent.session.detect_borg_binaries", lambda: [])
 
 
 @pytest.mark.unit
@@ -600,6 +632,121 @@ def test_session_runtime_sends_app_heartbeat_while_idle(monkeypatch):
 
 
 @pytest.mark.unit
+def test_session_delivers_result_over_rest_not_ws(patch_session_platform, monkeypatch):
+    """Job results are delivered over the REST job API, never over the WebSocket,
+    so a large result frame can't starve the keepalive and break the session."""
+    from agent.borg_ui_agent.session import AgentSessionRuntime
+
+    socket = FakeWebSocket(
+        [
+            {
+                "type": "command",
+                "command_id": "cmd-1",
+                "command": "filesystem.browse",
+                "job_id": 42,
+                "payload": {"path": "/home"},
+            },
+        ]
+    )
+    http = RecordingHttpClient()
+
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.browse_filesystem",
+        lambda path, include_hidden=False: {
+            "success": True,
+            "current_path": path,
+            "parent_path": "/",
+            "items": [],
+        },
+    )
+
+    runtime = AgentSessionRuntime(
+        AgentConfig("https://borgui.example.com", "agt_123", "secret"),
+        connect=lambda *args, **kwargs: socket,
+        http_client=http,
+    )
+    runtime.run_session(max_messages=1)
+
+    # Result delivered over REST...
+    assert len(http.completed) == 1
+    assert http.completed[0][0] == 42
+    assert http.completed[0][1]["success"] is True
+    # ...and NOT over the WebSocket.
+    assert all(frame.get("type") != "command_result" for frame in socket.sent)
+
+
+@pytest.mark.unit
+def test_session_command_client_delivers_error_over_rest():
+    """A failed command reports via REST fail_job (with error_message/return_code
+    preserved), not over the WebSocket."""
+    from agent.borg_ui_agent.session import SessionCommandClient
+
+    socket = FakeWebSocket([])
+    http = RecordingHttpClient()
+    client = SessionCommandClient(
+        socket, command_id="cmd-1", job_id=7, http_client=http
+    )
+
+    client.fail_job(7, error_message="boom", return_code=2)
+
+    assert http.failed == [(7, "boom", 2)]
+    assert all(frame.get("type") != "command_error" for frame in socket.sent)
+
+
+@pytest.mark.unit
+def test_session_terminal_rest_failure_is_swallowed():
+    """If REST delivery raises, the worker must not crash: the failure is logged
+    and swallowed, and the client still marks the job finished."""
+    from agent.borg_ui_agent.session import SessionCommandClient
+
+    class FailingHttpClient:
+        def complete_job(self, job_id, *, result):
+            raise RuntimeError("rest unreachable")
+
+    socket = FakeWebSocket([])
+    client = SessionCommandClient(
+        socket, command_id="cmd-1", job_id=9, http_client=FailingHttpClient()
+    )
+
+    client.complete_job(9, result={"ok": True})  # must not raise
+
+    assert client.finished is True
+    assert all(frame.get("type") != "command_result" for frame in socket.sent)
+
+
+@pytest.mark.unit
+def test_session_cancel_command_cancels_target_job_not_completes(
+    patch_session_platform,
+):
+    """A cancel command must record the target job as canceled (REST /cancel),
+    never completed — otherwise it races the worker's own cancel unwind."""
+    from agent.borg_ui_agent.session import AgentSessionRuntime
+
+    socket = FakeWebSocket(
+        [
+            {
+                "type": "command",
+                "command_id": "cmd-c",
+                "command": "cancel",
+                "job_id": 55,
+                "payload": {"job_id": 55},
+            },
+        ]
+    )
+    http = RecordingHttpClient()
+
+    runtime = AgentSessionRuntime(
+        AgentConfig("https://borgui.example.com", "agt_123", "secret"),
+        connect=lambda *args, **kwargs: socket,
+        http_client=http,
+    )
+    runtime.run_session(max_messages=1)
+
+    assert http.canceled == [55]
+    assert http.completed == []
+
+
+@pytest.mark.unit
 def test_session_runtime_handles_ephemeral_filesystem_browse(monkeypatch):
     from agent.borg_ui_agent.session import AgentSessionRuntime
 
@@ -866,12 +1013,15 @@ def test_session_runtime_reports_durable_job_events(monkeypatch):
         lambda command: fake_handler if command == "backup.create" else None,
     )
 
+    http = RecordingHttpClient()
     runtime = AgentSessionRuntime(
         AgentConfig("https://borgui.example.com", "agt_123", "secret"),
         connect=lambda *args, **kwargs: socket,
+        http_client=http,
     )
     runtime.run_session(max_messages=1)
 
+    # Control + telemetry frames stay on the WebSocket...
     assert socket.sent[1]["type"] == "command_ack"
     assert socket.sent[2]["type"] == "job_started"
     assert socket.sent[3] == {
@@ -884,8 +1034,9 @@ def test_session_runtime_reports_durable_job_events(monkeypatch):
     }
     assert socket.sent[4]["type"] == "progress"
     assert socket.sent[4]["progress_percent"] == 25
-    assert socket.sent[5]["type"] == "command_result"
-    assert socket.sent[5]["result"] == {"archive_name": "archive"}
+    # ...the terminal result goes over REST.
+    assert http.completed == [(77, {"archive_name": "archive"})]
+    assert all(frame.get("type") != "command_result" for frame in socket.sent)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

A managed agent runs each session command in a **worker thread** and reported the outcome (`command_result` / `command_error`) back over the **same WebSocket** the recv loop uses for keepalive.

A job result can be large — an archive listing is hundreds of KB. Sending it as one WebSocket frame holds `websocket-client`'s per-connection send lock for the whole write, which **starves the keepalive pong** the recv loop must emit. The server then hits its ws-ping timeout (uvicorn default **20 s**) and closes the session **mid-send** → the result is lost and the job stays in-flight until the reaper fails it **15 minutes** later.

Symptom: **archive browsing returns an empty dialog** (and the repo is briefly blocked for other operations by admission), while `borg list` on the node itself is fast.

```mermaid
sequenceDiagram
  participant Srv as Server (uvicorn)
  participant Ag as Agent recv-loop
  participant Wk as Worker thread
  Srv->>Ag: command (list_archive_contents)
  Note over Wk: runs borg list → ~660 KB result
  Srv-->>Ag: ws PING (every 20s)
  Wk->>Srv: command_result (660 KB) — holds WS send-lock
  Note over Ag: recv-loop can't PONG (send-lock held by worker)
  Srv--xSrv: ws-ping timeout (20s) → close connection
  Wk--xSrv: send fails: Broken pipe → result lost
  Note over Srv: job orphaned → reaped after 15 min → empty dialog
```

## Fix

Terminal outcomes for **persisted jobs** are delivered over the **REST job API** (`/jobs/{id}/complete` · `/fail` · `/cancel`) instead of the WebSocket. The socket then only carries small control frames + keepalive, so a large result can no longer starve the pong.

```mermaid
sequenceDiagram
  participant Srv as Server
  participant Ag as Agent recv-loop
  participant Wk as Worker thread
  Srv->>Ag: command (list_archive_contents)
  Note over Wk: runs borg list
  Srv-->>Ag: ws PING → Ag auto-PONGs (socket free)
  Wk->>Srv: POST /jobs/{id}/complete (result) — REST
  Srv-->>Wk: 200 OK (idempotent)
  Note over Srv,Ag: WS carries only control + keepalive → session stays healthy
```

Details:
- `/complete`, `/fail`, `/cancel` are **idempotent** (no-op on an already-final job), so a retry or a late delivery is harmless.
- The REST client wraps one `requests.Session` shared by worker threads, so terminal calls are **serialized under a lock**.
- **Ephemeral** commands (no job row — e.g. an interactive filesystem browse) still return their small result over the WS, correlated by `command_id`.
- Telemetry frames (`job_started` / `progress` / `log`) remain best-effort WS sends.

## Scope / risk

This only touches the **managed-agent WebSocket session** — a new code path that is not yet in service — so there is no impact on server-side execution or existing repositories. `command_result` handling on the server WS side is left intact (unused by persisted jobs now).

## Tests
- results go over REST, not the WS (persisted job)
- `command_error` → `fail_job` with `error_message`/`return_code` preserved (per review)
- ephemeral (job_id = None) result still returns over the WS
- idle heartbeat / durable job events unchanged otherwise


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional REST fallback for terminal job outcomes (completion, failure, and cancellation) when live terminal delivery isn’t available.
  * When REST delivery is used, terminal outcome frames are sent via the job API instead of over the live terminal channel.

* **Bug Fixes**
  * Made live terminal delivery best-effort so transient send failures don’t disrupt processing.
  * REST delivery errors are handled without preventing session completion.
  * Cancellation outcomes now flow through the dedicated terminal outcome path.

* **Tests**
  * Added/updated unit tests to verify REST job API delivery and to ensure terminal frames are not emitted over the live channel when REST is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->