### PR TITLE
fix(notifications): render event timestamps in the configured timezone

### DIFF
--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -7,14 +7,61 @@ Handles sending notifications for backup/restore events.
 import apprise
 from typing import Optional, List
 from sqlalchemy.orm import Session
-from datetime import datetime
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 import structlog
 import socket
 import re
 
-from app.database.models import NotificationSettings, Repository
+from app.database.models import NotificationSettings, Repository, SystemSettings
+from app.utils.datetime_utils import serialize_datetime
+from app.utils.schedule_time import (
+    DEFAULT_SCHEDULE_TIMEZONE,
+    get_container_timezone,
+    normalize_schedule_timezone,
+)
 
 logger = structlog.get_logger()
+
+
+def _resolve_report_timezone(db: Session) -> ZoneInfo:
+    """Timezone that notification timestamps should render in.
+
+    Mirrors the weekly-report path, trying each source in order: the
+    configured ``backup_reports_timezone``, then the container timezone,
+    then UTC. An invalid or unreadable earlier source falls through to
+    the next rather than short-circuiting to UTC. Never raises.
+    """
+    configured = None
+    try:
+        settings = db.query(SystemSettings).first()
+        configured = (
+            getattr(settings, "backup_reports_timezone", None) if settings else None
+        )
+    except Exception:
+        configured = None
+
+    for candidate in (configured, get_container_timezone(DEFAULT_SCHEDULE_TIMEZONE)):
+        if not candidate:
+            continue
+        try:
+            return ZoneInfo(normalize_schedule_timezone(candidate))
+        except Exception:
+            continue
+    return ZoneInfo("UTC")
+
+
+def _format_event_time(dt: Optional[datetime], tz: ZoneInfo) -> str:
+    """Render an event timestamp in ``tz``.
+
+    Naive datetimes are treated as UTC (the database stores naive UTC); a
+    ``None`` value means the current time.
+    """
+    if dt is None:
+        dt = datetime.now(timezone.utc)
+    elif dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(tz).strftime("%Y-%m-%d %H:%M:%S %Z")
 
 
 def _sanitize_ssh_url(url: str) -> str:
@@ -486,7 +533,7 @@ def _build_json_data(event_type: str, data: dict, compact: bool = False) -> str:
 
     json_data = {
         "event_type": event_type,
-        "timestamp": datetime.now().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         **data,
     }
 
@@ -609,9 +656,10 @@ class NotificationService:
                 {"label": "Expected Size", "value": _format_bytes(expected_size)}
             )
 
-        # Create timestamp
-        start_time = datetime.now()
-        timestamp_str = start_time.strftime("%Y-%m-%d %H:%M:%S")
+        # Create timestamp in the configured report timezone
+        report_tz = _resolve_report_timezone(db)
+        start_time = datetime.now(timezone.utc)
+        timestamp_str = _format_event_time(start_time, report_tz)
 
         # Create HTML body for email with professional badge
         html_title = f"{_get_status_badge('started', is_html=True)} Backup Started"
@@ -659,7 +707,7 @@ class NotificationService:
                         "job_name": job_name,
                         "source_directories": source_directories,
                         "expected_size": expected_size,
-                        "started_at": start_time.isoformat(),
+                        "started_at": serialize_datetime(start_time),
                     },
                     compact=_is_json_webhook(setting.service_url),
                 )
@@ -815,8 +863,9 @@ class NotificationService:
             content_blocks.append({"html": stats_html})
 
         # Use provided completion time or current time as fallback
-        completed_at = completion_time or datetime.now()
-        timestamp_str = completed_at.strftime("%Y-%m-%d %H:%M:%S")
+        report_tz = _resolve_report_timezone(db)
+        completed_at = completion_time or datetime.now(timezone.utc)
+        timestamp_str = _format_event_time(completed_at, report_tz)
 
         # Build footer with elapsed time if available
         footer = f"Completed at {timestamp_str}"
@@ -891,9 +940,7 @@ class NotificationService:
                         "archive_name": archive_name,
                         "job_name": job_name,
                         "stats": stats,
-                        "completed_at": completed_at.isoformat()
-                        if completed_at
-                        else None,
+                        "completed_at": serialize_datetime(completed_at),
                     },
                     compact=_is_json_webhook(setting.service_url),
                 )
@@ -973,14 +1020,16 @@ class NotificationService:
         content_blocks.append({"html": error_html})
 
         # Capture failure time
