### PR TITLE
fix(reaper): reap orphaned pending maintenance jobs that block a repository

### DIFF
--- a/app/core/borg_router.py
+++ b/app/core/borg_router.py
@@ -17,6 +17,48 @@ from typing import List, Optional
 logger = structlog.get_logger()
 
 
+def _fail_orphaned_maintenance_job(
+    db: Session, maintenance_kind: str, maintenance_job_id: int
+) -> None:
+    """Mark a maintenance ``*_job`` failed when its agent job could not be queued.
+
+    Without this the row stays 'pending' with no backing work and blocks the
+    repository via admission control until a reaper eventually clears it.
+    """
+    from datetime import datetime
+
+    from app.database.models import CheckJob, CompactJob, DeleteArchiveJob, PruneJob
+
+    models = {
+        "check": CheckJob,
+        "compact": CompactJob,
+        "prune": PruneJob,
+        "delete_archive": DeleteArchiveJob,
+    }
+    model = models.get(maintenance_kind)
+    if model is None:
+        return
+    try:
+        # The failed queue attempt (e.g. "database is locked") may have left this
+        # session's transaction unusable, which would make the query below raise
+        # and skip the update. Reset it first; the row was committed by the caller
+        # before dispatch, so the rollback cannot lose it.
+        db.rollback()
+        job = db.query(model).filter(model.id == maintenance_job_id).first()
+        if job is not None and job.status in ("pending", "running"):
+            job.status = "failed"
+            if hasattr(job, "error_message"):
+                job.error_message = (
+                    job.error_message
+                    or "agent job could not be queued (dispatch failed)"
+                )
+            if hasattr(job, "completed_at"):
+                job.completed_at = job.completed_at or datetime.utcnow()
+            db.commit()
+    except Exception:
+        db.rollback()
+
+
 class BorgRouter:
     def __init__(self, repo):
         self.repo = repo
@@ -488,14 +530,23 @@ class BorgRouter:
                 if system_settings and system_settings.backup_timeout
                 else settings.backup_timeout
             )
-            agent_job = queue_agent_repository_operation_job(
-                db,
-                repository,
-                job_kind=job_kind,
-                operation=operation,
-                maintenance_job_kind=maintenance_kind,
-                maintenance_job_id=maintenance_job_id,
-            )
+            try:
+                agent_job = queue_agent_repository_operation_job(
+                    db,
+                    repository,
+                    job_kind=job_kind,
+                    operation=operation,
+                    maintenance_job_kind=maintenance_kind,
+                    maintenance_job_id=maintenance_job_id,
+                )
+            except Exception:
+                # The maintenance *_job row was created by the caller before this
+                # runs. If we cannot even queue the agent job (e.g. database is
+                # locked), no agent job will ever update it -> it would stay
+                # 'pending' forever and block the repo via admission. Fail it
+                # closed so it never orphans, then propagate the error.
+                _fail_orphaned_maintenance_job(db, maintenance_kind, maintenance_job_id)
+                raise
             await dispatch_agent_job_best_effort(
                 db, agent_job, repository_id=repository.id
             )

