### PR TITLE
fix(db): two migration edge cases

### DIFF
--- a/app/database/db_upgrade.py
+++ b/app/database/db_upgrade.py
@@ -13,7 +13,8 @@ done before the copy runs -- copying by column name cannot reproduce them. Any
 user can upgrade straight from an old release to the latest; no manual stop on an
 intermediate version is required.
 
-Nothing is destroyed. The source is renamed, never deleted, and every deviation
+Nothing is destroyed. The source is kept as the rollback -- moved aside for a
+SQLite upgrade, left exactly where it is for a Postgres one -- and every deviation
 between source and target is reported rather than silently absorbed.
 """
 
@@ -675,12 +676,24 @@ def upgrade_from_settings() -> UpgradeReport:
 
 
 def _finalise(source_path: Path, target_path: Path | None, to_postgres: bool) -> Path:
-    """Move the source aside, and in the SQLite case put the new file in its place.
+    """Settle where the databases live once the transfer has succeeded.
 
-    The source becomes the backup in both cases, so "the old file is still there
-    and the target is empty" always means "not upgraded yet" -- one rule instead
-    of two, and no way to re-import a stale snapshot over a live database.
+    SQLite, in place: the new file takes the source's name and the source becomes
+    the `_bak` rollback -- so "the old file is still there and the target is empty"
+    always means "not upgraded yet", one rule with no way to re-import a stale
+    snapshot over a live database.
+
+    Postgres: the target is Postgres and `DATABASE_URL` points at it, so Postgres
+    alone decides whether the work is done -- the SQLite file is never consulted
+    again (see `_alembic_state`). It is therefore left exactly where it is, as the
+    rollback: reverting is removing `DATABASE_URL`, with nothing to rename back.
+    Leaving it also means a `_bak` an earlier in-place SQLite upgrade put beside it
+    is not in the way -- the source keeps its own name, so there is nothing to
+    collide with.
     """
+    if to_postgres:
+        return source_path
+
     backup = source_path.with_name(
         f"{source_path.stem}{BACKUP_SUFFIX}{source_path.suffix}"
     )
@@ -689,8 +702,7 @@ def _finalise(source_path: Path, target_path: Path | None, to_postgres: bool) ->
             f"{backup} already exists -- refusing to overwrite the rollback"
         )
     source_path.rename(backup)
-    if not to_postgres:
-        target_path.rename(source_path)
+    target_path.rename(source_path)
     return backup
 
 

--- a/app/database/db_upgrade.py
+++ b/app/database/db_upgrade.py
@@ -340,6 +340,13 @@ def _catch_up_source(source_path: Path, catch_up_path: Path) -> None:
     ladder runs first, and on a copy, never the source: it rewrites tables, and the
     source must stay intact to be the rollback. Afterwards the transforms the copy
     step depends on must be done; if one is not, refuse before anything is copied.