-        failure_time = datetime.now()
+        report_tz = _resolve_report_timezone(db)
+        failure_time = datetime.now(timezone.utc)
+        timestamp_str = _format_event_time(failure_time, report_tz)
 
         # Create HTML body with professional badge
         html_title = f"{_get_status_badge('failed', is_html=True)} Backup Failed"
         html_body = _create_html_email(
             title=html_title,
             content_blocks=content_blocks,
-            footer=f"Failed at {failure_time.strftime('%Y-%m-%d %H:%M:%S')}",
+            footer=f"Failed at {timestamp_str}",
         )
 
         # Create markdown body with professional badge (without HTML error box)
@@ -1004,7 +1053,7 @@ class NotificationService:
         markdown_body = _create_markdown_message(
             title=markdown_title,
             content_blocks=markdown_blocks,
-            footer=f"Failed at {failure_time.strftime('%Y-%m-%d %H:%M:%S')}",
+            footer=f"Failed at {timestamp_str}",
         )
 
         for setting in settings:
@@ -1035,7 +1084,7 @@ class NotificationService:
                         "job_name": job_name,
                         "job_id": job_id,
                         "error_message": error_message,
-                        "failed_at": failure_time.isoformat(),
+                        "failed_at": serialize_datetime(failure_time),
                     },
                     compact=_is_json_webhook(setting.service_url),
                 )
@@ -1203,12 +1252,14 @@ class NotificationService:
         content_blocks.append({"html": warning_html})
 
         # Capture completion time
-        completed_at = completion_time or datetime.now()
+        report_tz = _resolve_report_timezone(db)
+        completed_at = completion_time or datetime.now(timezone.utc)
+        timestamp_str = _format_event_time(completed_at, report_tz)
 
         # Build footer with elapsed time if available
-        footer = f"Completed at {completed_at.strftime('%Y-%m-%d %H:%M:%S')}"
+        footer = f"Completed at {timestamp_str}"
         if elapsed_time_str:
-            footer = f"Completed at {completed_at.strftime('%Y-%m-%d %H:%M:%S')} (took {elapsed_time_str})"
+            footer = f"Completed at {timestamp_str} (took {elapsed_time_str})"
 
         # Create HTML body with professional badge
         html_title = f"{_get_status_badge('warning', is_html=True)} Backup Completed with Warnings"
@@ -1281,7 +1332,7 @@ class NotificationService:
                         "job_name": job_name,
                         "warning_message": warning_message,
                         "stats": stats,
-                        "completed_at": completed_at.isoformat(),
+                        "completed_at": serialize_datetime(completed_at),
                     },
                     compact=_is_json_webhook(setting.service_url),
                 )
@@ -1354,8 +1405,9 @@ class NotificationService:
         content_blocks.append({"label": "Destination", "value": target_path})
 
         # Use provided completion time or current time as fallback
-        completed_at = completion_time or datetime.now()
-        timestamp_str = completed_at.strftime("%Y-%m-%d %H:%M:%S")
+        report_tz = _resolve_report_timezone(db)
+        completed_at = completion_time or datetime.now(timezone.utc)
+        timestamp_str = _format_event_time(completed_at, report_tz)
 
         html_title = f"{_get_status_badge('success', is_html=True)} Restore Successful"
         html_body = _create_html_email(
@@ -1401,7 +1453,7 @@ class NotificationService:
                         "archive_name": archive_name,
                         "job_name": job_name,
                         "target_path": target_path,
-                        "completed_at": completed_at.isoformat(),
+                        "completed_at": serialize_datetime(completed_at),
                     },
                     compact=_is_json_webhook(setting.service_url),
                 )
@@ -1477,11 +1529,15 @@ class NotificationService:
         </div>"""
         content_blocks.append({"html": error_html})
 
+        report_tz = _resolve_report_timezone(db)
+        failure_time = datetime.now(timezone.utc)
+        timestamp_str = _format_event_time(failure_time, report_tz)
+
         html_title = f"{_get_status_badge('failed', is_html=True)} Restore Failed"
         html_body = _create_html_email(
             title=html_title,
             content_blocks=content_blocks,
-            footer=f"Failed at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+            footer=f"Failed at {timestamp_str}",
         )
 
         # Create markdown body
@@ -1505,11 +1561,8 @@ class NotificationService:
         markdown_body = _create_markdown_message(
             title=markdown_title,
             content_blocks=markdown_blocks,
-            footer=f"Failed at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+            footer=f"Failed at {timestamp_str}",
         )
-
-        # Capture failure time for JSON
-        failure_time = datetime.now()
 
         for setting in settings:
             # Check if this notification applies to this repository
@@ -1539,7 +1592,7 @@ class NotificationService:
                         "archive_name": archive_name,
                         "job_name": job_name,
                         "error_message": error_message,
-                        "failed_at": failure_time.isoformat(),
+                        "failed_at": serialize_datetime(failure_time),
                     },
                     compact=_is_json_webhook(setting.service_url),
                 )
@@ -1603,13 +1656,17 @@ class NotificationService:
         </div>"""
         content_blocks.append({"html": error_html})
 
