### PR TITLE
fix(api): silence the FastAPI regex-deprecation warning on startup

### DIFF
--- a/app/routers/config.py
+++ b/app/routers/config.py
@@ -73,7 +73,7 @@ async def export_borgmatic_config(
 async def import_borgmatic_config(
     file: UploadFile = File(...),
     merge_strategy: str = Query(
-        "skip_duplicates", regex="^(skip_duplicates|replace|rename)$"
+        "skip_duplicates", pattern="^(skip_duplicates|replace|rename)$"
     ),
     dry_run: bool = Query(False),
     db: Session = Depends(get_db),


### PR DESCRIPTION
`Query(regex=...)` has been deprecated in favor of `pattern=` since FastAPI 0.100; the borgmatic-import route was the last caller and printed a `FastAPIDeprecationWarning` into every boot log:

```
/app/app/routers/config.py:75: FastAPIDeprecationWarning: `regex` has been deprecated, please use `pattern` instead
```

Same validation, new parameter name — a one-line change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated validation for the Borgmatic configuration import option while preserving the existing accepted values and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->