### PR TITLE
feat(agent): report borg warnings as warnings, not failures

### DIFF
--- a/agent/borg_ui_agent/backup.py
+++ b/agent/borg_ui_agent/backup.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
+from agent.borg_ui_agent.borg import is_warning_return_code
 from agent.borg_ui_agent.client import AgentClient
 
 
@@ -363,7 +364,10 @@ def execute_backup_create_job(
 
     return_code = process.wait()
     stdout_thread.join()
-    if return_code == 0:
+    if return_code == 0 or is_warning_return_code(return_code):
+        # Warnings (rc 1 / 100-127) still produced an archive: complete the
+        # job and let the server record completed_with_warnings from the
+        # return code, matching how server-side backups are classified.
         resolved_archive_name = (
             _parse_created_archive_name("".join(stdout_chunks)) or payload.archive_name
         )
@@ -377,7 +381,7 @@ def execute_backup_create_job(
         )
         return BackupExecutionResult(
             job_id=job_id,
-            status="completed",
+            status="completed" if return_code == 0 else "completed_with_warnings",
             return_code=return_code,
             message=f"borg create exited with code {return_code}",
         )

--- a/agent/borg_ui_agent/borg.py
+++ b/agent/borg_ui_agent/borg.py
@@ -93,3 +93,15 @@ def detect_borg_binaries(
         )
 
     return binaries
+
+
+def is_warning_return_code(return_code) -> bool:
+    """Borg's warning exit codes: legacy rc 1, modern range 100-127.
+
+    Warnings mean the operation ran to completion but something was worth
+    telling the operator (a file changed mid-read, a path was missing). They
+    are not failures, and the server records them as completed_with_warnings.
+    """
+    return isinstance(return_code, int) and (
+        return_code == 1 or 100 <= return_code <= 127
+    )

--- a/agent/borg_ui_agent/repository_ops.py
+++ b/agent/borg_ui_agent/repository_ops.py
@@ -21,6 +21,7 @@ from agent.borg_ui_agent.backup import (
     build_borg_env,
     parse_borg_progress,
 )
+from agent.borg_ui_agent.borg import is_warning_return_code
 from agent.borg_ui_agent.client import AgentClient
 
 
@@ -596,7 +597,10 @@ def _execute_short_repository_operation(
             job_id, sequence=2, stream="stderr", message=process.stderr.rstrip()
         )
 
-    if process.returncode == 0:
+    if process.returncode == 0 or is_warning_return_code(process.returncode):
+        # Warnings (rc 1 / 100-127) mean the operation ran through; the server
+        # records completed_with_warnings from the return code, matching the
+        # classification its own borg processes get.
         parsed = _parse_json_output(process.stdout)
         client.complete_job(
             job_id,
@@ -610,7 +614,9 @@ def _execute_short_repository_operation(
         )
         return RepositoryOperationResult(
             job_id=job_id,
-            status="completed",
+            status="completed"
+            if process.returncode == 0
+            else "completed_with_warnings",
             return_code=process.returncode,
             message=f"{payload.job_kind} exited with code {process.returncode}",
         )

--- a/app/api/agents.py
+++ b/app/api/agents.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
@@ -53,7 +54,26 @@ logger = structlog.get_logger()
 router = APIRouter(prefix="/api/agents", tags=["agents"])
 AGENT_SESSION_HELLO_TIMEOUT_SECONDS = 10.0
 
-FINAL_AGENT_JOB_STATUSES = {"completed", "failed", "canceled"}
+FINAL_AGENT_JOB_STATUSES = {
+    "completed",
+    "completed_with_warnings",
+    "failed",
+    "canceled",
+}
+
+
+def _is_borg_warning_return_code(return_code: Any) -> bool:
+    """Borg's warning exit codes: legacy rc 1, modern range 100-127.
+
+    Same classification the server-side services apply to their own borg
+    processes - the agent path finally speaks it too instead of collapsing
+    every non-zero exit into "failed".
+    """
+    return isinstance(return_code, int) and (
+        return_code == 1 or 100 <= return_code <= 127
+    )
+
+
 STALE_AGENT_JOB_REQUEUE_AFTER = timedelta(minutes=15)
 REPOSITORY_OPERATION_JOB_MODELS = {
     "check": CheckJob,
@@ -395,7 +415,7 @@ def _finish_linked_backup_job(
     backup_job.error_message = error_message
     backup_job.logs = _collect_agent_logs(agent_job, db)
     _sync_backup_progress(agent_job, backup_job)
-    if status_value == "completed":
+    if status_value in ("completed", "completed_with_warnings"):
         backup_job.progress = 100
         backup_job.progress_percent = 100.0
         archive_name = (agent_job.result or {}).get("archive_name")
@@ -461,7 +481,9 @@ def _finish_linked_repository_operation_job(
     operation_job.error_message = error_message
     operation_job.logs = _collect_agent_logs(agent_job, db)
     operation_job.has_logs = bool(operation_job.logs)
-    if status_value == "completed" and hasattr(operation_job, "progress"):
+    if status_value in ("completed", "completed_with_warnings") and hasattr(
+        operation_job, "progress"
+    ):
         operation_job.progress = 100
 
     repository = (
@@ -469,7 +491,7 @@ def _finish_linked_repository_operation_job(
         .filter(Repository.id == operation_job.repository_id)
         .first()
     )
-    if repository and status_value == "completed":
+    if repository and status_value in ("completed", "completed_with_warnings"):
         if isinstance(operation_job, CheckJob):
             repository.last_check = completed_at
         elif isinstance(operation_job, CompactJob):
@@ -575,15 +597,58 @@ def _complete_agent_job(
 ) -> None:
     if job.status in FINAL_AGENT_JOB_STATUSES:
         return
+    return_code = result.get("return_code") if isinstance(result, dict) else None
+    warning = _is_borg_warning_return_code(return_code)
+    if isinstance(return_code, int) and return_code != 0 and not warning:
+        # A completion report carrying an explicit borg *error* code is a
+        # failure, no matter which transport delivered it - the server is
+        # authoritative over the classification.
+        _fail_agent_job(
+            job,
+            db,
+            error_message=f"borg exited with code {return_code}",
+            return_code=return_code,
+            completed_at=completed_at,
+        )
+        return
+
     completed = _normalize_agent_timestamp(completed_at)
-    job.status = "completed"
+    status_value = "completed_with_warnings" if warning else "completed"
+    warning_message = (
+        json.dumps(
+            {
+                "key": "backend.errors.service.jobCompletedWithWarning",
+                "params": {"exitCode": return_code},
+            }
+        )
+        if warning
+        else None
+    )
+    job.status = status_value
     job.completed_at = completed
     job.result = result
-    job.error_message = None
+    job.error_message = warning_message
     job.updated_at = _now_utc()
-    _finish_linked_backup_job(job, db, status_value="completed", completed_at=completed)
+    _finish_linked_backup_job(
+        job,
+        db,
+        status_value=status_value,
+        completed_at=completed,
+        error_message=json.dumps(
+            {
+                "key": "backend.errors.service.backupCompletedWithWarning",
+                "params": {"exitCode": return_code},
+            }
+        )
+        if warning
+        else None,
+    )
     _finish_linked_repository_operation_job(
-        job, db, status_value="completed", completed_at=completed
+        job,
+        db,
+        status_value=status_value,
+        completed_at=completed,
+        error_message=warning_message,
     )
 
 
@@ -1211,23 +1276,10 @@ async def complete_job(
     if job.status in FINAL_AGENT_JOB_STATUSES:
         return AgentJobStatusResponse(id=job.id, status=job.status)
 
-    now = _now_utc()
-    job.status = "completed"
-    job.completed_at = _normalize_agent_timestamp(payload.completed_at)
-    job.result = payload.result
-    job.error_message = None
-    job.updated_at = now
-    _finish_linked_backup_job(
-        job,
-        db,
-        status_value="completed",
-        completed_at=job.completed_at,
-    )
-    _finish_linked_repository_operation_job(
-        job,
-        db,
-        status_value="completed",
-        completed_at=job.completed_at,
+    # Same path the WebSocket transport takes - one place decides how a
+    # completion (including borg warning exit codes) is classified.
+    _complete_agent_job(
+        job, db, result=payload.result, completed_at=payload.completed_at
     )
     db.commit()
 

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -5041,7 +5041,8 @@
         "restoreFailedZeroFilesPathNotFound": "Wiederherstellung fehlgeschlagen: 0 Dateien extrahiert (Exitcode {{exitCode}}). Pfad nicht im Archiv gefunden oder Ziel existiert nicht.",
         "restoreFailedZeroFilesNoOutput": "Wiederherstellung fehlgeschlagen: 0 Dateien extrahiert (Exitcode {{exitCode}}). Keine Fehlerausgabe von Borg. Dateien existieren möglicherweise nicht im Archiv oder der Zugriff wurde verweigert.",
         "restoreFailedExitCode": "Der Wiederherstellungsprozess wurde mit Code {{exitCode}} beendet",
-        "restoreFailed": "Wiederherstellung fehlgeschlagen"
+        "restoreFailed": "Wiederherstellung fehlgeschlagen",
+        "jobCompletedWithWarning": "Mit Warnung abgeschlossen (Exitcode {{exitCode}})"
       },
       "dashboard": {
         "failedGetSystemMetrics": "Fehler beim Abrufen der Systemmetriken",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -5041,7 +5041,8 @@
         "restoreFailedZeroFilesPathNotFound": "Restore failed: 0 files extracted (exit code {{exitCode}}). Path not found in archive or destination doesn't exist.",
         "restoreFailedZeroFilesNoOutput": "Restore failed: 0 files extracted (exit code {{exitCode}}). No error output from borg. Files may not exist in archive or permission denied.",
         "restoreFailedExitCode": "Restore process exited with code {{exitCode}}",
-        "restoreFailed": "Restore failed"
+        "restoreFailed": "Restore failed",
+        "jobCompletedWithWarning": "Completed with warning (exit code {{exitCode}})"
       },
       "dashboard": {
         "failedGetSystemMetrics": "Failed to get system metrics",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -5041,7 +5041,8 @@
         "restoreFailedZeroFilesPathNotFound": "Restauración fallida: 0 archivos extraídos (código de salida {{exitCode}}). Ruta no encontrada en el archivo o el destino no existe.",
         "restoreFailedZeroFilesNoOutput": "Restauración fallida: 0 archivos extraídos (código de salida {{exitCode}}). Sin salida de error de Borg. Es posible que los archivos no existan en el archivo o que el acceso esté denegado.",
         "restoreFailedExitCode": "El proceso de restauración terminó con el código {{exitCode}}",
-        "restoreFailed": "La restauración falló"
+        "restoreFailed": "La restauración falló",
+        "jobCompletedWithWarning": "Completado con advertencia (código de salida {{exitCode}})"
       },
       "dashboard": {
         "failedGetSystemMetrics": "Error al obtener las métricas del sistema",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -5041,7 +5041,8 @@
         "restoreFailedZeroFilesPathNotFound": "Ripristino fallito: 0 file estratti (codice uscita {{exitCode}}). Percorso non trovato nell'archivio o destinazione non esistente.",
         "restoreFailedZeroFilesNoOutput": "Ripristino fallito: 0 file estratti (codice uscita {{exitCode}}). Nessun output di errore da borg. I file potrebbero non esistere nell'archivio o permesso negato.",
         "restoreFailedExitCode": "Il processo di ripristino è uscito con codice {{exitCode}}",
-        "restoreFailed": "Ripristino fallito"
+        "restoreFailed": "Ripristino fallito",
+        "jobCompletedWithWarning": "Completato con avviso (codice di uscita {{exitCode}})"
       },
       "dashboard": {
         "failedGetSystemMetrics": "Impossibile ottenere le metriche di sistema",

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -2127,6 +2127,70 @@ def test_execute_backup_create_job_completes_successfully(monkeypatch):
 
 
 @pytest.mark.unit
+def test_execute_backup_create_job_warning_exit_completes_with_warnings(monkeypatch):
+    """rc=1 (borg warning: file changed, path missing) still produced an
+    archive: the agent completes the job with the return code instead of
+    failing it, and the server derives completed_with_warnings from that."""
+
+    def fake_popen(cmd, stdout, stderr, text, env, **kwargs):
+        return FakeProcess(
+            ['{"type":"archive_progress","finished":true}\n'],
+            1,
+        )
+
+    monkeypatch.setattr("agent.borg_ui_agent.backup.subprocess.Popen", fake_popen)
+    client = BackupClient()
+
+    result = execute_backup_create_job(
+        {
+            "id": 8,
+            "payload": {
+                "job_kind": "backup.create",
+                "repository_path": "/repo",
+                "archive_name": "archive",
+                "source_paths": ["/src"],
+            },
+        },
+        client,
+    )
+
+    assert result.status == "completed_with_warnings"
+    assert result.return_code == 1
+    complete_calls = [call for call in client.calls if call[0] == "complete_job"]
+    assert len(complete_calls) == 1
+    assert complete_calls[0][2]["return_code"] == 1
+    assert all(call[0] != "fail_job" for call in client.calls)
+
+
+@pytest.mark.unit
+def test_execute_backup_create_job_error_exit_still_fails(monkeypatch):
+    """rc=2 (borg error) keeps the failure semantics untouched."""
+
+    def fake_popen(cmd, stdout, stderr, text, env, **kwargs):
+        return FakeProcess([], 2)
+
+    monkeypatch.setattr("agent.borg_ui_agent.backup.subprocess.Popen", fake_popen)
+    client = BackupClient()
+
+    result = execute_backup_create_job(
+        {
+            "id": 9,
+            "payload": {
+                "job_kind": "backup.create",
+                "repository_path": "/repo",
+                "archive_name": "archive",
+                "source_paths": ["/src"],
+            },
+        },
+        client,
+    )
+
+    assert result.status == "failed"
+    assert any(call[0] == "fail_job" for call in client.calls)
+    assert all(call[0] != "complete_job" for call in client.calls)
+
+
+@pytest.mark.unit
 def test_build_borg_env_sets_noninteractive_access_defaults(monkeypatch):
     # borg 1.x and 2 both prompt "[yN]" on first access to an unknown
     # unencrypted (or relocated) repository. The agent runs borg

--- a/tests/unit/test_api_agents.py
+++ b/tests/unit/test_api_agents.py
@@ -11,6 +11,7 @@ from app.database.models import (
     AgentJob,
     AgentJobLog,
     AgentMachine,
+    BackupJob,
     LicensingState,
 )
 
@@ -755,6 +756,101 @@ class TestAgentJobTransport:
             headers=headers,
         )
         assert after_complete.status_code == 409
+
+    def test_warning_return_code_completes_with_warnings(
+        self, test_client: TestClient, test_db, admin_headers
+    ):
+        """Borg warning exit codes (legacy 1, modern 100-127) are not failures:
+        the job and its linked backup job end completed_with_warnings, the
+        archive name is still captured, and the warning is surfaced as the
+        same i18n message server-side backups use."""
+        registered = _register_agent(
+            test_client,
+            _create_enrollment_token(test_client, admin_headers)["token"],
+        )
+        agent = _get_agent(test_db, registered["agent_id"])
+        job = _create_agent_job(test_db, agent, status="running")
+        backup_job = BackupJob(repository="/repo", status="running")
+        test_db.add(backup_job)
+        test_db.commit()
+        job.backup_job_id = backup_job.id
+        test_db.commit()
+        headers = _agent_headers(registered["agent_token"])
+
+        complete = test_client.post(
+            f"/api/agents/jobs/{job.id}/complete",
+            json={
+                "result": {
+                    "archive_name": "warned-archive",
+                    "return_code": 1,
+                }
+            },
+            headers=headers,
+        )
+        assert complete.status_code == 200
+        assert complete.json()["status"] == "completed_with_warnings"
+
+        test_db.refresh(job)
+        test_db.refresh(backup_job)
+        assert job.status == "completed_with_warnings"
+        assert "jobCompletedWithWarning" in (job.error_message or "")
+        assert backup_job.status == "completed_with_warnings"
+        assert backup_job.archive_name == "warned-archive"
+        assert backup_job.progress == 100
+        assert "backupCompletedWithWarning" in (backup_job.error_message or "")
+
+        # A repeated report must stay idempotent for the new terminal status.
+        repeated = test_client.post(
+            f"/api/agents/jobs/{job.id}/complete",
+            json={"result": {"return_code": 1}},
+            headers=headers,
+        )
+        assert repeated.status_code == 200
+
+    def test_modern_warning_range_counts_as_warning(
+        self, test_client: TestClient, test_db, admin_headers
+    ):
+        registered = _register_agent(
+            test_client,
+            _create_enrollment_token(test_client, admin_headers)["token"],
+        )
+        agent = _get_agent(test_db, registered["agent_id"])
+        job = _create_agent_job(test_db, agent, status="running")
+        headers = _agent_headers(registered["agent_token"])
+
+        complete = test_client.post(
+            f"/api/agents/jobs/{job.id}/complete",
+            json={"result": {"return_code": 104}},
+            headers=headers,
+        )
+        assert complete.status_code == 200
+        test_db.refresh(job)
+        assert job.status == "completed_with_warnings"
+
+    def test_error_return_code_in_completion_report_fails_the_job(
+        self, test_client: TestClient, test_db, admin_headers
+    ):
+        """A completion report carrying an explicit borg error code (2-99) is
+        a failure - the server classifies, not the transport."""
+        registered = _register_agent(
+            test_client,
+            _create_enrollment_token(test_client, admin_headers)["token"],
+        )
+        agent = _get_agent(test_db, registered["agent_id"])
+        job = _create_agent_job(test_db, agent, status="running")
+        headers = _agent_headers(registered["agent_token"])
+
+        complete = test_client.post(
+            f"/api/agents/jobs/{job.id}/complete",
+            json={"result": {"return_code": 2}},
+            headers=headers,
+        )
+        assert complete.status_code == 200
+        assert complete.json()["status"] == "failed"
+
+        test_db.refresh(job)
+        assert job.status == "failed"
+        assert "exited with code 2" in (job.error_message or "")
 
     def test_repeated_complete_report_is_idempotent(
         self, test_client: TestClient, test_db, admin_headers


### PR DESCRIPTION
## Problem

The server has always classified the exit codes of its own borg processes three ways — `0` success, `1`/`100–127` `completed_with_warnings`, everything else failed — and the whole UI speaks that status: the Activity warning filter, the log save policy, the dashboard colors.

The agent path was the one mute participant: **any** non-zero exit became `failed`. A routine `file changed while we read it` (rc 1) turned an agent-executed plan red every night, and the Activity warning filter could never match an agent job — the status simply could not occur on that path.

## What this PR does

- The agent completes jobs whose borg exited with a warning code and reports the `return_code` (both runners: `backup.create` and the repository operations; shared classifier in `agent/borg_ui_agent/borg.py`). The archive/operation output is intact in these cases — that is what makes a warning a warning.
- The server derives `completed_with_warnings` from the reported return code in `_complete_agent_job` — for the agent job (new terminal status, `FINAL_AGENT_JOB_STATUSES` extended; job admission uses active-status whitelists and needs no change), the linked backup job (archive name still captured, same `backupCompletedWithWarning` i18n message server-side backups use) and linked maintenance jobs. `last_backup` / `last_check` / `last_compact` count warning completions as done, matching the server-side services.
- The REST completion route now delegates to `_complete_agent_job` instead of duplicating the classification inline — one place decides what a completion means, for both transports.
- Error semantics are untouched: rc 2–99 still fails.

## Compatibility

- Old agent + new server: unchanged (warnings keep failing, as before).
- New agent + old server: a warning completion is recorded as a plain success — transitional and harmless in both directions.
- No agent version bump in this PR to avoid colliding with the bump in #772; happy to rebase whichever lands second.

## Testing

- Server: warning completion via REST ends the agent job and its linked backup job as `completed_with_warnings` with archive name, progress 100 and the warning message; modern-range rc 104 classified the same; repeated completion stays idempotent.
- Agent: rc 1 completes with the return code and never calls `fail_job`; rc 2 still fails and never calls `complete_job`.
- Full unit suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Borg backup and repository operations that finish with warning exit codes are now marked as **Completed with warnings** instead of failed.
  * Warning details and exit codes are displayed in job status messages.
  * Linked backup and maintenance jobs now receive consistent completion statuses and progress updates.
  * Actual error exit codes continue to mark jobs as failed.

* **Localization**
  * Added warning-completion messages in English, German, Spanish, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->