### PR TITLE
feat(browse): poll agent archive listings instead of blocking

### DIFF
--- a/app/api/browse.py
+++ b/app/api/browse.py
@@ -1,4 +1,7 @@
+from typing import Optional
+
 from fastapi import APIRouter, Depends, HTTPException, status, Query
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 import os  # noqa: F401
 import structlog
@@ -15,6 +18,7 @@ from app.services.archive_browse_service import (
 )
 from app.services.cache_service import archive_cache
 from app.services.repository_executor import (
+    get_agent_archive_browse_job,
     is_agent_executor,
     queue_agent_repository_operation_job,
     wait_for_agent_repository_operation_job,
@@ -58,14 +62,30 @@ def _is_browse_result_payload(items) -> bool:
     )
 
 
-async def _list_archive_contents(
+# How long a single browse request waits for the agent's list_archive_contents
+# job before returning HTTP 202 so the client polls. Large managed archives
+# (hundreds of thousands of entries) can take longer than any single request
+# should block; small ones still resolve within this first window.
+BROWSE_AGENT_WAIT_SECONDS = 8
+
+
+async def _run_or_poll_agent_browse(
     db: Session,
     repository: Repository,
     *,
     archive_name: str,
     max_items: int,
-) -> dict:
-    if is_agent_executor(repository):
+    job_id: Optional[int],
+) -> tuple[Optional[dict], int]:
+    """Queue (``job_id`` is None) or resume (``job_id`` given) the agent's archive
+    listing job and wait a bounded window for it.
+
+    Returns ``(result, job_id)``. ``result`` is the completed job payload, or
+    ``None`` when the job is still running — the caller then returns HTTP 202 with
+    the job id so the client polls. The completed listing is parsed and cached by
+    the caller, so subsequent opens of the same archive are served from cache.
+    """
+    if job_id is None:
         agent_job = queue_agent_repository_operation_job(
             db,
             repository,
@@ -78,8 +98,31 @@ async def _list_archive_contents(
             repository_id=repository.id,
             archive_name=archive_name,
         )
-        return await wait_for_agent_repository_operation_job(db, agent_job.id)
+        job_id = agent_job.id
+    elif get_agent_archive_browse_job(db, repository, job_id, archive_name) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"key": "backend.errors.agents.jobNotFound"},
+        )
 
