### PR TITLE
fix(agent): opt into non-interactive access to unencrypted repos

### DIFF
--- a/agent/borg_ui_agent/backup.py
+++ b/agent/borg_ui_agent/backup.py
@@ -179,6 +179,35 @@ def _extract_environment(
     return environment
 
 
+# borg prompts interactively on first access to an unknown *unencrypted* repo
+# ("Attempting to access a previously unknown unencrypted repository! ... [yN]")
+# and again when a repository looks relocated. A managed agent runs borg
+# non-interactively, so those prompts hang (or abort with rc=2) every operation
+# on such a repository — which surfaces in the UI as empty stats (0 archives /
+# N/A size / never). Opt into non-interactive access exactly like the server
+# side does. Respected by borg 1.x and borg 2.
+_BORG_NONINTERACTIVE_ACCESS_DEFAULTS = {
+    "BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK": "yes",
+    "BORG_RELOCATED_REPO_ACCESS_IS_OK": "yes",
+}
+
+
+def build_borg_env(overrides: Optional[dict[str, str]] = None) -> dict[str, str]:
+    """Build the environment for a borg subprocess launched by the agent.
+
+    Starts from the agent process environment, layers the non-interactive
+    access defaults (only where not already set, so an explicit container
+    setting still wins), then applies the per-job overrides last so a value
+    sent by the server is never clobbered.
+    """
+    env = os.environ.copy()
+    for key, value in _BORG_NONINTERACTIVE_ACCESS_DEFAULTS.items():
+        env.setdefault(key, value)
+    if overrides:
+        env.update(overrides)
+    return env
+
+
 def parse_borg_progress(line: str) -> Optional[dict[str, Any]]:
     stripped = line.strip()
     if not stripped.startswith("{"):
@@ -265,8 +294,7 @@ def execute_backup_create_job(
         )
 
     cmd = payload.build_command()
-    env = os.environ.copy()
-    env.update(payload.environment)
+    env = build_borg_env(payload.environment)
 
     sequence = 0
     client.send_log(

--- a/agent/borg_ui_agent/repository_ops.py
+++ b/agent/borg_ui_agent/repository_ops.py
@@ -16,7 +16,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
-from agent.borg_ui_agent.backup import _extract_environment, parse_borg_progress
+from agent.borg_ui_agent.backup import (
+    _extract_environment,
+    build_borg_env,
+    parse_borg_progress,
+)
 from agent.borg_ui_agent.client import AgentClient
 
 
@@ -432,8 +436,7 @@ def execute_repository_operation_job(
             job_id=job_id, status="failed", message=error_message
         )
 
-    env = os.environ.copy()
-    env.update(payload.environment or {})
+    env = build_borg_env(payload.environment)
     sequence = 0
     client.send_log(
         job_id,

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -8,6 +8,7 @@ import pytest
 
 from agent.borg_ui_agent.backup import (
     BackupCreatePayload,
+    build_borg_env,
     execute_backup_create_job,
     parse_borg_progress,
 )
@@ -1641,12 +1642,43 @@ def test_execute_backup_create_job_completes_successfully(monkeypatch):
     assert result.status == "completed"
     assert popen_calls[0]["cmd"][-2:] == ["/repo::archive", "/src"]
     assert popen_calls[0]["env"]["BORG_PASSPHRASE"] == "secret"
+    # Unencrypted repos must not stall the non-interactive agent on borg's
+    # "previously unknown unencrypted repository [yN]" prompt (issue #741).
+    assert popen_calls[0]["env"]["BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK"] == "yes"
     assert popen_calls[0]["kwargs"]["start_new_session"] is True
     assert any(call[0] == "send_progress" for call in client.calls)
     complete_call = [call for call in client.calls if call[0] == "complete_job"][0]
     # No --json document on stdout -> fall back to the requested archive name.
     assert complete_call[2]["archive_name"] == "archive"
     assert complete_call[2]["return_code"] == 0
+
+
+@pytest.mark.unit
+def test_build_borg_env_sets_noninteractive_access_defaults(monkeypatch):
+    # borg 1.x and 2 both prompt "[yN]" on first access to an unknown
+    # unencrypted (or relocated) repository. The agent runs borg
+    # non-interactively, so without these flags every operation on such a repo
+    # hangs and the UI shows empty stats (0 archives / N/A / never) -> #741.
+    monkeypatch.delenv("BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK", raising=False)
+    monkeypatch.delenv("BORG_RELOCATED_REPO_ACCESS_IS_OK", raising=False)
+
+    env = build_borg_env()
+
+    assert env["BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK"] == "yes"
+    assert env["BORG_RELOCATED_REPO_ACCESS_IS_OK"] == "yes"
+
+
+@pytest.mark.unit
+def test_build_borg_env_overrides_win_but_container_setting_is_kept(monkeypatch):
+    # A per-job override (e.g. the passphrase) is layered last and wins.
+    env = build_borg_env({"BORG_PASSPHRASE": "secret"})
+    assert env["BORG_PASSPHRASE"] == "secret"
+    assert env["BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK"] == "yes"
+
+    # An explicit container-level setting is respected over the default.
+    monkeypatch.setenv("BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK", "no")
+    env = build_borg_env()
+    assert env["BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK"] == "no"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

borg prompts interactively on the first access to a previously **unknown
unencrypted** repository:

```
Warning: Attempting to access a previously unknown unencrypted repository!
Do you want to continue? [yN]
```

(and similarly on a *relocated* repository). The managed agent launches borg
non-interactively, so this prompt hangs the subprocess (or aborts it with
`rc=2` when stdin is at EOF). Every `repository.info` / `list` / `prune` /
`backup.create` job the agent runs against such a repository then gets stuck
or fails.

The server side already opts out of these prompts
(`app/core/borg.py`, `app/core/borg2.py` and `app/utils/borg_env.py` all set
`BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK=yes`), but the agent's borg
execution environment did not set it anywhere.

Reproduced with borg 1.4:

```
# unknown unencrypted repo, non-interactive
$ borg info ./repo --json </dev/null
Warning: Attempting to access a previously unknown unencrypted repository!
Do you want to continue? [yN] Aborting.          # exit 2

$ BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK=yes borg info ./repo --json </dev/null
{ ... }                                          # exit 0
```

## Fix

Add a shared `build_borg_env()` helper that seeds the agent's borg environment
with `BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK=yes` and
`BORG_RELOCATED_REPO_ACCESS_IS_OK=yes`, mirroring the server side. It is used by
both the backup path (`backup.create`) and every repository operation
(info / list / prune / compact / check / delete-archive / break-lock), so all
agent-side borg invocations are covered for borg 1.x and borg 2.

- Defaults are applied with `setdefault`, so an explicit container-level setting
  still wins.
- Per-job overrides (e.g. `BORG_PASSPHRASE`) are layered last and are never
  clobbered.

## Tests

- `test_build_borg_env_sets_noninteractive_access_defaults`
- `test_build_borg_env_overrides_win_but_container_setting_is_kept`
- extended `test_execute_backup_create_job_completes_successfully` to assert the
  flag reaches the borg subprocess environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Borg backup and repository operations now default to non-interactive behavior for unknown, unencrypted, or relocated repositories to avoid unexpected prompts or aborts.
  - The effective environment is constructed more reliably: job-specific environment overrides win where provided, while existing runtime settings are preserved otherwise.

- **Tests**
  - Added unit coverage for the new non-interactive environment defaults and override/preference behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->