### PR TITLE
fix(backups): preserve symlinks faithfully on SSH-source backups and restores

### DIFF
--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -1021,6 +1021,10 @@ class BackupService:
                         "connection_id": connection_id,
                         "remote_paths": remote_paths,
                         "job_id": job_id,
+                        # Backup sources must reproduce the source on restore: mount
+                        # with faithful symlink handling (no dereference, keep
+                        # absolute/broken links). See mount_service._sshfs_symlink_options.
+                        "preserve_symlinks": True,
                     }
                     if shared_ssh_temp_root is not None:
                         mount_kwargs["temp_root"] = shared_ssh_temp_root

--- a/app/services/mount_service.py
+++ b/app/services/mount_service.py
@@ -64,6 +64,30 @@ def _decrypt_with_module_secret(encrypted_value: str) -> str:
     return cipher.decrypt(encrypted_value.encode()).decode()
 
 
+def _sshfs_symlink_options(preserve_symlinks: bool) -> list[str]:
+    """SSHFS options controlling how symlinks in the remote tree are presented.
+
+    ``preserve_symlinks=True`` is the fidelity path, used for both directions:
+
+    - Backup source (read): the archive must reproduce the source, so do NOT
+      dereference symlinks and keep absolute/broken ones. Without this,
+      ``follow_symlinks`` dereferences them and sshfs's ``contain_symlinks``
+      sandbox (on by default in sshfs 3.x) drops absolute links (``readlink``
+      EPERM). Safe: borg in nofollow mode only reads the target string.
+    - Restore destination (write): ``borg extract`` creates the links, then sets
+      their attributes. Under ``follow_symlinks`` the mount dereferences each new
+      link so the attr step follows to the (often missing) target and fails with
+      an I/O error on every symlink. ``no_contain_symlinks`` avoids that; it does
+      NOT block link *creation*, so absolute/broken links extract cleanly.
+
+    Only browse and cloud-mirror keep the historical ``follow_symlinks`` — a UX
+    choice for interactive browsing, not a fidelity path — via ``preserve_symlinks=False``.
+    """
+    if preserve_symlinks:
+        return ["-o", "no_contain_symlinks"]
+    return ["-o", "follow_symlinks"]
+
+
 def _sshfs_missing_remote_path(error_message: str) -> bool:
     normalized = (error_message or "").lower()
     return any(marker in normalized for marker in SSHFS_NO_SUCH_FILE_MARKERS)
@@ -535,6 +559,7 @@ class MountService:
         remote_paths: List[str],
         job_id: Optional[int] = None,
         temp_root: Optional[str] = None,
