### PR TITLE
fix(backups): stabilize SSHFS source mount roots

### DIFF
--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -1738,6 +1738,7 @@ class BackupService:
             close_db = True
         temp_key_file = None  # Track SSH key file for cleanup
         borg_command_lock = None
+        sshfs_cache_lock = None
 
         try:
             # Get job
@@ -2239,6 +2240,25 @@ class BackupService:
             self._validate_local_source_paths_exist(
                 source_paths_for_existence_check, skip_paths=snapshot_source_paths
             )
+
+            if repo_record and repo_record.id:
+                sshfs_cache_lock = await acquire_repository_command_lock(
+                    repo_record.id,
+                    scope="sshfs-cache",
+                )
+                logger.info(
+                    "Acquired repository SSHFS cache lock for backup",
+                    job_id=job_id,
+                    repository_id=repo_record.id,
+                )
+                db.refresh(job)
+                if job.status == "cancelled":
+                    logger.info(
+                        "Backup cancelled while waiting for repository SSHFS cache lock",
+                        job_id=job_id,
+                        repository_id=repo_record.id,
+                    )
+                    return
 
             # Calculate total expected size of source directories in background
             # This runs asynchronously without blocking backup start
@@ -3528,6 +3548,17 @@ class BackupService:
                 logger.error(
                     "Failed to cleanup SSH mounts", job_id=job_id, error=str(e)
                 )
+
+            if sshfs_cache_lock is not None:
+                try:
+                    sshfs_cache_lock.release()
+                    logger.info(
+                        "Released repository SSHFS cache lock after backup cleanup",
+                        job_id=job_id,
+                    )
+                except RuntimeError:
+                    pass
+                sshfs_cache_lock = None
 
             # Clean up temporary SSH key file if it exists
             try:

--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -59,6 +59,16 @@ def _uses_remote_execution(job: BackupJob) -> bool:
     ).strip().lower() == "remote_direct"
 
 
+def _stable_sshfs_temp_root(repository_id: int | None) -> str | None:
+    if repository_id is None:
+        return None
+    return os.path.join(
+        settings.data_dir,
+        "sshfs-cache",
+        f"repository-{repository_id}",
+    )
+
+
 class BackupService:
     """Service for executing backups with real-time log streaming"""
 
@@ -1197,7 +1207,11 @@ class BackupService:
             )
 
     async def _prepare_source_paths(
-        self, source_paths: list[str], job_id: int, source_connection_id: int = None
+        self,
+        source_paths: list[str],
+        job_id: int,
+        source_connection_id: int = None,
+        stable_sshfs_temp_root: str | None = None,
     ) -> tuple[list[str], list[tuple[str, str]]]:
         """
         Prepare source paths for backup by mounting SSH URLs via SSHFS
@@ -1291,7 +1305,9 @@ class BackupService:
             # Second pass: Mount SSH paths. Reuse the first SSHFS temp root across
             # source connections so Borg can run from one cwd and store relative
             # remote paths instead of /tmp/sshfs_mount_* implementation paths.
-            shared_ssh_temp_root = None
+            shared_ssh_temp_root = (
+                stable_sshfs_temp_root if ssh_paths_by_connection else None
+            )
             for connection_id, paths_data in ssh_paths_by_connection.items():
                 remote_paths = [parsed["path"] for _, parsed, _ in paths_data]
                 connection = paths_data[0][2]  # Get connection from first item
@@ -2250,6 +2266,9 @@ class BackupService:
                 source_paths,
                 job_id,
                 source_connection_id=effective_source_ssh_connection_id,
+                stable_sshfs_temp_root=_stable_sshfs_temp_root(
+                    repo_record.id if repo_record else None
+                ),
             )
             if not processed_source_paths:
                 logger.error(

--- a/app/services/mount_service.py
+++ b/app/services/mount_service.py
@@ -178,14 +178,25 @@ class MountService:
 
     def _cleanup_orphaned_temp_dirs(self):
         """
-        Clean up orphaned /tmp/sshfs_mount_* directories from crashed processes.
+        Clean up orphaned SSHFS temp directories from crashed processes.
         Only removes directories that aren't being tracked by active mounts.
         """
         try:
             import glob
 
-            # Find all sshfs_mount temp directories
-            temp_dirs = glob.glob("/tmp/sshfs_mount_*")
+            # Find all legacy /tmp roots and repository-stable cache roots.
+            temp_dirs = list(
+                dict.fromkeys(
+                    [
+                        *glob.glob("/tmp/sshfs_mount_*"),
+                        *glob.glob(
+                            str(
+                                Path(settings.data_dir) / "sshfs-cache" / "repository-*"
+                            )
+                        ),
+                    ]
+                )
+            )
 
             # Get all temp_roots that are currently tracked
             tracked_temp_roots = set()

--- a/app/services/mount_service.py
+++ b/app/services/mount_service.py
@@ -179,7 +179,8 @@ class MountService:
     def _cleanup_orphaned_temp_dirs(self):
         """
         Clean up orphaned SSHFS temp directories from crashed processes.