+        report_tz = _resolve_report_timezone(db)
+        failure_time = datetime.now(timezone.utc)
+        timestamp_str = _format_event_time(failure_time, report_tz)
+
         html_title = (
             f"{_get_status_badge('failed', is_html=True)} Scheduled Backup Failed"
         )
         html_body = _create_html_email(
             title=html_title,
             content_blocks=content_blocks,
-            footer=f"Failed at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+            footer=f"Failed at {timestamp_str}",
         )
 
         # Create markdown body
@@ -1632,11 +1689,8 @@ class NotificationService:
         markdown_body = _create_markdown_message(
             title=markdown_title,
             content_blocks=markdown_blocks,
-            footer=f"Failed at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+            footer=f"Failed at {timestamp_str}",
         )
-
-        # Capture failure time for JSON
-        failure_time = datetime.now()
 
         for setting in settings:
             # Check if this notification applies to this repository
@@ -1665,7 +1719,7 @@ class NotificationService:
                         "repository_name": repo.name if repo else repository_name,
                         "repository_path": repo.path if repo else repository_name,
                         "error_message": error_message,
-                        "failed_at": failure_time.isoformat(),
+                        "failed_at": serialize_datetime(failure_time),
                     },
                     compact=_is_json_webhook(setting.service_url),
                 )
@@ -1995,8 +2049,9 @@ class NotificationService:
             )
             content_blocks.append({"label": "Details", "value": error_display})
 
-        completion_time = datetime.now()
-        timestamp_str = completion_time.strftime("%Y-%m-%d %H:%M:%S")
+        report_tz = _resolve_report_timezone(db)
+        completion_time = datetime.now(timezone.utc)
+        timestamp_str = _format_event_time(completion_time, report_tz)
 
         html_title = f"{_get_status_badge(badge_type, is_html=True)} {title_text}"
         html_body = _create_html_email(
@@ -2043,7 +2098,7 @@ class NotificationService:
                         "error_message": error_message
                         if status != "completed"
                         else None,
-                        "completed_at": completion_time.isoformat(),
+                        "completed_at": serialize_datetime(completion_time),
                     },
                     compact=_is_json_webhook(setting.service_url),
                 )
@@ -2138,8 +2193,9 @@ class NotificationService:
             content_blocks.append({"label": "Error", "value": error_display})
 
         # Create timestamp
-        completion_time = datetime.now()
-        timestamp_str = completion_time.strftime("%Y-%m-%d %H:%M:%S")
+        report_tz = _resolve_report_timezone(db)
+        completion_time = datetime.now(timezone.utc)
+        timestamp_str = _format_event_time(completion_time, report_tz)
 
         # Choose title and badge based on status
         if status == "completed":
@@ -2201,7 +2257,7 @@ class NotificationService:
                         "status": status,
                         "duration_seconds": duration_seconds,
                         "error_message": error_message if status == "failed" else None,
-                        "completed_at": completion_time.isoformat(),
+                        "completed_at": serialize_datetime(completion_time),
                     },
                     compact=_is_json_webhook(setting.service_url),
                 )

--- a/tests/unit/test_notification_service.py
+++ b/tests/unit/test_notification_service.py
@@ -1200,3 +1200,91 @@ async def test_local_repo_urls_unchanged(test_db, mock_apprise):
     call_args = apprise_instance.notify.call_args[1]
     body = call_args["body"]
     assert "/local/path/to/repo" in body
