### PR TITLE
fix(agent): stop persisting browse listings in the DB and bound the job list

### DIFF
--- a/app/api/browse.py
+++ b/app/api/browse.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 import os  # noqa: F401
 import structlog
 
-from app.database.models import User, Repository, SystemSettings
+from app.database.models import User, Repository, SystemSettings, AgentJob
 from app.database.database import get_db
 from app.api.auth import get_current_user
 from app.core.borg_router import BorgRouter
@@ -35,6 +35,29 @@ from app.utils.ssh_utils import (
 logger = structlog.get_logger(__name__)
 
 router = APIRouter()
+
+
+def _drop_agent_job_result(db: Session, agent_job_id: int) -> None:
+    """Clear a consumed browse listing from ``agent_jobs.result``.
+
+    A ``list_archive_contents`` result holds the archive's full ``borg list``
+    output and can be large. It only needs to survive until the polling browse
+    request reads it once; the parsed items are cached afterwards and the agent
+    can reproduce them on demand. Clearing it avoids keeping one copy per browse.
+    """
+    try:
+        db.query(AgentJob).filter(AgentJob.id == agent_job_id).update(
+            {AgentJob.result: None}, synchronize_session=False
+        )
+        db.commit()
+    except Exception as exc:  # best-effort cleanup; never fail the browse on it
+        db.rollback()
+        logger.warning(
+            "Failed to drop consumed agent browse job result",
+            agent_job_id=agent_job_id,
+            error=str(exc),
+        )
+
 
 # Memory safety limits
 MAX_ITEMS_IN_MEMORY = 1_000_000  # Maximum number of items to load into memory
@@ -148,6 +171,9 @@ async def browse_archive_contents(
     db: Session = Depends(get_db),
 ):
     """Browse contents of an archive at a specific path (directory-by-directory)"""
+    # Job id whose result should be cleared in `finally`, set only once a
+    # completed agent listing has been consumed (None for local repos / pending).
+    consumed_browse_job_id: Optional[int] = None
     try:
         repository = db.query(Repository).filter(Repository.id == repository_id).first()
         if not repository:
@@ -204,11 +230,12 @@ async def browse_archive_contents(
                     job_id=job_id,
                 )
                 if result is None:
-                    # Job still running — tell the client to poll with this id.
+                    # Still running — client polls with this id; not consumed yet.
                     return JSONResponse(
                         status_code=status.HTTP_202_ACCEPTED,
                         content={"status": "pending", "jobId": browse_job_id},
                     )
+                consumed_browse_job_id = browse_job_id
             else:
                 result = await _list_archive_contents_local(
                     db,
@@ -321,3 +348,6 @@ async def browse_archive_contents(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to browse archive: {str(e)}",
         )
+    finally:
+        if consumed_browse_job_id is not None:
+            _drop_agent_job_result(db, consumed_browse_job_id)

--- a/app/api/managed_machines.py
+++ b/app/api/managed_machines.py
@@ -4,9 +4,9 @@ import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, defer
 import structlog
 
 from app.core.agent_auth import AGENT_TOKEN_PREFIX_LENGTH
@@ -120,14 +120,13 @@ class AgentMachineResponse(BaseModel):
         json_encoders = {datetime: lambda v: serialize_datetime(v)}
 
 
-class AgentJobResponse(BaseModel):
+class AgentJobBase(BaseModel):
     id: int
     agent_machine_id: int
     backup_job_id: Optional[int] = None
     job_type: str
     status: str
     payload: dict[str, Any]
-    result: Optional[dict[str, Any]] = None
     claimed_at: Optional[datetime] = None
     started_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
@@ -140,6 +139,18 @@ class AgentJobResponse(BaseModel):
     class Config:
         from_attributes = True
         json_encoders = {datetime: lambda v: serialize_datetime(v)}
+
+
+class AgentJobResponse(AgentJobBase):
+    result: Optional[dict[str, Any]] = None
+
+
+class AgentJobSummaryResponse(AgentJobBase):
+    """``AgentJobResponse`` without the ``result`` blob, for the job list.
+
+    A completed ``list_archive_contents`` job can carry a large result; the list
+    never renders it, so returning it for every job is needless overhead.
+    """
 
 
 class AgentJobLogEntryResponse(BaseModel):
@@ -711,12 +722,30 @@ async def delete_agent_machine(
         )
 
 
-@router.get("/agent-jobs", response_model=list[AgentJobResponse])
+DEFAULT_AGENT_JOBS_LIMIT = 200
+MAX_AGENT_JOBS_LIMIT = 1000
+
+
+@router.get("/agent-jobs", response_model=list[AgentJobSummaryResponse])
 async def list_agent_jobs(
+    limit: int = Query(
+        DEFAULT_AGENT_JOBS_LIMIT,
+        ge=1,
+        le=MAX_AGENT_JOBS_LIMIT,
+        description="Maximum number of most-recent jobs to return.",
+    ),
     _: User = Depends(get_current_admin_user),
     db: Session = Depends(get_db),
 ):
-    return db.query(AgentJob).order_by(AgentJob.created_at.desc()).all()
+    # Never load/serialize `result` (a list_archive_contents result can be large)
+    # and bound the row count; the list view only needs metadata.
+    return (
+        db.query(AgentJob)
+        .options(defer(AgentJob.result))
+        .order_by(AgentJob.created_at.desc())
+        .limit(limit)
+        .all()
+    )
 
 
 @router.get(

--- a/app/database/migrations/126_clear_persisted_archive_browse_listings.py
+++ b/app/database/migrations/126_clear_persisted_archive_browse_listings.py
@@ -1,0 +1,63 @@
+"""Clear persisted archive browse listings from agent_jobs.result.
+
+A ``repository.list_archive_contents`` job used to keep the archive's full
+``borg list`` output in ``agent_jobs.result`` indefinitely. That output is
+transient — it is cached once the browse request reads it and can be re-fetched
+from the agent on demand — so it should never have been retained. On large
+archives it is hundreds of MB per job, which bloats the database over time.
+
+This migration clears it from existing rows and reclaims the freed space; the
+code no longer persists it going forward.
+"""
+
+import structlog
+from sqlalchemy import inspect, text
+
+logger = structlog.get_logger()
+
+
+def _bind(db):
+    return db.get_bind() if hasattr(db, "get_bind") else db
+
+
+def _has_table(db, table_name: str) -> bool:
+    return table_name in inspect(_bind(db)).get_table_names()
+
+
+def upgrade(db):
+    # json_extract is SQLite-specific; borg-ui runs on SQLite. Skip elsewhere.
+    if not _has_table(db, "agent_jobs") or _bind(db).dialect.name != "sqlite":
+        return
+
+    result = db.execute(
+        text(
+            "UPDATE agent_jobs SET result = NULL "
+            "WHERE result IS NOT NULL "
+            "AND json_extract(payload, '$.job_kind') = "
+            "'repository.list_archive_contents'"
+        )
+    )
+    db.commit()
+
+    if not result.rowcount:
+        return
+
+    # Nulling only frees the pages for reuse; VACUUM shrinks the file on disk.
+    # Migrations run during container startup with no other DB users, so the
+    # whole-file rewrite is safe here. VACUUM must run outside a transaction
+    # (AUTOCOMMIT), and it needs scratch space ~= the DB size — if that fails we
+    # log and move on: the rows are already cleared, so the DB stops growing
+    # regardless.
+    try:
+        db.execution_options(isolation_level="AUTOCOMMIT").execute(text("VACUUM"))
+    except Exception as exc:  # pragma: no cover - environment-dependent
+        logger.warning(
+            "VACUUM after clearing browse listings failed; freed pages will be "
+            "reused but the file was not shrunk",
+            error=str(exc),
+        )
+
+
+def downgrade(db):
+    # Irreversible: the cleared listings were transient and re-fetchable.
+    pass

--- a/tests/unit/test_api_browse.py
+++ b/tests/unit/test_api_browse.py
@@ -3,6 +3,7 @@ Unit tests for browse/filesystem API endpoints
 """
 
 import json
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -941,3 +942,32 @@ class TestFilesystemEndpoints:
         )
 
         assert response.status_code == 404
+
+
+def test_drop_agent_job_result_nulls_persisted_listing(test_db):
+    """The consumed browse result (a potentially huge list_archive_contents
+    payload) must be dropped from agent_jobs.result so the app DB does not
+    accumulate it."""
+    agent = _create_agent(test_db, "repository.list_archive_contents")
+    now = datetime.now(timezone.utc)
+    job = AgentJob(
+        agent_machine_id=agent.id,
+        job_type="repository",
+        status="completed",
+        payload={
+            "schema_version": 1,
+            "job_kind": "repository.list_archive_contents",
+        },
+        result={"stdout": "x" * 4096},
+        created_at=now,
+        updated_at=now,
+    )
+    test_db.add(job)
+    test_db.commit()
+    test_db.refresh(job)
+    assert job.result is not None
+
+    browse_api._drop_agent_job_result(test_db, job.id)
+
+    test_db.refresh(job)
+    assert job.result is None

--- a/tests/unit/test_api_managed_machines.py
+++ b/tests/unit/test_api_managed_machines.py
@@ -136,6 +136,53 @@ def test_managed_machine_admin_list_api_remains_readable_without_pro_plan(
     assert jobs_response.json()[0]["id"] == job.id
 
 
+def test_agent_jobs_list_omits_result_blob_and_honors_limit(
+    test_client: TestClient, admin_headers, test_db
+):
+    """The job list must never serialize the (possibly hundreds-of-MB) `result`
+    blob and must bound the number of rows returned."""
+    agent = _agent(test_db)
+    now = datetime.now(timezone.utc)
+    older = AgentJob(
+        agent_machine_id=agent.id,
+        job_type="repository",
+        status="completed",
+        payload={"schema_version": 1, "job_kind": "repository.list_archive_contents"},
+        result={"stdout": "x" * 100_000},
+        created_at=now - timedelta(minutes=5),
+        updated_at=now - timedelta(minutes=5),
+    )
+    newer = AgentJob(
+        agent_machine_id=agent.id,
+        job_type="backup",
+        status="completed",
+        payload={"schema_version": 1, "job_kind": "backup.create"},
+        result={"archive_name": "a"},
+        created_at=now,
+        updated_at=now,
+    )
+    test_db.add_all([older, newer])
+    test_db.commit()
+    test_db.refresh(newer)
+
+    response = test_client.get(
+        "/api/managed-machines/agent-jobs", headers=admin_headers
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 2
+    assert body[0]["id"] == newer.id  # newest first
+    assert all("result" not in job for job in body)
+
+    limited = test_client.get(
+        "/api/managed-machines/agent-jobs",
+        params={"limit": 1},
+        headers=admin_headers,
+    )
+    assert limited.status_code == 200
+    assert [job["id"] for job in limited.json()] == [newer.id]
+
+
 def test_managed_machine_admin_write_api_requires_pro_plan(
     test_client: TestClient, admin_headers, test_db
 ):


### PR DESCRIPTION
## Impact & urgency

Not a new regression — the persisted browse listing was introduced in `f075bce4` ("fix(agent): dispatch backups and browse archives via agent"), so it has shipped in **every release since v2.2.0**. On managed-agent installs `agent_jobs.result` grows unboundedly (one install reached ~2 GB within a week) and `GET /managed-machines/agent-jobs` then stalls loading it. Because it affects all `v2.2.x`, landing this in the next tagged release would be valuable; the included migration also reclaims the already-accumulated space on existing installs.

## Problem

Two issues around managed-agent archive browsing compound into unbounded app-DB growth and a stalled admin UI:

1. **Browse listings are persisted forever.** A completed `repository.list_archive_contents` job stores the archive's full `borg list` output in `agent_jobs.result`. For a large archive that is hundreds of MB, and it is never cleared — every browse adds another copy. The listing is purely transient: it only needs to survive until the polling browse request reads it once, after which the parsed items live in the archive cache and the agent can reproduce them on demand.

2. **`GET /managed-machines/agent-jobs` returns everything, including results.** The endpoint returns *all* agent jobs with their full `result` blobs and no limit. Once a few large browse results have accumulated, a single call loads and serializes gigabytes and blocks the event loop for tens of seconds — so the managed-agent page (which polls this endpoint) can no longer refresh, and every concurrent request waits behind it.

## Fix

- **browse**: clear `agent_jobs.result` once the listing has been consumed into the cache (guarded in `finally`; the 202 "still pending" path keeps it so the next poll can still read it).
- **agent-jobs list**: never load or serialize `result` — SQLAlchemy `defer(AgentJob.result)` plus a result-less `AgentJobSummaryResponse` — and bound the row count with a `limit` query param (default 200, max 1000). The list view only needs metadata; a single-job fetch still carries the result.
- **migration**: clear `result` for existing `repository.list_archive_contents` jobs and VACUUM to return the freed space to the filesystem (startup-only, best-effort).

## Tests

- `_drop_agent_job_result` nulls a persisted listing.
- The job list omits `result` and honours `limit`.
- Existing browse tests (queue/poll/202/resume) still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent job listings now support a bounded `limit` (newest-first).
  * Agent job listings return metadata only, omitting the large result payload.
* **Bug Fixes**
  * Browse returns HTTP 202 with a job ID while agent results are still pending.
  * After browse results are consumed, stored results are cleared to reduce payload retention (including for previously persisted cached listings via an SQLite-safe migration).
* **Tests**
  * Added/expanded unit tests for result clearing, listing shape, newest-first ordering, and `limit` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
