### PR TITLE
fix: harden maintenance reaping — SQLite WAL + runtime maintenance_status reconciler

### DIFF
--- a/app/database/database.py
+++ b/app/database/database.py
@@ -38,6 +38,12 @@ if settings.database_url.startswith("sqlite"):
     def set_sqlite_pragma(dbapi_conn, connection_record):
         cursor = dbapi_conn.cursor()
         cursor.execute("PRAGMA foreign_keys=ON")
+        # WAL lets readers proceed without blocking the single writer, and
+        # busy_timeout retries a transiently-locked write instead of raising
+        # "database is locked" -- both matter under the concurrent multi-repo
+        # maintenance load that a plan run creates.
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA busy_timeout=5000")
         cursor.close()
 
 

--- a/app/services/agent_job_reaper.py
+++ b/app/services/agent_job_reaper.py
@@ -140,9 +140,16 @@ def reap_stale_agent_jobs(
 
 def _reap_once() -> int:
     """One reap pass with its own session (runs in a worker thread)."""
+    from app.utils.process_utils import reconcile_stale_backup_maintenance
+
     db = SessionLocal()
     try:
-        return reap_stale_agent_jobs(db)
+        reaped = reap_stale_agent_jobs(db)
+        # Also reconcile backup rows stuck in a running maintenance state whose
+        # maintenance op died without writing a terminal status (startup-only
+        # cleanup previously left these "running" until the next restart).
+        reaped += reconcile_stale_backup_maintenance(db)
+        return reaped
     finally:
         db.close()
 

--- a/app/utils/process_utils.py
+++ b/app/utils/process_utils.py
@@ -8,7 +8,7 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 import structlog
-from datetime import datetime
+from datetime import datetime, timedelta
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
 from app.config import settings
@@ -193,6 +193,103 @@ def _mark_stale_backup_maintenance_failed(db: Session, now: datetime) -> int:
         )
 
     return normalized_count
