### PR TITLE
feat(agent): Let an unprivileged managed agent back up the whole machine

### DIFF
--- a/app/api/agent_installer.py
+++ b/app/api/agent_installer.py
@@ -366,6 +366,27 @@ else
     --name "${AGENT_NAME}"
 fi
 
+# Backing up a whole machine means reading files the service user does not own.
+# Without this, only --service-user root can produce a complete backup, and any
+# operator wanting one is pushed to running the agent as root.
+#
+# CAP_DAC_READ_SEARCH grants exactly what a backup needs — read any file — and
+# nothing else: no writing, no chown, no command execution. It inherits to the
+# Borg child process, is scoped to this service rather than to a binary anyone
+# can execute, and is compatible with NoNewPrivileges, so the unit keeps its
+# hardened baseline.
+#
+# Restoring to paths the service user cannot write needs more than this and is
+# deliberately not granted.
+#
+# A root service already holds every capability, and a bounding set there would
+# restrict it rather than extend it, so the block is left out in that case.
+SERVICE_CAPABILITIES=""
+if [[ "${SERVICE_USER}" != "root" ]]; then
+  SERVICE_CAPABILITIES="AmbientCapabilities=CAP_DAC_READ_SEARCH
+CapabilityBoundingSet=CAP_DAC_READ_SEARCH"
+fi
+
 cat >/etc/systemd/system/borg-ui-agent.service <<SERVICE
 [Unit]
 Description=Borg UI managed agent
@@ -383,6 +404,7 @@ WorkingDirectory=${SERVICE_HOME}
 NoNewPrivileges=true
 PrivateTmp=true
 ReadWritePaths=${SERVICE_READ_WRITE_PATHS}
+${SERVICE_CAPABILITIES}
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/unit/test_agent_installer_api.py
+++ b/tests/unit/test_agent_installer_api.py
@@ -126,6 +126,31 @@ def test_agent_installer_script_prepares_config_for_selected_service_user(
     assert "chmod 0600 /etc/borg-ui-agent/config.toml" in response.text
 
 
+def test_agent_installer_grants_read_capability_to_non_root_service(
+    test_client: TestClient,
+):
+    """A non-root service cannot read files it does not own, so without this a
+    complete backup requires --service-user root."""
+    response = test_client.get("/agent/install.sh")
+
+    assert "AmbientCapabilities=CAP_DAC_READ_SEARCH" in response.text
+    assert "CapabilityBoundingSet=CAP_DAC_READ_SEARCH" in response.text
+    # The capability is compatible with the hardened baseline, which stays.
+    assert "NoNewPrivileges=true" in response.text
+    assert "${SERVICE_CAPABILITIES}" in response.text
+
+
+def test_agent_installer_omits_capabilities_for_a_root_service(
+    test_client: TestClient,
+):
+    """Root already holds every capability; a bounding set would only take
+    capabilities away from it."""
+    response = test_client.get("/agent/install.sh")
+
+    assert 'SERVICE_CAPABILITIES=""' in response.text
+    assert 'if [[ "${SERVICE_USER}" != "root" ]]; then' in response.text
+
+
 def test_agent_installer_script_allows_borg2_prereleases(test_client: TestClient):
     response = test_client.get("/agent/install.sh")
 


### PR DESCRIPTION
## The problem

A managed agent installed with `--service-user current` or `--service-user borg-ui-agent` runs as a normal user, and a normal user cannot read files it does not own. The backup does not fail — Borg writes the archive anyway, reports `dir_open: [Errno 13] Permission denied` for each path it could not read, and exits with a *warning* code (105 under Borg 2's modern exit codes, 1 under Borg 1's legacy ones).

The result is an archive that quietly misses whatever the service account cannot read. In practice this pushes anyone who wants a complete backup towards `--service-user root`, which makes the dedicated-user options in `2026-05-22-borg-installer-management.md` less useful than they look.

## The change

The generated unit grants a single capability to non-root service users:

```
AmbientCapabilities=CAP_DAC_READ_SEARCH
CapabilityBoundingSet=CAP_DAC_READ_SEARCH
```

`CAP_DAC_READ_SEARCH` is exactly "may read any file and traverse any directory" — and nothing else. No writing, no `chown`, no command execution. It inherits to the Borg child process, so `borg create` sees everything, and it is attached to the service rather than to a binary that any user on the machine could execute.

`NoNewPrivileges=true` stays set: ambient capabilities are compatible with it, so the unit keeps its hardened baseline.

For `--service-user root` the block is omitted. Root already holds every capability, and adding a bounding set there would *restrict* the service rather than extend it.

Restoring to paths the service user cannot write needs more than read access — write, `chown` — and is deliberately not granted here.

## Verification

Measured in both directions rather than assumed:

- **Without** the capability, an unprivileged Borg run over a directory it cannot read reports `dir_open: [Errno 13] Permission denied` and exits 105 (Borg 2), writing an archive that silently omits those paths.
- **With** it, a live agent running as an unprivileged user backed up `/etc`, `/home`, `/opt` and `/usr/local/bin` with rc 0 — nothing skipped for permissions.

Two unit tests cover the generated unit: that the capability is granted alongside `NoNewPrivileges`, and that it is omitted for a root service.

## Scope

47 added lines, nothing removed or changed. No new flags, no change to any existing default: an agent installed as root behaves exactly as before, and an agent installed as a normal user simply stops missing files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved full-machine backup support for installations running under a non-root service account.
  * Limited granted system privileges to read-only file access while preserving existing security protections.
  * Root-based installations continue to run without additional capability settings.

* **Tests**
  * Added coverage verifying capability configuration for both root and non-root installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->