+    try:
+        result = await wait_for_agent_repository_operation_job(
+            db, job_id, timeout_seconds=BROWSE_AGENT_WAIT_SECONDS
+        )
+    except HTTPException as exc:
+        if exc.status_code == status.HTTP_504_GATEWAY_TIMEOUT:
+            return None, job_id
+        raise
+    return result, job_id
+
+
+async def _list_archive_contents_local(
+    db: Session,
+    repository: Repository,
+    *,
+    archive_name: str,
+    max_items: int,
+) -> dict:
     env, temp_key_file = _build_repo_env(repository, db)
     try:
         return await BorgRouter(repository).list_archive_contents(
@@ -97,6 +140,10 @@ async def browse_archive_contents(
     repository_id: int,
     archive_name: str,
     path: str = Query("", description="Path within archive to browse"),
+    job_id: Optional[int] = Query(
+        None,
+        description="Poll an in-flight agent browse job queued by a prior call",
+    ),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -146,12 +193,29 @@ async def browse_archive_contents(
         else:
             # If not in cache, fetch from borg with streaming (prevents OOM)
             # Pass max_items as max_lines to ensure borg process is killed if limit exceeded
-            result = await _list_archive_contents(
-                db,
-                repository,
-                archive_name=archive_name,
-                max_items=max_items,
-            )
+            if is_agent_executor(repository):
+                # Agent listings run remotely and can be slow; queue/poll a job
+                # instead of blocking the request until it finishes or times out.
+                result, browse_job_id = await _run_or_poll_agent_browse(
+                    db,
+                    repository,
+                    archive_name=archive_name,
+                    max_items=max_items,
+                    job_id=job_id,
+                )
+                if result is None:
+                    # Job still running — tell the client to poll with this id.
+                    return JSONResponse(
+                        status_code=status.HTTP_202_ACCEPTED,
+                        content={"status": "pending", "jobId": browse_job_id},
+                    )
+            else:
+                result = await _list_archive_contents_local(
+                    db,
+                    repository,
+                    archive_name=archive_name,
+                    max_items=max_items,
+                )
 
             # Check if line limit was exceeded (borg process was killed to prevent OOM)
             if result.get("line_count_exceeded"):

--- a/app/services/repository_executor.py
+++ b/app/services/repository_executor.py
@@ -350,6 +350,32 @@ def queue_agent_repository_operation_job(
     return agent_job
 
 
+def get_agent_archive_browse_job(
+    db: Session,
+    repository: Repository,
+    agent_job_id: int,
+    archive_name: str,
+) -> Optional[AgentJob]:
+    """Return a previously-queued ``list_archive_contents`` job iff it belongs to
+    this repository and archive.
+
+    Archive browsing is asynchronous: the first request queues the job and the
+    client then polls with the returned job id. This validates that a polled job
+    id really is this repository's browse job for this archive, so one viewer
+    cannot poll another repository's listing by guessing an id.
+    """
+    agent_job = db.query(AgentJob).filter(AgentJob.id == agent_job_id).first()
+    if agent_job is None:
+        return None
+    payload = agent_job.payload if isinstance(agent_job.payload, dict) else {}
+    repository_matches = (payload.get("repository") or {}).get("id") == repository.id
+    kind_matches = payload.get("job_kind") == "repository.list_archive_contents"
+    archive_matches = (payload.get("operation") or {}).get("archive") == archive_name
+    return (
+        agent_job if repository_matches and kind_matches and archive_matches else None
+    )
+
+
 async def wait_for_agent_repository_operation_job(
     db: Session,
     agent_job_id: int,

--- a/frontend/src/components/ArchiveContentsDialog.stories.tsx
+++ b/frontend/src/components/ArchiveContentsDialog.stories.tsx
@@ -1,0 +1,59 @@
+import { useEffect, type ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import MockAdapter from 'axios-mock-adapter'
+import ArchiveContentsDialog from './ArchiveContentsDialog'
+import { httpClient, type Repository } from '../services/borgApi/client'
+import type { Archive } from '../types'
+
+const repository = {
+  id: 1,
+  name: 'Test Repo',
+  path: '/test',
+  borg_version: 1,
+} as Repository
+
+const archive = {
+  id: '1',
+  name: 'backup-2026-07-08',
+  archive: 'backup-2026-07-08',
+  start: '2026-07-08T10:00:00Z',
+  time: '2026-07-08T10:00:00Z',
+} as Archive
+
+// Keep the v1 browse endpoint replying 202 so the dialog stays in the async
+// "still listing" state and renders the slow-loading hint over the skeletons.
+function usePendingBrowse() {
+  useEffect(() => {
+    const mock = new MockAdapter(httpClient, { onNoMatch: 'passthrough' })
+    mock.onGet(/\/browse\//).reply(202, { status: 'pending', jobId: 1 })
+    return () => {
+      mock.restore()
+    }
+  }, [])
+}
+
+const meta = {
+  title: 'Components/ArchiveContentsDialog',
+  component: ArchiveContentsDialog,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof ArchiveContentsDialog>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function AwaitingAgentStory(args: ComponentProps<typeof ArchiveContentsDialog>) {
+  usePendingBrowse()
+  return <ArchiveContentsDialog {...args} />
+}
+
+// The 202 slow-loading hint rendered above the skeletons while a managed-agent
+// listing is still running.
+export const AwaitingAgentListing: Story = {
+  args: {
+    open: true,
+    archive,
+    repository,
+    onClose: () => {},
+  },
+  render: (args) => <AwaitingAgentStory {...args} />,
+}

--- a/frontend/src/components/ArchiveContentsDialog.tsx
+++ b/frontend/src/components/ArchiveContentsDialog.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { alpha, Box, Typography } from '@mui/material'
-import { ShieldCheck } from 'lucide-react'
+import { Hourglass, ShieldCheck } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useQuery } from '@tanstack/react-query'
 import { BorgApiClient, type Repository } from '../services/borgApi/client'
@@ -52,12 +52,21 @@ export default function ArchiveContentsDialog({
   const { t } = useTranslation()
   const [currentPath, setCurrentPath] = useState('')
   const [downloading, setDownloading] = useState(false)
+  // Handle of an in-flight agent listing job (see getArchiveContents): a slow
+  // managed archive returns 202 + this id, which we pass back to poll the job.
+  const jobIdRef = useRef<number | null>(null)
 
   useEffect(() => {
     if (open && archive) {
       setCurrentPath('')
+      jobIdRef.current = null
     }
   }, [open, archive])
+
+  // A new path is a fresh listing context; drop any in-flight poll handle.
+  useEffect(() => {
+    jobIdRef.current = null
+  }, [currentPath])
 
   const { data: archiveContents, isFetching } = useQuery({
     queryKey: ['archive-contents', repository?.id, archive?.name, currentPath],
@@ -65,11 +74,23 @@ export default function ArchiveContentsDialog({
       if (!repository || !archive) {
         throw new Error('Repository or archive not selected')
       }
-      return new BorgApiClient(repository).getArchiveContents(archive.id, archive.name, currentPath)
+      const response = await new BorgApiClient(repository).getArchiveContents(
+        archive.id,
+        archive.name,
+        currentPath,
+        jobIdRef.current ?? undefined
+      )
+      // 202 = the agent listing is still running; remember the job id so the next
+      // poll resumes it instead of queueing a duplicate.
+      jobIdRef.current = response.status === 202 ? (response.data?.jobId ?? jobIdRef.current) : null
+      return response
     },
     enabled: !!archive && !!repository && open,
     staleTime: 5 * 60 * 1000,
+    refetchInterval: (query) => (query.state.data?.status === 202 ? 1500 : false),
   })
+
+  const isAwaitingAgent = archiveContents?.status === 202
 
   const canaryDescription = t('archiveContents.managedCanaryDescription')
   const items = useMemo<StorageBrowserItem[] | null>(() => {
@@ -93,6 +114,28 @@ export default function ArchiveContentsDialog({
 
   const isInsideCanaryPath = isRestoreCanaryPath(currentPath)
 
+  const loadingHint = isAwaitingAgent ? (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 1,
+        px: 1.5,
+        py: 1,
+        borderRadius: 1,
+        bgcolor: (theme) => alpha(theme.palette.info.main, 0.08),
+        border: '1px solid',
+        borderColor: (theme) => alpha(theme.palette.info.main, 0.25),
+        flexShrink: 0,
+      }}
+    >
+      <Hourglass size={17} style={{ marginTop: 2, flexShrink: 0 }} />
+      <Typography variant="body2" color="text.secondary">
+        {t('archiveContents.slowLoadingHint')}
+      </Typography>
+    </Box>
+  ) : undefined
+
   return (
     <StorageBrowserDialog
       open={open}
@@ -100,7 +143,8 @@ export default function ArchiveContentsDialog({
       subtitle={archive?.name}
       currentPath={currentPath}
       items={items}
-      isLoading={isFetching}
+      isLoading={isFetching || isAwaitingAgent}
+      loadingHint={loadingHint}
       rootLabel={t('archiveContents.root')}
       closeLabel={t('common.buttons.close')}
       emptyDirectoryLabel={t('archiveContents.emptyDirectory')}

--- a/frontend/src/components/ArchivePathSelector.stories.tsx
+++ b/frontend/src/components/ArchivePathSelector.stories.tsx
@@ -1,0 +1,61 @@
+import { useEffect, type ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box } from '@mui/material'
+import MockAdapter from 'axios-mock-adapter'
+import ArchivePathSelector from './ArchivePathSelector'
+import { httpClient, type Repository } from '../services/borgApi/client'
+import type { Archive } from '../types'
+
+const repository = {
+  id: 1,
+  name: 'Test Repo',
+  path: '/test',
+  borg_version: 1,
+} as Repository
+
+const archive: Pick<Archive, 'id' | 'name'> = {
+  id: '1',
+  name: 'backup-2026-07-08',
+}
+
+// Keep the browse endpoint replying 202 so the selector stays in the async
+// "still listing" state and renders the spinner + slow-loading hint.
+function usePendingBrowse() {
+  useEffect(() => {
+    const mock = new MockAdapter(httpClient, { onNoMatch: 'passthrough' })
+    mock.onGet(/\/browse\//).reply(202, { status: 'pending', jobId: 1 })
+    return () => {
+      mock.restore()
+    }
+  }, [])
+}
+
+const meta = {
+  title: 'Components/ArchivePathSelector',
+  component: ArchivePathSelector,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof ArchivePathSelector>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function AwaitingAgentStory(args: ComponentProps<typeof ArchivePathSelector>) {
+  usePendingBrowse()
+  return (
+    <Box sx={{ p: 3, maxWidth: 720 }}>
+      <ArchivePathSelector {...args} />
+    </Box>
+  )
+}
+
+// The awaiting-agent state: the spinner plus the slow-loading hint while a
+// managed-agent listing is still running.
+export const AwaitingAgentListing: Story = {
+  args: {
+    repository,
+    archive,
+    data: { selectedPaths: [] },
+    onChange: () => {},
+  },
+  render: (args) => <AwaitingAgentStory {...args} />,
+}

--- a/frontend/src/components/ArchivePathSelector.tsx
+++ b/frontend/src/components/ArchivePathSelector.tsx
@@ -43,6 +43,10 @@ interface ArchiveItem {
 
 const RESTORE_CANARY_MANAGED_TYPE = 'restore_canary'
 
+// Give up polling a stuck agent listing after this long and surface a timeout,
+// rather than hammering the server every 1.5s forever while the dialog stays open.
+const BROWSE_POLL_TIMEOUT_MS = 10 * 60 * 1000
+
 function isRestoreCanaryPath(path?: string) {
   const normalized = (path || '').replace(/^\/+/, '').replace(/\/+$/, '')
   return normalized === '.borg-ui' || normalized.startsWith('.borg-ui/')
@@ -80,34 +84,61 @@ export default function ArchivePathSelector({
   const [currentPath, setCurrentPath] = useState<string>('')
   const [items, setItems] = useState<ArchiveItem[]>([])
   const [loading, setLoading] = useState<boolean>(false)
+  const [awaitingAgent, setAwaitingAgent] = useState<boolean>(false)
   const [error, setError] = useState<string | null>(null)
   const selectedPaths = new Set(data.selectedPaths || [])
   const selectedItems = data.selectedItems || []
 
   useEffect(() => {
+    let cancelled = false
+
     const fetchContents = async () => {
       setLoading(true)
       setError(null)
+      setAwaitingAgent(false)
 
       try {
-        const response = await new BorgApiClient(repository).getArchiveContents(
-          archive.id,
-          archive.name,
-          currentPath
-        )
+        const client = new BorgApiClient(repository)
+        // Agent listings are asynchronous: a 202 means the job is still running,
+        // so poll with the returned id until it completes — but give up after
+        // BROWSE_POLL_TIMEOUT_MS so a wedged job doesn't poll the server forever.
+        const deadline = Date.now() + BROWSE_POLL_TIMEOUT_MS
+        let response = await client.getArchiveContents(archive.id, archive.name, currentPath)
+        let jobId: number | undefined
+        while (response.status === 202) {
+          if (cancelled) return
+          if (Date.now() > deadline) {
+            setError(t('wizard.restoreFiles.loadContentsTimeout'))
+            return
+          }
+          setAwaitingAgent(true)
+          jobId = response.data?.jobId ?? jobId
+          await new Promise((resolve) => setTimeout(resolve, 1500))
+          if (cancelled) return
+          response = await client.getArchiveContents(archive.id, archive.name, currentPath, jobId)
+        }
+        if (cancelled) return
         setItems(response.data.items || [])
       } catch (err: unknown) {
+        if (cancelled) return
         const error = err as { response?: { data?: { detail?: string } } }
         const errorMsg =
           translateBackendKey(error.response?.data?.detail) ||
           t('wizard.restoreFiles.failedToLoadContents')
         setError(errorMsg)
       } finally {
-        setLoading(false)
+        if (!cancelled) {
+          setLoading(false)
+          setAwaitingAgent(false)
+        }
       }
     }
 
     fetchContents()
+
+    return () => {
+      cancelled = true
+    }
   }, [repository, archive.id, archive.name, currentPath, t])
 
   const pathParts = currentPath ? currentPath.split('/').filter(Boolean) : []
@@ -311,8 +342,25 @@ export default function ArchivePathSelector({
 
         <Box sx={{ flex: 1, overflow: 'auto' }}>
           {loading && (
-            <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 2,
+                p: 4,
+              }}
+            >
               <CircularProgress size={32} />
+              {awaitingAgent && (
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ maxWidth: 420, textAlign: 'center' }}
+                >
+                  {t('archiveContents.slowLoadingHint')}
+                </Typography>
+              )}
             </Box>
           )}
 

--- a/frontend/src/components/StorageBrowserDialog.stories.tsx
+++ b/frontend/src/components/StorageBrowserDialog.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box, Typography } from '@mui/material'
+import { Hourglass } from 'lucide-react'
+import StorageBrowserDialog, { type StorageBrowserItem } from './StorageBrowserDialog'
+
+const meta = {
+  title: 'Components/StorageBrowserDialog',
+  component: StorageBrowserDialog,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    open: true,
+    title: 'Archive Contents',
+    subtitle: 'backup-2026-07-08',
+    currentPath: '',
+    rootLabel: 'Root',
+    closeLabel: 'Close',
+    emptyDirectoryLabel: 'This directory is empty',
+    onClose: () => {},
+    onNavigate: () => {},
+  },
+} satisfies Meta<typeof StorageBrowserDialog>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const items: StorageBrowserItem[] = [
+  { name: 'home', path: 'home', type: 'directory', size: null },
+  { name: 'etc', path: 'etc', type: 'directory', size: null },
+  {
+    name: 'notes.txt',
+    path: 'notes.txt',
+    type: 'file',
+    size: 1024,
+    modified: '2026-07-08T10:00:00Z',
+  },
+]
+
+const slowLoadingHint = (
+  <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, px: 1.5, py: 1 }}>
+    <Hourglass size={17} style={{ marginTop: 2, flexShrink: 0 }} />
+    <Typography variant="body2" color="text.secondary">
+      This archive is large, so listing its files takes a little longer. Hang tight.
+    </Typography>
+  </Box>
+)
+
+export const Populated: Story = {
+  args: { items, showModifiedColumn: true },
+}
+
+export const Loading: Story = {
+  args: { items: null, isLoading: true },
+}
+
+// The loadingHint slot: a friendly note rendered above the skeletons while a slow
+// (managed-agent) listing is still running.
+export const LoadingWithHint: Story = {
+  args: { items: null, isLoading: true, loadingHint: slowLoadingHint },
+}

--- a/frontend/src/components/StorageBrowserDialog.tsx
+++ b/frontend/src/components/StorageBrowserDialog.tsx
@@ -36,6 +36,7 @@ interface StorageBrowserDialogProps {
   currentPath: string
   items?: StorageBrowserItem[] | null
   isLoading?: boolean
+  loadingHint?: ReactNode
   rootLabel: string
   closeLabel: string
   emptyDirectoryLabel: string
@@ -136,6 +137,7 @@ export default function StorageBrowserDialog({
   currentPath,
   items,
   isLoading = false,
+  loadingHint,
   rootLabel,
   closeLabel,
   emptyDirectoryLabel,
@@ -247,33 +249,36 @@ export default function StorageBrowserDialog({
 
           <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
             {isLoading ? (
-              <Stack spacing={0.5}>
-                {[
-                  { width: '55%', isFolder: true },
-                  { width: '40%', isFolder: true },
-                  { width: '70%', isFolder: true },
-                  { width: '62%', isFolder: false },
-                  { width: '48%', isFolder: false },
-                  { width: '75%', isFolder: false },
-                  { width: '33%', isFolder: false },
-                ].map((row, index) => (
-                  <Box
-                    key={index}
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 1.5,
-                      p: 1.5,
-                      borderRadius: 1,
-                      bgcolor: (theme) =>
-                        row.isFolder ? alpha(theme.palette.primary.main, 0.05) : 'action.hover',
-                    }}
-                  >
-                    <Skeleton variant="rounded" width={20} height={20} sx={{ flexShrink: 0 }} />
-                    <Skeleton variant="text" sx={{ flex: 1, maxWidth: row.width }} />
-                    <Skeleton variant="text" width={52} />
-                  </Box>
-                ))}
+              <Stack spacing={1.5} sx={{ height: '100%' }}>
+                {loadingHint}
+                <Stack spacing={0.5}>
+                  {[
+                    { width: '55%', isFolder: true },
+                    { width: '40%', isFolder: true },
+                    { width: '70%', isFolder: true },
+                    { width: '62%', isFolder: false },
+                    { width: '48%', isFolder: false },
+                    { width: '75%', isFolder: false },
+                    { width: '33%', isFolder: false },
+                  ].map((row, index) => (
+                    <Box
+                      key={index}
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1.5,
+                        p: 1.5,
+                        borderRadius: 1,
+                        bgcolor: (theme) =>
+                          row.isFolder ? alpha(theme.palette.primary.main, 0.05) : 'action.hover',
+                      }}
+                    >
+                      <Skeleton variant="rounded" width={20} height={20} sx={{ flexShrink: 0 }} />
+                      <Skeleton variant="text" sx={{ flex: 1, maxWidth: row.width }} />
+                      <Skeleton variant="text" width={52} />
+                    </Box>
+                  ))}
+                </Stack>
               </Stack>
             ) : items ? (
               hasItems ? (

--- a/frontend/src/components/__tests__/ArchiveContentsDialog.test.tsx
+++ b/frontend/src/components/__tests__/ArchiveContentsDialog.test.tsx
@@ -102,6 +102,56 @@ describe('ArchiveContentsDialog', () => {
     })
   })
 
+  it('polls a pending agent listing and shows the wait hint until items arrive', async () => {
+    // First response: 202, the agent listing is still running (slow archive).
+    // The client remembers the job id and polls; the poll then returns the items.
+    mockGetArchiveContents
+      .mockResolvedValueOnce({
+        status: 202,
+        data: { status: 'pending', jobId: 77 },
+      } as AxiosResponse)
+      .mockResolvedValue({
+        status: 200,
+        data: { items: [{ name: 'file.txt', path: 'file.txt', type: 'file', size: 5 }] },
+      } as AxiosResponse)
+
+    renderWithProviders(
+      <ArchiveContentsDialog
+        open={true}
+        archive={mockArchive}
+        repository={mockRepository}
+        {...mockHandlers}
+      />
+    )
+
+    // The friendly "taking longer" hint appears while the job runs.
+    await waitFor(() => {
+      expect(screen.getByText(/takes a little longer/i)).toBeInTheDocument()
+    })
+
+    // The poll passes the job id back so the server resumes the same job.
+    await waitFor(
+      () => {
+        expect(mockGetArchiveContents).toHaveBeenCalledWith(
+          mockArchive.id,
+          mockArchive.name,
+          '',
+          77
+        )
+      },
+      { timeout: 3000 }
+    )
+
+    // Once the job completes the items render and the hint disappears.
+    await waitFor(
+      () => {
+        expect(screen.getByText('file.txt')).toBeInTheDocument()
+      },
+      { timeout: 3000 }
+    )
+    expect(screen.queryByText(/takes a little longer/i)).not.toBeInTheDocument()
+  })
+
   it('displays empty archive message when no items', async () => {
     mockGetArchiveContents.mockResolvedValue({
       data: { items: [] },
@@ -281,7 +331,8 @@ describe('ArchiveContentsDialog', () => {
       expect(mockGetArchiveContents).toHaveBeenCalledWith(
         mockArchive.id,
         mockArchive.name,
-        'documents'
+        'documents',
+        undefined
       )
     })
   })
@@ -455,7 +506,12 @@ describe('ArchiveContentsDialog', () => {
 
     // Verify it starts at root path
     await waitFor(() => {
-      expect(mockGetArchiveContents).toHaveBeenCalledWith(mockArchive.id, mockArchive.name, '')
+      expect(mockGetArchiveContents).toHaveBeenCalledWith(
+        mockArchive.id,
+        mockArchive.name,
+        '',
+        undefined
+      )
     })
   })
 

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -3849,7 +3849,8 @@
       "clearAll": "Alle löschen",
       "selectDirTooltip": "Verzeichnis und alle Inhalte auswählen",
       "helpText": "Klicke auf Dateien, um sie auszuwählen, oder auf Ordner, um zu navigieren. Verwende das Kontrollkästchen neben Ordnern, um ganze Verzeichnisse auszuwählen.",
-      "failedToLoadContents": "Archivinhalt konnte nicht geladen werden"
+      "failedToLoadContents": "Archivinhalt konnte nicht geladen werden",
+      "loadContentsTimeout": "Lädt noch — dieses Archiv dauert länger als erwartet. Bitte in einem Moment erneut versuchen."
     },
     "restorePath": {
       "title": "Wiederherstellungsort wählen",
@@ -4090,6 +4091,7 @@
   "archiveContents": {
     "title": "Archivinhalt",
     "loading": "Lädt Archivinhalt...",
+    "slowLoadingHint": "Dieses Archiv ist groß, daher dauert das Auflisten der Dateien etwas länger. Einen Moment — das passiert nur beim ersten Mal, danach ist es zwischengespeichert.",
     "emptyDirectory": "Dieses Verzeichnis ist leer",
     "emptyArchive": "Dieses Archiv ist leer",
     "emptyArchiveDesc": "In diesem Archiv wurden keine Dateien gesichert. Dies kann passieren, wenn das Quellverzeichnis während der Sicherung leer oder nicht zugänglich war.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -3849,7 +3849,8 @@
       "clearAll": "Clear all",
       "selectDirTooltip": "Select directory and all contents",
       "helpText": "Click files to select them, or click folders to navigate. Use the checkbox next to folders to select entire directories.",
-      "failedToLoadContents": "Failed to load archive contents"
+      "failedToLoadContents": "Failed to load archive contents",
+      "loadContentsTimeout": "Still loading — this archive is taking longer than expected. Try again in a moment."
     },
     "restorePath": {
       "title": "Choose restore location",
@@ -4090,6 +4091,7 @@
   "archiveContents": {
     "title": "Archive Contents",
     "loading": "Loading archive contents...",
+    "slowLoadingHint": "This archive is large, so listing its files takes a little longer. Hang tight — this only happens the first time; afterwards it's cached.",
     "emptyDirectory": "This directory is empty",
     "emptyArchive": "This archive is empty",
     "emptyArchiveDesc": "No files were backed up in this archive. This may happen if the source directory was empty or inaccessible during the backup.",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -3849,7 +3849,8 @@
       "clearAll": "Borrar todo",
       "selectDirTooltip": "Seleccionar directorio y todo su contenido",
       "helpText": "Haz clic en los archivos para seleccionarlos, o en las carpetas para navegar. Usa la casilla junto a las carpetas para seleccionar directorios completos.",
-      "failedToLoadContents": "Error al cargar el contenido del archivo"
+      "failedToLoadContents": "Error al cargar el contenido del archivo",
+      "loadContentsTimeout": "Aún cargando — este archivo está tardando más de lo esperado. Inténtalo de nuevo en un momento."
     },
     "restorePath": {
       "title": "Elegir ubicación de restauración",
@@ -4090,6 +4091,7 @@
   "archiveContents": {
     "title": "Contenido del archivo",
     "loading": "Cargando contenido del archivo...",
+    "slowLoadingHint": "Este archivo es grande, por lo que listar sus ficheros tarda un poco más. Un momento — esto solo ocurre la primera vez; después queda en caché.",
     "emptyDirectory": "Este directorio está vacío",
     "emptyArchive": "Este archivo está vacío",
     "emptyArchiveDesc": "No se respaldaron archivos en este archivo. Esto puede ocurrir si el directorio de origen estaba vacío o inaccesible durante la copia de seguridad.",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -3849,7 +3849,8 @@
       "clearAll": "Cancella tutto",
       "selectDirTooltip": "Seleziona directory e tutto il contenuto",
       "helpText": "Clicca sui file per selezionarli, o sulle cartelle per navigare. Usa la casella di controllo accanto alle cartelle per selezionare intere directory.",
-      "failedToLoadContents": "Impossibile caricare il contenuto dell'archivio"
+      "failedToLoadContents": "Impossibile caricare il contenuto dell'archivio",
+      "loadContentsTimeout": "Ancora in caricamento — questo archivio richiede più tempo del previsto. Riprova tra un momento."
     },
     "restorePath": {
       "title": "Scegli posizione di ripristino",
@@ -4090,6 +4091,7 @@
   "archiveContents": {
     "title": "Contenuto Archivio",
     "loading": "Caricamento contenuto archivio...",
+    "slowLoadingHint": "Questo archivio è grande, quindi elencare i suoi file richiede un po' più di tempo. Un attimo — succede solo la prima volta, poi viene messo in cache.",
     "emptyDirectory": "Questa directory è vuota",
     "emptyArchive": "Questo archivio è vuoto",
     "emptyArchiveDesc": "Nessun file è stato salvato in questo archivio. Questo può accadere se la directory sorgente era vuota o inaccessibile durante il backup.",

--- a/frontend/src/services/borgApi/client.test.ts
+++ b/frontend/src/services/borgApi/client.test.ts
@@ -133,6 +133,19 @@ describe('BorgApiClient', () => {
     })
   })
 
+  it('passes the browse poll job id on v1 archive-contents requests', async () => {
+    const clientModule = await import('./client')
+    const getMock = vi.spyOn(clientModule.httpClient, 'get').mockResolvedValue({} as never)
+    const { BorgApiClient } = clientModule
+    const client = new BorgApiClient({ id: 7, borg_version: 1, path: '/repo-v1' } as never)
+
+    client.getArchiveContents('archive-id', 'archive-name', '/etc', 42)
+
+    expect(getMock).toHaveBeenCalledWith('/browse/7/archive-name', {
+      params: { path: '/etc', job_id: 42 },
+    })
+  })
+
   it('uses v2 routes for Borg 2 repositories', async () => {
     const clientModule = await import('./client')
     const getMock = vi.spyOn(clientModule.httpClient, 'get').mockResolvedValue({} as never)

--- a/frontend/src/services/borgApi/client.ts
+++ b/frontend/src/services/borgApi/client.ts
@@ -137,7 +137,7 @@ export class BorgApiClient {
     })
   }
 
-  getArchiveContents(archiveId: string, archiveName: string, path = '') {
+  getArchiveContents(archiveId: string, archiveName: string, path = '', jobId?: number) {
     if (this.v === '/v2') {
       return httpClient.get(`/v2/archives/${archiveId}/contents`, {
         params: { repository: this.repoId, path },
@@ -146,9 +146,11 @@ export class BorgApiClient {
     // v1 browse (cached, path-filtered). For a Borg 2 archive series the name is
     // ambiguous (matches N archives → borg errors), so select the specific
     // archive by its id via the `aid:` selector; Borg 1 names are unique.
+    // Agent-backed archives are listed asynchronously: the first call may return
+    // 202 + a jobId, which the caller passes back here to poll the running job.
     const selector = this.isV2 && archiveId ? `aid:${archiveId}` : archiveName
     return httpClient.get(`/browse/${this.repoId}/${encodeURIComponent(selector)}`, {
-      params: { path },
+      params: { path, ...(jobId != null ? { job_id: jobId } : {}) },
     })
   }
 

--- a/tests/unit/test_api_browse.py
+++ b/tests/unit/test_api_browse.py
@@ -444,6 +444,7 @@ class TestBrowseArchiveBehavior:
                 repository_id=repo.id,
                 archive_name="archive-1",
                 path="home/karan/test-backup-source",
+                job_id=None,
                 current_user=admin_user,
                 db=test_db,
             )
@@ -470,8 +471,276 @@ class TestBrowseArchiveBehavior:
             repository_id=repo.id,
             archive_name="archive-1",
         )
-        wait_for_agent.assert_awaited_once_with(test_db, agent_job.id)
+        wait_for_agent.assert_awaited_once_with(
+            test_db, agent_job.id, timeout_seconds=browse_api.BROWSE_AGENT_WAIT_SECONDS
+        )
         list_local.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_browse_agent_archive_returns_202_while_job_runs(
+        self,
+        test_db,
+        admin_user,
+    ):
+        """A slow agent listing does not block the request: when the job is still
+        running after the wait window, the endpoint returns 202 + the job id so
+        the client can poll instead of getting a 504 (and an empty dialog)."""
+        agent = _create_agent(test_db, "repository.list_archive_contents")
+        repo = Repository(
+            name="Agent Browse Pending Repo",
+            path="/agent/repositories/pending",
+            encryption="none",
+            compression="none",
+            repository_type="local",
+            executor_type="agent",
+            execution_target="agent",
+            agent_machine_id=agent.id,
+        )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+
+        with (
+            patch.object(
+                browse_api.archive_cache, "get", new=AsyncMock(return_value=None)
+            ),
+            patch.object(
+                browse_api.archive_cache, "set", new=AsyncMock(return_value=True)
+            ),
+            patch(
+                "app.api.browse.dispatch_agent_job_best_effort",
+                new=AsyncMock(return_value=True),
+            ) as dispatch_agent,
+            patch(
+                "app.api.browse.wait_for_agent_repository_operation_job",
+                new=AsyncMock(
+                    side_effect=HTTPException(
+                        status_code=504,
+                        detail={
+                            "key": "backend.errors.agents.repositoryOperationTimeout"
+                        },
+                    )
+                ),
+            ) as wait_for_agent,
+        ):
+            response = await browse_api.browse_archive_contents(
+                repository_id=repo.id,
+                archive_name="archive-1",
+                path="",
+                job_id=None,
+                current_user=admin_user,
+                db=test_db,
+            )
+
+        agent_job = test_db.query(AgentJob).one()
+        assert response.status_code == 202
+        assert json.loads(response.body) == {"status": "pending", "jobId": agent_job.id}
+        dispatch_agent.assert_awaited_once()
+        wait_for_agent.assert_awaited_once_with(
+            test_db, agent_job.id, timeout_seconds=browse_api.BROWSE_AGENT_WAIT_SECONDS
+        )
+
+    @pytest.mark.asyncio
+    async def test_browse_agent_archive_poll_resumes_existing_job(
+        self,
+        test_db,
+        admin_user,
+    ):
+        """Polling with a job_id resumes the queued job (no new job, no dispatch)
+        and returns the parsed items once it completes."""
+        agent = _create_agent(test_db, "repository.list_archive_contents")
+        repo = Repository(
+            name="Agent Browse Poll Repo",
+            path="/agent/repositories/poll",
+            encryption="none",
+            compression="none",
+            repository_type="local",
+            executor_type="agent",
+            execution_target="agent",
+            agent_machine_id=agent.id,
+        )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+
+        existing_job = browse_api.queue_agent_repository_operation_job(
+            test_db,
+            repo,
+            job_kind="repository.list_archive_contents",
+            operation={
+                "archive": "archive-1",
+                "path": "",
+                "max_lines": browse_api.MAX_ITEMS_IN_MEMORY,
+            },
+        )
+        stdout = json.dumps(
+            {
+                "path": "home/file.txt",
+                "type": "f",
+                "size": 12,
+                "mtime": "2026-05-30T15:16:14",
+            }
+        )
+
+        with (
+            patch.object(
+                browse_api.archive_cache, "get", new=AsyncMock(return_value=None)
+            ),
+            patch.object(
+                browse_api.archive_cache, "set", new=AsyncMock(return_value=True)
+            ),
+            patch(
+                "app.api.browse.dispatch_agent_job_best_effort",
+                new=AsyncMock(return_value=True),
+            ) as dispatch_agent,
+            patch(
+                "app.api.browse.wait_for_agent_repository_operation_job",
+                new=AsyncMock(return_value={"stdout": stdout}),
+            ) as wait_for_agent,
+        ):
+            response = await browse_api.browse_archive_contents(
+                repository_id=repo.id,
+                archive_name="archive-1",
+                path="home",
+                job_id=existing_job.id,
+                current_user=admin_user,
+                db=test_db,
+            )
+
+        assert response["items"] == [
+            {
+                "name": "file.txt",
+                "type": "file",
+                "size": 12,
+                "mtime": "2026-05-30T15:16:14",
+                "path": "home/file.txt",
+            }
+        ]
+        # No second job queued and no re-dispatch — the existing job was reused.
+        assert test_db.query(AgentJob).count() == 1
+        dispatch_agent.assert_not_awaited()
+        wait_for_agent.assert_awaited_once_with(
+            test_db,
+            existing_job.id,
+            timeout_seconds=browse_api.BROWSE_AGENT_WAIT_SECONDS,
+        )
+
+    @pytest.mark.asyncio
+    async def test_browse_agent_archive_poll_rejects_foreign_job_id(
+        self,
+        test_db,
+        admin_user,
+    ):
+        """A job_id that is not this repository's browse job for this archive is
+        rejected with 404 — one viewer cannot poll another repo's listing."""
+        agent = _create_agent(test_db, "repository.list_archive_contents")
+        repo = Repository(
+            name="Agent Browse Foreign Repo",
+            path="/agent/repositories/foreign",
+            encryption="none",
+            compression="none",
+            repository_type="local",
+            executor_type="agent",
+            execution_target="agent",
+            agent_machine_id=agent.id,
+        )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+
+        with (
+            patch.object(
+                browse_api.archive_cache, "get", new=AsyncMock(return_value=None)
+            ),
+            patch(
+                "app.api.browse.wait_for_agent_repository_operation_job",
+                new=AsyncMock(),
+            ) as wait_for_agent,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await browse_api.browse_archive_contents(
+                    repository_id=repo.id,
+                    archive_name="archive-1",
+                    path="",
+                    job_id=999999,
+                    current_user=admin_user,
+                    db=test_db,
+                )
+
+        assert exc_info.value.status_code == 404
+        wait_for_agent.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_browse_agent_archive_poll_rejects_other_repository_job(
+        self,
+        test_db,
+        admin_user,
+    ):
+        """A real browse job that belongs to *another* repository is rejected
+        with 404 — the ownership check (not mere absence) drives the refusal, so
+        one viewer cannot poll another repository's listing by guessing a valid
+        id."""
+        agent = _create_agent(test_db, "repository.list_archive_contents")
+        own_repo = Repository(
+            name="Agent Browse Own Repo",
+            path="/agent/repositories/own",
+            encryption="none",
+            compression="none",
+            repository_type="local",
+            executor_type="agent",
+            execution_target="agent",
+            agent_machine_id=agent.id,
+        )
+        foreign_repo = Repository(
+            name="Agent Browse Foreign Repo (real job)",
+            path="/agent/repositories/foreign-real",
+            encryption="none",
+            compression="none",
+            repository_type="local",
+            executor_type="agent",
+            execution_target="agent",
+            agent_machine_id=agent.id,
+        )
+        test_db.add_all([own_repo, foreign_repo])
+        test_db.commit()
+        test_db.refresh(own_repo)
+        test_db.refresh(foreign_repo)
+
+        # A genuine, queued browse job — but for the *foreign* repository.
+        foreign_job = browse_api.queue_agent_repository_operation_job(
+            test_db,
+            foreign_repo,
+            job_kind="repository.list_archive_contents",
+            operation={
+                "archive": "archive-1",
+                "path": "",
+                "max_lines": browse_api.MAX_ITEMS_IN_MEMORY,
+            },
+        )
+
+        with (
+            patch.object(
+                browse_api.archive_cache, "get", new=AsyncMock(return_value=None)
+            ),
+            patch(
+                "app.api.browse.wait_for_agent_repository_operation_job",
+                new=AsyncMock(),
+            ) as wait_for_agent,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await browse_api.browse_archive_contents(
+                    repository_id=own_repo.id,
+                    archive_name="archive-1",
+                    path="",
+                    job_id=foreign_job.id,
+                    current_user=admin_user,
+                    db=test_db,
+                )
+
+        # The job exists, so this exercises the repository-ownership branch, not
+        # the "job not found" branch.
+        assert exc_info.value.status_code == 404
+        wait_for_agent.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_browse_archive_uses_repo_ssh_environment_when_cache_misses(


### PR DESCRIPTION
## Problem

Browsing an archive on a **managed-agent** repository queues a remote
`list_archive_contents` job and blocks the HTTP request on a fixed 15 s wait
(`wait_for_agent_repository_operation_job`). Large archives (hundreds of
thousands of entries) never finish within that window, so the request returns
**504** and the browse dialog comes up **empty**. And because the job *does*
finish moments later but its result is discarded, every reopen re-queues the
whole listing again.

Server-side (non-agent) borg listings aren't subject to the 15 s cap (they await
borg directly), so this only bites the managed-agent path.

## Change

Make the agent listing **pollable** instead of blocking.

**Before**
```
GET /browse/{repo}/{archive}
  └─ queue → dispatch → wait ≤15s ──(slow)──▶ 504, empty dialog, result discarded
```

**After**
```
GET /browse/{repo}/{archive}          → queue job, wait a short window
  └─ still running? ─▶ 202 {jobId}     → client polls GET …?job_id=<id>
        └─ job resumed (validated) ─▶ still running? ─▶ 202
                                   ─▶ done? ─▶ parse + cache ─▶ 200 {items}
```

- The first call queues the job and waits a short window
  (`BROWSE_AGENT_WAIT_SECONDS = 8`). Small archives still resolve within that
  first request — no behaviour change for them.
- If it's still running, the endpoint returns **202** `{status:"pending", jobId}`.
  The client polls with `?job_id=`, which **resumes the same job** — validated
  against the repository + archive (`get_agent_archive_browse_job`) so a viewer
  can't poll another repository's listing by guessing an id.
- On completion the listing is parsed and cached, so subsequent opens of the
  same archive are served from cache.
- **The server-side (non-agent) borg path is unchanged** — still synchronous.

Frontend: the archive-contents dialog (react-query `refetchInterval`) and the
restore path selector both poll while the job runs and show a friendly
"this is a larger archive, hang tight" hint over the loading skeleton
(i18n en/de/es/it).

## Tests

- **Backend**: agent browse returns 202 while the job runs, a poll resumes the
  job and returns the parsed items, and a foreign `job_id` is rejected with 404.
- **Frontend**: the `job_id` param is threaded through the client, and the
  dialog's poll → hint → items flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Managed archive browsing now queues agent listings and polls until results are ready.
  * Support for polling an existing in-flight browse using a job identifier.
* **Bug Fixes**
  * Improved “slow loading / taking longer than expected” user messaging during pending listings.
  * Polling is bounded by a timeout and reuses only valid queued jobs.
* **Documentation**
  * Added localized UI strings for slow-loading and load-timeout states.
* **Tests**
  * Extended backend and frontend tests for the 202→200 flow, job reuse, and failure/404 cases.
* **Chores**
  * Added Storybook stories for the awaiting-agent listing state and loading-with-hint UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->