+
+    A source that already speaks Alembic is past the ladder: it is skipped. This
+    only happens when an Alembic SQLite database is moved into a fresh Postgres --
+    the target has no schema, so it is not the durable-fork "already upgraded" case
+    -- and running the legacy ladder against an Alembic database is the very thing
+    the target side forbids. The snapshot is still copied from; it just is not
+    walked up a ladder it has already climbed.
     """
     from app.database.migrations import run_migrations
 
@@ -351,6 +358,9 @@ def _catch_up_source(source_path: Path, catch_up_path: Path) -> None:
     # the ladder on exactly the databases it exists to rescue.
     ladder_engine = create_engine(_sqlite_url(catch_up_path))
     try:
+        with ladder_engine.connect() as conn:
+            if inspect(conn).has_table("alembic_version"):
+                return  # already on Alembic; the snapshot is copied from as-is
         failed = run_migrations(ladder_engine)
         _require_transforms_applied(ladder_engine, failed)
     except Exception:

--- a/tests/unit/test_db_upgrade.py
+++ b/tests/unit/test_db_upgrade.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import sessionmaker
 from app.database.database import Base
 from app.database.db_upgrade import (
     _TRANSFORM_SENTINELS,
+    _catch_up_source,
     _unresolved_transforms,
     alembic_init,
 )
@@ -455,6 +456,57 @@ def test_an_alembic_database_behind_head_follows_alembic_not_the_ladder(
         for c in inspect(create_engine(f"sqlite:///{db}")).get_columns("repositories")
     }
     assert "check_interval_days" in cols
+
+
+@pytest.mark.unit
+def test_catch_up_skips_the_ladder_on_an_already_alembic_source(tmp_path, monkeypatch):
+    """The source side of the same rule: the legacy ladder must never run against a
+    database that already has alembic_version. It is only reached when an Alembic
+    SQLite database is moved into a fresh Postgres (the target is empty, so the
+    durable fork does not short-circuit); the ladder would be a no-op there, but it
+    must not run at all. Exercise the function directly -- the SQLite-to-SQLite path
+    never reaches it, because an Alembic source is caught by the fork first."""
+    db = tmp_path / "borg.db"
+    alembic_init(db)  # a fresh Alembic-managed database, stamped at head
+
+    import app.database.migrations as legacy
+
+    monkeypatch.setattr(legacy, "run_migrations", _boom)  # blow up if the ladder runs
+
+    catch_up = tmp_path / "borg_catchup.db"
+    _catch_up_source(db, catch_up)  # must not raise
+
+    # the snapshot is kept for the transfer to copy from, and it carries the stamp
+    assert catch_up.exists()
+    with create_engine(f"sqlite:///{catch_up}").connect() as conn:
+        assert inspect(conn).has_table("alembic_version")
+
+
+@pytest.mark.unit
+@requires_postgres
+def test_an_alembic_sqlite_moves_to_postgres_without_running_the_ladder(
+    tmp_path, monkeypatch
+):
+    """End to end: a SQLite database already on Alembic, then pointed at Postgres,
+    copies its rows across without walking the legacy ladder again."""
+    db = tmp_path / "borg.db"
+    alembic_init(db)  # fresh Alembic SQLite, at head, no rollback file to collide
+    session = sessionmaker(bind=create_engine(f"sqlite:///{db}"))()
+    session.add(Repository(name="r", path="/srv/r"))
+    session.commit()
+    session.close()
+    _reset_postgres()
+
+    import app.database.migrations as legacy
+
+    monkeypatch.setattr(legacy, "run_migrations", _boom)  # the ladder must not run
+
+    report = alembic_init(db, POSTGRES_URL)
+
+    assert report.action == "transferred"
+    session = sessionmaker(bind=create_engine(POSTGRES_URL))()
+    assert session.query(Repository).count() == 1
+    session.close()
 
 
 @pytest.mark.unit

--- a/tests/unit/test_db_upgrade.py
+++ b/tests/unit/test_db_upgrade.py
@@ -15,6 +15,7 @@ from app.database.database import Base
 from app.database.db_upgrade import (
     _TRANSFORM_SENTINELS,
     _catch_up_source,
+    _finalise,
     _unresolved_transforms,
     alembic_init,
 )
@@ -212,6 +213,39 @@ def test_an_existing_rollback_is_never_overwritten(tmp_path):
 
     assert (tmp_path / "borg_bak.db").read_text() == "an older rollback nobody may lose"
     assert db.exists()
+
+
+@pytest.mark.unit
+def test_a_postgres_migration_leaves_the_sqlite_in_place(tmp_path):
+    """Postgres is the live database after the transfer, so the SQLite file is not
+    moved aside -- it stays under its own name as the rollback, and reverting is
+    just removing DATABASE_URL. Exercised on `_finalise` directly, where the source
+    is settled; the full Postgres transfer path needs a running Postgres."""
+    db = tmp_path / "borg.db"
+    db.write_text("the live sqlite database")
+
+    kept = _finalise(db, None, to_postgres=True)
+
+    assert kept == db
+    assert db.exists() and db.read_text() == "the live sqlite database"
+    assert not (tmp_path / "borg_bak.db").exists()  # not renamed, no rollback minted
+
+
+@pytest.mark.unit
+def test_a_postgres_migration_does_not_collide_with_an_earlier_rollback(tmp_path):
+    """A database taken SQLite -> Alembic in place, then later to Postgres, has a
+    `_bak` beside it from the first step. Because the Postgres path leaves the
+    source under its own name, that older rollback is never in the way."""
+    db = tmp_path / "borg.db"
+    db.write_text("the live sqlite database")
+    (tmp_path / "borg_bak.db").write_text("the rollback from the in-place upgrade")
+
+    kept = _finalise(db, None, to_postgres=True)  # must not raise
+
+    assert kept == db
+    assert (
+        tmp_path / "borg_bak.db"
+    ).read_text() == "the rollback from the in-place upgrade"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Two edge-case fixes to the one-time upgrade from #768.

- **Don't re-apply legacy migrations on an already-migrated database** — an
  Alembic SQLite moved into a fresh Postgres re-ran them; skip when the source
  already carries `alembic_version`.
- **Leave `borg.db` in place when migrating to Postgres** — renaming it to `_bak`
  was pointless (Postgres is the live database) and collided with a `_bak` a prior
  in-place upgrade left behind.

One commit each, with tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database upgrades when moving from SQLite to PostgreSQL.
  - PostgreSQL upgrades now preserve the original SQLite database and avoid creating unnecessary rollback files.
  - SQLite upgrades now create a rollback backup before replacing the active database.
  - Existing migration metadata is preserved, preventing already-upgraded databases from rerunning legacy migrations.

- **Tests**
  - Added coverage for PostgreSQL finalization, SQLite rollback handling, and complete database transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->