-        Only removes directories that aren't being tracked by active mounts.
+        Only removes directories that aren't being tracked by active mounts or
+        visible in the kernel mount table.
         """
         try:
             import glob
@@ -204,10 +205,47 @@ class MountService:
                 if mount_info.temp_root:
                     tracked_temp_roots.add(mount_info.temp_root)
 
+            active_mount_points = self._get_active_mount_points()
+            stable_cache_parent = Path(settings.data_dir) / "sshfs-cache"
+
+            def is_stable_cache_root(temp_dir: str) -> bool:
+                temp_path = Path(temp_dir)
+                return (
+                    temp_path.parent == stable_cache_parent
+                    and temp_path.name.startswith("repository-")
+                )
+
+            def has_active_mount_inside(temp_dir: str) -> bool:
+                if active_mount_points is None:
+                    return False
+                temp_path = Path(temp_dir).resolve()
+                for mount_point in active_mount_points:
+                    try:
+                        mount_path = Path(mount_point).resolve()
+                    except OSError:
+                        mount_path = Path(mount_point)
+                    if mount_path == temp_path or mount_path.is_relative_to(temp_path):
+                        return True
+                return False
+
             # Remove orphaned directories
             orphaned_count = 0
             for temp_dir in temp_dirs:
                 if temp_dir not in tracked_temp_roots:
+                    if is_stable_cache_root(temp_dir) and active_mount_points is None:
+                        logger.debug(
+                            "Skipping stable SSHFS cache root cleanup without mount table",
+                            temp_dir=temp_dir,
+                        )
+                        continue
+                    if is_stable_cache_root(temp_dir) and has_active_mount_inside(
+                        temp_dir
+                    ):
+                        logger.debug(
+                            "Skipping mounted stable SSHFS cache root cleanup",
+                            temp_dir=temp_dir,
+                        )
+                        continue
                     try:
                         # Check if directory is empty or can be safely removed
                         shutil.rmtree(temp_dir, ignore_errors=True)

--- a/tests/unit/test_backup_service.py
+++ b/tests/unit/test_backup_service.py
@@ -7,7 +7,7 @@ import asyncio
 import tempfile
 from pathlib import Path
 from datetime import datetime
-from unittest.mock import Mock, patch, AsyncMock, MagicMock
+from unittest.mock import ANY, Mock, patch, AsyncMock, MagicMock
 from sqlalchemy.orm import sessionmaker
 from app.services.backup_service import BackupService
 from app.services.filesystem_snapshot_service import PreparedFilesystemSnapshot
@@ -1151,6 +1151,7 @@ class TestBackupService:
             ["/snap/job-1/0-app"],
             job.id,
             source_connection_id=None,
+            stable_sshfs_temp_root=ANY,
         )
         calculate_size.assert_called_once_with(job.id, ["/snap/job-1/0-app"], [])
         cleanup_snapshots.assert_awaited_once_with(job.id)

--- a/tests/unit/test_backup_service_mocks.py
+++ b/tests/unit/test_backup_service_mocks.py
@@ -132,6 +132,50 @@ async def test_prepare_source_paths_reuses_first_sshfs_temp_root_for_multiple_co
 
 
 @pytest.mark.asyncio
+async def test_prepare_source_paths_uses_stable_sshfs_temp_root_for_first_mount(
+    backup_service_fixture, mock_db_session
+):
+    source = SSHConnection(
+        id=11,
+        host="server-a.example",
+        username="backup-a",
+        port=22,
+    )
+
+    ssh_query = MagicMock()
+    ssh_query.filter.return_value.first.return_value = source
+
+    def query_side_effect(model):
+        m = MagicMock()
+        if model == SSHConnection:
+            return ssh_query
+        return m
+
+    mock_db_session.query.side_effect = query_side_effect
+    stable_root = "/data/sshfs-cache/repository-7"
+
+    with (
+        patch("app.services.backup_service.SessionLocal", return_value=mock_db_session),
+        patch(
+            "app.services.mount_service.mount_service.mount_ssh_paths_shared",
+            new=AsyncMock(return_value=(stable_root, [("mount-a", "home/app/data")])),
+        ) as mount_shared,
+    ):
+        (
+            processed_paths,
+            ssh_mount_info,
+        ) = await backup_service_fixture._prepare_source_paths(
+            ["ssh://backup-a@server-a.example:22/home/app/data"],
+            job_id=42,
+            stable_sshfs_temp_root=stable_root,
+        )
+
+    assert processed_paths == ["home/app/data"]
+    assert ssh_mount_info == [(stable_root, "home/app/data")]
+    assert mount_shared.await_args.kwargs["temp_root"] == stable_root
+
+
+@pytest.mark.asyncio
 async def test_execute_backup_command(
     backup_service_fixture, mock_db_session, tmp_path
 ):
@@ -228,6 +272,88 @@ async def test_execute_backup_command(
                     # Verify content of the archive argument
                     archive_arg = [a for a in create_call_args if "::" in a][0]
                     assert archive_arg.startswith("/backups/repo::manual-backup-")
+
+
+@pytest.mark.asyncio
+async def test_execute_backup_passes_repository_stable_sshfs_root_to_source_prepare(
+    backup_service_fixture, mock_db_session
+):
+    job_id = 43
+    repo = Repository(
+        id=7,
+        path="/backups/repo",
+        source_directories='["/home/app/data"]',
+        source_ssh_connection_id=11,
+        compression="lz4",
+        mode="full",
+    )
+    source = SSHConnection(
+        id=11,
+        host="server-a.example",
+        username="backup-a",
+        port=22,
+    )
+    job = BackupJob(id=job_id, status="pending")
+    stable_root = "/tmp/borg-data/sshfs-cache/repository-7"
+
+    def query_side_effect(model):
+        m = MagicMock()
+        if model == BackupJob:
+            m.filter.return_value.first.return_value = job
+        elif model == Repository:
+            m.filter.return_value.first.return_value = repo
+        elif model == SSHConnection:
+            m.filter.return_value.first.return_value = source
+        elif model == SystemSettings:
+            m.first.return_value = SystemSettings()
+        elif model == RepositoryScript:
+            m.filter.return_value.count.return_value = 0
+        return m
+
+    mock_db_session.query.side_effect = query_side_effect
+    mock_process = AsyncMock()
+    mock_process.returncode = 0
+    mock_process.stdout = AsyncMock()
+    mock_process.stdout.__aiter__.return_value = iter([])
+    prepare_source_paths = AsyncMock(
+        return_value=(["home/app/data"], [(stable_root, "home/app/data")])
+    )
+
+    with (
+        patch("app.services.backup_service.SessionLocal", return_value=mock_db_session),
+        patch(
+            "app.services.backup_service.BorgRouter.validate_local_repository_access",
+            return_value=None,
+        ),
+        patch.object(
+            backup_service_fixture,
+            "_prepare_source_paths",
+            prepare_source_paths,
+        ),
+        patch.object(
+            backup_service_fixture,
+            "_calculate_and_update_size_background",
+            new=AsyncMock(),
+        ),
+        patch(
+            "app.services.backup_service.asyncio.create_subprocess_exec",
+            return_value=mock_process,
+        ),
+        patch(
+            "app.services.backup_service.notification_service",
+            _notification_service_mock(),
+        ),
+    ):
+        await backup_service_fixture.execute_backup(
+            job_id, repo.path, db=mock_db_session
+        )
+
+    prepare_source_paths.assert_awaited_once_with(
+        ["ssh://backup-a@server-a.example:22/home/app/data"],
+        job_id,
+        source_connection_id=11,
+        stable_sshfs_temp_root=stable_root,
+    )
 
 
 @pytest.mark.asyncio
@@ -1253,6 +1379,7 @@ async def test_execute_backup_resolves_grouped_source_locations(
     mock_process.returncode = 0
     mock_process.stdout = AsyncMock()
     mock_process.stdout.__aiter__.return_value = iter([])
+    stable_root = "/tmp/borg-data/sshfs-cache/repository-1"
 
     with (
         patch("app.services.backup_service.SessionLocal", return_value=mock_db_session),
@@ -1276,10 +1403,10 @@ async def test_execute_backup_resolves_grouped_source_locations(
             "_prepare_source_paths",
             new=AsyncMock(
                 return_value=(
-                    [str(local_source), "data", "var/lib/service"],
+                    ["data", "var/lib/service", str(local_source)],
                     [
-                        ("/tmp/sshfs-a", "data"),
-                        ("/tmp/sshfs-b", "var/lib/service"),
+                        (stable_root, "data"),
+                        (stable_root, "var/lib/service"),
                     ],
                 )
             ),
@@ -1311,6 +1438,7 @@ async def test_execute_backup_resolves_grouped_source_locations(
         ],
         job_id,
         source_connection_id=None,
+        stable_sshfs_temp_root=stable_root,
     )
 
 

--- a/tests/unit/test_mount_service.py
+++ b/tests/unit/test_mount_service.py
@@ -181,6 +181,31 @@ class TestMountService:
         assert not orphaned_root.exists()
         assert tracked_root.exists()
 
+    def test_cleanup_orphaned_temp_dirs_preserves_mounted_stable_sshfs_cache_root(
+        self, mount_service
+    ):
+        data_dir = mount_service.mount_base_dir.parent
+        mounted_root = data_dir / "sshfs-cache" / "repository-9"
+        mounted_path = mounted_root / "srv" / "data"
+        mounted_path.mkdir(parents=True)
+
+        def glob_side_effect(pattern):
+            if pattern == "/tmp/sshfs_mount_*":
+                return []
+            return [str(mounted_root)]
+
+        with (
+            patch("glob.glob", side_effect=glob_side_effect),
+            patch.object(
+                mount_service,
+                "_get_active_mount_points",
+                return_value={str(mounted_path)},
+            ),
+        ):
+            mount_service._cleanup_orphaned_temp_dirs()
+
+        assert mounted_root.exists()
+
     def test_list_mounts(self, mount_service):
         """Test listing active mounts"""
         # Initially empty

--- a/tests/unit/test_mount_service.py
+++ b/tests/unit/test_mount_service.py
@@ -153,6 +153,34 @@ class TestMountService:
         assert not os.path.exists(temp_root)
         assert not os.path.exists(temp_key_file)
 
+    def test_cleanup_orphaned_temp_dirs_removes_stable_sshfs_cache_roots(
+        self, mount_service
+    ):
+        data_dir = mount_service.mount_base_dir.parent
+        orphaned_root = data_dir / "sshfs-cache" / "repository-7"
+        tracked_root = data_dir / "sshfs-cache" / "repository-8"
+        orphaned_root.mkdir(parents=True)
+        tracked_root.mkdir(parents=True)
+        mount_service.active_mounts["tracked"] = MountInfo(
+            mount_id="tracked",
+            mount_type=MountType.SSHFS,
+            mount_point=str(tracked_root / "srv"),
+            source="sshfs://example/srv",
+            created_at=datetime.now(timezone.utc),
+            temp_root=str(tracked_root),
+        )
+
+        def glob_side_effect(pattern):
+            if pattern == "/tmp/sshfs_mount_*":
+                return []
+            return [str(orphaned_root), str(tracked_root)]
+
+        with patch("glob.glob", side_effect=glob_side_effect):
+            mount_service._cleanup_orphaned_temp_dirs()
+
+        assert not orphaned_root.exists()
+        assert tracked_root.exists()
+
     def test_list_mounts(self, mount_service):
         """Test listing active mounts"""
         # Initially empty


### PR DESCRIPTION
## Description
Stabilizes the SSHFS source mount root used by server-executed remote source backups. Borg UI now prepares SSHFS sources under a per-repository path in the data directory instead of a fresh `/tmp/sshfs_mount_*` path for each run, while preserving the existing relative `borg create` source paths so archive layout stays unchanged.

This update also hardens the stable root lifecycle:
- same-repository stable SSHFS roots are serialized with a dedicated `sshfs-cache` lock from source preparation through SSHFS cleanup;
- orphan cleanup checks the kernel mount table before deleting stable cache roots and preserves roots with active mounts that are missing from in-memory state.

## Related Issue
Fixes #681

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing
- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Commands run:
- `/Users/karanhudia/Documents/Projects/borg-ui/.venv/bin/python -m pytest tests/unit/test_backup_service_mocks.py tests/unit/test_backup_service.py tests/unit/test_mount_service.py tests/unit/test_mount_service_mocks.py -q`
- `/Users/karanhudia/Documents/Projects/borg-ui/.venv/bin/ruff check app/services/backup_service.py app/services/mount_service.py tests/unit/test_backup_service_mocks.py tests/unit/test_backup_service.py tests/unit/test_mount_service.py tests/unit/test_mount_service_mocks.py`
- `git diff --check`

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Not applicable; backend behavior change only.

## Additional Context
Borg records absolute source paths in its files cache, even when source paths are passed relative to the backup process working directory. Keeping the SSHFS root stable addresses the changing absolute path portion of the issue. SSHFS inode instability is separate, so users may still need an inode-free `--files-cache` mode such as `ctime,size` or `mtime,size` depending on their server.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU Affero General Public License v3.0 (AGPL-3.0), the same license as this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * SSH-based backups now reuse stable, repository-specific SSHFS cache locations to improve consistency and reduce churn.
  * SSHFS mounting now uses a repository-scoped cache lock to prevent concurrent cache usage issues during a backup run.
* **Bug Fixes**
  * Orphaned SSHFS temp/cache directories are cleaned up more safely, including repository-stable cache roots, while preserving directories that are still actively mounted.
* **Tests**
  * Added/updated unit tests to validate stable cache reuse and the expanded orphan cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->