### PR TITLE
fix(migrations): preserve the primary-key form when migration 126 rebuilds hook tables

### DIFF
--- a/app/database/migrations/126_add_agent_script_to_plan_hooks.py
+++ b/app/database/migrations/126_add_agent_script_to_plan_hooks.py
@@ -9,7 +9,9 @@ Purely additive: existing rows keep their ``script_id``; ``agent_script_name`` i
 NULL for every current hook. SQLite cannot ALTER a column's nullability in place,
 so ``script_id`` is relaxed with the established table-recreation pattern
 (see migration 067). The rebuild is PRAGMA-driven so it preserves columns added
-by later migrations, foreign keys (with their ON DELETE actions) and indexes.
+by later migrations, foreign keys (with their ON DELETE actions), indexes and
+whether the primary key is AUTOINCREMENT -- ``script_executions`` is declared
+that way (migration 027), ``backup_plan_scripts`` is not (migration 118).
 
 Idempotent: adding the column is guarded on its presence, and the rebuild is
 skipped once ``script_id`` is already nullable.
@@ -40,6 +42,20 @@ def _script_id_is_notnull(connection, table):
     return False
 
 
+def _uses_autoincrement(connection, table):
+    """Whether ``table``'s primary key is declared AUTOINCREMENT.
+
+    PRAGMA table_info does not report it, so the stored DDL is inspected. SQLite
+    permits AUTOINCREMENT on a single INTEGER PRIMARY KEY only, so matching the
+    keyword against the table's DDL is unambiguous.
+    """
+    row = connection.execute(
+        text("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = :table"),
+        {"table": table},
+    ).fetchone()
+    return bool(row and row[0] and "AUTOINCREMENT" in row[0].upper())
+
+
 def _relax_script_id_notnull(connection, table, *, extra_unique=None):
     """Recreate ``table`` with ``script_id`` nullable, preserving everything else."""
     if not _has_table(connection, table) or not _script_id_is_notnull(
@@ -48,11 +64,15 @@ def _relax_script_id_notnull(connection, table, *, extra_unique=None):
         return
 
     col_rows = _columns(connection, table)
+    autoincrement = _uses_autoincrement(connection, table)
 
     col_defs = []
     for _cid, name, type_, notnull, dflt_value, pk in col_rows:
         if pk:
-            col_defs.append(f"    {name} {type_} PRIMARY KEY AUTOINCREMENT")
+            pk_def = f"    {name} {type_} PRIMARY KEY"
+            if autoincrement:
+                pk_def += " AUTOINCREMENT"
+            col_defs.append(pk_def)
             continue
         parts = [f"    {name}", type_ or ""]
         if notnull and name != "script_id":  # relax script_id only


### PR DESCRIPTION
## Problem

Migration 126 (`add_agent_script_to_plan_hooks`) relaxes `script_id` to nullable using the established table-recreation pattern. When it rebuilds `backup_plan_scripts` and `script_executions`, it emits the primary key with a **hardcoded** `PRIMARY KEY AUTOINCREMENT`.

That silently overrides migration 118, which deliberately declares `backup_plan_scripts` *without* `AUTOINCREMENT`. So any install that already has `backup_plan_scripts` (a 118-era table with `script_id NOT NULL`) and then runs 126 ends up with an `AUTOINCREMENT` primary key the schema never intended — a `sqlite_sequence` row and rowid-reuse suppression that migration 118 explicitly avoided.

(A fresh install is unaffected: `create_all` builds `script_id` nullable, so 126 early-returns and never rebuilds. The drift only appears on the upgrade path — every existing install with backup plans passes through it.)

## Change

Read the AUTOINCREMENT declaration from the stored DDL instead of hardcoding it, so the rebuild preserves what each table was actually created with:

- `script_executions` — declared `AUTOINCREMENT` in migration 027 → preserved.
- `backup_plan_scripts` — declared without it in migration 118 → no longer forced on.

New helper `_uses_autoincrement(connection, table)` inspects `sqlite_master.sql` (PRAGMA `table_info` doesn't report AUTOINCREMENT). SQLite permits `AUTOINCREMENT` only on a single `INTEGER PRIMARY KEY`, so matching the keyword against the stored DDL is unambiguous. The rebuild then appends `AUTOINCREMENT` only when the original table had it.

Purely a correctness fix to the rebuild — no schema change beyond restoring the intended primary-key form, and still idempotent (skipped once `script_id` is nullable).

## Tests

The repository has no migration-level unit test harness, so this follows the existing convention (no dedicated test). Verified by hand: on a 118-era `backup_plan_scripts`, the rebuilt table no longer carries `AUTOINCREMENT`; on `script_executions` it is preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backup-plan hooks can now use scripts published by agents.
  * Script executions can be associated with an agent-published script name.

* **Bug Fixes**
  * Existing backup-plan script records are preserved during schema updates.
  * Database upgrades are safer to rerun and avoid disrupting existing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->