### PR TITLE
fix(ci): restrict Dependabot auto-merge to patches

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,21 +21,28 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Enable auto-merge for minor and patch updates
-        # Auto-merge patch and minor updates for production dependencies
-        # Major updates require manual review
-        if: |
-          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-           steps.metadata.outputs.update-type == 'version-update:semver-minor')
+      - name: Decide auto-merge policy
+        id: policy
+        env:
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+        run: |
+          if [ "$UPDATE_TYPE" = "version-update:semver-patch" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enable auto-merge for patch updates
+        # Minor updates can be breaking for dependencies below 1.0.0. Grouped
+        # updates also hide their individual version changes behind one label.
+        if: steps.policy.outputs.allowed == 'true'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment on PR
-        if: |
-          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-           steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        if: steps.policy.outputs.allowed == 'true'
         uses: actions/github-script@v9
         with:
           script: |


### PR DESCRIPTION
## Description

Restricts the Dependabot auto-merge workflow to semver patch updates. The workflow now derives one policy output which gates both the merge action and its status comment.

## Related Issue

Fixes #769

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass

Validated the workflow YAML with Ruby and confirmed the policy permits patches while rejecting minor and major updates.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable: workflow-only change.

## Additional Context

Minor updates can be breaking for dependencies below 1.0.0, and grouped Dependabot updates conceal individual dependency changes behind a single update type. Repository auto-merge remains a separate setting and is not enabled by this PR.

---

By submitting this pull request, I agree that my contributions will be licensed under the GNU Affero General Public License v3.0 (AGPL-3.0), the same license as this project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update handling to allow automatic merging only for patch-level releases.
  * Minor and major dependency updates will no longer be automatically merged.
  * Added clearer policy checks before enabling auto-merge and posting status comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->