+
+
+# A backup row stuck in a running maintenance state for longer than this (with no
+# live child job) is reconciled at runtime. Kept generous so genuinely-running
+# maintenance whose child row is written a moment later is never killed; the
+# liveness guard below is the primary protection.
+MAINTENANCE_RECONCILE_AFTER = timedelta(minutes=5)
+
+_MAINTENANCE_CHILD_MODELS = {
+    "running_prune": PruneJob,
+    "running_compact": CompactJob,
+    "running_check": CheckJob,
+}
+
+
+def _has_running_maintenance_child(
+    db: Session, backup_job: BackupJob, maintenance_status: str
+) -> bool:
+    """True if a maintenance child job for this repo is still actually running.
+
+    The PruneJob/CompactJob/CheckJob row is created and set to 'running' for both
+    server-side and agent-delegated maintenance, so it is a reliable liveness
+    signal. Agent maintenance jobs carry no backup_job_id, so we correlate by
+    repository (mirroring _has_running_check_child).
+    """
+    model = _MAINTENANCE_CHILD_MODELS.get(maintenance_status)
+    if model is None:
+        return False
+    query = db.query(model.id).filter(model.status == "running")
+    if backup_job.repository_id is not None:
+        query = query.filter(model.repository_id == backup_job.repository_id)
+    else:
+        query = query.filter(model.repository_path == backup_job.repository)
+    return query.first() is not None
+
+
+def _strip_tz(value: datetime) -> datetime:
+    """Drop tzinfo so a possibly-aware DB value compares with naive utcnow()."""
+    return value.replace(tzinfo=None) if value.tzinfo is not None else value
+
+
+def reconcile_stale_backup_maintenance(
+    db: Session,
+    *,
+    now: Optional[datetime] = None,
+    reap_after: timedelta = MAINTENANCE_RECONCILE_AFTER,
+) -> int:
+    """Normalize backup rows stuck in a running maintenance state, at RUNTIME.
+
+    ``_mark_stale_backup_maintenance_failed`` runs only at startup and assumes
+    nothing is live. This runs periodically, so it must not kill genuinely
+    running maintenance: it skips any row whose maintenance child job is still
+    'running', and only reaps rows older than ``reap_after``.
+
+    This closes the gap where an agent-delegated maintenance op fails without
+    writing a terminal ``maintenance_status`` -- the child job reaper only fires
+    on a 'running' child, and the agent-job reaper propagates via backup_job_id
+    (which repository maintenance jobs do not carry). Returns the count reaped.
+    """
+    # Normalize to naive UTC so the age comparison holds even if a caller passes
+    # a tz-aware `now` (DB datetimes are naive UTC).
+    now = _strip_tz(now or datetime.utcnow())
+    cutoff = now - reap_after
+
+    stuck = (
+        db.query(BackupJob)
+        .filter(
+            BackupJob.maintenance_status.in_(list(RUNNING_BACKUP_MAINTENANCE_FAILURES)),
+        )
+        .all()
+    )
+
+    reaped = 0
+    for backup_job in stuck:
+        state = backup_job.maintenance_status
+        # 1) genuinely in-progress maintenance -> leave alone
+        if _has_running_maintenance_child(db, backup_job, state):
+            continue
+        # 2) age guard (BackupJob has no updated_at; completed_at is set when the
+        #    backup phase finished, i.e. before maintenance started)
+        activity = backup_job.completed_at or backup_job.created_at
+        if activity is not None and _strip_tz(activity) > cutoff:
+            continue
+        _mark_backup_maintenance_failed(backup_job, state, now)
+        reaped += 1
+        logger.info(
+            "Reconciled stale backup maintenance state at runtime",
+            backup_job_id=backup_job.id,
+            repository=backup_job.repository,
+            previous_maintenance_status=state,
+            new_maintenance_status=backup_job.maintenance_status,
+        )
+
+    if reaped:
+        db.commit()
+
+    return reaped
 
 
 def is_process_alive(pid: int, stored_start_time: int) -> bool:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -7,6 +7,7 @@ from app.utils.process_utils import (
     break_repository_lock,
     cleanup_orphaned_jobs,
     cleanup_orphaned_mounts,
+    reconcile_stale_backup_maintenance,
 )
 from app.database.models import (
     BackupJob,
@@ -304,6 +305,124 @@ class TestProcessUtils:
         db_session.refresh(backup_job)
         assert backup_job.status == "completed"
         assert backup_job.maintenance_status == "check_failed"
+
+    def test_reconcile_stale_backup_maintenance_reaps_stuck_prune_without_child(
+        self, db_session
+    ):
+        from datetime import timedelta
+
+        repo = Repository(
+            name="Stuck Prune Repo",
+            path="/repos/stuck-prune",
+            encryption="none",
+            repository_type="local",
+        )
+        db_session.add(repo)
+        db_session.flush()
+        old = datetime.utcnow() - timedelta(minutes=10)
+        backup_job = BackupJob(
+            repository=repo.path,
+            repository_id=repo.id,
+            status="completed",
+            started_at=old,
+            completed_at=old,
+            maintenance_status="running_prune",
+        )
+        db_session.add(backup_job)
+        db_session.commit()
+
+        reaped = reconcile_stale_backup_maintenance(db_session)
+
+        assert reaped == 1
+        db_session.refresh(backup_job)
+        assert backup_job.maintenance_status == "prune_failed"
+        assert backup_job.status == "completed"  # backup itself stays completed
+
+    def test_reconcile_stale_backup_maintenance_preserves_live_prune(self, db_session):
+        from datetime import timedelta
+
+        repo = Repository(
+            name="Live Prune Repo",
+            path="/repos/live-prune",
+            encryption="none",
+            repository_type="local",
+        )
+        db_session.add(repo)
+        db_session.flush()
+        old = datetime.utcnow() - timedelta(minutes=10)
+        backup_job = BackupJob(
+            repository=repo.path,
+            repository_id=repo.id,
+            status="completed",
+            started_at=old,
+            completed_at=old,
+            maintenance_status="running_prune",
+        )
+        # a genuinely running prune child for the same repo -> must be preserved
+        db_session.add(
+            PruneJob(
+                repository_id=repo.id,
+                repository_path=repo.path,
+                status="running",
+            )
+        )
+        db_session.add(backup_job)
+        db_session.commit()
+
+        reaped = reconcile_stale_backup_maintenance(db_session)
+
+        assert reaped == 0
+        db_session.refresh(backup_job)
+        assert backup_job.maintenance_status == "running_prune"
+
+    def test_reconcile_stale_backup_maintenance_skips_fresh(self, db_session):
+        repo = Repository(
+            name="Fresh Prune Repo",
+            path="/repos/fresh-prune",
+            encryption="none",
+            repository_type="local",
+        )
+        db_session.add(repo)
+        db_session.flush()
+        now = datetime.utcnow()
+        backup_job = BackupJob(
+            repository=repo.path,
+            repository_id=repo.id,
+            status="completed",
+            started_at=now,
+            completed_at=now,  # just finished -> under the age threshold
+            maintenance_status="running_prune",
+        )
+        db_session.add(backup_job)
+        db_session.commit()
+
+        reaped = reconcile_stale_backup_maintenance(db_session)
+
+        assert reaped == 0
+        db_session.refresh(backup_job)
+        assert backup_job.maintenance_status == "running_prune"
+
+    def test_reap_once_runs_agent_and_maintenance_reapers(self):
+        # The background loop must run BOTH the agent-job reaper and the new
+        # maintenance reconciler each tick.
+        with (
+            patch("app.services.agent_job_reaper.SessionLocal"),
+            patch(
+                "app.services.agent_job_reaper.reap_stale_agent_jobs",
+                return_value=2,
+            ) as m_agent,
+            patch(
+                "app.utils.process_utils.reconcile_stale_backup_maintenance",
+                return_value=3,
+            ) as m_maint,
+        ):
+            from app.services.agent_job_reaper import _reap_once
+
+            total = _reap_once()
+
+        assert total == 5
+        m_agent.assert_called_once()
+        m_maint.assert_called_once()
 
     @patch("app.utils.process_utils.is_process_alive", return_value=True)
     def test_cleanup_orphaned_jobs_preserves_running_check_with_live_child_process(


### PR DESCRIPTION
## Problem
A plan run prunes/compacts many repositories concurrently. Two robustness gaps surface under that load:

1. **`database is locked` orphans a maintenance job.** With SQLite's default rollback journal and no busy timeout, a concurrent write raises `database is locked`; a transaction that already committed a `prune_jobs`/`compact_jobs`/`check_jobs` row then fails on the follow-up write, leaving the row stuck `pending` with no backing work.
2. **Stuck `maintenance_status` is only reconciled at startup.** `_mark_stale_backup_maintenance_failed` runs from `cleanup_orphaned_jobs` on container start. If a maintenance op dies without writing a terminal status, the backup row stays `running_prune`/`running_compact`/`running_check` — and the UI shows it "running" — until the next restart.

## Change
- **SQLite WAL + `busy_timeout`** in the connect pragma (next to the existing `foreign_keys` pragma): readers no longer block the single writer, and a transiently-locked write retries (5s) instead of raising. This dampens the `database is locked` trigger.
- **Runtime maintenance reconciler** (`reconcile_stale_backup_maintenance`), run each tick from the existing `agent_job_reaper` loop. It normalizes a stuck `maintenance_status` to its terminal `*_failed` value at runtime, guarded so it never kills live maintenance:
  - skips a repo with a `running` `PruneJob`/`CompactJob`/`CheckJob` child (generalizes the existing `running_check` liveness guard to all three via `_has_running_maintenance_child`),
  - only reaps rows older than a 5-minute threshold (`BackupJob` has no `updated_at`; `completed_at`/`created_at` is the age signal).

## Tests
- `reconcile_stale_backup_maintenance`: reaps a stuck `running_prune` with no live child → `prune_failed`; **preserves** it when a `running` `PruneJob` exists; **skips** freshly-finished rows under the age threshold.
- `_reap_once` runs both the agent-job reaper and the maintenance reconciler each tick.
- `ruff check` + `ruff format --check` + the touched unit tests green.

## Notes
General robustness — no dependency on any in-flight feature branch, so it can land independently. A follow-up PR (delegation-coupled) will additionally reap orphaned `*_jobs` that carry no backing agent job and make agent-maintenance dispatch atomic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Automatically recovers backup maintenance tasks left stuck after interruptions or container restarts.
  - Keeps maintenance tasks that are still actively running.
  - Avoids incorrectly marking recently completed maintenance as failed.
  - Improves SQLite reliability during concurrent activity by enabling write-ahead logging and a busy timeout.
  - Ensures the scheduled reaper counts stale maintenance reconciliations in its recovery totals.
- **Tests**
  - Added database-backed coverage for stale, active, and recently completed maintenance scenarios.
  - Updated tests to verify combined reaper recovery totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->