+
+
+@pytest.mark.asyncio
+async def test_completed_at_uses_configured_report_timezone(
+    test_db, mock_apprise, mock_repository, email_notification_setting
+):
+    """Completed-at footer renders in backup_reports_timezone, not GMT (issue #771)."""
+    from datetime import datetime
+    from app.database.models import SystemSettings
+
+    test_db.add(SystemSettings(backup_reports_timezone="Asia/Kolkata"))
+    test_db.commit()
+
+    apprise_instance = mock_apprise.return_value
+    apprise_instance.add.return_value = True
+    apprise_instance.notify.return_value = True
+
+    # Naive UTC value, exactly as stored on BackupJob.completed_at
+    await notification_service.send_backup_success(
+        test_db,
+        mock_repository.name,
+        "archive-2024",
+        completion_time=datetime(2025, 11, 9, 14, 56, 53),
+    )
+
+    body = apprise_instance.notify.call_args[1]["body"]
+    # Asia/Kolkata is UTC+5:30 -> 20:26:53 IST, never the raw 14:56:53 UTC
+    assert "Completed at 2025-11-09 20:26:53 IST" in body
+    assert "14:56:53" not in body
+
+
+@pytest.mark.asyncio
+async def test_backup_start_and_success_use_same_timezone(
+    test_db, mock_apprise, mock_repository
+):
+    """Started-at and Completed-at must render in the same configured zone."""
+    from datetime import datetime
+    from app.database.models import SystemSettings
+
+    test_db.add(SystemSettings(backup_reports_timezone="Asia/Kolkata"))
+    setting = NotificationSettings(
+        name="Both",
+        service_url="slack://token/channel",
+        enabled=True,
+        notify_on_backup_start=True,
+        notify_on_backup_success=True,
+        monitor_all_repositories=True,
+    )
+    test_db.add(setting)
+    test_db.commit()
+
+    apprise_instance = mock_apprise.return_value
+    apprise_instance.add.return_value = True
+    apprise_instance.notify.return_value = True
+
+    await notification_service.send_backup_start(
+        test_db, mock_repository.name, "archive-2024"
+    )
+    start_body = apprise_instance.notify.call_args[1]["body"]
+
+    await notification_service.send_backup_success(
+        test_db,
+        mock_repository.name,
+        "archive-2024",
+        completion_time=datetime(2025, 11, 9, 14, 56, 53),
+    )
+    complete_body = apprise_instance.notify.call_args[1]["body"]
+
+    assert "Started at" in start_body and "IST" in start_body
+    assert "Completed at 2025-11-09 20:26:53 IST" in complete_body
+
+
+def test_resolve_report_timezone_invalid_config_falls_back_to_container(test_db):
+    """An invalid configured timezone falls through to the container zone, not UTC."""
+    from app.database.models import SystemSettings
+    from app.services.notification_service import _resolve_report_timezone
+
+    test_db.add(SystemSettings(backup_reports_timezone="Not/AZone"))
+    test_db.commit()
+
+    with patch(
+        "app.services.notification_service.get_container_timezone",
+        return_value="Asia/Kolkata",
+    ):
+        tz = _resolve_report_timezone(test_db)
+
+    # Invalid configured value must not short-circuit to UTC
+    assert str(tz) == "Asia/Kolkata"


### PR DESCRIPTION
Fixes #771.

## Problem

Notification footers mixed two clocks within the same message:

- **"Started at"** (`send_backup_start`) used `datetime.now()` → container-local time.
- **"Completed at"** (`send_backup_success` / `send_backup_warning`) rendered the stored `job.completed_at`, which is written as naive UTC, through a raw `strftime()` → always GMT.

So a single backup notification showed the start in local time and the completion in GMT.

The inconsistency was broader than the two functions in the report: every footer either rendered a stored UTC timestamp (→ GMT) or `datetime.now()` (→ container-local), and **none** of them honored the `backup_reports_timezone` setting — even though the weekly-report path already does (`backup_monitoring_service._report_timezone`).

Separately, the JSON webhook payloads serialized event datetimes with a bare `isoformat()` on naive UTC values, i.e. without a `+00:00`/`Z` offset, so a downstream consumer would misread them as local time.

## Change

- Two helpers in `notification_service.py`:
  - `_resolve_report_timezone(db)` — resolves `backup_reports_timezone`, falling back to the container timezone, then UTC (same precedence as the weekly report).
  - `_format_event_time(dt, tz)` — treats naive datetimes as UTC (the database stores naive UTC) and renders them in the resolved zone with an explicit zone abbreviation (`%Z`).
- Every notification footer (start / success / warning / failure / restore success/failure / schedule failure / restore-check / check completion) now formats its timestamp through those helpers, so start, complete and fail all render in one configured zone.
- JSON webhook payloads now use the existing `serialize_datetime()` helper, which emits a UTC offset.

No schema change and no change to how timestamps are stored — only how they are rendered in notifications.

## Tests

Added regression coverage in `tests/unit/test_notification_service.py`:

- `test_completed_at_uses_configured_report_timezone` — with `backup_reports_timezone = "Asia/Kolkata"`, a completion stored as `14:56:53` UTC renders as `20:26:53 IST`, never the raw UTC value.
- `test_backup_start_and_success_use_same_timezone` — the start and success footers render in the same configured zone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notification “report time” footers now render in the configured report timezone (with correct localization for backup events).
  * Event timestamps are consistently generated and formatted across backup, restore, scheduling, and related notifications.
  * Webhook payload timestamp fields now use standardized UTC-aware serialization for more consistent results.
  * Improved timezone fallback behavior to container timezone or UTC when needed.
* **Tests**
  * Added unit coverage for timezone rendering and fallback behavior for backup notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->