### PR TITLE
fix(agent): honor configured list/info timeout on agent archive+info endpoints

### DIFF
--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -5958,7 +5958,11 @@ async def list_repository_archives(
                 job_kind="repository.list_archives",
             )
             await dispatch_agent_job_best_effort(db, agent_job, repository_id=repo_id)
-            result = await wait_for_agent_repository_operation_job(db, agent_job.id)
+            result = await wait_for_agent_repository_operation_job(
+                db,
+                agent_job.id,
+                timeout_seconds=get_operation_timeouts(db)["list_timeout"],
+            )
             archives_data = _parse_agent_json_result(result)
             archives = archives_data.get("archives", [])
             archives = enrich_archives_with_backup_metadata(archives, repository, db)
@@ -6046,7 +6050,11 @@ async def get_repository_info(
                 job_kind="repository.info",
             )
             await dispatch_agent_job_best_effort(db, agent_job, repository_id=repo_id)
-            result = await wait_for_agent_repository_operation_job(db, agent_job.id)
+            result = await wait_for_agent_repository_operation_job(
+                db,
+                agent_job.id,
+                timeout_seconds=get_operation_timeouts(db)["info_timeout"],
+            )
             info_data = _parse_agent_json_result(result)
 
             # The dialog's stats panel (the Borg 2 view in particular) is driven

--- a/tests/unit/test_api_repositories.py
+++ b/tests/unit/test_api_repositories.py
@@ -56,6 +56,18 @@ def _enable_borg_v2(test_db):
     _set_plan(test_db, "pro")
 
 
+def _set_operation_timeouts(test_db, *, info_timeout, list_timeout):
+    """Configure distinct info/list timeouts so a test can prove each endpoint
+    reads its own configuration key (not the other one)."""
+    settings_row = test_db.query(SystemSettings).first()
+    if settings_row is None:
+        settings_row = SystemSettings()
+        test_db.add(settings_row)
+    settings_row.info_timeout = info_timeout
+    settings_row.list_timeout = list_timeout
+    test_db.commit()
+
+
 def _set_plan(test_db, plan: str) -> None:
     state = test_db.query(LicensingState).first()
     if state is None:
@@ -1103,6 +1115,7 @@ class TestRepositoriesCreate:
         repo.agent_machine_id = agent.id
         test_db.commit()
         test_db.refresh(repo)
+        _set_operation_timeouts(test_db, info_timeout=615, list_timeout=627)
 
         with (
             patch(
@@ -1137,7 +1150,9 @@ class TestRepositoriesCreate:
         assert info["archives"] == [{"name": "archive-1", "stats": {"nfiles": 3}}]
         agent_job = test_db.query(AgentJob).one()
         assert agent_job.payload["job_kind"] == "repository.info"
-        wait_for_agent.assert_awaited_once_with(test_db, agent_job.id)
+        wait_for_agent.assert_awaited_once_with(
+            test_db, agent_job.id, timeout_seconds=615
+        )
         run_local.assert_not_called()
 
     async def test_agent_stats_refresh_keeps_count_when_list_job_fails(self, test_db):
@@ -1210,6 +1225,7 @@ class TestRepositoriesCreate:
         repo.agent_machine_id = agent.id
         test_db.commit()
         test_db.refresh(repo)
+        _set_operation_timeouts(test_db, info_timeout=615, list_timeout=627)
 
         with patch(
             "app.api.repositories.wait_for_agent_repository_operation_job",
@@ -1223,7 +1239,9 @@ class TestRepositoriesCreate:
         assert response.json()["archives"][0]["name"] == "archive-1"
         agent_job = test_db.query(AgentJob).one()
         assert agent_job.payload["job_kind"] == "repository.list_archives"
-        wait_for_agent.assert_awaited_once_with(test_db, agent_job.id)
+        wait_for_agent.assert_awaited_once_with(
+            test_db, agent_job.id, timeout_seconds=627
+        )
 
     def test_agent_job_completion_updates_repository_maintenance_job(
         self, test_client: TestClient, admin_headers, test_db


### PR DESCRIPTION
## Problem

For managed-agent repositories, opening the repository view shows **no archives at all**. The archive list (and the info/stats panel) come up empty even though the repository has archives.

## Root cause

`GET /{repo_id}/archives` (`list_repository_archives`) and `GET /{repo_id}/info` (`get_repository_info`) delegate to the managed agent when `is_agent_executor(repository)`, but they awaited the agent job with the **bare 15s default** of `wait_for_agent_repository_operation_job(db, agent_job.id)`:

```python
result = await wait_for_agent_repository_operation_job(db, agent_job.id)
```

A Borg 2 `repo-list` / `info` run on the agent against a slow remote (e.g. a Storage Box reached over plain/dumb sftp with no server-side borg) routinely takes ~20s. That exceeds the 15s default, so the endpoint raises `504 repositoryOperationTimeout` and the UI renders an empty archive list.

The sibling Borg 2 delegation call sites in the same file already pass the configurable timeout (`get_operation_timeouts(db)["list_timeout"|"info_timeout"]`, default 600s); these two endpoints were simply missed.

## Fix

Pass the configured `list_timeout` / `info_timeout` to both endpoints, matching the existing pattern:

```python
result = await wait_for_agent_repository_operation_job(
    db,
    agent_job.id,
    timeout_seconds=get_operation_timeouts(db)["list_timeout"],  # / info_timeout
)
```

The wait still returns as soon as the agent job completes or fails, so the happy path is unchanged — this only lifts the artificial 15s ceiling for slower remotes.

## Testing

- Reproduced against a managed agent backing a Borg 2 sftp repository: `GET /{repo_id}/archives` and `/info` consistently 504'd at 15s while the underlying `repository.list_archives` agent job completed in ~20s and returned valid JSON. With the fix the endpoints return the archive list.
- `python -m py_compile app/api/repositories.py` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of agent-backed repository archive listings and repository information requests by applying the appropriate operation timeouts.
* **Tests**
  * Updated unit tests to configure distinct timeouts for “info” vs “list/archives” operations and verify the correct timeout value is used when awaiting agent jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->