### PR TITLE
fix(security): clear the pip-audit and npm-audit gates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ apprise==1.11.0
 bcrypt==5.0.0
 coverage[toml]==7.14.1
 croniter==6.2.2
-cryptography==49.0.0
+cryptography==50.0.0
 fastapi-cache2==0.2.2
 fastapi==0.136.3
 gunicorn==26.0.0

--- a/security/npm-audit-known-vulns.json
+++ b/security/npm-audit-known-vulns.json
@@ -5,5 +5,12 @@
     "reason": "RSC Mode CSRF bypass. This app is a Vite SPA using <BrowserRouter> (see frontend/src/main.tsx), not React Router's RSC mode, so the vector does not apply. The only published fix is react-router 8.3.0, a v7->v8 major upgrade out of scope for a security-hygiene change.",
     "reviewed_at": "2026-07-27",
     "source": "https://github.com/advisories/GHSA-qwww-vcr4-c8h2"
+  },
+  {
+    "id": "GHSA-55q2-fjhq-7xh7",
+    "package": "dompurify",
+    "reason": "IN_PLACE hook removal leaving a detached subtree executable requires DOMPurify.sanitize with { IN_PLACE: true } and a removed hook. dompurify is a transitive dependency here; the app does not import or call DOMPurify, uses no IN_PLACE mode, and removes no hooks (verified: no DOMPurify usage and no IN_PLACE anywhere in frontend/src), so the vulnerable path is unreachable.",
+    "reviewed_at": "2026-08-07",
+    "source": "https://github.com/advisories/GHSA-55q2-fjhq-7xh7"
   }
 ]

--- a/tests/unit/test_npm_audit_known_vulns.py
+++ b/tests/unit/test_npm_audit_known_vulns.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -80,6 +81,37 @@ def test_the_tracked_allowlist_loads_and_every_entry_carries_a_reason():
     assert any(e["id"] == "GHSA-qwww-vcr4-c8h2" for e in known)
     for entry in known:
         assert entry.get("reason"), f"{entry['id']} must carry a reason"
+
+
+def test_the_dompurify_advisory_stays_non_applicable():
+    """Enforce the invariant the DOMPurify allowlist entry rests on.
+
+    GHSA-55q2-fjhq-7xh7 (IN_PLACE hook removal leaving a detached subtree
+    executable) is allowlisted as non-applicable because nothing in the app uses
+    DOMPurify: it is a transitive dependency, never imported, never run with
+    IN_PLACE. That assumption is what makes the entry correct, so tie it to a
+    check -- if a change introduces DOMPurify usage this fails, and the entry is
+    re-reviewed rather than silently masking a now-reachable sink.
+    """
+    known = load_known_vulns(DEFAULT_KNOWN_VULNS_FILE)
+    assert any(e["id"] == "GHSA-55q2-fjhq-7xh7" for e in known), (
+        "expected the DOMPurify advisory in the allowlist; update this guard if it "
+        "was removed"
+    )
+
+    repo = Path(__file__).resolve().parents[2]
+    frontend_src = repo / "frontend" / "src"
+    offenders = [
+        str(path.relative_to(repo))
+        for path in frontend_src.rglob("*")
+        if path.suffix in {".ts", ".tsx", ".js", ".jsx"}
+        and re.search(r"dompurify", path.read_text(encoding="utf-8"), re.IGNORECASE)
+    ]
+    assert not offenders, (
+        f"DOMPurify is referenced in {offenders}: the GHSA-55q2-fjhq-7xh7 allowlist "
+        "entry assumes DOMPurify is unused (transitive only, no IN_PLACE, no hooks) "
+        "-- that no longer holds; re-review the entry."
+    )
 
 
 def test_validate_report_rejects_an_error_payload():

--- a/tests/unit/test_npm_audit_known_vulns.py
+++ b/tests/unit/test_npm_audit_known_vulns.py
@@ -101,6 +101,11 @@ def test_the_dompurify_advisory_stays_non_applicable():
 
     repo = Path(__file__).resolve().parents[2]
     frontend_src = repo / "frontend" / "src"
+    assert frontend_src.is_dir(), (
+        f"{frontend_src} is missing: without it the scan finds nothing and the guard "
+        "would pass vacuously, hiding the very DOMPurify usage it exists to catch. "
+        "Run from a full checkout."
+    )
     offenders = [
         str(path.relative_to(repo))
         for path in frontend_src.rglob("*")


### PR DESCRIPTION
Two dependency-audit advisories that block the security gates repo-wide,
independent of any feature branch (nothing else touches the pins):

- **pip-audit** — bump `cryptography` 49.0.0 → 50.0.0 to clear **PYSEC-2026-3552**
  (fixed in 50.0.0).
- **npm audit** — track **GHSA-55q2-fjhq-7xh7** (DOMPurify IN_PLACE hook removal)
  as reviewed non-applicable in `security/npm-audit-known-vulns.json`: dompurify is
  a transitive dependency, the app never imports DOMPurify and uses no `IN_PLACE`
  mode, so the sink is unreachable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Updated the cryptography component to version 50.0.0, providing the latest security and maintenance improvements.
  * Documented an audited DOMPurify advisory exception applicable to the current application configuration.
  * Added automated validation to ensure the exception remains appropriate and is reviewed if DOMPurify usage changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->