--- a/app/services/agent_job_reaper.py
+++ b/app/services/agent_job_reaper.py
@@ -140,15 +140,22 @@ def reap_stale_agent_jobs(
 
 def _reap_once() -> int:
     """One reap pass with its own session (runs in a worker thread)."""
-    from app.utils.process_utils import reconcile_stale_backup_maintenance
+    from app.utils.process_utils import (
+        reconcile_orphaned_maintenance_jobs,
+        reconcile_stale_backup_maintenance,
+    )
 
     db = SessionLocal()
     try:
         reaped = reap_stale_agent_jobs(db)
-        # Also reconcile backup rows stuck in a running maintenance state whose
+        # Reconcile backup rows stuck in a running maintenance state whose
         # maintenance op died without writing a terminal status (startup-only
         # cleanup previously left these "running" until the next restart).
         reaped += reconcile_stale_backup_maintenance(db)
+        # Fail maintenance *_jobs left 'pending' with no agent job to run them
+        # (e.g. the agent job could not be queued under a db-lock) -- otherwise
+        # they block the repository via admission control forever.
+        reaped += reconcile_orphaned_maintenance_jobs(db)
         return reaped
     finally:
         db.close()

--- a/app/utils/process_utils.py
+++ b/app/utils/process_utils.py
@@ -9,16 +9,18 @@ from pathlib import Path
 from typing import Optional
 import structlog
 from datetime import datetime, timedelta
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import Session
 from app.config import settings
 from app.core.borg_router import BorgRouter
 from app.database.models import (
+    AgentJob,
     BackupPlanRun,
     BackupPlanRunRepository,
     CheckJob,
     CompactJob,
     BackupJob,
+    DeleteArchiveJob,
     PruneJob,
     RestoreCheckJob,
     RestoreJob,
@@ -288,6 +290,115 @@ def reconcile_stale_backup_maintenance(
 
     if reaped:
         db.commit()
+
+    return reaped
+
+
+# An agent maintenance job carries no backup_job_id, so a *_job is correlated to
+# its agent job via the payload's maintenance_job {kind, id}.
+_ACTIVE_AGENT_STATUSES = ("queued", "claimed", "cancel_requested", "running")
+_ORPHAN_MAINTENANCE_MODELS = (
+    ("prune", PruneJob),
+    ("compact", CompactJob),
+    ("check", CheckJob),
+    ("delete_archive", DeleteArchiveJob),
+)
+
+
+def _has_active_agent_job_for(
+    db: Session, maintenance_kind: str, maintenance_job_id: int
+) -> bool:
+    """True if a live agent job exists for this maintenance ``*_job``."""
+    active = (
+        db.query(AgentJob)
+        .filter(
+            AgentJob.job_type == "repository",
+            AgentJob.status.in_(_ACTIVE_AGENT_STATUSES),
+        )
+        .all()
+    )
+    for agent_job in active:
+        payload = agent_job.payload if isinstance(agent_job.payload, dict) else {}
+        maintenance_job = (payload.get("operation") or {}).get("maintenance_job") or {}
+        if (
+            maintenance_job.get("kind") == maintenance_kind
+            and maintenance_job.get("id") == maintenance_job_id
+        ):
+            return True
+    return False
+
+
+def reconcile_orphaned_maintenance_jobs(
+    db: Session,
+    *,
+    now: Optional[datetime] = None,
+    reap_after: timedelta = MAINTENANCE_RECONCILE_AFTER,
+) -> int:
+    """Fail maintenance ``*_jobs`` left 'pending' with no agent job to run them.
+
+    The ``*_job`` row (PruneJob/CompactJob/CheckJob/DeleteArchiveJob) is created
+    before its agent job is queued; if the queue fails (e.g. ``database is
+    locked``) no agent job exists, so the row stays 'pending' forever and blocks
+    the repository via admission control. Reap old pending rows that have no
+    active agent job.
+
+    Only 'pending' is reaped here: 'running' rows are covered by the existing
+    process-liveness reapers, and a server-side maintenance op runs in-process
+    without an agent job (so absence of an agent job does not imply orphaned for
+    a running row). The age guard bounds a legitimately just-created row.
+    """
+    now = _strip_tz(now or datetime.utcnow())
+    cutoff = now - reap_after
+
+    reaped = 0
+    for kind, model in _ORPHAN_MAINTENANCE_MODELS:
+        candidates = (
+            db.query(model.id, model.created_at, model.repository_id)
+            .filter(model.status == "pending")
+            .all()
+        )
+        for job_id, created_at, repository_id in candidates:
+            if created_at is not None and _strip_tz(created_at) > cutoff:
+                continue  # too fresh; its agent job may be queued a moment later
+            if _has_active_agent_job_for(db, kind, job_id):
+                continue  # dispatched, waiting for the agent
+            # Fail closed with a guarded UPDATE: it only touches a row that is
+            # STILL 'pending', so a concurrent dispatch that has meanwhile moved
+            # it to 'running' is left untouched. A load-then-mutate would instead
+            # overwrite that live transition on commit. coalesce keeps any
+            # error_message/completed_at already set.
+            updated = (
+                db.query(model)
+                .filter(model.id == job_id, model.status == "pending")
+                .update(
+                    {
+                        model.status: "failed",
+                        model.error_message: func.coalesce(
+                            model.error_message,
+                            "orphaned: no agent job was queued for this maintenance",
+                        ),
+                        model.completed_at: func.coalesce(model.completed_at, now),
+                    },
+                    synchronize_session=False,
+                )
+            )
+            if not updated:
+                continue  # another transaction claimed the row first
+            # Re-check correlation now the row is claimed: an agent job could have
+            # been queued between the check above and this UPDATE (status was
+            # still 'pending' then). If so, preserve the dispatched job by
+            # reverting rather than committing a spurious 'failed'.
+            if _has_active_agent_job_for(db, kind, job_id):
+                db.rollback()
+                continue
+            db.commit()
+            reaped += 1
+            logger.info(
+                "Reaped orphaned pending maintenance job",
+                job_model=model.__name__,
+                job_id=job_id,
+                repository_id=repository_id,
+            )
 
     return reaped
 

--- a/tests/unit/test_borg_router.py
+++ b/tests/unit/test_borg_router.py
@@ -160,6 +160,93 @@ async def test_run_agent_maintenance_translates_http_errors_for_background_flows
     assert "check" in str(excinfo.value)
 
 
+@pytest.mark.parametrize(
+    "maintenance_kind, job_kind, model_name, extra",
+    [
+        ("prune", "repository.prune", "PruneJob", {}),
+        ("compact", "repository.compact", "CompactJob", {}),
+        ("check", "repository.check", "CheckJob", {}),
+        (
+            "delete_archive",
+            "repository.delete_archive",
+            "DeleteArchiveJob",
+            {"archive_name": "arch-1"},
+        ),
+    ],
+)
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_agent_maintenance_fails_the_job_when_queue_fails(
+    db_session, maintenance_kind, job_kind, model_name, extra
+):
+    # If the agent job cannot even be queued (e.g. database is locked), the
+    # already-created maintenance *_job must be failed closed so it does not
+    # orphan and block the repo via admission. A real "database is locked" dooms
+    # the session's transaction, so the fail-closed helper has to recover it and
+    # still persist 'failed' -- exercise the real helper against a real row, not
+    # a mock that would hide that defect. Parameterized across every maintenance
+    # kind so a wrong entry in the kind->model mapping cannot slip through.
+    from datetime import datetime
+
+    import app.database.models as models_mod
+    from app.database.models import PruneJob, Repository
+
+    model = getattr(models_mod, model_name)
+    repo_row = Repository(
+        name=f"Locked {model_name}",
+        path=f"/repos/locked-{maintenance_kind}",
+        encryption="none",
+        repository_type="local",
+    )
+    db_session.add(repo_row)
+    db_session.flush()
+    job = model(
+        repository_id=repo_row.id,
+        repository_path=repo_row.path,
+        status="pending",
+        created_at=datetime.utcnow(),
+        **extra,
+    )
+    db_session.add(job)
+    db_session.commit()
+    job_id = job.id
+
+    repo = SimpleNamespace(borg_version=2, id=repo_row.id, executor_type="agent")
+
+    def _doom_then_fail(*args, **kwargs):
+        # Emulate a "database is locked" style failure that dooms the session's
+        # transaction: a failed flush (here a NOT NULL violation, stand-in for a
+        # failed commit) leaves it requiring a rollback before any further query
+        # can run -- exactly the state the fail-closed helper must recover from.
+        try:
+            db_session.add(PruneJob(repository_path="/x", status="pending"))
+            db_session.flush()  # repository_id is NOT NULL -> IntegrityError
+        except Exception:
+            pass
+        raise RuntimeError("database is locked")
+
+    with (
+        patch("app.database.database.SessionLocal", return_value=db_session),
+        patch(
+            "app.services.repository_executor.queue_agent_repository_operation_job",
+            side_effect=_doom_then_fail,
+        ),
+        pytest.raises(RuntimeError, match="database is locked"),
+    ):
+        await BorgRouter(repo)._run_agent_maintenance(
+            job_kind=job_kind,
+            maintenance_kind=maintenance_kind,
+            maintenance_job_id=job_id,
+        )
+
+    # The real _fail_orphaned_maintenance_job ran despite the doomed transaction
+    # and persisted the failed state.
+    refreshed = db_session.query(model).get(job_id)
+    assert refreshed.status == "failed"
+    assert refreshed.completed_at is not None
+    assert refreshed.error_message
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_compact_delegates_to_agent_when_managed():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,7 @@
 import json
 from datetime import datetime, timezone
+
+import pytest
 from unittest.mock import patch, mock_open, MagicMock
 from app.utils.datetime_utils import serialize_datetime
 from app.utils.process_utils import (
@@ -8,17 +10,36 @@ from app.utils.process_utils import (
     cleanup_orphaned_jobs,
     cleanup_orphaned_mounts,
     reconcile_stale_backup_maintenance,
+    reconcile_orphaned_maintenance_jobs,
 )
 from app.database.models import (
+    AgentJob,
+    AgentMachine,
     BackupJob,
     BackupPlan,
     BackupPlanRun,
     BackupPlanRunRepository,
     CheckJob,
     CompactJob,
+    DeleteArchiveJob,
     PruneJob,
     Repository,
 )
+
+# (maintenance_kind, model, extra required kwargs, agent-payload job_kind) for the
+# four maintenance job types the reaper reconciles.
+_MAINTENANCE_CASES = [
+    ("prune", PruneJob, {}, "repository.prune"),
+    ("compact", CompactJob, {}, "repository.compact"),
+    ("check", CheckJob, {}, "repository.check"),
+    (
+        "delete_archive",
+        DeleteArchiveJob,
+        {"archive_name": "arch-1"},
+        "repository.delete_archive",
+    ),
+]
+from app.core.security import get_password_hash
 
 # ==========================================
 # Datetime Utils Tests
@@ -402,9 +423,9 @@ class TestProcessUtils:
         db_session.refresh(backup_job)
         assert backup_job.maintenance_status == "running_prune"
 
-    def test_reap_once_runs_agent_and_maintenance_reapers(self):
-        # The background loop must run BOTH the agent-job reaper and the new
-        # maintenance reconciler each tick.
+    def test_reap_once_runs_all_three_reaper_passes(self):
+        # The background loop must run the agent-job reaper, the maintenance
+        # status reconciler AND the orphaned-*_job reaper each tick.
         with (
             patch("app.services.agent_job_reaper.SessionLocal"),
             patch(
@@ -415,14 +436,206 @@ class TestProcessUtils:
                 "app.utils.process_utils.reconcile_stale_backup_maintenance",
                 return_value=3,
             ) as m_maint,
+            patch(
+                "app.utils.process_utils.reconcile_orphaned_maintenance_jobs",
+                return_value=1,
+            ) as m_orphan,
         ):
             from app.services.agent_job_reaper import _reap_once
 
             total = _reap_once()
 
-        assert total == 5
+        assert total == 6
         m_agent.assert_called_once()
         m_maint.assert_called_once()
+        m_orphan.assert_called_once()
+
+    @pytest.mark.parametrize("kind, model, extra, job_kind", _MAINTENANCE_CASES)
+    def test_reconcile_orphaned_reaps_old_pending_without_agent_job(
+        self, db_session, kind, model, extra, job_kind
+    ):
+        from datetime import timedelta
+
+        repo = Repository(
+            name=f"Orphan {kind} Repo",
+            path=f"/repos/orphan-{kind}",
+            encryption="none",
+            repository_type="local",
+        )
+        db_session.add(repo)
+        db_session.flush()
+        # pending maintenance job created long ago, no agent job was ever queued
+        job = model(
+            repository_id=repo.id,
+            repository_path=repo.path,
+            status="pending",
+            created_at=datetime.utcnow() - timedelta(minutes=10),
+            **extra,
+        )
+        db_session.add(job)
+        db_session.commit()
+
+        reaped = reconcile_orphaned_maintenance_jobs(db_session)
+
+        assert reaped == 1
+        db_session.refresh(job)
+        assert job.status == "failed"
+
+    @pytest.mark.parametrize("kind, model, extra, job_kind", _MAINTENANCE_CASES)
+    def test_reconcile_orphaned_preserves_pending_with_active_agent_job(
+        self, db_session, kind, model, extra, job_kind
+    ):
+        from datetime import timedelta
+
+        repo = Repository(
+            name=f"Dispatched {kind} Repo",
+            path=f"/repos/dispatched-{kind}",
+            encryption="none",
+            repository_type="local",
+        )
+        agent = AgentMachine(
+            name="Agent",
+            agent_id="agt_orphan_test",
+            token_hash=get_password_hash("secret"),
+            token_prefix="secret",
+            status="online",
+        )
+        db_session.add_all([repo, agent])
+        db_session.flush()
+        job = model(
+            repository_id=repo.id,
+            repository_path=repo.path,
+            status="pending",
+            created_at=datetime.utcnow() - timedelta(minutes=10),
+            **extra,
+        )
+        db_session.add(job)
+        db_session.flush()
+        # a live agent job IS queued for this maintenance job -> must be preserved
+        db_session.add(
+            AgentJob(
+                agent_machine_id=agent.id,
+                job_type="repository",
+                status="queued",
+                payload={
+                    "job_kind": job_kind,
+                    "operation": {
+                        "maintenance_job": {"kind": kind, "id": job.id},
+                    },
+                },
+            )
+        )
+        db_session.commit()
+
+        reaped = reconcile_orphaned_maintenance_jobs(db_session)
+
+        assert reaped == 0
+        db_session.refresh(job)
+        assert job.status == "pending"
+
+    def test_reconcile_orphaned_preserves_row_that_turns_running_mid_reap(
+        self, db_session
+    ):
+        from datetime import timedelta
+        from unittest.mock import patch
+
+        repo = Repository(
+            name="Racing Prune Repo",
+            path="/repos/racing-prune",
+            encryption="none",
+            repository_type="local",
+        )
+        db_session.add(repo)
+        db_session.flush()
+        prune = PruneJob(
+            repository_id=repo.id,
+            repository_path=repo.path,
+            status="pending",
+            created_at=datetime.utcnow() - timedelta(minutes=10),
+        )
+        db_session.add(prune)
+        db_session.commit()
+
+        # Simulate a concurrent dispatch that flips the row to 'running' after it
+        # is selected as a candidate but before the guarded UPDATE. The
+        # correlation check still reports no active agent job, so only the
+        # WHERE status == 'pending' guard can prevent a spurious 'failed'.
+        def _flip_to_running(db, kind, job_id):
+            db.query(PruneJob).filter(PruneJob.id == job_id).update(
+                {PruneJob.status: "running"}, synchronize_session=False
+            )
+            db.commit()
+            return False
+
+        with patch(
+            "app.utils.process_utils._has_active_agent_job_for",
+            side_effect=_flip_to_running,
+        ):
+            reaped = reconcile_orphaned_maintenance_jobs(db_session)
+
+        assert reaped == 0
+        db_session.refresh(prune)
+        assert prune.status == "running"
+
+    def test_reconcile_orphaned_preserves_when_correlation_appears_after_update(
+        self, db_session
+    ):
+        from datetime import timedelta
+        from unittest.mock import patch
+
+        repo = Repository(
+            name="Late Dispatch Repo",
+            path="/repos/late-dispatch",
+            encryption="none",
+            repository_type="local",
+        )
+        db_session.add(repo)
+        db_session.flush()
+        prune = PruneJob(
+            repository_id=repo.id,
+            repository_path=repo.path,
+            status="pending",
+            created_at=datetime.utcnow() - timedelta(minutes=10),
+        )
+        db_session.add(prune)
+        db_session.commit()
+
+        # No agent job at candidate-selection time (first call -> False), but one
+        # appears before the re-check after the guarded UPDATE (second call ->
+        # True). The row must be rolled back to 'pending', not reaped.
+        with patch(
+            "app.utils.process_utils._has_active_agent_job_for",
+            side_effect=[False, True],
+        ):
+            reaped = reconcile_orphaned_maintenance_jobs(db_session)
+
+        assert reaped == 0
+        db_session.refresh(prune)
+        assert prune.status == "pending"
+
+    def test_reconcile_orphaned_skips_fresh_pending(self, db_session):
+        repo = Repository(
+            name="Fresh Orphan Repo",
+            path="/repos/fresh-orphan",
+            encryption="none",
+            repository_type="local",
+        )
+        db_session.add(repo)
+        db_session.flush()
+        prune = PruneJob(
+            repository_id=repo.id,
+            repository_path=repo.path,
+            status="pending",
+            created_at=datetime.utcnow(),  # just created -> under age threshold
+        )
+        db_session.add(prune)
+        db_session.commit()
+
+        reaped = reconcile_orphaned_maintenance_jobs(db_session)
+
+        assert reaped == 0
+        db_session.refresh(prune)
+        assert prune.status == "pending"
 
     @patch("app.utils.process_utils.is_process_alive", return_value=True)
     def test_cleanup_orphaned_jobs_preserves_running_check_with_live_child_process(


### PR DESCRIPTION
## Problem

A repository can be blocked forever by an orphaned maintenance job. The plan/maintenance flow creates a `PruneJob`/`CompactJob`/`CheckJob`/`DeleteArchiveJob` row and *then* queues the agent job for it. Two ways this leaves a permanently-`pending` row that no agent job will ever update:

1. **Queue failure after commit** — if queuing raises (e.g. `database is locked` under a concurrent multi-repo plan run), the `*_job` row is already committed but the agent job never gets created.
2. **Pre-existing stuck rows** — a crash between creating the row and queuing, or rows already stuck from an earlier version.

Admission control counts a `pending` maintenance job as active write work, so the repository stays blocked indefinitely. Verified live: `prune_jobs` stuck at 129 on one install.

## Change

Two layers — remove the root cause, then add a safety net.

**Fail-closed dispatch** (`_run_agent_maintenance`): wrap the queue call so that on *any* failure the linked `*_job` is marked `failed` (`_fail_orphaned_maintenance_job`) before the error propagates. The row can no longer be left `pending` with no agent job.

**Reaper reconciliation** (`reconcile_orphaned_maintenance_jobs`, run as a third pass in the reaper loop): fail a `*_job` that is `pending`, older than the existing 5-minute age guard, and has no active agent job. The agent job is correlated via the agent payload's `maintenance_job {kind, id}` (repository agent jobs carry no `backup_job_id`). Only `pending` is reaped — `running` rows are already covered by the existing process-liveness reapers, and server-side maintenance runs in-process without an agent job at all.

## Tests

- `tests/unit/test_borg_router.py` — dispatch failure marks the maintenance job failed instead of leaking a `pending` row.
- `tests/unit/test_utils.py` — reaper reconciles an orphaned `pending` maintenance job past the age guard and leaves `running`/correlated ones untouched.

Backend-only; no frontend or migration changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented maintenance tasks from getting stuck as pending when agent queuing fails.
  * Added automatic reconciliation to fail orphaned, aged maintenance tasks that no longer have active agent work.
  * Preserved maintenance tasks that are still associated with active/queued agent operations.
* **Reliability**
  * Enhanced background reaping to include orphaned maintenance cleanup in each cycle.
  * Improved failed-job reporting with error details and completion timestamps when available.
* **Tests**
  * Added unit and database-backed coverage for queue failures, orphaned tasks, active associations, race handling, and age-threshold skipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->