### PR TITLE
feat(ui): surface plan script executions in live and history run views

### DIFF
--- a/frontend/src/components/ActiveBackupPlanRunCard.tsx
+++ b/frontend/src/components/ActiveBackupPlanRunCard.tsx
@@ -27,14 +27,14 @@ import {
 } from 'lucide-react'
 import type { BackupJob, BackupPlan, BackupPlanRun, BackupPlanRunRepository } from '../types'
 import { formatBytes, formatDurationSeconds, formatTimeRange } from '../utils/dateUtils'
+import { PlanRunScriptsSection, type BackupPlanRunLogJob } from './PlanRunScripts'
+import { canViewBackupJobLogs as canViewLogs } from './planRunScriptLogs'
 
 // Brand emerald is reserved for the live pulse dot (the only brand touch on
 // this otherwise neutral card). Everything else uses text.primary tints.
 const LIVE_DOT = '#059669'
 
-export type ActivePlanRunLogJob =
-  | BackupJob
-  | { id: number; status: string; type: 'script_execution'; has_logs?: boolean }
+export type ActivePlanRunLogJob = BackupPlanRunLogJob
 
 interface ActiveBackupPlanRunCardProps {
   run: BackupPlanRun
@@ -46,10 +46,6 @@ interface ActiveBackupPlanRunCardProps {
 
 function isActive(status?: string): boolean {
   return status === 'pending' || status === 'running'
-}
-
-function canViewLogs(job?: BackupJob | null): job is BackupJob {
-  return Boolean(job && job.status !== 'pending' && (job.has_logs || job.status === 'running'))
 }
 
 function getRepositoryLabel(runRepository: BackupPlanRunRepository): string {
@@ -601,6 +597,12 @@ const ActiveBackupPlanRunCard: React.FC<ActiveBackupPlanRunCardProps> = ({
             >
               {currentFile}
             </Typography>
+          </Box>
+        )}
+
+        {run.script_executions && run.script_executions.length > 0 && (
+          <Box sx={{ mt: 1.5 }}>
+            <PlanRunScriptsSection run={run} onViewLogs={onViewLogs} />
           </Box>
         )}
 

--- a/frontend/src/components/BackupPlanRunCard.stories.tsx
+++ b/frontend/src/components/BackupPlanRunCard.stories.tsx
@@ -1,0 +1,124 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box } from '@mui/material'
+import { BackupPlanRunCard } from './BackupPlanRunsPanel'
+import type { BackupPlan, BackupPlanRun } from '../types'
+
+const plan: BackupPlan = {
+  id: 44,
+  name: 'Nightly accounting backup',
+  enabled: true,
+  source_type: 'local',
+  source_directories: ['/srv/accounting'],
+  exclude_patterns: ['*.tmp'],
+  archive_name_template: '{hostname}-{now}',
+  compression: 'zstd',
+  repository_run_mode: 'series',
+  max_parallel_repositories: 1,
+  failure_behavior: 'stop',
+  schedule_enabled: true,
+  timezone: 'America/New_York',
+  repository_count: 1,
+}
+
+// A completed run whose pre/post script hooks are surfaced in the "Plan scripts"
+// section: two agent pre-backup hooks that succeeded (with exit codes) and a
+// post-backup hook that failed (with its error message).
+const runWithScriptExecutions: BackupPlanRun = {
+  id: 351,
+  backup_plan_id: plan.id,
+  trigger: 'manual',
+  status: 'completed_with_warnings',
+  started_at: '2026-05-23T02:00:00Z',
+  completed_at: '2026-05-23T02:06:12Z',
+  created_at: '2026-05-23T02:00:00Z',
+  repositories: [
+    {
+      id: 420,
+      repository_id: 31,
+      status: 'completed',
+      repository: {
+        id: 31,
+        name: 'Accounting repository',
+        path: '/backups/accounting',
+        borg_version: 2,
+      },
+      backup_job: {
+        id: 910,
+        repository_id: 31,
+        repository: '/backups/accounting',
+        type: 'backup',
+        status: 'completed',
+        started_at: '2026-05-23T02:01:00Z',
+        completed_at: '2026-05-23T02:06:00Z',
+        has_logs: true,
+        execution_mode: 'agent',
+      },
+    },
+  ],
+  script_executions: [
+    {
+      id: 1,
+      script_id: null,
+      script_name: 'backup-cluster-mariadb',
+      hook_type: 'pre-backup',
+      status: 'completed',
+      started_at: '2026-05-23T02:00:00Z',
+      completed_at: '2026-05-23T02:00:54Z',
+      execution_time: 53.94,
+      exit_code: 0,
+      has_logs: true,
+    },
+    {
+      id: 2,
+      script_id: null,
+      script_name: 'backup-cluster-postgres',
+      hook_type: 'pre-backup',
+      status: 'completed',
+      started_at: '2026-05-23T02:00:54Z',
+      completed_at: '2026-05-23T02:01:00Z',
+      execution_time: 6.2,
+      exit_code: 0,
+      has_logs: true,
+    },
+    {
+      id: 3,
+      script_id: 77,
+      script_name: 'notify-webhook',
+      hook_type: 'post-backup',
+      status: 'failed',
+      started_at: '2026-05-23T02:06:00Z',
+      completed_at: '2026-05-23T02:06:12Z',
+      execution_time: 12.0,
+      exit_code: 2,
+      error_message: 'Webhook returned HTTP 503',
+      has_logs: true,
+    },
+  ],
+}
+
+const meta = {
+  title: 'Components/BackupPlanRunCard',
+  component: BackupPlanRunCard,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    run: runWithScriptExecutions,
+    plan,
+    onCancel: () => {},
+    onViewLogs: () => {},
+  },
+  render: (args) => (
+    <Box sx={{ p: 3, maxWidth: 720 }}>
+      <BackupPlanRunCard {...args} />
+    </Box>
+  ),
+} satisfies Meta<typeof BackupPlanRunCard>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+// Detailed run card with the "Plan scripts" section: completed agent hooks (with
+// exit codes) and a failed hook showing its error.
+export const WithScriptExecutions: Story = {}

--- a/frontend/src/components/BackupPlanRunsPanel.tsx
+++ b/frontend/src/components/BackupPlanRunsPanel.tsx
@@ -28,13 +28,7 @@ import DataTable, { type ActionButton, type Column } from './DataTable'
 import RepositoryCell from './RepositoryCell'
 import RetryJobDialog from './RetryJobDialog'
 import StatusBadge from './StatusBadge'
-import type {
-  BackupJob,
-  BackupPlan,
-  BackupPlanRun,
-  BackupPlanRunRepository,
-  BackupPlanScriptExecution,
-} from '../types'
+import type { BackupPlan, BackupPlanRun, BackupPlanRunRepository } from '../types'
 import {
   formatBytes as formatBytesUtil,
   formatDate,
@@ -45,6 +39,14 @@ import {
   getBackupPlanRunRetryDisabledReason,
   shouldShowBackupPlanRunRetryAction,
 } from './backupPlanRunRetry'
+import { PlanRunScriptsSection } from './PlanRunScripts'
+import {
+  canViewBackupJobLogs as canViewLogs,
+  canViewScriptLogs,
+  type BackupPlanRunLogJob,
+} from './planRunScriptLogs'
+
+export type { BackupPlanRunLogJob } from './planRunScriptLogs'
 
 function isActiveRun(status?: string): boolean {
   return status === 'pending' || status === 'running'
@@ -68,10 +70,6 @@ function isFinishedRepositoryRun(runRepository: BackupPlanRunRepository): boolea
   return !isActiveRun(runRepository.status)
 }
 
-function canViewLogs(job?: BackupJob | null): job is BackupJob {
-  return Boolean(job && job.status !== 'pending' && (job.has_logs || job.status === 'running'))
-}
-
 function getTransportLabel(
   runRepository: BackupPlanRunRepository,
   t: (key: string) => string
@@ -92,21 +90,6 @@ function getTransportLabel(
     return t('backupPlans.runsDialog.transport.server')
   }
   return null
-}
-
-export type BackupPlanRunLogJob =
-  | BackupJob
-  | {
-      id: number
-      status: string
-      type: 'script_execution'
-      has_logs?: boolean
-    }
-
-function canViewScriptLogs(execution: BackupPlanScriptExecution): boolean {
-  return (
-    execution.status !== 'pending' && Boolean(execution.has_logs || execution.status === 'running')
-  )
 }
 
 function getRepositoryLabel(runRepository: BackupPlanRunRepository): string {
@@ -319,94 +302,6 @@ function RepositoryRunRow({
   )
 }
 
-function ScriptExecutionRow({
-  execution,
-  onViewLogs,
-}: {
-  execution: BackupPlanScriptExecution
-  onViewLogs: (job: BackupPlanRunLogJob) => void
-}) {
-  const { t } = useTranslation()
-  const hookLabel =
-    execution.hook_type === 'pre-backup'
-      ? t('backupPlans.runsDialog.prePlanScript')
-      : execution.hook_type === 'post-backup'
-        ? t('backupPlans.runsDialog.postPlanScript')
-        : execution.hook_type || t('backupPlans.runsDialog.planScript')
-  const statusLabel = t(`backupPlans.statuses.${execution.status}`, {
-    defaultValue: formatRunStatus(execution.status),
-  })
-
-  return (
-    <Box
-      sx={{
-        border: 1,
-        borderColor: 'divider',
-        borderRadius: 1,
-        p: 1.5,
-        bgcolor: 'background.paper',
-      }}
-    >
-      <Stack
-        direction={{ xs: 'column', sm: 'row' }}
-        spacing={1}
-        alignItems={{ xs: 'flex-start', sm: 'center' }}
-        justifyContent="space-between"
-      >
-        <Stack direction="row" spacing={1} alignItems="center" sx={{ minWidth: 0 }}>
-          <Box sx={{ color: 'text.secondary', display: 'flex', flexShrink: 0 }}>
-            <FileText size={16} />
-          </Box>
-          <Box sx={{ minWidth: 0 }}>
-            <Typography variant="subtitle2" noWrap>
-              {hookLabel}: {execution.script_name}
-            </Typography>
-            <Stack direction="row" spacing={1.5} flexWrap="wrap" useFlexGap>
-              {execution.exit_code !== null && execution.exit_code !== undefined && (
-                <Typography variant="caption" color="text.secondary">
-                  {t('backupPlans.runsDialog.exitCode', { code: execution.exit_code })}
-                </Typography>
-              )}
-              {execution.execution_time !== null && execution.execution_time !== undefined && (
-                <Typography variant="caption" color="text.secondary">
-                  {t('backupPlans.runsDialog.scriptDuration', {
-                    seconds: execution.execution_time.toFixed(2),
-                  })}
-                </Typography>
-              )}
-            </Stack>
-          </Box>
-        </Stack>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <Chip size="small" label={statusLabel} color={runStatusColor(execution.status)} />
-          {canViewScriptLogs(execution) && (
-            <Button
-              size="small"
-              variant="text"
-              startIcon={<Eye size={14} />}
-              onClick={() =>
-                onViewLogs({
-                  id: execution.id,
-                  status: execution.status,
-                  type: 'script_execution',
-                  has_logs: execution.has_logs,
-                })
-              }
-            >
-              {t('backupPlans.runsDialog.viewLogs')}
-            </Button>
-          )}
-        </Stack>
-      </Stack>
-      {execution.error_message && (
-        <Typography variant="caption" color="error" sx={{ mt: 1, display: 'block' }}>
-          {execution.error_message}
-        </Typography>
-      )}
-    </Box>
-  )
-}
-
 function InlineMetric({
   icon,
   label,
@@ -542,20 +437,7 @@ export function BackupPlanRunCard({
             </Alert>
           )}
 
-          {run.script_executions && run.script_executions.length > 0 && (
-            <Stack spacing={1.25}>
-              <Typography variant="subtitle2" fontWeight={700}>
-                {t('backupPlans.runsDialog.planScripts')}
-              </Typography>
-              {run.script_executions.map((execution) => (
-                <ScriptExecutionRow
-                  key={execution.id}
-                  execution={execution}
-                  onViewLogs={onViewLogs}
-                />
-              ))}
-            </Stack>
-          )}
+          <PlanRunScriptsSection run={run} onViewLogs={onViewLogs} />
 
           {run.repositories.length === 0 ? (
             <Alert severity="info">{t('backupPlans.runsPanel.noRepositories')}</Alert>

--- a/frontend/src/components/PlanRunScripts.tsx
+++ b/frontend/src/components/PlanRunScripts.tsx
@@ -1,0 +1,140 @@
+import { Box, Button, Chip, Stack, Typography } from '@mui/material'
+import { Eye, FileText } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import type { BackupPlanRun, BackupPlanScriptExecution } from '../types'
+import { canViewScriptLogs, type BackupPlanRunLogJob } from './planRunScriptLogs'
+
+export type { BackupPlanRunLogJob } from './planRunScriptLogs'
+
+function scriptStatusColor(
+  status?: string
+): 'default' | 'primary' | 'success' | 'warning' | 'error' {
+  if (status === 'completed') return 'success'
+  if (status === 'completed_with_warnings' || status === 'warning') return 'warning'
+  if (status === 'failed' || status === 'cancelled' || status === 'canceled') return 'error'
+  if (status === 'running' || status === 'pending') return 'primary'
+  return 'default'
+}
+
+function formatScriptStatus(status?: string): string {
+  if (!status) return ''
+  return status
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+export function ScriptExecutionRow({
+  execution,
+  onViewLogs,
+}: {
+  execution: BackupPlanScriptExecution
+  onViewLogs: (job: BackupPlanRunLogJob) => void
+}) {
+  const { t } = useTranslation()
+  const hookLabel =
+    execution.hook_type === 'pre-backup'
+      ? t('backupPlans.runsDialog.prePlanScript')
+      : execution.hook_type === 'post-backup'
+        ? t('backupPlans.runsDialog.postPlanScript')
+        : execution.hook_type || t('backupPlans.runsDialog.planScript')
+  const statusLabel = t(`backupPlans.statuses.${execution.status}`, {
+    defaultValue: formatScriptStatus(execution.status),
+  })
+
+  return (
+    <Box
+      sx={{
+        border: 1,
+        borderColor: 'divider',
+        borderRadius: 1,
+        p: 1.5,
+        bgcolor: 'background.paper',
+      }}
+    >
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={1}
+        alignItems={{ xs: 'flex-start', sm: 'center' }}
+        justifyContent="space-between"
+      >
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ minWidth: 0 }}>
+          <Box sx={{ color: 'text.secondary', display: 'flex', flexShrink: 0 }}>
+            <FileText size={16} />
+          </Box>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography variant="subtitle2" noWrap>
+              {hookLabel}: {execution.script_name}
+            </Typography>
+            <Stack direction="row" spacing={1.5} flexWrap="wrap" useFlexGap>
+              {execution.exit_code !== null && execution.exit_code !== undefined && (
+                <Typography variant="caption" color="text.secondary">
+                  {t('backupPlans.runsDialog.exitCode', { code: execution.exit_code })}
+                </Typography>
+              )}
+              {execution.execution_time !== null && execution.execution_time !== undefined && (
+                <Typography variant="caption" color="text.secondary">
+                  {t('backupPlans.runsDialog.scriptDuration', {
+                    seconds: execution.execution_time.toFixed(2),
+                  })}
+                </Typography>
+              )}
+            </Stack>
+          </Box>
+        </Stack>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Chip size="small" label={statusLabel} color={scriptStatusColor(execution.status)} />
+          {canViewScriptLogs(execution) && (
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<Eye size={14} />}
+              onClick={() =>
+                onViewLogs({
+                  id: execution.id,
+                  status: execution.status,
+                  type: 'script_execution',
+                  has_logs: execution.has_logs,
+                })
+              }
+            >
+              {t('backupPlans.runsDialog.viewLogs')}
+            </Button>
+          )}
+        </Stack>
+      </Stack>
+      {execution.error_message && (
+        <Typography variant="caption" color="error" sx={{ mt: 1, display: 'block' }}>
+          {execution.error_message}
+        </Typography>
+      )}
+    </Box>
+  )
+}
+
+// The "Plan scripts" section of a run: lists each pre/post hook execution with
+// its status and a log link. Renders nothing when the run has no hooks.
+export function PlanRunScriptsSection({
+  run,
+  onViewLogs,
+  title,
+}: {
+  run: BackupPlanRun
+  onViewLogs: (job: BackupPlanRunLogJob) => void
+  title?: string
+}) {
+  const { t } = useTranslation()
+  const executions = run.script_executions
+  if (!executions || executions.length === 0) return null
+  return (
+    <Stack spacing={1.25}>
+      <Typography variant="subtitle2" fontWeight={700}>
+        {title ?? t('backupPlans.runsDialog.planScripts')}
+      </Typography>
+      {executions.map((execution) => (
+        <ScriptExecutionRow key={execution.id} execution={execution} onViewLogs={onViewLogs} />
+      ))}
+    </Stack>
+  )
+}

--- a/frontend/src/components/planRunScriptLogs.ts
+++ b/frontend/src/components/planRunScriptLogs.ts
@@ -1,0 +1,28 @@
+import type { BackupJob, BackupPlanScriptExecution } from '../types'
+
+// A log target opened from a plan run: either a repository backup job or one of
+// the plan's script (hook) executions. Shared source of truth for the type and
+// the log-eligibility rule used by every plan-run script surface.
+export type BackupPlanRunLogJob =
+  | BackupJob
+  | {
+      id: number
+      status: string
+      type: 'script_execution'
+      has_logs?: boolean
+    }
+
+// A script execution's logs are viewable once it has actually run (not pending)
+// and either the server flagged output or it is still running (live). Single
+// definition so the row button and first-log selection can't drift apart.
+export function canViewScriptLogs(execution: BackupPlanScriptExecution): boolean {
+  return (
+    execution.status !== 'pending' && Boolean(execution.has_logs || execution.status === 'running')
+  )
+}
+
+// The same eligibility rule for a repository backup job. Shared so the run
+// panels, the active-run card and first-log selection stay aligned.
+export function canViewBackupJobLogs(job?: BackupJob | null): job is BackupJob {
+  return Boolean(job && job.status !== 'pending' && (job.has_logs || job.status === 'running'))
+}

--- a/frontend/src/pages/backup-plans/plan-runs/PlanRunsHistoryTable.tsx
+++ b/frontend/src/pages/backup-plans/plan-runs/PlanRunsHistoryTable.tsx
@@ -1,6 +1,7 @@
 import {
   alpha,
   Box,
+  Collapse,
   IconButton,
   Stack,
   Table,
@@ -12,11 +13,12 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
-import { Ban, Eye, RotateCcw } from 'lucide-react'
+import { Ban, ChevronDown, ChevronRight, Eye, RotateCcw } from 'lucide-react'
 import type { TFunction } from 'i18next'
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 
 import type { BackupPlanRunLogJob } from '../../../components/BackupPlanRunsPanel'
+import { PlanRunScriptsSection } from '../../../components/PlanRunScripts'
 import RetryJobDialog from '../../../components/RetryJobDialog'
 import {
   getBackupPlanRunRetryDisabledReason,
@@ -53,6 +55,14 @@ export function PlanRunsHistoryTable({
   t,
 }: PlanRunsHistoryTableProps) {
   const [retryRun, setRetryRun] = useState<BackupPlanRun | null>(null)
+  const [expandedRuns, setExpandedRuns] = useState<Set<number>>(new Set())
+  const toggleExpanded = (runId: number) =>
+    setExpandedRuns((prev) => {
+      const next = new Set(prev)
+      if (next.has(runId)) next.delete(runId)
+      else next.add(runId)
+      return next
+    })
   const formatStatusLabel = (status?: string) =>
     status
       ? t(`backupPlans.statuses.${status}`, { defaultValue: formatRunStatus(status) })
@@ -104,6 +114,8 @@ export function PlanRunsHistoryTable({
               const startedAt = run.started_at || run.created_at
               const logJob = findFirstLogJobForRun(run)
               const active = isActiveRun(run.status)
+              const scriptCount = run.script_executions?.length ?? 0
+              const expanded = expandedRuns.has(run.id)
               const retryDisabledReason = getBackupPlanRunRetryDisabledReason(run, t, {
                 canRetry: canRetryRun(run),
                 hasActiveRunForPlan: hasActiveRunForPlan(run),
@@ -114,98 +126,101 @@ export function PlanRunsHistoryTable({
                   : retryDisabledReason || t('backupPlans.runsPanel.retryTooltips.ready')
 
               return (
-                <TableRow key={run.id} hover>
-                  <TableCell
-                    sx={{
-                      fontFamily: '"JetBrains Mono","Fira Code",ui-monospace,monospace',
-                      fontSize: '0.78rem',
-                      color: 'text.secondary',
-                    }}
+                <Fragment key={run.id}>
+                  <TableRow
+                    hover
+                    sx={expanded ? { '& > td': { borderBottom: 'unset' } } : undefined}
                   >
-                    #{run.id}
-                  </TableCell>
-                  <TableCell>
-                    {startedAt ? (
-                      <Tooltip title={formatDateTimeFull(startedAt)} arrow>
-                        <Typography
-                          variant="body2"
-                          color="text.secondary"
-                          sx={{ cursor: 'help', display: 'inline-block' }}
-                        >
-                          {formatRelativeTime(startedAt)}
-                        </Typography>
-                      </Tooltip>
-                    ) : (
-                      <Typography variant="body2" color="text.disabled">
-                        —
-                      </Typography>
-                    )}
-                  </TableCell>
-                  <TableCell>
-                    <Stack direction="row" spacing={0.5} alignItems="center">
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          color: runStatusIconColor(run.status),
-                          lineHeight: 0,
-                        }}
-                      >
-                        <RunStatusLeadIcon status={run.status} />
-                      </Box>
-                      <Typography variant="body2">{formatStatusLabel(run.status)}</Typography>
-                    </Stack>
-                  </TableCell>
-                  <TableCell>
-                    <Typography
-                      variant="body2"
-                      color="text.secondary"
+                    <TableCell
                       sx={{
                         fontFamily: '"JetBrains Mono","Fira Code",ui-monospace,monospace',
                         fontSize: '0.78rem',
+                        color: 'text.secondary',
                       }}
                     >
-                      {formatTimeRange(run.started_at, run.completed_at, run.status)}
-                    </Typography>
-                  </TableCell>
-                  <TableCell align="right">
-                    <Stack direction="row" spacing={0.25} justifyContent="flex-end">
-                      {logJob && (
-                        <Tooltip
-                          title={t('backupPlans.runsDialog.viewLogs', {
-                            defaultValue: 'View logs',
-                          })}
-                          arrow
-                        >
+                      <Stack direction="row" spacing={0.25} alignItems="center">
+                        {scriptCount > 0 ? (
                           <IconButton
                             size="small"
-                            onClick={() => onViewLogs(logJob)}
-                            aria-label={t('backupPlans.runsDialog.viewLogs', {
+                            onClick={() => toggleExpanded(run.id)}
+                            aria-expanded={expanded}
+                            aria-label={
+                              expanded
+                                ? t('backupPlans.runsTable.hideScripts', {
+                                    defaultValue: 'Hide scripts',
+                                  })
+                                : t('backupPlans.runsTable.showScripts', {
+                                    defaultValue: 'Show scripts',
+                                  })
+                            }
+                            sx={{ width: 22, height: 22, color: 'text.secondary' }}
+                          >
+                            {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                          </IconButton>
+                        ) : (
+                          <Box sx={{ width: 22, flexShrink: 0 }} />
+                        )}
+                        <span>#{run.id}</span>
+                      </Stack>
+                    </TableCell>
+                    <TableCell>
+                      {startedAt ? (
+                        <Tooltip title={formatDateTimeFull(startedAt)} arrow>
+                          <Typography
+                            variant="body2"
+                            color="text.secondary"
+                            sx={{ cursor: 'help', display: 'inline-block' }}
+                          >
+                            {formatRelativeTime(startedAt)}
+                          </Typography>
+                        </Tooltip>
+                      ) : (
+                        <Typography variant="body2" color="text.disabled">
+                          —
+                        </Typography>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Stack direction="row" spacing={0.5} alignItems="center">
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            color: runStatusIconColor(run.status),
+                            lineHeight: 0,
+                          }}
+                        >
+                          <RunStatusLeadIcon status={run.status} />
+                        </Box>
+                        <Typography variant="body2">{formatStatusLabel(run.status)}</Typography>
+                      </Stack>
+                    </TableCell>
+                    <TableCell>
+                      <Typography
+                        variant="body2"
+                        color="text.secondary"
+                        sx={{
+                          fontFamily: '"JetBrains Mono","Fira Code",ui-monospace,monospace',
+                          fontSize: '0.78rem',
+                        }}
+                      >
+                        {formatTimeRange(run.started_at, run.completed_at, run.status)}
+                      </Typography>
+                    </TableCell>
+                    <TableCell align="right">
+                      <Stack direction="row" spacing={0.25} justifyContent="flex-end">
+                        {logJob && (
+                          <Tooltip
+                            title={t('backupPlans.runsDialog.viewLogs', {
                               defaultValue: 'View logs',
                             })}
-                            sx={{
-                              width: 28,
-                              height: 28,
-                              color: 'info.main',
-                              '&:hover': {
-                                bgcolor: (theme) => alpha(theme.palette.info.main, 0.12),
-                              },
-                            }}
+                            arrow
                           >
-                            <Eye size={15} />
-                          </IconButton>
-                        </Tooltip>
-                      )}
-                      {onRetry && shouldShowBackupPlanRunRetryAction(run) && (
-                        <Tooltip title={retryTooltip} arrow>
-                          <span>
                             <IconButton
                               size="small"
-                              onClick={() => {
-                                if (retryDisabledReason) return
-                                setRetryRun(run)
-                              }}
-                              disabled={retryingRunId === run.id || Boolean(retryDisabledReason)}
-                              aria-label={retryTooltip}
+                              onClick={() => onViewLogs(logJob)}
+                              aria-label={t('backupPlans.runsDialog.viewLogs', {
+                                defaultValue: 'View logs',
+                              })}
                               sx={{
                                 width: 28,
                                 height: 28,
@@ -213,44 +228,80 @@ export function PlanRunsHistoryTable({
                                 '&:hover': {
                                   bgcolor: (theme) => alpha(theme.palette.info.main, 0.12),
                                 },
-                                '&.Mui-disabled': { opacity: 0.35 },
                               }}
                             >
-                              <RotateCcw size={15} />
+                              <Eye size={15} />
                             </IconButton>
-                          </span>
-                        </Tooltip>
-                      )}
-                      {active && (
-                        <Tooltip
-                          title={t('backupPlans.runsPanel.cancelRun', {
-                            defaultValue: 'Cancel run',
-                          })}
-                          arrow
-                        >
-                          <IconButton
-                            size="small"
-                            onClick={() => onCancel(run.id)}
-                            disabled={cancelling === run.id}
-                            aria-label={t('backupPlans.runsPanel.cancelRun', {
+                          </Tooltip>
+                        )}
+                        {onRetry && shouldShowBackupPlanRunRetryAction(run) && (
+                          <Tooltip title={retryTooltip} arrow>
+                            <span>
+                              <IconButton
+                                size="small"
+                                onClick={() => {
+                                  if (retryDisabledReason) return
+                                  setRetryRun(run)
+                                }}
+                                disabled={retryingRunId === run.id || Boolean(retryDisabledReason)}
+                                aria-label={retryTooltip}
+                                sx={{
+                                  width: 28,
+                                  height: 28,
+                                  color: 'info.main',
+                                  '&:hover': {
+                                    bgcolor: (theme) => alpha(theme.palette.info.main, 0.12),
+                                  },
+                                  '&.Mui-disabled': { opacity: 0.35 },
+                                }}
+                              >
+                                <RotateCcw size={15} />
+                              </IconButton>
+                            </span>
+                          </Tooltip>
+                        )}
+                        {active && (
+                          <Tooltip
+                            title={t('backupPlans.runsPanel.cancelRun', {
                               defaultValue: 'Cancel run',
                             })}
-                            sx={{
-                              width: 28,
-                              height: 28,
-                              color: 'warning.main',
-                              '&:hover': {
-                                bgcolor: (theme) => alpha(theme.palette.warning.main, 0.12),
-                              },
-                            }}
+                            arrow
                           >
-                            <Ban size={15} />
-                          </IconButton>
-                        </Tooltip>
-                      )}
-                    </Stack>
-                  </TableCell>
-                </TableRow>
+                            <IconButton
+                              size="small"
+                              onClick={() => onCancel(run.id)}
+                              disabled={cancelling === run.id}
+                              aria-label={t('backupPlans.runsPanel.cancelRun', {
+                                defaultValue: 'Cancel run',
+                              })}
+                              sx={{
+                                width: 28,
+                                height: 28,
+                                color: 'warning.main',
+                                '&:hover': {
+                                  bgcolor: (theme) => alpha(theme.palette.warning.main, 0.12),
+                                },
+                              }}
+                            >
+                              <Ban size={15} />
+                            </IconButton>
+                          </Tooltip>
+                        )}
+                      </Stack>
+                    </TableCell>
+                  </TableRow>
+                  {scriptCount > 0 && (
+                    <TableRow>
+                      <TableCell colSpan={5} sx={{ py: 0, border: 0 }}>
+                        <Collapse in={expanded} unmountOnExit>
+                          <Box sx={{ py: 1.5, px: 1 }}>
+                            <PlanRunScriptsSection run={run} onViewLogs={onViewLogs} />
+                          </Box>
+                        </Collapse>
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </Fragment>
               )
             })}
           </TableBody>

--- a/frontend/src/pages/backup-plans/plan-runs/__tests__/PlanRunsHistoryTable.test.tsx
+++ b/frontend/src/pages/backup-plans/plan-runs/__tests__/PlanRunsHistoryTable.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { TFunction } from 'i18next'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { BackupPlanRun } from '../../../../types'
+import { PlanRunsHistoryTable } from '../PlanRunsHistoryTable'
+
+// The component takes `t` as a prop; the shared script section uses the global
+// i18n instance, so raw values (script names) render regardless.
+const t = ((key: string, opts?: { defaultValue?: string }) =>
+  opts?.defaultValue ?? key) as unknown as TFunction
+
+function makeRun(overrides: Partial<BackupPlanRun> = {}): BackupPlanRun {
+  return {
+    id: 571,
+    backup_plan_id: 3,
+    trigger: 'manual',
+    status: 'completed',
+    started_at: '2026-07-09T10:44:00Z',
+    completed_at: '2026-07-09T10:49:49Z',
+    created_at: '2026-07-09T10:44:00Z',
+    repositories: [],
+    script_executions: [
+      {
+        id: 3,
+        script_id: null,
+        script_name: 'backup-cluster-mariadb',
+        hook_type: 'pre-backup',
+        status: 'completed',
+        started_at: '2026-07-09T10:48:39Z',
+        completed_at: '2026-07-09T10:48:41Z',
+        execution_time: 2.1,
+        exit_code: 0,
+        has_logs: true,
+      },
+    ],
+    ...overrides,
+  } as BackupPlanRun
+}
+
+describe('PlanRunsHistoryTable', () => {
+  it('reveals a run’s script executions when its row is expanded', async () => {
+    const user = userEvent.setup()
+    const onViewLogs = vi.fn()
+
+    render(
+      <PlanRunsHistoryTable
+        runs={[makeRun()]}
+        cancelling={null}
+        onViewLogs={onViewLogs}
+        onCancel={vi.fn()}
+        t={t}
+      />
+    )
+
+    // Collapsed by default: the script row is not mounted.
+    expect(screen.queryByText(/backup-cluster-mariadb/)).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /show scripts/i }))
+
+    const scriptRow = await screen.findByText(/backup-cluster-mariadb/)
+    expect(scriptRow).toBeInTheDocument()
+
+    // Two "view logs" affordances must be present: the row-level eye and the
+    // expanded script row's own button. Asserting the count guards against the
+    // script-row button silently not rendering (which would leave only the eye).
+    const viewLogsButtons = screen.getAllByRole('button', { name: /view logs/i })
+    expect(viewLogsButtons).toHaveLength(2)
+    // Click the in-row (script) button — the last one in DOM order.
+    await user.click(viewLogsButtons[viewLogsButtons.length - 1])
+    expect(onViewLogs).toHaveBeenCalledWith({
+      id: 3,
+      status: 'completed',
+      type: 'script_execution',
+      has_logs: true,
+    })
+  })
+
+  it('opens the borg backup job — not a pre-backup script — from the run-level eye', async () => {
+    const user = userEvent.setup()
+    const onViewLogs = vi.fn()
+
+    // A completed run whose pre-backup script (mariadb) AND borg job both have
+    // viewable logs. The row-level eye must open the borg job; the script has
+    // its own button inside the expanded section.
+    const run = makeRun({
+      repositories: [
+        {
+          id: 91,
+          repository_id: 7,
+          status: 'completed',
+          backup_job: {
+            id: 640,
+            repository: '/repos/primary',
+            repository_id: 7,
+            status: 'completed',
+            has_logs: true,
+          },
+        },
+      ],
+    })
+
+    render(
+      <PlanRunsHistoryTable
+        runs={[run]}
+        cancelling={null}
+        onViewLogs={onViewLogs}
+        onCancel={vi.fn()}
+        t={t}
+      />
+    )
+
+    // Collapsed: the only "view logs" affordance is the row-level eye.
+    await user.click(screen.getByRole('button', { name: /view logs/i }))
+
+    expect(onViewLogs).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 640, status: 'completed' })
+    )
+    expect(onViewLogs).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'script_execution' })
+    )
+  })
+
+  it('shows no expand control for runs without script executions', () => {
+    render(
+      <PlanRunsHistoryTable
+        runs={[makeRun({ script_executions: [] })]}
+        cancelling={null}
+        onViewLogs={vi.fn()}
+        onCancel={vi.fn()}
+        t={t}
+      />
+    )
+
+    expect(screen.queryByRole('button', { name: /show scripts/i })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/backup-plans/plan-runs/findFirstLogJobForRun.ts
+++ b/frontend/src/pages/backup-plans/plan-runs/findFirstLogJobForRun.ts
@@ -1,10 +1,23 @@
-import { type BackupPlanRunLogJob } from '../../../components/BackupPlanRunsPanel'
+import {
+  canViewBackupJobLogs,
+  canViewScriptLogs,
+  type BackupPlanRunLogJob,
+} from '../../../components/planRunScriptLogs'
 import type { BackupPlanRun } from '../../../types'
 
 export function findFirstLogJobForRun(run: BackupPlanRun): BackupPlanRunLogJob | null {
-  const scriptExecution = run.script_executions?.find(
-    (exec) => exec.status !== 'pending' && (exec.has_logs || exec.status === 'running')
+  // The run-level eye opens the primary artifact: the borg backup job. Script
+  // (hook) executions have their own per-row "View Logs" affordance, so prefer
+  // the backup job here and only fall back to a script when borg never produced
+  // a viewable log (e.g. the run failed during a pre-backup hook).
+  const repositoryRun = run.repositories.find((candidate) =>
+    canViewBackupJobLogs(candidate.backup_job)
   )
+  if (repositoryRun?.backup_job) {
+    return repositoryRun.backup_job
+  }
+
+  const scriptExecution = run.script_executions?.find(canViewScriptLogs)
   if (scriptExecution) {
     return {
       id: scriptExecution.id,
@@ -14,11 +27,5 @@ export function findFirstLogJobForRun(run: BackupPlanRun): BackupPlanRunLogJob |
     }
   }
 
-  const repositoryRun = run.repositories.find(
-    (candidate) =>
-      candidate.backup_job &&
-      candidate.backup_job.status !== 'pending' &&
-      (candidate.backup_job.has_logs || candidate.backup_job.status === 'running')
-  )
-  return repositoryRun?.backup_job ?? null
+  return null
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -356,7 +356,8 @@ export interface BackupPlanRunRepository {
 
 export interface BackupPlanScriptExecution {
   id: number
-  script_id: number
+  // Null for agent-published hooks (identified by script_name/agent_script_name).
+  script_id: number | null
   script_name: string
   hook_type?: string | null
   status: string


### PR DESCRIPTION
## Surface plan script executions in the run UI

Backup-plan pre/post **script hook** executions were effectively invisible in the run UI:
- the run-history dialog showed one "view logs" action per run that resolved to the borg job, never the hooks;
- the live active-run card listed only repositories.

So after a run you couldn't tell whether a pre/post hook ran, what its exit code was, or see its output — even though the executions are recorded and their logs are already served by the activity API.

### Change (frontend-only)
A shared `PlanRunScripts` component (`ScriptExecutionRow` + `PlanRunScriptsSection`) rendered in two places:
- **`ActiveBackupPlanRunCard`** (live): lists each hook with its status while the run is in progress — e.g. a pre-backup hook shows `running` before the repository backup starts.
- **`PlanRunsHistoryTable`** (history): an expandable row per run listing its hook executions with status, exit code and a log link.

`BackupPlanRunsPanel` is deduplicated onto the shared component.

### Notes
- **No API or policy change.** The run serializers already emit `script_executions` with a `has_logs` flag, and the activity log viewer already supports the `script_execution` type. Log visibility continues to follow the existing log-save policy; a running hook stays log-capable, so its output is viewable live.
- Works for both server library-script hooks and (once merged alongside the managed-agent work) agent script hooks — the UI is agnostic to how the hook executed.

Tests: a `PlanRunsHistoryTable` suite (expand reveals the hooks; no expander when a run has none) plus the existing `BackupPlanRunsPanel` suite. `tsc`/`eslint`/`vitest`/`build` green. Verified end-to-end on a live cluster (pre-backup DB-dump hooks shown `running` live and listed in the completed run's history).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expandable script execution details to backup plan run history.
  * Added script status, exit code, duration, error messages, and log access indicators.
  * Added support for viewing logs from eligible script executions.
  * Added display support for hooks without a linked script ID.

* **Bug Fixes**
  * Improved selection of the first available log source for plan runs.
  * Standardized when repository and script execution logs can be viewed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->