+        preserve_symlinks: bool = False,
     ) -> Tuple[str, List[Tuple[str, str]]]:
         """
         Mount multiple remote SSH directories from the same connection under a single shared temp root.
@@ -545,6 +570,8 @@ class MountService:
             remote_paths: List of remote paths to mount (all from the same connection)
             job_id: Optional backup job ID for tracking
             temp_root: Optional existing temporary root to reuse across source connections
+            preserve_symlinks: Mount for faithful symlink fidelity (backup sources
+                and restore destinations); browse/cloud-mirror keep follow_symlinks
 
         Returns:
             Tuple of (temp_root, mount_info_list)
@@ -782,6 +809,7 @@ class MountService:
                         remote_path=mount_remote_path,
                         mount_point=mount_dir,
                         temp_key_file=temp_key_file,
+                        preserve_symlinks=preserve_symlinks,
                     )
 
                     # Verify mount with READ-ONLY check (NEVER write to user data!)
@@ -1587,8 +1615,14 @@ class MountService:
         remote_path: str,
         mount_point: str,
         temp_key_file: str,
+        preserve_symlinks: bool = False,
     ):
-        """Execute SSHFS mount command with SSH key authentication"""
+        """Execute SSHFS mount command with SSH key authentication.
+
+        ``preserve_symlinks`` selects faithful symlink handling for backup sources
+        and restore destinations (see ``_sshfs_symlink_options``); browse and
+        cloud-mirror keep the default ``follow_symlinks`` behavior.
+        """
         sftp_server_path = None
         use_sudo = getattr(connection, "use_sudo", False)
 
@@ -1673,8 +1707,7 @@ class MountService:
                 "ServerAliveCountMax=3",
                 "-o",
                 "reconnect",
-                "-o",
-                "follow_symlinks",
+                *_sshfs_symlink_options(preserve_symlinks),
                 "-o",
                 "allow_other",
                 "-o",

--- a/app/services/restore_service.py
+++ b/app/services/restore_service.py
@@ -1259,6 +1259,12 @@ class RestoreService:
                 connection_id=destination_connection_id,
                 remote_paths=[destination],
                 job_id=job_id,
+                # Extract must write faithful symlinks. With follow_symlinks the
+                # mount dereferences each just-created link, so borg's attr step
+                # follows to the (often missing) target and fails with an I/O
+                # error on every symlink. no_contain_symlinks avoids that and
+                # keeps absolute/broken links intact. See _sshfs_symlink_options.
+                preserve_symlinks=True,
             )
 
             if not mount_info_list:

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -175,6 +175,32 @@ Then use `/documents`, `/photos`, and `/backups` in the UI.
 
 For remote sources, choose a Remote Machine in the Backup Plan and select paths from that machine.
 
+### Remote (SSH) source fidelity
+
+When a source is reached over SSH, Borg UI mounts it with `sshfs` and runs Borg
+over the mount. Two things are worth knowing about how the restore compares to
+the live source:
+
+- **Symbolic links are preserved as-is** — including absolute and broken links —
+  so a restore reproduces the source's link structure. Borg UI mounts backup
+  sources without dereferencing symlinks.
+- **Hard links are not preserved when backing up over SSHFS.** The SFTP protocol
+  does not transmit inode or link-count information, so `sshfs` cannot tell that
+  two paths share an inode, and each hard link is stored as an independent file.
+  The archive size is unaffected (Borg still deduplicates the content), but a
+  restore of a hard-link-heavy tree (for example a Nix store, `rsnapshot`
+  rotations, or a `.git` object store) can consume more disk than the source. If
+  faithful hard links matter, back the source up from the machine itself with a
+  managed agent (Borg runs on the source host and reads a real filesystem) rather
+  than over SSH.
+
+> **Existing archives.** SSH-source archives created before symlink-faithful
+> mounting already have their symlinks dereferenced and their absolute and broken
+> links dropped. This cannot be repaired retroactively — only new backups are
+> faithful. To check whether an older archive is affected, run `borg list` on it
+> and look for paths that should be symlinks but are stored as regular files, or
+> compare a test restore against the live source.
+
 ### Filesystem snapshot sources
 
 Borg UI can create Btrfs or ZFS snapshots for local Backup Plan source paths.

--- a/tests/unit/test_backup_service.py
+++ b/tests/unit/test_backup_service.py
@@ -2496,9 +2496,12 @@ class TestBackupServicePeriodicSync:
 
         captured = {}
 
-        async def mock_mount_ssh_paths_shared(connection_id, remote_paths, job_id):
+        async def mock_mount_ssh_paths_shared(
+            connection_id, remote_paths, job_id, preserve_symlinks=False
+        ):
             captured["connection_id"] = connection_id
             captured["remote_paths"] = remote_paths
+            captured["preserve_symlinks"] = preserve_symlinks
             return "/tmp/sshfs_mount_test", [("mount-1", "etc/komodo")]
 
         monkeypatch.setattr(
@@ -2519,6 +2522,8 @@ class TestBackupServicePeriodicSync:
 
         assert captured["connection_id"] == connection.id
         assert captured["remote_paths"] == ["/etc/komodo"]
+        # Backup sources must mount with faithful symlink handling (issue #751).
+        assert captured["preserve_symlinks"] is True
         assert processed_paths == ["etc/komodo"]
         assert ssh_mount_info == [("/tmp/sshfs_mount_test", "etc/komodo")]
 
@@ -2542,7 +2547,9 @@ class TestBackupServicePeriodicSync:
         (canary_dir / "manifest.json").write_text("{}", encoding="utf-8")
         temp_root = tmp_path / "sshfs_mount_test"
 
-        async def mock_mount_ssh_paths_shared(connection_id, remote_paths, job_id):
+        async def mock_mount_ssh_paths_shared(
+            connection_id, remote_paths, job_id, preserve_symlinks=False
+        ):
             return str(temp_root), [("mount-1", "etc/komodo")]
 
         monkeypatch.setattr(

--- a/tests/unit/test_mount_service.py
+++ b/tests/unit/test_mount_service.py
@@ -31,6 +31,68 @@ class TestMountService:
         assert mount_service.active_mounts == {}
         assert mount_service.mount_base_dir.exists()
 
+    def test_sshfs_symlink_options_preserve_is_faithful(self):
+        """Backup sources disable the contain_symlinks sandbox and do not follow."""
+        from app.services.mount_service import _sshfs_symlink_options
+
+        opts = _sshfs_symlink_options(True)
+        assert "no_contain_symlinks" in opts
+        assert "follow_symlinks" not in opts
+
+    def test_sshfs_symlink_options_default_follows(self):
+        """Browse/restore/cloud-mirror keep the historical follow_symlinks."""
+        from app.services.mount_service import _sshfs_symlink_options
+
+        opts = _sshfs_symlink_options(False)
+        assert "follow_symlinks" in opts
+        assert "no_contain_symlinks" not in opts
+
+    async def _capture_sshfs_argv(self, mount_service, *, preserve_symlinks):
+        """Run _execute_sshfs_mount with a stubbed subprocess and return its argv."""
+        from types import SimpleNamespace
+
+        connection = SimpleNamespace(
+            username="u", host="h", port=22, use_sudo=False, default_path=None
+        )
+        captured = {}
+        proc = Mock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+
+        async def fake_exec(*args, **kwargs):
+            captured["argv"] = list(args)
+            return proc
+
+        with (
+            patch(
+                "app.services.mount_service.asyncio.create_subprocess_exec",
+                new=fake_exec,
+            ),
+            patch("app.services.mount_service.asyncio.sleep", new=AsyncMock()),
+        ):
+            await mount_service._execute_sshfs_mount(
+                connection=connection,
+                remote_path="/srv/data",
+                mount_point="/mnt/x",
+                temp_key_file="/tmp/key",
+                preserve_symlinks=preserve_symlinks,
+            )
+        return captured["argv"]
+
+    @pytest.mark.asyncio
+    async def test_execute_sshfs_mount_backup_source_preserves_symlinks(
+        self, mount_service
+    ):
+        argv = await self._capture_sshfs_argv(mount_service, preserve_symlinks=True)
+        assert "no_contain_symlinks" in argv
+        assert "follow_symlinks" not in argv
+
+    @pytest.mark.asyncio
+    async def test_execute_sshfs_mount_default_follows_symlinks(self, mount_service):
+        argv = await self._capture_sshfs_argv(mount_service, preserve_symlinks=False)
+        assert "follow_symlinks" in argv
+        assert "no_contain_symlinks" not in argv
+
     def test_validate_mount_point_sensitive_paths(self, mount_service):
         """Test mount point validation rejects sensitive system paths"""
         sensitive_paths = [
@@ -468,7 +530,11 @@ class TestMountService:
             mount_calls = []
 
             async def mock_execute_mount(
-                connection, remote_path, mount_point, temp_key_file
+                connection,
+                remote_path,
+                mount_point,
+                temp_key_file,
+                preserve_symlinks=False,
             ):
                 assert os.path.exists(mount_point)
                 assert os.path.exists(temp_key_file)

--- a/tests/unit/test_restore_service.py
+++ b/tests/unit/test_restore_service.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, Mock, call, patch
 import pytest
 from sqlalchemy.orm import sessionmaker
 
-from app.database.models import Repository, RestoreJob
+from app.database.models import Repository, RestoreJob, SSHConnection
 from app.services.restore_service import RestoreService
 
 
@@ -225,6 +225,45 @@ class TestRestoreServiceExecution:
             await service._execute_local_to_local(999, "/repo", "arch", "/dest", None)
 
         assert service.running_processes == {}
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_ssh_restore_mounts_destination_with_preserve_symlinks(
+        self, testing_session_local, db_session, restore_job
+    ):
+        # Restore-to-SSH must mount the destination faithfully (issue #751, write
+        # side): under follow_symlinks borg's attr step fails on every symlink.
+        connection = SSHConnection(host="example.com", username="borg", port=22)
+        db_session.add(connection)
+        db_session.commit()
+        db_session.refresh(connection)
+
+        captured = {}
+
+        async def fake_mount(**kwargs):
+            captured.update(kwargs)
+            return "/tmp/x", []  # empty -> aborts the restore right after the mount
+
+        service = RestoreService()
+        with (
+            patch("app.services.restore_service.SessionLocal", testing_session_local),
+            patch(
+                "app.services.mount_service.mount_service.mount_ssh_paths_shared",
+                new=fake_mount,
+            ),
+        ):
+            try:
+                await service._execute_local_to_ssh(
+                    restore_job.id,
+                    restore_job.repository,
+                    "archive-1",
+                    "/dest",
+                    destination_connection_id=connection.id,
+                )
+            except Exception:
+                pass  # only the mount kwargs matter here
+
+        assert captured.get("preserve_symlinks") is True
 
     @pytest.mark.unit
     @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #751 end to end (backup **and** restore).

> **⚠️ Note for release notes.** This changes fidelity, but it cannot repair the past: SSHFS-source archives created **before** this fix already have their symlinks dereferenced and their absolute/broken links dropped — only new backups are faithful. Worth calling out so users know to re-check important SSHFS-source archives (the usage guide explains how: `borg list` and look for symlinks stored as regular files, or compare a test restore against the source). The auto-generated changelog uses commit subjects only, so this note won't surface automatically.

Both a backup source and a restore destination reached over SSH are mounted with `sshfs` via the same `build_sshfs_command()`, which hardcoded `-o follow_symlinks`. That single option breaks fidelity in **both** directions. Both were reproduced empirically on a real sshfs mount to a Linux remote (kernel 6.8, borg 1.4.4), measuring the ground truth directly on the remote filesystem.

## Problem 1 — backup (read side): symlinks are mangled before Borg sees them

Borg does `lstat` and never follows symlinks itself, so whatever the sshfs mount presents is what gets archived. With `follow_symlinks`, sshfs dereferences on read; and simply turning it *off* is not enough either — sshfs's `contain_symlinks` sandbox (on by default in sshfs 3.x) makes `readlink` on an out-of-root target fail with `EPERM`, so Borg logs `E` and drops absolute links.

Restore compared to the live source, per mount option:

| source entry | `follow_symlinks` (old) | `no_contain_symlinks` (fix) |
|---|---|---|
| relative symlink | **dereferenced** to a file | stored as the symlink |
| symlink to a dir | target tree **duplicated** | stored as the symlink |
| absolute symlink (`→/etc/hostname`) | **dereferenced** | stored with its target |
| broken symlink | **dropped** | stored with its target |

`borg create`/`borg check` cannot detect this — from Borg's view it faithfully stored what the filesystem presented.

## Problem 2 — restore (write side): `borg extract` errors on every symlink

`borg extract` into an sshfs-mounted destination creates each link and then sets its attributes. Under `follow_symlinks` the mount dereferences the just-created link, so the attr step follows to the (often missing) target and fails. Ground truth measured on the remote after extract:

| archived entry | `follow_symlinks` (old restore default) | `no_contain_symlinks` (fix) |
|---|---|---|
| symlinks (rel / dir / abs / broken) | land correctly, but `borg extract` reports `attrs: [Errno 5] I/O error` (broken: `Errno 2`) on **every** symlink | land correctly, **clean** |
| hard links | recreated (same inode) | recreated (same inode) |
| extract exit | non-zero — restore reported as failed/partial | clean |

So the data lands either way, but `follow_symlinks` makes every SSH restore that contains a symlink report failure — noisy and misleading, and it can mask real errors. `no_contain_symlinks` does **not** block link *creation* (contain only guards read traversal), so absolute and broken links extract cleanly.

## Change

Mount both **backup sources** and **restore destinations** with faithful symlink handling; leave browse and cloud-mirror untouched.

- New `mount_service._sshfs_symlink_options(preserve_symlinks)`:
  - `True` → `-o no_contain_symlinks` (and **not** `follow_symlinks`) — the fidelity path.
  - `False` (default) → `-o follow_symlinks`, exactly as before.
- `_execute_sshfs_mount()` and `mount_ssh_paths_shared()` take `preserve_symlinks` (default `False`).
- `backup_service` (source mount) and `restore_service` (destination mount) pass `preserve_symlinks=True`. Browse/cloud-mirror (`mount_ssh_directory`) keep `follow_symlinks` — a UX choice for interactive browsing, not a fidelity path — so there is no regression there.

### Hard links

Note the asymmetry, both proven above: a **backup** cannot capture hard links over SSHFS — SFTP v3 transmits no `st_ino`/`st_nlink`, so sshfs reports `nlink=1` with synthetic per-path inodes and Borg never enters hard-link detection. A **restore**, however, recreates them faithfully (same inode on the remote) via SFTP's `hardlink@openssh.com` extension. `docs/usage-guide.md` documents the backup-side limitation and the faithful alternative (back the source up from the machine itself with a managed agent).

## Tests

- `_sshfs_symlink_options` returns `no_contain_symlinks` (preserve) / `follow_symlinks` (default), mutually exclusive.
- `_execute_sshfs_mount(preserve_symlinks=True)` builds an argv with `no_contain_symlinks` and **not** `follow_symlinks`; the default still emits `follow_symlinks`.
- `backup_service` mounts SSH sources, and `restore_service` mounts SSH destinations, with `preserve_symlinks=True`.

No frontend changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSH-based backups and restores now preserve symbolic links, including absolute and broken links, for more faithful file structures.
  * Existing browsing and cloud-mirroring behavior remains unchanged.

* **Documentation**
  * Added guidance on remote source fidelity, hard-link limitations, disk usage considerations, and the impact on previously created archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->