### PR TITLE
feat: add availability-triggered backup scheduling

### DIFF
--- a/app/api/activity.py
+++ b/app/api/activity.py
@@ -65,6 +65,7 @@ def _get_agent_log_lines(db: Session, agent_job_id: int) -> list[str]:
 
 
 class ActivityItem(BaseModel):
+    activity_key: Optional[str] = None
     id: int
     type: str  # backup, restore, check, restore_check, compact, package, rclone_*
     status: str  # 'pending', 'running', 'completed', 'needs_backup', 'failed', 'completed_with_warnings'
@@ -418,6 +419,7 @@ async def list_recent_activity(
             )
             activities.append(
                 {
+                    "activity_key": f"backup-plan-run-{run.id}",
                     "id": run.id,
                     "type": "availability_check",
                     "status": "skipped",
@@ -452,12 +454,13 @@ async def list_recent_activity(
             schedule = db.get(ScheduledJob, skip.scheduled_job_id)
             activities.append(
                 {
+                    "activity_key": f"availability-schedule-skip-{skip.id}",
                     "id": skip.id,
                     "type": "availability_check",
                     "status": "skipped",
                     "started_at": skip.occurred_at,
                     "completed_at": skip.occurred_at,
-                    "error_message": skip.detail,
+                    "error_message": None,
                     "repository": schedule.name if schedule else "Backup automation",
                     "repository_path": None,
                     "log_file_path": None,

--- a/app/api/activity.py
+++ b/app/api/activity.py
@@ -20,6 +20,8 @@ from app.database.models import (
     AgentJobLog,
     BackupJob,
     BackupPlan,
+    BackupPlanRun,
+    AvailabilityScheduleSkip,
     RestoreJob,
     CheckJob,
     CompactJob,
@@ -77,6 +79,7 @@ class ActivityItem(BaseModel):
     backup_plan_id: Optional[int] = None  # BackupPlan ID if triggered by a plan
     backup_plan_run_id: Optional[int] = None  # BackupPlanRun ID if triggered by a plan
     backup_plan_name: Optional[str] = None  # BackupPlan name if triggered by a plan
+    skip_reason: Optional[str] = None
 
     # Type-specific metadata
     archive_name: Optional[str] = None  # For backup/restore
@@ -391,6 +394,79 @@ async def list_recent_activity(
                         output_text=[job.logs, job.error_message],
                         file_path=job.log_file_path,
                     ),
+                }
+            )
+
+    # Availability Plan skips are plan-run records, not BackupJobs: Borg was never
+    # invoked, so they must be added independently to Activity.
+    if not job_type or job_type == "availability_check":
+        plan_skips = (
+            db.query(BackupPlanRun)
+            .filter(
+                BackupPlanRun.status == "skipped",
+                BackupPlanRun.trigger == "availability",
+            )
+            .order_by(BackupPlanRun.completed_at.desc(), BackupPlanRun.id.desc())
+            .limit(limit)
+            .all()
+        )
+        for run in plan_skips:
+            if status and status != "skipped":
+                continue
+            plan = (
+                db.get(BackupPlan, run.backup_plan_id) if run.backup_plan_id else None
+            )
+            activities.append(
+                {
+                    "id": run.id,
+                    "type": "availability_check",
+                    "status": "skipped",
+                    "started_at": run.started_at,
+                    "completed_at": run.completed_at,
+                    "error_message": run.error_message,
+                    "repository": plan.name if plan else "Backup plan",
+                    "repository_path": None,
+                    "log_file_path": None,
+                    "triggered_by": "backup_plan",
+                    "backup_plan_id": run.backup_plan_id,
+                    "backup_plan_run_id": run.id,
+                    "backup_plan_name": plan.name if plan else None,
+                    "skip_reason": run.skip_reason,
+                    "has_logs": False,
+                    "_sort_at": run.completed_at or run.created_at,
+                }
+            )
+
+        automation_skips = (
+            db.query(AvailabilityScheduleSkip)
+            .order_by(
+                AvailabilityScheduleSkip.occurred_at.desc(),
+                AvailabilityScheduleSkip.id.desc(),
+            )
+            .limit(limit)
+            .all()
+        )
+        for skip in automation_skips:
+            if status and status != "skipped":
+                continue
+            schedule = db.get(ScheduledJob, skip.scheduled_job_id)
+            activities.append(
+                {
+                    "id": skip.id,
+                    "type": "availability_check",
+                    "status": "skipped",
+                    "started_at": skip.occurred_at,
+                    "completed_at": skip.occurred_at,
+                    "error_message": skip.detail,
+                    "repository": schedule.name if schedule else "Backup automation",
+                    "repository_path": None,
+                    "log_file_path": None,
+                    "triggered_by": "schedule",
+                    "schedule_id": skip.scheduled_job_id,
+                    "schedule_name": schedule.name if schedule else None,
+                    "skip_reason": skip.reason,
+                    "has_logs": False,
+                    "_sort_at": skip.occurred_at,
                 }
             )
 

--- a/app/api/backup_plans.py
+++ b/app/api/backup_plans.py
@@ -56,6 +56,10 @@ from app.utils.schedule_time import (
     calculate_next_cron_run,
     normalize_schedule_timezone,
 )
+from app.services.schedule_availability import (
+    DEFAULT_AVAILABILITY_CHECK_INTERVAL_MINUTES,
+    validate_availability_intervals,
+)
 from app.utils.source_locations import (
     decode_source_locations,
     legacy_source_fields,
@@ -140,6 +144,11 @@ class BackupPlanPayload(BaseModel):
     max_parallel_repositories: int = 1
     failure_behavior: str = "continue"
     schedule_enabled: bool = False
+    schedule_mode: str = "cron"
+    availability_check_interval_minutes: int = (
+        DEFAULT_AVAILABILITY_CHECK_INTERVAL_MINUTES
+    )
+    min_success_interval_minutes: int = 0
     cron_expression: Optional[str] = None
     timezone: str = "UTC"
     pre_backup_script_id: Optional[int] = None
@@ -622,6 +631,9 @@ def _serialize_plan(plan: BackupPlan, *, detail: bool = False) -> dict[str, Any]
         "max_parallel_repositories": plan.max_parallel_repositories,
         "failure_behavior": plan.failure_behavior,
         "schedule_enabled": bool(plan.schedule_enabled),
+        "schedule_mode": plan.schedule_mode,
+        "availability_check_interval_minutes": plan.availability_check_interval_minutes,
+        "min_success_interval_minutes": plan.min_success_interval_minutes,
         "cron_expression": plan.cron_expression,
         "timezone": plan.timezone,
         "last_run": serialize_datetime(plan.last_run),
@@ -790,6 +802,7 @@ def _serialize_plan_run(
         "started_at": serialize_datetime(run.started_at),
         "completed_at": serialize_datetime(run.completed_at),
         "error_message": run.error_message,
+        "skip_reason": run.skip_reason,
         "created_at": serialize_datetime(run.created_at),
         "retry_attempt": run.retry_attempt or 1,
         "retry_original_run_id": run.retry_original_run_id,
@@ -1149,7 +1162,22 @@ def _validate_payload(
 
     normalized_tz = normalize_schedule_timezone(payload.timezone)
     payload.timezone = normalized_tz
-    if payload.schedule_enabled:
+    if payload.schedule_mode not in {"cron", "availability"}:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"key": "backend.errors.schedule.invalidMode"},
+        )
+    try:
+        validate_availability_intervals(
+            payload.availability_check_interval_minutes,
+            payload.min_success_interval_minutes,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"key": "backend.errors.schedule.invalidAvailabilityInterval"},
+        ) from exc
+    if payload.schedule_enabled and payload.schedule_mode == "cron":
         if not payload.cron_expression:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -1297,14 +1325,27 @@ def _apply_payload(plan: BackupPlan, payload: BackupPlanPayload) -> None:
     plan.max_parallel_repositories = payload.max_parallel_repositories
     plan.failure_behavior = payload.failure_behavior
     plan.schedule_enabled = payload.schedule_enabled
-    plan.cron_expression = payload.cron_expression if payload.schedule_enabled else None
+    plan.schedule_mode = payload.schedule_mode
+    plan.availability_check_interval_minutes = (
+        payload.availability_check_interval_minutes
+    )
+    plan.min_success_interval_minutes = payload.min_success_interval_minutes
+    plan.cron_expression = (
+        payload.cron_expression
+        if payload.schedule_enabled and payload.schedule_mode == "cron"
+        else None
+    )
     plan.timezone = payload.timezone
     plan.next_run = (
         calculate_next_cron_run(
             payload.cron_expression, schedule_timezone=payload.timezone
         )
         if payload.schedule_enabled and payload.cron_expression
-        else None
+        else (
+            datetime.utcnow()
+            if payload.schedule_enabled and payload.schedule_mode == "availability"
+            else None
+        )
     )
     plan.pre_backup_script_id = payload.pre_backup_script_id
     plan.post_backup_script_id = payload.post_backup_script_id

--- a/app/api/backup_plans.py
+++ b/app/api/backup_plans.py
@@ -1336,17 +1336,16 @@ def _apply_payload(plan: BackupPlan, payload: BackupPlanPayload) -> None:
         else None
     )
     plan.timezone = payload.timezone
-    plan.next_run = (
-        calculate_next_cron_run(
-            payload.cron_expression, schedule_timezone=payload.timezone
+    if not payload.schedule_enabled:
+        plan.next_run = None
+    elif payload.schedule_mode == "availability":
+        plan.next_run = datetime.utcnow()
+    elif plan.cron_expression:
+        plan.next_run = calculate_next_cron_run(
+            plan.cron_expression, schedule_timezone=payload.timezone
         )
-        if payload.schedule_enabled and payload.cron_expression
-        else (
-            datetime.utcnow()
-            if payload.schedule_enabled and payload.schedule_mode == "availability"
-            else None
-        )
-    )
+    else:
+        plan.next_run = None
     plan.pre_backup_script_id = payload.pre_backup_script_id
     plan.post_backup_script_id = payload.post_backup_script_id
     plan.pre_backup_script_parameters = payload.pre_backup_script_parameters

--- a/app/api/schedule.py
+++ b/app/api/schedule.py
@@ -10,6 +10,7 @@ from app.database.models import (
     User,
     ScheduledJob,
     ScheduledJobRepository,
+    AvailabilityScheduleSkip,
     BackupJob,
     CompactJob,
     PruneJob,
@@ -47,10 +48,36 @@ from app.utils.schedule_time import (
     normalize_schedule_timezone,
     to_utc_naive,
 )
+from app.services.schedule_availability import (
+    DEFAULT_AVAILABILITY_CHECK_INTERVAL_MINUTES,
+    repositories_available,
+    validate_availability_intervals,
+)
 
 logger = structlog.get_logger()
 router = APIRouter(tags=["schedule"], dependencies=[Depends(authorize_request)])
 _active_scheduled_backup_runs: set[str] = set()
+
+
+def _record_availability_skip(
+    db: Session,
+    job: ScheduledJob,
+    now: datetime,
+    *,
+    reason: str,
+    detail: str,
+) -> None:
+    """Persist a neutral availability decision for Activity history."""
+    db.add(
+        AvailabilityScheduleSkip(
+            scheduled_job_id=job.id,
+            reason=reason,
+            detail=detail,
+            occurred_at=now,
+            next_check_at=job.next_run,
+        )
+    )
+
 
 # Pydantic models
 from pydantic import BaseModel
@@ -58,7 +85,12 @@ from pydantic import BaseModel
 
 class ScheduledJobCreate(BaseModel):
     name: str
-    cron_expression: str
+    cron_expression: Optional[str] = None
+    schedule_mode: str = "cron"
+    availability_check_interval_minutes: int = (
+        DEFAULT_AVAILABILITY_CHECK_INTERVAL_MINUTES
+    )
+    min_success_interval_minutes: int = 0
     timezone: Optional[str] = None
     repository: Optional[str] = None  # Legacy single-repo (by path)
     repository_id: Optional[int] = None  # Single-repo (by ID)
@@ -95,6 +127,9 @@ class ScheduledJobCreate(BaseModel):
 class ScheduledJobUpdate(BaseModel):
     name: Optional[str] = None
     cron_expression: Optional[str] = None
+    schedule_mode: Optional[str] = None
+    availability_check_interval_minutes: Optional[int] = None
+    min_success_interval_minutes: Optional[int] = None
     timezone: Optional[str] = None
     repository: Optional[str] = None  # Legacy single-repo (by path)
     repository_id: Optional[int] = None  # Single-repo (by ID)
@@ -422,6 +457,9 @@ async def get_scheduled_jobs(
                     "id": job.id,
                     "name": job.name,
                     "cron_expression": job.cron_expression,
+                    "schedule_mode": job.schedule_mode,
+                    "availability_check_interval_minutes": job.availability_check_interval_minutes,
+                    "min_success_interval_minutes": job.min_success_interval_minutes,
                     "timezone": job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
                     "repository": job.repository,
                     "repository_id": job.repository_id,
@@ -581,13 +619,33 @@ async def create_scheduled_job(
             )
             # Continue anyway - the atomic transaction + rollback will protect us
 
-        # Validate timezone and cron expression
+        if job_data.schedule_mode not in {"cron", "availability"}:
+            raise HTTPException(
+                status_code=422, detail={"key": "backend.errors.schedule.invalidMode"}
+            )
+        try:
+            validate_availability_intervals(
+                job_data.availability_check_interval_minutes,
+                job_data.min_success_interval_minutes,
+            )
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=422,
+                detail={"key": "backend.errors.schedule.invalidAvailabilityInterval"},
+            ) from exc
+
+        # Validate timezone for both trigger types. Cron parsing only applies
+        # to the fixed-time trigger; availability schedules start polling now.
         try:
             schedule_timezone = normalize_schedule_timezone(job_data.timezone)
-            next_run = _calculate_next_schedule_run(
-                job_data.cron_expression,
-                schedule_timezone=schedule_timezone,
-            )
+            if job_data.schedule_mode == "availability":
+                next_run = to_utc_naive(datetime.now(timezone.utc))
+            else:
+                if not job_data.cron_expression:
+                    raise ValueError("cron expression is required")
+                next_run = _calculate_next_schedule_run(
+                    job_data.cron_expression, schedule_timezone=schedule_timezone
+                )
         except InvalidScheduleTimezone as e:
             _raise_invalid_schedule_timezone(e)
         except Exception as e:
@@ -633,7 +691,12 @@ async def create_scheduled_job(
         # Create scheduled job
         scheduled_job = ScheduledJob(
             name=job_data.name,
-            cron_expression=job_data.cron_expression,
+            cron_expression=(
+                job_data.cron_expression if job_data.schedule_mode == "cron" else None
+            ),
+            schedule_mode=job_data.schedule_mode,
+            availability_check_interval_minutes=job_data.availability_check_interval_minutes,
+            min_success_interval_minutes=job_data.min_success_interval_minutes,
             timezone=schedule_timezone,
             repository=job_data.repository,  # Legacy
             repository_id=job_data.repository_id,  # Single-repo by ID
@@ -777,6 +840,13 @@ async def create_scheduled_job(
                 "id": scheduled_job.id,
                 "name": scheduled_job.name,
                 "cron_expression": scheduled_job.cron_expression,
+                "schedule_mode": scheduled_job.schedule_mode,
+                "availability_check_interval_minutes": (
+                    scheduled_job.availability_check_interval_minutes
+                ),
+                "min_success_interval_minutes": (
+                    scheduled_job.min_success_interval_minutes
+                ),
                 "timezone": scheduled_job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
                 "repository": scheduled_job.repository,
                 "enabled": scheduled_job.enabled,
@@ -1040,6 +1110,9 @@ async def get_scheduled_job(
                 "id": job.id,
                 "name": job.name,
                 "cron_expression": job.cron_expression,
+                "schedule_mode": job.schedule_mode,
+                "availability_check_interval_minutes": job.availability_check_interval_minutes,
+                "min_success_interval_minutes": job.min_success_interval_minutes,
                 "timezone": job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
                 "repository": job.repository,
                 "enabled": job.enabled,
@@ -1121,23 +1194,58 @@ async def update_scheduled_job(
         schedule_definition_changed = (
             job_data.cron_expression is not None
             or "timezone" in job_data.model_fields_set
+            or job_data.schedule_mode is not None
+            or job_data.availability_check_interval_minutes is not None
+            or job_data.min_success_interval_minutes is not None
         )
         if schedule_definition_changed:
-            next_cron_expression = (
-                job_data.cron_expression
-                if job_data.cron_expression is not None
-                else job.cron_expression
+            next_schedule_mode = job_data.schedule_mode or job.schedule_mode
+            next_check_interval = (
+                job_data.availability_check_interval_minutes
+                if job_data.availability_check_interval_minutes is not None
+                else job.availability_check_interval_minutes
             )
+            next_min_success_interval = (
+                job_data.min_success_interval_minutes
+                if job_data.min_success_interval_minutes is not None
+                else job.min_success_interval_minutes
+            )
+            if next_schedule_mode not in {"cron", "availability"}:
+                raise HTTPException(
+                    status_code=422,
+                    detail={"key": "backend.errors.schedule.invalidMode"},
+                )
+            try:
+                validate_availability_intervals(
+                    next_check_interval, next_min_success_interval
+                )
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=422,
+                    detail={
+                        "key": "backend.errors.schedule.invalidAvailabilityInterval"
+                    },
+                ) from exc
             try:
                 next_schedule_timezone = normalize_schedule_timezone(
                     job_data.timezone
                     if "timezone" in job_data.model_fields_set
                     else job.timezone
                 )
-                next_run = _calculate_next_schedule_run(
-                    next_cron_expression,
-                    schedule_timezone=next_schedule_timezone,
-                )
+                if next_schedule_mode == "availability":
+                    next_cron_expression = None
+                    next_run = to_utc_naive(datetime.now(timezone.utc))
+                else:
+                    next_cron_expression = (
+                        job_data.cron_expression
+                        if job_data.cron_expression is not None
+                        else job.cron_expression
+                    )
+                    if not next_cron_expression:
+                        raise ValueError("cron expression is required")
+                    next_run = _calculate_next_schedule_run(
+                        next_cron_expression, schedule_timezone=next_schedule_timezone
+                    )
             except InvalidScheduleTimezone as e:
                 _raise_invalid_schedule_timezone(e)
             except Exception as e:
@@ -1150,6 +1258,9 @@ async def update_scheduled_job(
                 )
 
             job.cron_expression = next_cron_expression
+            job.schedule_mode = next_schedule_mode
+            job.availability_check_interval_minutes = next_check_interval
+            job.min_success_interval_minutes = next_min_success_interval
             job.timezone = next_schedule_timezone
             job.next_run = next_run
 
@@ -1162,9 +1273,13 @@ async def update_scheduled_job(
             job.enabled = job_data.enabled
             if job.enabled and not was_enabled and not schedule_definition_changed:
                 try:
-                    job.next_run = _calculate_next_schedule_run(
-                        job.cron_expression,
-                        schedule_timezone=job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
+                    job.next_run = (
+                        to_utc_naive(datetime.now(timezone.utc))
+                        if job.schedule_mode == "availability"
+                        else _calculate_next_schedule_run(
+                            job.cron_expression,
+                            schedule_timezone=job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
+                        )
                     )
                 except InvalidScheduleTimezone as e:
                     _raise_invalid_schedule_timezone(e)
@@ -1358,9 +1473,13 @@ async def toggle_scheduled_job(
         job.enabled = not job.enabled
         if job.enabled:
             try:
-                job.next_run = _calculate_next_schedule_run(
-                    job.cron_expression,
-                    schedule_timezone=job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
+                job.next_run = (
+                    to_utc_naive(datetime.now(timezone.utc))
+                    if job.schedule_mode == "availability"
+                    else _calculate_next_schedule_run(
+                        job.cron_expression,
+                        schedule_timezone=job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
+                    )
                 )
             except InvalidScheduleTimezone as e:
                 _raise_invalid_schedule_timezone(e)
@@ -1427,11 +1546,16 @@ async def duplicate_scheduled_job(
             counter += 1
             new_name = f"{base_name} ({counter})"
 
-        # Calculate next run time from cron expression
+        # Calculate the appropriate first run for the duplicate.
         try:
-            next_run = _calculate_next_schedule_run(
-                original_job.cron_expression,
-                schedule_timezone=original_job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
+            next_run = (
+                to_utc_naive(datetime.now(timezone.utc))
+                if original_job.schedule_mode == "availability"
+                else _calculate_next_schedule_run(
+                    original_job.cron_expression,
+                    schedule_timezone=original_job.timezone
+                    or DEFAULT_SCHEDULE_TIMEZONE,
+                )
             )
         except InvalidScheduleTimezone as e:
             _raise_invalid_schedule_timezone(e)
@@ -1448,6 +1572,11 @@ async def duplicate_scheduled_job(
         duplicated_job = ScheduledJob(
             name=new_name,
             cron_expression=original_job.cron_expression,
+            schedule_mode=original_job.schedule_mode,
+            availability_check_interval_minutes=(
+                original_job.availability_check_interval_minutes
+            ),
+            min_success_interval_minutes=original_job.min_success_interval_minutes,
             timezone=original_job.timezone or DEFAULT_SCHEDULE_TIMEZONE,
             repository=original_job.repository,
             repository_id=original_job.repository_id,
@@ -2798,6 +2927,86 @@ async def dispatch_due_scheduled_backups(
         if dispatched >= available_slots:
             break
         try:
+            if job.schedule_mode == "availability":
+                last_success = (
+                    db.query(BackupJob.completed_at)
+                    .filter(
+                        BackupJob.scheduled_job_id == job.id,
+                        BackupJob.status.in_(["completed", "completed_with_warnings"]),
+                        BackupJob.completed_at.isnot(None),
+                    )
+                    .order_by(BackupJob.completed_at.desc())
+                    .first()
+                )
+                if last_success and job.min_success_interval_minutes:
+                    allowed_at = to_utc_naive(last_success[0]) + timedelta(
+                        minutes=job.min_success_interval_minutes
+                    )
+                    if now < allowed_at:
+                        job.next_run = min(
+                            allowed_at,
+                            now
+                            + timedelta(
+                                minutes=job.availability_check_interval_minutes
+                            ),
+                        )
+                        _record_availability_skip(
+                            db,
+                            job,
+                            now,
+                            reason="minimum_interval_not_elapsed",
+                            detail="Minimum interval after the last successful backup has not elapsed.",
+                        )
+                        db.commit()
+                        logger.info(
+                            "Availability schedule skipped: minimum success interval",
+                            job_id=job.id,
+                        )
+                        continue
+                linked_repositories = (
+                    db.query(Repository)
+                    .join(
+                        ScheduledJobRepository,
+                        ScheduledJobRepository.repository_id == Repository.id,
+                    )
+                    .filter(ScheduledJobRepository.scheduled_job_id == job.id)
+                    .all()
+                )
+                if not linked_repositories and job.repository_id:
+                    repository = db.get(Repository, job.repository_id)
+                    linked_repositories = [repository] if repository else []
+                if not linked_repositories and job.repository:
+                    repository = (
+                        db.query(Repository)
+                        .filter(Repository.path == job.repository)
+                        .first()
+                    )
+                    linked_repositories = [repository] if repository else []
+                decision = repositories_available(db, linked_repositories)
+                if not linked_repositories or not decision.available:
+                    job.next_run = now + timedelta(
+                        minutes=job.availability_check_interval_minutes
+                    )
+                    _record_availability_skip(
+                        db,
+                        job,
+                        now,
+                        reason="source_unavailable",
+                        detail=(
+                            decision.reason
+                            if linked_repositories
+                            else "No repositories are configured for this automation."
+                        ),
+                    )
+                    db.commit()
+                    logger.info(
+                        "Availability schedule skipped: source unavailable",
+                        job_id=job.id,
+                        reason=decision.reason
+                        if linked_repositories
+                        else "no repositories configured",
+                    )
+                    continue
             run_key = _dispatch_due_scheduled_job(db, job, now)
             if run_key:
                 dispatched += 1

--- a/app/api/schedule.py
+++ b/app/api/schedule.py
@@ -2923,6 +2923,7 @@ async def dispatch_due_scheduled_backups(
         return
 
     dispatched = 0
+    skipped = 0
     for job in jobs:
         if dispatched >= available_slots:
             break
@@ -2958,6 +2959,7 @@ async def dispatch_due_scheduled_backups(
                             detail="Minimum interval after the last successful backup has not elapsed.",
                         )
                         db.commit()
+                        skipped += 1
                         logger.info(
                             "Availability schedule skipped: minimum success interval",
                             job_id=job.id,
@@ -2982,7 +2984,13 @@ async def dispatch_due_scheduled_backups(
                         .first()
                     )
                     linked_repositories = [repository] if repository else []
-                decision = repositories_available(db, linked_repositories)
+                if not linked_repositories:
+                    decision_reason = (
+                        "No repositories are configured for this automation."
+                    )
+                else:
+                    decision = await repositories_available(db, linked_repositories)
+                    decision_reason = decision.reason
                 if not linked_repositories or not decision.available:
                     job.next_run = now + timedelta(
                         minutes=job.availability_check_interval_minutes
@@ -2993,16 +3001,17 @@ async def dispatch_due_scheduled_backups(
                         now,
                         reason="source_unavailable",
                         detail=(
-                            decision.reason
+                            decision_reason
                             if linked_repositories
                             else "No repositories are configured for this automation."
                         ),
                     )
                     db.commit()
+                    skipped += 1
                     logger.info(
                         "Availability schedule skipped: source unavailable",
                         job_id=job.id,
-                        reason=decision.reason
+                        reason=decision_reason
                         if linked_repositories
                         else "no repositories configured",
                     )
@@ -3027,7 +3036,7 @@ async def dispatch_due_scheduled_backups(
                     error=str(notif_error),
                 )
 
-    deferred = len(jobs) - dispatched
+    deferred = len(jobs) - dispatched - skipped
     if deferred > 0:
         logger.info(
             "Deferred due scheduled backups until capacity is available",
@@ -3048,7 +3057,7 @@ async def check_scheduled_jobs():
                 backup_plan_execution_service,
             )
 
-            backup_plan_execution_service.dispatch_due_runs(db, now)
+            await backup_plan_execution_service.dispatch_due_runs(db, now)
             await run_due_scheduled_checks(db, now)
             await run_due_scheduled_restore_checks(db, now)
             dispatch_due_scheduled_rclone_mirrors(db, now)

--- a/app/database/alembic/versions/a3d1e7b4c9f2_add_availability_schedule_modes.py
+++ b/app/database/alembic/versions/a3d1e7b4c9f2_add_availability_schedule_modes.py
@@ -1,0 +1,52 @@
+"""add availability schedule modes
+
+Revision ID: a3d1e7b4c9f2
+Revises: f6c46c665fd3
+Create Date: 2026-08-07
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "a3d1e7b4c9f2"
+down_revision = "f6c46c665fd3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    for table in ("backup_plans", "scheduled_jobs"):
+        with op.batch_alter_table(table) as batch_op:
+            batch_op.add_column(
+                sa.Column(
+                    "schedule_mode", sa.String(), nullable=False, server_default="cron"
+                )
+            )
+            batch_op.add_column(
+                sa.Column(
+                    "availability_check_interval_minutes",
+                    sa.Integer(),
+                    nullable=False,
+                    server_default="30",
+                )
+            )
+            batch_op.add_column(
+                sa.Column(
+                    "min_success_interval_minutes",
+                    sa.Integer(),
+                    nullable=False,
+                    server_default="0",
+                )
+            )
+    with op.batch_alter_table("scheduled_jobs") as batch_op:
+        batch_op.alter_column(
+            "cron_expression", existing_type=sa.String(), nullable=True
+        )
+
+
+def downgrade() -> None:
+    # Availability schedules may not have a cron expression, so restoring the
+    # old NOT NULL constraint is unsafe. Keep this downgrade intentionally
+    # additive/non-destructive, matching the project's migration policy.
+    pass

--- a/app/database/alembic/versions/c7e4f8a1d2b3_add_availability_schedule_skip_history.py
+++ b/app/database/alembic/versions/c7e4f8a1d2b3_add_availability_schedule_skip_history.py
@@ -1,0 +1,59 @@
+"""add durable availability schedule skip history
+
+Revision ID: c7e4f8a1d2b3
+Revises: a3d1e7b4c9f2
+Create Date: 2026-08-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "c7e4f8a1d2b3"
+down_revision = "a3d1e7b4c9f2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("backup_plan_runs") as batch_op:
+        batch_op.add_column(sa.Column("skip_reason", sa.String(), nullable=True))
+
+    op.create_table(
+        "availability_schedule_skips",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "scheduled_job_id",
+            sa.Integer(),
+            sa.ForeignKey("scheduled_jobs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("reason", sa.String(), nullable=False),
+        sa.Column("detail", sa.Text(), nullable=True),
+        sa.Column("occurred_at", sa.DateTime(), nullable=False),
+        sa.Column("next_check_at", sa.DateTime(), nullable=True),
+    )
+    op.create_index(
+        "ix_availability_schedule_skips_scheduled_job_id",
+        "availability_schedule_skips",
+        ["scheduled_job_id"],
+    )
+    op.create_index(
+        "ix_availability_schedule_skips_occurred_at",
+        "availability_schedule_skips",
+        ["occurred_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_availability_schedule_skips_occurred_at",
+        table_name="availability_schedule_skips",
+    )
+    op.drop_index(
+        "ix_availability_schedule_skips_scheduled_job_id",
+        table_name="availability_schedule_skips",
+    )
+    op.drop_table("availability_schedule_skips")
+    with op.batch_alter_table("backup_plan_runs") as batch_op:
+        batch_op.drop_column("skip_reason")

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -778,9 +778,10 @@ class ScheduledJob(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, unique=True, nullable=False, index=True)
-    cron_expression = Column(
-        String, nullable=False
-    )  # e.g., "0 2 * * *" for daily at 2 AM
+    cron_expression = Column(String, nullable=True)  # Required for cron mode
+    schedule_mode = Column(String, default="cron", nullable=False)
+    availability_check_interval_minutes = Column(Integer, default=30, nullable=False)
+    min_success_interval_minutes = Column(Integer, default=0, nullable=False)
     timezone = Column(
         String, default="UTC", nullable=False
     )  # IANA timezone used to interpret cron_expression
@@ -842,6 +843,26 @@ class ScheduledJob(Base):
 
     created_at = Column(DateTime, default=utc_now)
     updated_at = Column(DateTime, nullable=True)
+
+
+class AvailabilityScheduleSkip(Base):
+    """A neutral, durable decision not to dispatch an availability automation."""
+
+    __tablename__ = "availability_schedule_skips"
+
+    id = Column(Integer, primary_key=True, index=True)
+    scheduled_job_id = Column(
+        Integer,
+        ForeignKey("scheduled_jobs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    reason = Column(String, nullable=False)
+    detail = Column(Text, nullable=True)
+    occurred_at = Column(DateTime, default=utc_now, nullable=False, index=True)
+    next_check_at = Column(DateTime, nullable=True)
+
+    scheduled_job = relationship("ScheduledJob")
 
 
 class ScheduledJobRepository(Base):
@@ -913,6 +934,9 @@ class BackupPlan(Base):
     failure_behavior = Column(String, default="continue", nullable=False)
 
     schedule_enabled = Column(Boolean, default=False, nullable=False)
+    schedule_mode = Column(String, default="cron", nullable=False)
+    availability_check_interval_minutes = Column(Integer, default=30, nullable=False)
+    min_success_interval_minutes = Column(Integer, default=0, nullable=False)
     cron_expression = Column(String, nullable=True)
     timezone = Column(String, default="UTC", nullable=False)
     last_run = Column(DateTime, nullable=True)
@@ -1052,6 +1076,9 @@ class BackupPlanRun(Base):
     started_at = Column(DateTime, nullable=True)
     completed_at = Column(DateTime, nullable=True)
     error_message = Column(Text, nullable=True)
+    # A scheduler decision that deliberately did not dispatch work. This remains
+    # separate from error_message so API consumers can render it as neutral.
+    skip_reason = Column(String, nullable=True)
     created_at = Column(DateTime, default=utc_now, nullable=False)
 
     retry_original_run_id = Column(

--- a/app/services/backup_plan_execution_service.py
+++ b/app/services/backup_plan_execution_service.py
@@ -6,7 +6,7 @@ import os
 import shlex
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Any, Optional
 
@@ -59,8 +59,9 @@ from app.services.template_service import get_system_variables
 from app.utils.archive_names import build_archive_name
 from app.utils.script_params import SYSTEM_VARIABLE_PREFIX
 from app.utils.ssh_utils import ssh_key_auth_args, write_ssh_key_to_tempfile
-from app.utils.source_locations import decode_source_locations
 from app.utils.schedule_time import calculate_next_cron_run, to_utc_naive
+from app.utils.source_locations import decode_source_locations
+from app.services.schedule_availability import source_locations_available
 
 logger = structlog.get_logger()
 
@@ -596,6 +597,66 @@ class BackupPlanExecutionService:
         for plan in due_plans:
             if self.has_active_run(db, plan.id):
                 continue
+            if plan.schedule_mode == "availability":
+                last_success = (
+                    db.query(BackupPlanRun.completed_at)
+                    .filter(
+                        BackupPlanRun.backup_plan_id == plan.id,
+                        BackupPlanRun.status.in_(SUCCESS_BACKUP_STATUSES),
+                        BackupPlanRun.completed_at.isnot(None),
+                    )
+                    .order_by(BackupPlanRun.completed_at.desc())
+                    .first()
+                )
+                if last_success and plan.min_success_interval_minutes:
+                    allowed_at = to_utc_naive(last_success[0]) + timedelta(
+                        minutes=plan.min_success_interval_minutes
+                    )
+                    if now < allowed_at:
+                        plan.next_run = min(
+                            allowed_at,
+                            now
+                            + timedelta(
+                                minutes=plan.availability_check_interval_minutes
+                            ),
+                        )
+                        self._record_availability_skip(
+                            db,
+                            plan,
+                            now,
+                            reason="minimum_interval_not_elapsed",
+                            detail="Minimum interval after the last successful backup has not elapsed.",
+                        )
+                        db.commit()
+                        logger.info(
+                            "Availability schedule skipped: minimum success interval",
+                            backup_plan_id=plan.id,
+                        )
+                        continue
+                decision = source_locations_available(
+                    db,
+                    decode_source_locations(plan.source_locations),
+                    fallback_source_type=plan.source_type,
+                    fallback_ssh_connection_id=plan.source_ssh_connection_id,
+                )
+                if not decision.available:
+                    plan.next_run = now + timedelta(
+                        minutes=plan.availability_check_interval_minutes
+                    )
+                    self._record_availability_skip(
+                        db,
+                        plan,
+                        now,
+                        reason="source_unavailable",
+                        detail=decision.reason or "The backup source is unavailable.",
+                    )
+                    db.commit()
+                    logger.info(
+                        "Availability schedule skipped: source unavailable",
+                        backup_plan_id=plan.id,
+                        reason=decision.reason,
+                    )
+                    continue
             access_decision = evaluate_backup_plan_access(db, plan)
             if not access_decision.allowed:
                 logger.warning(
@@ -639,6 +700,45 @@ class BackupPlanExecutionService:
                 )
                 db.rollback()
         return dispatched
+
+    @staticmethod
+    def _record_availability_skip(
+        db: Session,
+        plan: BackupPlan,
+        now: datetime,
+        *,
+        reason: str,
+        detail: str,
+    ) -> None:
+        """Persist a neutral availability decision for the plan run history.
+
+        A skipped poll is useful operator evidence, but it must not look like a
+        failed backup or affect the successful-run interval calculation.
+        """
+        run = BackupPlanRun(
+            backup_plan_id=plan.id,
+            trigger="availability",
+            status="skipped",
+            started_at=now,
+            completed_at=now,
+            error_message=detail,
+            skip_reason=reason,
+            created_at=now,
+        )
+        db.add(run)
+        db.flush()
+        for link in plan.repositories:
+            if link.enabled:
+                db.add(
+                    BackupPlanRunRepository(
+                        backup_plan_run_id=run.id,
+                        repository_id=link.repository_id,
+                        status="skipped",
+                        started_at=now,
+                        completed_at=now,
+                        error_message=detail,
+                    )
+                )
 
     def has_active_run(self, db: Session, plan_id: int) -> bool:
         return (

--- a/app/services/backup_plan_execution_service.py
+++ b/app/services/backup_plan_execution_service.py
@@ -575,7 +575,7 @@ def _remote_script_body(script: str, env: dict[str, str]) -> str:
 
 
 class BackupPlanExecutionService:
-    def dispatch_due_runs(self, db: Session, now: datetime) -> int:
+    async def dispatch_due_runs(self, db: Session, now: datetime) -> int:
         now = to_utc_naive(now)
         due_plans = (
             db.query(BackupPlan)
@@ -633,7 +633,7 @@ class BackupPlanExecutionService:
                             backup_plan_id=plan.id,
                         )
                         continue
-                decision = source_locations_available(
+                decision = await source_locations_available(
                     db,
                     decode_source_locations(plan.source_locations),
                     fallback_source_type=plan.source_type,
@@ -721,7 +721,6 @@ class BackupPlanExecutionService:
             status="skipped",
             started_at=now,
             completed_at=now,
-            error_message=detail,
             skip_reason=reason,
             created_at=now,
         )
@@ -736,7 +735,6 @@ class BackupPlanExecutionService:
                         status="skipped",
                         started_at=now,
                         completed_at=now,
-                        error_message=detail,
                     )
                 )
 

--- a/app/services/job_history_retention.py
+++ b/app/services/job_history_retention.py
@@ -53,6 +53,7 @@ from app.database.models import (
     BackupJob,
     BackupJobRetryLineage,
     BackupPlanRun,
+    AvailabilityScheduleSkip,
     CheckJob,
     CompactJob,
     DeleteArchiveJob,
@@ -95,6 +96,7 @@ _JOB_TABLES = (
     (PackageInstallJob, ("stdout", "stderr")),
     (ScriptExecution, ("stdout", "stderr")),
     (BackupPlanRun, ()),
+    (AvailabilityScheduleSkip, ()),
 )
 
 
@@ -108,14 +110,19 @@ def _older_than(model, cutoff):
     the freshest timestamp the table has: completed_at, then updated_at
     (refreshed on every agent log line), then started_at, then created_at.
     """
-    columns = [model.completed_at]
-    if hasattr(model, "updated_at"):
-        columns.append(model.updated_at)
-    if hasattr(model, "started_at"):
-        columns.append(model.started_at)
-    if hasattr(model, "created_at"):
-        columns.append(model.created_at)
-    return (func.coalesce(*columns) < cutoff,)
+    columns = []
+    for name in (
+        "completed_at",
+        "occurred_at",
+        "updated_at",
+        "started_at",
+        "created_at",
+    ):
+        column = getattr(model, name, None)
+        if column is not None:
+            columns.append(column)
+    timestamp = columns[0] if len(columns) == 1 else func.coalesce(*columns)
+    return (timestamp < cutoff,)
 
 
 def _delete_chunked(db: Session, model, filters) -> int:

--- a/app/services/schedule_availability.py
+++ b/app/services/schedule_availability.py
@@ -1,0 +1,107 @@
+"""Availability gates shared by availability-triggered backup schedules.
+
+The gate is deliberately side-effect free: an unavailable source is a neutral
+skip, never a failed backup job or notification-worthy scheduler exception.
+"""
+
+from __future__ import annotations
+
+import socket
+from dataclasses import dataclass
+from typing import Iterable
+from sqlalchemy.orm import Session
+
+from app.database.models import Repository, SSHConnection
+from app.services.agent_connection_manager import agent_connection_manager
+
+DEFAULT_AVAILABILITY_CHECK_INTERVAL_MINUTES = 30
+MIN_AVAILABILITY_CHECK_INTERVAL_MINUTES = 1
+MAX_AVAILABILITY_CHECK_INTERVAL_MINUTES = 24 * 60
+MAX_MIN_SUCCESS_INTERVAL_MINUTES = 365 * 24 * 60
+
+
+@dataclass(frozen=True)
+class AvailabilityDecision:
+    available: bool
+    reason: str | None = None
+
+
+def validate_availability_intervals(
+    check_minutes: int, min_success_minutes: int
+) -> None:
+    if (
+        not MIN_AVAILABILITY_CHECK_INTERVAL_MINUTES
+        <= check_minutes
+        <= MAX_AVAILABILITY_CHECK_INTERVAL_MINUTES
+    ):
+        raise ValueError(
+            "availability_check_interval_minutes must be between 1 and 1440"
+        )
+    if not 0 <= min_success_minutes <= MAX_MIN_SUCCESS_INTERVAL_MINUTES:
+        raise ValueError("min_success_interval_minutes must be between 0 and 525600")
+
+
+def _ssh_reachable(connection: SSHConnection) -> bool:
+    if not connection.host:
+        return False
+    try:
+        with socket.create_connection(
+            (connection.host, connection.port or 22), timeout=3
+        ):
+            return True
+    except OSError:
+        return False
+
+
+def repositories_available(
+    db: Session, repositories: Iterable[Repository]
+) -> AvailabilityDecision:
+    """Require every selected source to be available; local sources are available."""
+    for repository in repositories:
+        if repository.agent_machine_id is not None:
+            if not agent_connection_manager.is_connected(repository.agent_machine_id):
+                return AvailabilityDecision(
+                    False, f"managed agent unavailable for {repository.name}"
+                )
+            continue
+        if repository.source_ssh_connection_id is not None:
+            connection = db.get(SSHConnection, repository.source_ssh_connection_id)
+            if connection is None or not _ssh_reachable(connection):
+                return AvailabilityDecision(
+                    False, f"SSH source unavailable for {repository.name}"
+                )
+    return AvailabilityDecision(True)
+
+
+def source_locations_available(
+    db: Session,
+    locations: Iterable[dict],
+    *,
+    fallback_source_type: str = "local",
+    fallback_ssh_connection_id: int | None = None,
+) -> AvailabilityDecision:
+    """Check plan source locations, falling back to the plan's legacy source fields."""
+    locations = list(locations)
+    if not locations:
+        locations = [
+            {
+                "source_type": fallback_source_type,
+                "source_ssh_connection_id": fallback_ssh_connection_id,
+            }
+        ]
+    for location in locations:
+        source_type = location.get("source_type", "local")
+        if source_type == "agent":
+            agent_id = location.get("agent_machine_id")
+            if agent_id is None or not agent_connection_manager.is_connected(
+                int(agent_id)
+            ):
+                return AvailabilityDecision(False, "managed agent unavailable")
+        elif source_type == "remote":
+            connection_id = location.get("source_ssh_connection_id")
+            connection = (
+                db.get(SSHConnection, int(connection_id)) if connection_id else None
+            )
+            if connection is None or not _ssh_reachable(connection):
+                return AvailabilityDecision(False, "SSH source unavailable")
+    return AvailabilityDecision(True)

--- a/app/services/schedule_availability.py
+++ b/app/services/schedule_availability.py
@@ -6,6 +6,7 @@ skip, never a failed backup job or notification-worthy scheduler exception.
 
 from __future__ import annotations
 
+import asyncio
 import socket
 from dataclasses import dataclass
 from typing import Iterable
@@ -53,7 +54,7 @@ def _ssh_reachable(connection: SSHConnection) -> bool:
         return False
 
 
-def repositories_available(
+async def repositories_available(
     db: Session, repositories: Iterable[Repository]
 ) -> AvailabilityDecision:
     """Require every selected source to be available; local sources are available."""
@@ -66,14 +67,16 @@ def repositories_available(
             continue
         if repository.source_ssh_connection_id is not None:
             connection = db.get(SSHConnection, repository.source_ssh_connection_id)
-            if connection is None or not _ssh_reachable(connection):
+            if connection is None or not await asyncio.to_thread(
+                _ssh_reachable, connection
+            ):
                 return AvailabilityDecision(
                     False, f"SSH source unavailable for {repository.name}"
                 )
     return AvailabilityDecision(True)
 
 
-def source_locations_available(
+async def source_locations_available(
     db: Session,
     locations: Iterable[dict],
     *,
@@ -102,6 +105,8 @@ def source_locations_available(
             connection = (
                 db.get(SSHConnection, int(connection_id)) if connection_id else None
             )
-            if connection is None or not _ssh_reachable(connection):
+            if connection is None or not await asyncio.to_thread(
+                _ssh_reachable, connection
+            ):
                 return AvailabilityDecision(False, "SSH source unavailable")
     return AvailabilityDecision(True)

--- a/docs/engineering/plans/2026-08-07-availability-based-backup-scheduling.md
+++ b/docs/engineering/plans/2026-08-07-availability-based-backup-scheduling.md
@@ -25,7 +25,7 @@ Vitest, Storybook.
 - `app/api/backup_plans.py`
 - `app/api/schedule.py`
 - `app/services/backup_plan_execution_service.py`
-- `app/services/availability_schedule_service.py` (new)
+- `app/services/schedule_availability.py` (new)
 - scheduler startup/tick code that currently dispatches scheduled jobs
 - backup notification/monitoring service(s)
 - schedule and backup-plan API, execution, and scheduler tests
@@ -39,36 +39,36 @@ Vitest, Storybook.
 
 ## Task 1: Map current contracts and write failing backend tests
 
-- [ ] Identify the exact scheduled-job dispatch loop, plan dispatch loop,
+- [x] Identify the exact scheduled-job dispatch loop, plan dispatch loop,
   active-run locking, current history records, and notification decision points.
-- [ ] Add failing migration/model tests for trigger fields on `BackupPlan` and
+- [x] Add failing migration/model tests for trigger fields on `BackupPlan` and
   `ScheduledJob`, `skip_reason` on plan runs, and durable automation run
   history.
-- [ ] Add API tests for both resources: cron remains valid/default; availability
+- [x] Add API tests for both resources: cron remains valid/default; availability
   requires positive bounded polling and minimum intervals; incompatible fields
   are rejected; responses round-trip the selected mode.
-- [ ] Add resolver tests for local, healthy/unhealthy managed-agent, reachable/
+- [x] Add resolver tests for local, healthy/unhealthy managed-agent, reachable/
   unreachable SSH, elapsed/not-elapsed intervals, active run, and target
   readiness.
 - [ ] Add concurrency tests proving two scheduler workers/ticks cannot claim
   two availability runs for the same entity.
-- [ ] Add history/notification tests proving each non-dispatch reason is
+- [x] Add history/notification tests proving each non-dispatch reason is
   `skipped`, not failure-notified, and does not update successful-run state.
 
 ## Task 2: Persist and validate trigger settings
 
-- [ ] Add nullable `schedule_trigger`, `availability_check_interval_minutes`,
-  and `minimum_success_interval_minutes` columns to `backup_plans` and
-  `scheduled_jobs` through the Alembic availability-schedule revision. Backfill trigger to
-  `cron`.
-- [ ] Add `ScheduledJobRun` with entity ID, trigger, status, skip reason,
+- [x] Add `schedule_mode`, `availability_check_interval_minutes`, and
+  `min_success_interval_minutes` columns to `backup_plans` and
+  `scheduled_jobs` through the Alembic availability-schedule revision. They are
+  `NOT NULL` with server defaults, and existing rows backfill to `cron`.
+- [x] Add `AvailabilityScheduleSkip` with entity ID, skip reason,
   timestamps, detail/error message, and indexes for latest state/history.
-- [ ] Add nullable `skip_reason` to `BackupPlanRun`; use existing status values
+- [x] Add nullable `skip_reason` to `BackupPlanRun`; use existing status values
   where possible.
-- [ ] Implement a single validation/normalization helper shared by plan and
+- [x] Implement a single validation/normalization helper shared by plan and
   automation APIs. It must enforce the mode-specific contract and preserve
   legacy cron behavior.
-- [ ] Serialize trigger configuration, last successful run, next poll, and run
+- [x] Serialize trigger configuration, last successful run, next poll, and run
   history data without removing existing response fields.
 
 ## Task 3: Implement safe dispatch and history

--- a/docs/engineering/plans/2026-08-07-availability-based-backup-scheduling.md
+++ b/docs/engineering/plans/2026-08-07-availability-based-backup-scheduling.md
@@ -1,0 +1,140 @@
+# Availability-Based Backup Scheduling Implementation Plan
+
+> **For agentic workers:** Use `superpowers:test-driven-development` for each
+> implementation task and `superpowers:verification-before-completion` before
+> claiming completion, committing, or pushing.
+
+**Goal:** Let Backup Plans and Backup Automations run at a fixed cron time or
+when their source is available, with a minimum time between successful backups.
+
+**Architecture:** Persist one explicit trigger mode and its mode-specific
+settings on both scheduling models. A shared availability dispatcher evaluates
+source/target readiness and the last successful run before atomically creating
+a normal execution run. It records non-dispatches as neutral skipped history
+events. Existing fixed-time code paths remain the default and unchanged.
+
+**Tech Stack:** FastAPI, SQLAlchemy, asyncio scheduler, pytest, React, MUI,
+Vitest, Storybook.
+
+---
+
+## Files to Inspect and Modify
+
+- `app/database/models.py`
+- `app/database/alembic/versions/a3d1e7b4c9f2_add_availability_schedule_modes.py`
+- `app/api/backup_plans.py`
+- `app/api/schedule.py`
+- `app/services/backup_plan_execution_service.py`
+- `app/services/availability_schedule_service.py` (new)
+- scheduler startup/tick code that currently dispatches scheduled jobs
+- backup notification/monitoring service(s)
+- schedule and backup-plan API, execution, and scheduler tests
+- `frontend/src/components/ScheduleWizard.tsx` (rename incrementally only if
+  low-risk; user-visible name changes are required)
+- `frontend/src/components/shared/SchedulePicker.tsx` and its stories/tests
+- Backup Plan wizard schedule/review components and stories/tests
+- `frontend/src/pages/Schedule.tsx`, `ScheduleByPlanTab.tsx`, translations, and
+  schedule-page tests
+- relevant user navigation documentation
+
+## Task 1: Map current contracts and write failing backend tests
+
+- [ ] Identify the exact scheduled-job dispatch loop, plan dispatch loop,
+  active-run locking, current history records, and notification decision points.
+- [ ] Add failing migration/model tests for trigger fields on `BackupPlan` and
+  `ScheduledJob`, `skip_reason` on plan runs, and durable automation run
+  history.
+- [ ] Add API tests for both resources: cron remains valid/default; availability
+  requires positive bounded polling and minimum intervals; incompatible fields
+  are rejected; responses round-trip the selected mode.
+- [ ] Add resolver tests for local, healthy/unhealthy managed-agent, reachable/
+  unreachable SSH, elapsed/not-elapsed intervals, active run, and target
+  readiness.
+- [ ] Add concurrency tests proving two scheduler workers/ticks cannot claim
+  two availability runs for the same entity.
+- [ ] Add history/notification tests proving each non-dispatch reason is
+  `skipped`, not failure-notified, and does not update successful-run state.
+
+## Task 2: Persist and validate trigger settings
+
+- [ ] Add nullable `schedule_trigger`, `availability_check_interval_minutes`,
+  and `minimum_success_interval_minutes` columns to `backup_plans` and
+  `scheduled_jobs` through the Alembic availability-schedule revision. Backfill trigger to
+  `cron`.
+- [ ] Add `ScheduledJobRun` with entity ID, trigger, status, skip reason,
+  timestamps, detail/error message, and indexes for latest state/history.
+- [ ] Add nullable `skip_reason` to `BackupPlanRun`; use existing status values
+  where possible.
+- [ ] Implement a single validation/normalization helper shared by plan and
+  automation APIs. It must enforce the mode-specific contract and preserve
+  legacy cron behavior.
+- [ ] Serialize trigger configuration, last successful run, next poll, and run
+  history data without removing existing response fields.
+
+## Task 3: Implement safe dispatch and history
+
+- [ ] Implement `availability_schedule_service` with an injectable clock and
+  source readiness adapters. Use agent presence for managed-agent sources and a
+  lightweight SSH/TCP probe for SSH sources.
+- [ ] Add a common decision result type: dispatch or a named neutral skip
+  reason. Do not run hooks or Borg during probing.
+- [ ] Implement database-backed claim/check logic that rechecks enabled state,
+  active run, target readiness, and latest *successful* run in one transaction.
+- [ ] Wire availability ticks into the existing scheduler. Poll only when an
+  item's interval is due, set meaningful next-poll metadata, and retain cron
+  calculation exclusively for cron mode.
+- [ ] Route claimed Backup Plans through `BackupPlanExecutionService`; route
+  claimed Backup Automations through their existing execution path.
+- [ ] Persist skipped decisions in plan and automation histories. Wire skip
+  suppression into alerting/monitoring and retain normal alerts for actual
+  attempted-run failures.
+- [ ] Require all enabled target repositories to pass lightweight pre-dispatch
+  validation before a multi-repository automation is claimed; record one
+  target-specific skipped event rather than a partial run.
+
+## Task 4: Add frontend trigger controls and terminology
+
+- [ ] Extend shared `SchedulePicker` (and supporting schedule types) with a
+  composed Run trigger control. Reuse `CronExpressionInput`,
+  `CronBuilderDialog`, and the `SchedulePicker` timezone selector for cron
+  mode; do not introduce ad hoc cron/timezone fields.
+- [ ] Add availability-mode fields for poll interval and minimum success
+  interval, including validation and detected source-signal explanation.
+- [ ] Integrate the shared control into both Backup Plan and Backup Automation
+  wizards, payload hydration, edit flows, and review summaries.
+- [ ] Rename user-visible standalone scheduling language from Legacy Backup
+  Schedules/Create legacy schedule to Backup automations/Create backup
+  automation. Keep route/API/model compatibility and avoid broad risky internal
+  renames unless covered by tests.
+- [ ] Update run history/activity UI to render neutral skipped state and a clear
+  source-unavailable, target-unavailable, minimum-interval, or active-run
+  reason.
+- [ ] Add localized strings and update relevant user navigation docs.
+- [ ] Add/update Storybook stories for cron and availability triggers in both
+  workflows, plus skipped-history display.
+
+## Task 5: Verification
+
+- [ ] Run targeted backend tests for migration, APIs, dispatch decisions,
+  concurrency, histories, and notifications.
+- [ ] Run `ruff check app tests` and `ruff format --check app tests`.
+- [ ] Run `cd frontend && npm run check:locales`, `npm run typecheck`, `npm run
+  lint`, and focused Vitest tests.
+- [ ] Run or update Storybook tests and capture local visual proof with `cd
+  frontend && npm run snapshots`; do not commit generated snapshots.
+- [ ] Manually verify each workflow: cron behavior stays unchanged; an offline
+  SSH source creates a neutral skip; a reachable source runs after its interval;
+  a second near-boundary poll is held; failed runs do not reset the interval;
+  multi-target readiness blocks partial availability runs.
+
+## Rollout and Compatibility Checks
+
+- [ ] Verify migration against SQLite and supported production databases, and
+  ensure existing schedule rows become `cron` without a change in `next_run`.
+- [ ] Verify borgmatic import/export and repository-to-plan conversion retain
+  cron behavior; availability settings must not be silently represented as a
+  cron expression.
+- [ ] Verify dashboards/counts that distinguish plans from scheduled jobs now
+  use Backup automation wording without altering their numerical semantics.
+- [ ] Confirm all availability skip reasons are observable in history/logging
+  and absent from failure-notification paths.

--- a/docs/engineering/specs/2026-08-07-availability-based-backup-scheduling.md
+++ b/docs/engineering/specs/2026-08-07-availability-based-backup-scheduling.md
@@ -1,0 +1,178 @@
+# Availability-Based Backup Scheduling Spec
+
+## Problem
+
+Fixed cron times work for always-on machines, but a client that is sleeping or
+offline at its scheduled time creates a misleading failed backup and misses its
+backup window. Increasing cron frequency is not a safe workaround: it creates
+duplicate archives and can run again immediately across a day boundary.
+
+Issue [#714](https://github.com/karanhudia/borg-ui/issues/714) requests an
+unattended, availability-gated backup that runs at the first safe opportunity.
+
+## Desired Outcome
+
+Both Backup Plans and standalone Backup Automations can be triggered either at
+a fixed time or when their source becomes available. Availability-triggered
+items are checked at a configured cadence and start one run only when the
+source is reachable and the configured minimum interval since the last
+successful run has elapsed.
+
+The existing user-facing term **Legacy Backup Schedules** is replaced with
+**Backup automations**. This is a terminology and presentation change, not an
+API or database identity change: existing `ScheduledJob` records, endpoints,
+URLs, and imported borgmatic schedules remain compatible.
+
+## Scope
+
+- Add a shared trigger model to `BackupPlan` and `ScheduledJob` (the backing
+  model for Backup Automations).
+- Keep the existing fixed-time cron behavior as the default for all existing
+  records.
+- Add availability checks for managed-agent and SSH sources.
+- Add a configurable polling cadence and minimum-success interval.
+- Record a neutral, explainable skipped event whenever an availability polling
+  decision does not dispatch a backup.
+- Suppress failure notifications for those intentional skips.
+- Rename UI copy, navigation, help, accessibility labels, and documentation
+  from legacy schedules/backups to Backup automations where the reference means
+  a `ScheduledJob` workflow.
+
+## Non-Goals
+
+- Altering manual **Run now** behavior. A manual run bypasses the availability
+  trigger and minimum-success interval, while retaining normal execution
+  validation.
+- Replacing cron syntax or changing the behavior of existing fixed-time jobs.
+- Per-repository independent availability triggers in one multi-repository
+  automation. That can be considered later as an explicit partial-run feature.
+- Treating a failed backup, cancelled backup, or a warning-complete backup as a
+  successful interval reset.
+
+## Trigger Model
+
+Each scheduled entity has these settings:
+
+| Field | Fixed time | When available |
+| --- | --- | --- |
+| `schedule_trigger` | `cron` (default) | `availability` |
+| `cron_expression` | required | `NULL` |
+| `timezone` | required, current behavior | retained for display/API consistency; not used to evaluate elapsed intervals |
+| `availability_check_interval_minutes` | `NULL` | required positive bounded integer |
+| `minimum_success_interval_minutes` | `NULL` | required positive bounded integer |
+
+The initial bounds are 5 minutes through 7 days for the poll interval and 1
+hour through 30 days for the minimum interval. Defaults for a newly selected
+availability trigger are 30 minutes and 20 hours. These are product defaults,
+not an implicit migration of existing cron schedules.
+
+Elapsed time is calculated from UTC timestamps, never local clock dates. A
+successful run at 23:55 therefore cannot be followed by an availability run at
+00:05 unless the full configured interval has elapsed.
+
+## Availability Semantics
+
+At each due availability poll, in one decision transaction:
+
+1. Re-read the enabled item and ensure it has no active run.
+2. Resolve the source's availability signal.
+   - A managed-agent source is available only when its current connected/presence
+     state is healthy.
+   - An SSH source is available only when the lightweight existing SSH/TCP
+     reachability probe succeeds. The probe must not execute backup hooks,
+     unlock repositories, or start Borg.
+   - A local source is always available; its mode remains useful as an
+     interval-gated automatic backup.
+3. Require all enabled target repositories in a multi-repository item to pass
+   the existing lightweight pre-dispatch availability/credential validation.
+   This **all targets** policy prevents silently turning one configured backup
+   into a partial success. A failed target check produces one skipped item-wide
+   event that identifies the target; it does not run the other targets.
+4. Find the entity's latest completed `success` run. If `now - successful_at`
+   is less than the configured minimum interval, do not dispatch.
+5. Atomically claim a run only after all gates pass, then use the current normal
+   execution path. Concurrent scheduler ticks or web workers must not create
+   duplicate runs.
+
+Availability does not guarantee that a subsequent Borg invocation will succeed.
+Once a run has been claimed, ordinary connection, Borg, hook, repository, and
+notification failure behavior remains unchanged.
+
+## Skips, History, and Notifications
+
+Every availability poll that does not dispatch creates an event with status
+`skipped`, a machine-readable reason, timestamp, and human-readable detail.
+Initial reason values are:
+
+- `source_unavailable`
+- `target_unavailable`
+- `minimum_interval_not_elapsed`
+- `run_already_active`
+- `disabled_or_reconfigured` (only when a claimed poll becomes invalid before
+  dispatch; normally not shown as a user-visible issue)
+
+Backup Plan skips use `BackupPlanRun` records with an availability-specific
+trigger and `skip_reason`. Backup Automation skips use durable
+`AvailabilityScheduleSkip` records rather than relying only on logs, so their
+history is equally inspectable. Existing `last_run` remains supported for
+compatibility and display.
+
+Skipped records are neutral: they do not increment failed-backup counters,
+produce failure alerts, invoke failure notification channels, or reset the
+minimum-success interval. They are visible in run history and activity with a
+"Skipped" state and reason. A future notification preference may opt in to
+availability summaries, but none is sent initially.
+
+## API and Persistence Contract
+
+`POST`/`PUT` Backup Plan and Backup Automation payloads accept and return the
+trigger fields above. Validation requires exactly the fields appropriate to the
+selected trigger; it rejects cron in availability mode and availability fields
+in cron mode rather than retaining ambiguous hidden configuration.
+
+The Alembic availability-schedule revision adds trigger fields to `backup_plans` and
+`scheduled_jobs`, plus an indexed `availability_schedule_skips` table and
+`skip_reason` on `backup_plan_runs`. Existing rows receive `schedule_mode = 'cron'`
+and retain their existing cron expression, timezone, next run, and behavior.
+
+All API route names and persisted `ScheduledJob` identifiers remain unchanged.
+Responses may add `trigger_display`/next-poll metadata for presentation but
+must retain current schedule response fields until a separately versioned API
+cleanup.
+
+## UI and Content
+
+The Schedule controls in both the Backup Plan wizard and Backup Automation
+wizard use the shared `SchedulePicker` family. Add a **Run trigger** choice:
+
+- **At a fixed time** shows the existing cron expression builder and timezone
+  selector.
+- **When source is available** hides cron controls and shows check interval,
+  minimum interval after a successful run, and a read-only explanation of the
+  detected availability signal (managed agent connected, SSH reachable, or
+  local source).
+
+Review screens summarize the chosen trigger. The Schedule page calls the
+standalone section **Backup automations** and uses "Create backup automation",
+"Edit backup automation", and "Run backup automation". Internal component and
+type renames may be incremental, but user-visible legacy terminology should be
+removed in this feature. Existing routes and stored data are not renamed.
+
+Changed components require Storybook stories covering cron and availability
+states, including an unavailable/interval-held history example. Navigation
+guidance in user documentation must use Backup automations.
+
+## Acceptance Criteria
+
+- A user can configure either trigger type on a Backup Plan and a Backup
+  Automation.
+- Existing cron records run unchanged after migration.
+- An availability-triggered SSH or managed-agent backup runs on the first
+  successful poll after its minimum interval expires.
+- A polling decision that cannot run is persisted as a neutral skipped event
+  with a specific reason and sends no failure notification.
+- No two availability polls can start duplicate runs for the same item.
+- A multi-repository item does not silently run only a subset of its configured
+  enabled targets.
+- UI and user documentation say Backup automations, not Legacy Backup
+  Schedules, for standalone scheduled jobs.

--- a/docs/engineering/specs/2026-08-07-availability-based-backup-scheduling.md
+++ b/docs/engineering/specs/2026-08-07-availability-based-backup-scheduling.md
@@ -55,16 +55,16 @@ Each scheduled entity has these settings:
 
 | Field | Fixed time | When available |
 | --- | --- | --- |
-| `schedule_trigger` | `cron` (default) | `availability` |
+| `schedule_mode` | `cron` (default) | `availability` |
 | `cron_expression` | required | `NULL` |
 | `timezone` | required, current behavior | retained for display/API consistency; not used to evaluate elapsed intervals |
 | `availability_check_interval_minutes` | `NULL` | required positive bounded integer |
-| `minimum_success_interval_minutes` | `NULL` | required positive bounded integer |
+| `min_success_interval_minutes` | `NULL` | bounded integer (default `0`) |
 
-The initial bounds are 5 minutes through 7 days for the poll interval and 1
-hour through 30 days for the minimum interval. Defaults for a newly selected
-availability trigger are 30 minutes and 20 hours. These are product defaults,
-not an implicit migration of existing cron schedules.
+The poll interval is bounded from 1 through 1,440 minutes. The minimum-success
+interval is bounded from 0 through 525,600 minutes and defaults to 0. The UI
+starts availability schedules at 30 minutes and 20 hours; these are product
+defaults, not an implicit migration of existing cron schedules.
 
 Elapsed time is calculated from UTC timestamps, never local clock dates. A
 successful run at 23:55 therefore cannot be followed by an availability run at
@@ -105,10 +105,10 @@ Every availability poll that does not dispatch creates an event with status
 Initial reason values are:
 
 - `source_unavailable`
-- `target_unavailable`
+- `target_unavailable` (planned)
 - `minimum_interval_not_elapsed`
-- `run_already_active`
-- `disabled_or_reconfigured` (only when a claimed poll becomes invalid before
+- `run_already_active` (planned)
+- `disabled_or_reconfigured` (planned; only when a claimed poll becomes invalid before
   dispatch; normally not shown as a user-visible issue)
 
 Backup Plan skips use `BackupPlanRun` records with an availability-specific
@@ -126,9 +126,9 @@ availability summaries, but none is sent initially.
 ## API and Persistence Contract
 
 `POST`/`PUT` Backup Plan and Backup Automation payloads accept and return the
-trigger fields above. Validation requires exactly the fields appropriate to the
-selected trigger; it rejects cron in availability mode and availability fields
-in cron mode rather than retaining ambiguous hidden configuration.
+trigger fields above. Validation accepts both field groups for compatibility;
+when `schedule_mode` is `availability`, it discards `cron_expression` and
+starts polling immediately. Cron mode retains its normal cron validation.
 
 The Alembic availability-schedule revision adds trigger fields to `backup_plans` and
 `scheduled_jobs`, plus an indexed `availability_schedule_skips` table and

--- a/frontend/src/components/BackupJobsTable.tsx
+++ b/frontend/src/components/BackupJobsTable.tsx
@@ -115,6 +115,8 @@ const getTypeLabel = (type: string, t: (key: string) => string): string => {
       return t('backupJobsTable.types.rcloneHydrate')
     case 'script_execution':
       return t('backupJobsTable.types.scriptExecution')
+    case 'availability_check':
+      return t('backupJobsTable.types.availabilityCheck')
     default:
       return type
   }
@@ -144,6 +146,8 @@ const getTypeColor = (
       return 'primary'
     case 'script_execution':
       return 'secondary'
+    case 'availability_check':
+      return 'default'
     default:
       return 'default'
   }
@@ -164,6 +168,17 @@ const getTransportLabel = (
   }
   if (!executionMode) return null
   return t('backupJobsTable.transport.server')
+}
+
+const getSkipReasonLabel = (job: Job, t: (key: string) => string): string | null => {
+  if (job.status !== 'skipped') return null
+  if (job.skip_reason === 'minimum_interval_not_elapsed') {
+    return t('availabilitySchedule.skipReasons.minimumIntervalNotElapsed')
+  }
+  if (job.skip_reason === 'source_unavailable') {
+    return t('availabilitySchedule.skipReasons.sourceUnavailable')
+  }
+  return job.error_message || null
 }
 
 const RETRYABLE_BACKUP_JOB_STATUSES = new Set(['failed', 'cancelled'])
@@ -592,9 +607,13 @@ export const BackupJobsTable = <T extends Job = Job>({
       width: '180px',
       render: (job: T) => {
         const transportLabel = getTransportLabel(job.execution_mode, job.route_strategy, t)
+        const skipReasonLabel = getSkipReasonLabel(job, t)
         return (
           <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap" useFlexGap>
-            <StatusBadge status={job.status} />
+            <StatusBadge status={job.status} tooltip={skipReasonLabel || undefined} />
+            {skipReasonLabel && (
+              <Chip size="small" variant="outlined" color="default" label={skipReasonLabel} />
+            )}
             {transportLabel && <Chip size="small" variant="outlined" label={transportLabel} />}
           </Stack>
         )
@@ -782,7 +801,7 @@ export const BackupJobsTable = <T extends Job = Job>({
       onClick: handleDeleteClick,
       color: 'error',
       tooltip: t('backupJobsTable.actions.delete'),
-      show: (job) => job.status !== 'running', // Allow deleting pending jobs (useful for stuck jobs)
+      show: (job) => job.status !== 'running' && job.type !== 'availability_check', // Availability decisions are immutable history, not jobs.
     })
   }
 

--- a/frontend/src/components/BackupJobsTable.tsx
+++ b/frontend/src/components/BackupJobsTable.tsx
@@ -520,6 +520,10 @@ export const BackupJobsTable = <T extends Job = Job>({
           return <Typography variant="body2">{displayName}</Typography>
         }
 
+        if (job.type === 'availability_check') {
+          return <Typography variant="body2">{job.repository || '-'}</Typography>
+        }
+
         // For backup/restore/check/compact in Activity tab
         if (job.repository_path) {
           return (

--- a/frontend/src/components/BackupPlanRunsPanel.stories.tsx
+++ b/frontend/src/components/BackupPlanRunsPanel.stories.tsx
@@ -110,6 +110,19 @@ const noFailedRepositoriesRun: BackupPlanRun = {
   ],
 }
 
+const skippedAvailabilityRun: BackupPlanRun = {
+  id: 343,
+  backup_plan_id: plan.id,
+  trigger: 'availability',
+  status: 'skipped',
+  skip_reason: 'minimum_interval_not_elapsed',
+  error_message: 'Minimum interval after the last successful backup has not elapsed.',
+  started_at: '2026-05-22T08:15:00Z',
+  completed_at: '2026-05-22T08:15:00Z',
+  created_at: '2026-05-22T08:15:00Z',
+  repositories: [],
+}
+
 const allowRetry = (_run: BackupPlanRun): boolean => true
 const denyRetry = (_run: BackupPlanRun): boolean => false
 
@@ -162,5 +175,11 @@ export const DisabledNoFailedRepositories: Story = {
 export const DisabledNoPermission: Story = {
   args: {
     canRetryRun: denyRetry,
+  },
+}
+
+export const SkippedAvailabilityCheck: Story = {
+  args: {
+    runs: [skippedAvailabilityRun],
   },
 }

--- a/frontend/src/components/BackupPlanRunsPanel.tsx
+++ b/frontend/src/components/BackupPlanRunsPanel.tsx
@@ -54,8 +54,8 @@ function isActiveRun(status?: string): boolean {
 
 function runStatusColor(status?: string): 'default' | 'primary' | 'success' | 'warning' | 'error' {
   if (status === 'completed') return 'success'
-  if (status === 'completed_with_warnings' || status === 'partial' || status === 'skipped')
-    return 'warning'
+  if (status === 'completed_with_warnings' || status === 'partial') return 'warning'
+  if (status === 'skipped') return 'default'
   if (status === 'failed' || status === 'cancelled') return 'error'
   if (isActiveRun(status)) return 'primary'
   return 'default'
@@ -598,7 +598,28 @@ export default function BackupPlanRunsPanel({
       width: '160px',
       render: (run) => (
         <Stack spacing={0.75}>
-          <StatusBadge status={run.status} />
+          <StatusBadge
+            status={run.status}
+            tooltip={
+              run.skip_reason === 'minimum_interval_not_elapsed'
+                ? t('availabilitySchedule.skipReasons.minimumIntervalNotElapsed')
+                : run.skip_reason === 'source_unavailable'
+                  ? t('availabilitySchedule.skipReasons.sourceUnavailable')
+                  : undefined
+            }
+          />
+          {run.skip_reason && (
+            <Chip
+              size="small"
+              variant="outlined"
+              label={
+                run.skip_reason === 'minimum_interval_not_elapsed'
+                  ? t('availabilitySchedule.skipReasons.minimumIntervalNotElapsed')
+                  : t('availabilitySchedule.skipReasons.sourceUnavailable')
+              }
+              sx={{ alignSelf: 'flex-start' }}
+            />
+          )}
           {isActiveRun(run.status) && (
             <LinearProgress
               variant={getRunProgress(run) === 0 ? 'indeterminate' : 'determinate'}

--- a/frontend/src/components/ScheduleWizard.tsx
+++ b/frontend/src/components/ScheduleWizard.tsx
@@ -18,7 +18,7 @@ import { Repository } from '../types'
 export interface ScheduledJob {
   id: number
   name: string
-  cron_expression: string
+  cron_expression: string | null
   schedule_mode?: 'cron' | 'availability'
   timezone?: string | null
   availability_check_interval_minutes?: number | null
@@ -66,7 +66,7 @@ export interface ScheduleData {
   description: string | null
   repository_ids: number[]
   enabled: boolean
-  cron_expression: string
+  cron_expression: string | null
   schedule_mode: 'cron' | 'availability'
   timezone: string
   availability_check_interval_minutes: number
@@ -200,14 +200,11 @@ const ScheduleWizard: React.FC<ScheduleWizardProps> = ({
       name: scheduledJob.name,
       description: scheduledJob.description || '',
       repositoryIds: Array.from(new Set(repository_ids)),
-      cronExpression: scheduledJob.cron_expression,
+      cronExpression: scheduledJob.cron_expression || '',
       timezone: scheduledJob.timezone || 'UTC',
       scheduleMode: scheduledJob.schedule_mode || 'cron',
       availabilityCheckIntervalMinutes: scheduledJob.availability_check_interval_minutes ?? 30,
-      minimumSuccessIntervalHours: Math.max(
-        1,
-        Math.round((scheduledJob.min_success_interval_minutes ?? 20 * 60) / 60)
-      ),
+      minimumSuccessIntervalHours: (scheduledJob.min_success_interval_minutes ?? 20 * 60) / 60,
       archiveNameTemplate: scheduledJob.archive_name_template || '{job_name}-{now}',
       preBackupScriptId: scheduledJob.pre_backup_script_id || null,
       postBackupScriptId: scheduledJob.post_backup_script_id || null,
@@ -263,8 +260,8 @@ const ScheduleWizard: React.FC<ScheduleWizardProps> = ({
         return true
 
       case 'schedule':
-        if (!wizardState.cronExpression.trim()) return false
-        if (!wizardState.timezone.trim()) return false
+        if (wizardState.scheduleMode === 'cron' && !wizardState.cronExpression.trim()) return false
+        if (wizardState.scheduleMode === 'cron' && !wizardState.timezone.trim()) return false
         if (
           wizardState.scheduleMode === 'availability' &&
           wizardState.availabilityCheckIntervalMinutes < 1
@@ -272,7 +269,7 @@ const ScheduleWizard: React.FC<ScheduleWizardProps> = ({
           return false
         if (
           wizardState.scheduleMode === 'availability' &&
-          wizardState.minimumSuccessIntervalHours < 1
+          wizardState.minimumSuccessIntervalHours < 0
         )
           return false
         if (!wizardState.archiveNameTemplate.trim()) return false
@@ -302,11 +299,11 @@ const ScheduleWizard: React.FC<ScheduleWizardProps> = ({
       description: wizardState.description || null,
       repository_ids: Array.from(new Set(wizardState.repositoryIds)),
       enabled: mode === 'edit' && scheduledJob ? scheduledJob.enabled : true,
-      cron_expression: wizardState.cronExpression,
+      cron_expression: wizardState.scheduleMode === 'cron' ? wizardState.cronExpression : null,
       schedule_mode: wizardState.scheduleMode,
       timezone: wizardState.timezone,
       availability_check_interval_minutes: wizardState.availabilityCheckIntervalMinutes,
-      min_success_interval_minutes: wizardState.minimumSuccessIntervalHours * 60,
+      min_success_interval_minutes: Math.round(wizardState.minimumSuccessIntervalHours * 60),
       archive_name_template: wizardState.archiveNameTemplate,
       pre_backup_script_id: wizardState.preBackupScriptId,
       post_backup_script_id: wizardState.postBackupScriptId,

--- a/frontend/src/components/ScheduleWizard.tsx
+++ b/frontend/src/components/ScheduleWizard.tsx
@@ -19,7 +19,10 @@ export interface ScheduledJob {
   id: number
   name: string
   cron_expression: string
+  schedule_mode?: 'cron' | 'availability'
   timezone?: string | null
+  availability_check_interval_minutes?: number | null
+  min_success_interval_minutes?: number | null
   repository: string | null
   repository_id: number | null
   repository_ids: number[] | null
@@ -64,7 +67,10 @@ export interface ScheduleData {
   repository_ids: number[]
   enabled: boolean
   cron_expression: string
+  schedule_mode: 'cron' | 'availability'
   timezone: string
+  availability_check_interval_minutes: number
+  min_success_interval_minutes: number
   archive_name_template: string
   pre_backup_script_id: number | null
   post_backup_script_id: number | null
@@ -92,6 +98,9 @@ interface WizardState {
   // Step 2: Schedule
   cronExpression: string
   timezone: string
+  scheduleMode: 'cron' | 'availability'
+  availabilityCheckIntervalMinutes: number
+  minimumSuccessIntervalHours: number
   archiveNameTemplate: string
 
   // Step 3: Scripts
@@ -119,6 +128,9 @@ const createInitialState = (): WizardState => ({
   repositoryIds: [],
   cronExpression: '0 2 * * *',
   timezone: getBrowserTimeZone(),
+  scheduleMode: 'cron',
+  availabilityCheckIntervalMinutes: 30,
+  minimumSuccessIntervalHours: 20,
   archiveNameTemplate: '{job_name}-{now}',
   preBackupScriptId: null,
   postBackupScriptId: null,
@@ -190,6 +202,12 @@ const ScheduleWizard: React.FC<ScheduleWizardProps> = ({
       repositoryIds: Array.from(new Set(repository_ids)),
       cronExpression: scheduledJob.cron_expression,
       timezone: scheduledJob.timezone || 'UTC',
+      scheduleMode: scheduledJob.schedule_mode || 'cron',
+      availabilityCheckIntervalMinutes: scheduledJob.availability_check_interval_minutes ?? 30,
+      minimumSuccessIntervalHours: Math.max(
+        1,
+        Math.round((scheduledJob.min_success_interval_minutes ?? 20 * 60) / 60)
+      ),
       archiveNameTemplate: scheduledJob.archive_name_template || '{job_name}-{now}',
       preBackupScriptId: scheduledJob.pre_backup_script_id || null,
       postBackupScriptId: scheduledJob.post_backup_script_id || null,
@@ -247,6 +265,16 @@ const ScheduleWizard: React.FC<ScheduleWizardProps> = ({
       case 'schedule':
         if (!wizardState.cronExpression.trim()) return false
         if (!wizardState.timezone.trim()) return false
+        if (
+          wizardState.scheduleMode === 'availability' &&
+          wizardState.availabilityCheckIntervalMinutes < 1
+        )
+          return false
+        if (
+          wizardState.scheduleMode === 'availability' &&
+          wizardState.minimumSuccessIntervalHours < 1
+        )
+          return false
         if (!wizardState.archiveNameTemplate.trim()) return false
         return true
 
@@ -275,7 +303,10 @@ const ScheduleWizard: React.FC<ScheduleWizardProps> = ({
       repository_ids: Array.from(new Set(wizardState.repositoryIds)),
       enabled: mode === 'edit' && scheduledJob ? scheduledJob.enabled : true,
       cron_expression: wizardState.cronExpression,
+      schedule_mode: wizardState.scheduleMode,
       timezone: wizardState.timezone,
+      availability_check_interval_minutes: wizardState.availabilityCheckIntervalMinutes,
+      min_success_interval_minutes: wizardState.minimumSuccessIntervalHours * 60,
       archive_name_template: wizardState.archiveNameTemplate,
       pre_backup_script_id: wizardState.preBackupScriptId,
       post_backup_script_id: wizardState.postBackupScriptId,
@@ -328,6 +359,9 @@ const ScheduleWizard: React.FC<ScheduleWizardProps> = ({
             data={{
               cronExpression: wizardState.cronExpression,
               timezone: wizardState.timezone,
+              scheduleMode: wizardState.scheduleMode,
+              availabilityCheckIntervalMinutes: wizardState.availabilityCheckIntervalMinutes,
+              minimumSuccessIntervalHours: wizardState.minimumSuccessIntervalHours,
               archiveNameTemplate: wizardState.archiveNameTemplate,
             }}
             jobName={wizardState.name}

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Chip, Tooltip } from '@mui/material'
 import { useTranslation } from 'react-i18next'
+import { CircleMinus } from 'lucide-react'
 
 interface StatusBadgeProps {
   status: string
@@ -11,7 +12,7 @@ interface StatusBadgeProps {
 
 /**
  * Standardized status badge component used across Activity, Schedule, and Dashboard views
- * Shows consistent color and label representation for all job statuses (no icon)
+ * Shows consistent color and label representation for all job statuses.
  */
 export const StatusBadge: React.FC<StatusBadgeProps> = ({
   status,
@@ -36,6 +37,7 @@ export const StatusBadge: React.FC<StatusBadgeProps> = ({
       case 'in_progress':
         return 'info'
       case 'pending':
+      case 'skipped':
         return 'default'
       default:
         return 'default'
@@ -59,6 +61,8 @@ export const StatusBadge: React.FC<StatusBadgeProps> = ({
         return t('status.pending')
       case 'cancelled':
         return t('status.cancelled')
+      case 'skipped':
+        return t('status.skipped')
       default:
         return status.charAt(0).toUpperCase() + status.slice(1)
     }
@@ -69,6 +73,7 @@ export const StatusBadge: React.FC<StatusBadgeProps> = ({
   return (
     <Tooltip title={tooltip || label} arrow>
       <Chip
+        icon={status.toLowerCase() === 'skipped' ? <CircleMinus size={15} /> : undefined}
         label={label}
         color={getStatusColor(status)}
         size={size}

--- a/frontend/src/components/__tests__/RepositoryCard.test.tsx
+++ b/frontend/src/components/__tests__/RepositoryCard.test.tsx
@@ -476,10 +476,12 @@ describe('RepositoryCard', () => {
         />
       )
 
-      expect(screen.queryByRole('button', { name: /Legacy Backup/i })).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /Run backup automation/i })
+      ).not.toBeInTheDocument()
     })
 
-    it('shows legacy backup button for full mode repositories with source paths', () => {
+    it('shows backup automations button for full mode repositories with source paths', () => {
       renderWithProviders(
         <RepositoryCard
           repository={mockRepository}
@@ -490,7 +492,7 @@ describe('RepositoryCard', () => {
         />
       )
 
-      expect(screen.getByRole('button', { name: /Legacy Backup/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Run backup automation/i })).toBeInTheDocument()
     })
 
     it('shows Create Backup Plan as the primary repository backup action', () => {
@@ -505,7 +507,9 @@ describe('RepositoryCard', () => {
       )
 
       expect(screen.getByRole('button', { name: /Create Backup Plan/i })).toBeInTheDocument()
-      expect(screen.queryByRole('button', { name: /Legacy Backup/i })).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /Run backup automation/i })
+      ).not.toBeInTheDocument()
     })
 
     it('hides Compact and Prune buttons for observe mode but still allows Delete', () => {
@@ -720,7 +724,7 @@ describe('RepositoryCard', () => {
       expect(mockCallbacks.onBreakLock).toHaveBeenCalledTimes(1)
     })
 
-    it('calls onBackupNow and tracks event when Legacy Backup button is clicked', () => {
+    it('calls onBackupNow and tracks event when Run backup automation is clicked', () => {
       renderWithProviders(
         <RepositoryCard
           repository={mockRepository}
@@ -731,7 +735,7 @@ describe('RepositoryCard', () => {
         />
       )
 
-      fireEvent.click(screen.getByRole('button', { name: /Legacy Backup/i }))
+      fireEvent.click(screen.getByRole('button', { name: /Run backup automation/i }))
       expect(mockCallbacks.onBackupNow).toHaveBeenCalledTimes(1)
       expect(mockAnalyticsTracking.trackBackup).toHaveBeenCalledWith(
         'Start',
@@ -882,7 +886,7 @@ describe('RepositoryCard', () => {
       expect(screen.getByRole('button', { name: /Check/i })).toBeDisabled()
       expect(screen.getByRole('button', { name: /Compact/i })).toBeDisabled()
       expect(screen.getByRole('button', { name: /Prune/i })).toBeDisabled()
-      expect(screen.getByRole('button', { name: /Legacy Backup/i })).toBeDisabled()
+      expect(screen.getByRole('button', { name: /Run backup automation/i })).toBeDisabled()
       expect(screen.getByRole('button', { name: /Create Backup Plan/i })).toBeDisabled()
       expect(screen.getByRole('button', { name: /View Archives/i })).toBeDisabled()
     })
@@ -1366,7 +1370,7 @@ describe('RepositoryCard', () => {
       expect(screen.getByRole('button', { name: /Check/i })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /Compact/i })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /Prune/i })).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: /Legacy Backup/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Run backup automation/i })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /Create Backup Plan/i })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /View Archives/i })).toBeInTheDocument()
 

--- a/frontend/src/components/shared/SchedulePicker.stories.tsx
+++ b/frontend/src/components/shared/SchedulePicker.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
+
+import SchedulePicker, { type ScheduleMode } from './SchedulePicker'
+
+const meta = {
+  title: 'Shared/SchedulePicker',
+  component: SchedulePicker,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof SchedulePicker>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const AvailabilityTriggerPreview = () => {
+  const [scheduleMode, setScheduleMode] = useState<ScheduleMode>('availability')
+  const [cronExpression, setCronExpression] = useState('0 2 * * *')
+  const [timezone, setTimezone] = useState('UTC')
+  const [checkMinutes, setCheckMinutes] = useState(30)
+  const [minimumHours, setMinimumHours] = useState(20)
+
+  return (
+    <SchedulePicker
+      cronExpression={cronExpression}
+      timezone={timezone}
+      scheduleMode={scheduleMode}
+      availabilityCheckIntervalMinutes={checkMinutes}
+      minimumSuccessIntervalHours={minimumHours}
+      showTriggerMode
+      onChange={(updates) => {
+        if (updates.scheduleMode) setScheduleMode(updates.scheduleMode)
+        if (updates.cronExpression !== undefined) setCronExpression(updates.cronExpression)
+        if (updates.timezone) setTimezone(updates.timezone)
+        if (updates.availabilityCheckIntervalMinutes !== undefined) {
+          setCheckMinutes(updates.availabilityCheckIntervalMinutes)
+        }
+        if (updates.minimumSuccessIntervalHours !== undefined) {
+          setMinimumHours(updates.minimumSuccessIntervalHours)
+        }
+      }}
+    />
+  )
+}
+
+export const AvailabilityTrigger: Story = {
+  args: {
+    cronExpression: '0 2 * * *',
+    timezone: 'UTC',
+    onChange: () => {},
+  },
+  render: () => <AvailabilityTriggerPreview />,
+}

--- a/frontend/src/components/shared/SchedulePicker.tsx
+++ b/frontend/src/components/shared/SchedulePicker.tsx
@@ -1,21 +1,43 @@
 import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Autocomplete, Box, Stack, TextField, Tooltip, Typography } from '@mui/material'
+import {
+  Autocomplete,
+  Box,
+  FormControlLabel,
+  Stack,
+  Switch,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material'
 import { Info } from 'lucide-react'
 import CronExpressionParser from 'cron-parser'
 import CronExpressionInput from './CronExpressionInput'
 import { getBrowserTimeZone, getSupportedTimeZones } from '../../utils/dateUtils'
 
+export type ScheduleMode = 'cron' | 'availability'
+
 interface SchedulePickerProps {
   cronExpression: string
   timezone: string
-  onChange: (updates: { cronExpression?: string; timezone?: string }) => void
+  onChange: (updates: {
+    cronExpression?: string
+    timezone?: string
+    scheduleMode?: ScheduleMode
+    availabilityCheckIntervalMinutes?: number
+    minimumSuccessIntervalHours?: number
+  }) => void
+  scheduleMode?: ScheduleMode
+  availabilityCheckIntervalMinutes?: number
+  minimumSuccessIntervalHours?: number
   disabled?: boolean
   required?: boolean
   size?: 'small' | 'medium'
   cronLabel?: string
   cronHelperText?: string
   timezoneLabel?: string
+  /** Shows the missed-run catch-up policy controls. */
+  showTriggerMode?: boolean
   /** How many upcoming runs to show in the preview tooltip. Defaults to 3. */
   previewRunCount?: number
 }
@@ -38,6 +60,10 @@ const SchedulePicker: React.FC<SchedulePickerProps> = ({
   cronLabel,
   cronHelperText,
   timezoneLabel,
+  scheduleMode = 'cron',
+  availabilityCheckIntervalMinutes = 30,
+  minimumSuccessIntervalHours = 20,
+  showTriggerMode = false,
   previewRunCount = 3,
 }) => {
   const { t } = useTranslation()
@@ -80,39 +106,108 @@ const SchedulePicker: React.FC<SchedulePickerProps> = ({
 
   return (
     <Stack spacing={2}>
-      <CronExpressionInput
-        value={cronExpression}
-        onChange={(cron) => onChange({ cronExpression: cron })}
-        label={cronLabel ?? t('wizard.scheduleWizard.config.scheduleLabel')}
-        helperText={cronHelperText ?? t('wizard.scheduleWizard.config.scheduleHelper')}
-        required={required}
-        disabled={disabled}
-        size={size}
-      />
+      {showTriggerMode && (
+        <FormControlLabel
+          disabled={disabled}
+          control={
+            <Switch
+              checked={scheduleMode === 'availability'}
+              onChange={(event) =>
+                onChange({ scheduleMode: event.target.checked ? 'availability' : 'cron' })
+              }
+            />
+          }
+          label={t('schedule.trigger.catchUp', {
+            defaultValue: 'Run missed backups when the source becomes available',
+          })}
+        />
+      )}
 
-      <Autocomplete
-        options={timezoneOptions}
-        value={effectiveTimezone}
-        onChange={(_, value) => {
-          if (value) onChange({ timezone: value })
-        }}
-        disableClearable
-        disabled={disabled}
-        fullWidth
-        size={size}
-        autoHighlight
-        renderInput={(params) => (
+      <>
+        <CronExpressionInput
+          value={cronExpression}
+          onChange={(cron) => onChange({ cronExpression: cron })}
+          label={cronLabel ?? t('wizard.scheduleWizard.config.scheduleLabel')}
+          helperText={cronHelperText ?? t('wizard.scheduleWizard.config.scheduleHelper')}
+          required={required}
+          disabled={disabled}
+          size={size}
+        />
+
+        <Autocomplete
+          options={timezoneOptions}
+          value={effectiveTimezone}
+          onChange={(_, value) => {
+            if (value) onChange({ timezone: value })
+          }}
+          disableClearable
+          disabled={disabled}
+          fullWidth
+          size={size}
+          autoHighlight
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label={
+                timezoneLabel ??
+                t('wizard.scheduleWizard.config.timezoneLabel', { defaultValue: 'Timezone' })
+              }
+              required={required}
+              placeholder="Asia/Kolkata"
+            />
+          )}
+        />
+      </>
+
+      {scheduleMode === 'availability' && (
+        <Stack spacing={2}>
+          <Typography variant="body2" color="text.secondary">
+            {t('schedule.trigger.availabilityDescription', {
+              defaultValue:
+                'Borg UI checks for a reachable source and runs after the minimum interval has elapsed.',
+            })}
+          </Typography>
           <TextField
-            {...params}
-            label={
-              timezoneLabel ??
-              t('wizard.scheduleWizard.config.timezoneLabel', { defaultValue: 'Timezone' })
+            label={t('schedule.trigger.checkInterval', { defaultValue: 'Check every (minutes)' })}
+            helperText={t('schedule.trigger.checkIntervalHelper', {
+              defaultValue: 'How often Borg UI checks whether the source is available.',
+            })}
+            type="number"
+            value={availabilityCheckIntervalMinutes}
+            onChange={(event) =>
+              onChange({
+                availabilityCheckIntervalMinutes: Math.max(1, Number(event.target.value) || 1),
+              })
             }
+            inputProps={{ min: 1 }}
             required={required}
-            placeholder="Asia/Kolkata"
+            disabled={disabled}
+            size={size}
+            fullWidth
           />
-        )}
-      />
+          <TextField
+            label={t('schedule.trigger.minimumInterval', {
+              defaultValue: 'Minimum interval after a successful run (hours)',
+            })}
+            helperText={t('schedule.trigger.minimumIntervalHelper', {
+              defaultValue:
+                'Borg UI will not start another backup before this interval has elapsed.',
+            })}
+            type="number"
+            value={minimumSuccessIntervalHours}
+            onChange={(event) =>
+              onChange({
+                minimumSuccessIntervalHours: Math.max(1, Number(event.target.value) || 1),
+              })
+            }
+            inputProps={{ min: 1 }}
+            required={required}
+            disabled={disabled}
+            size={size}
+            fullWidth
+          />
+        </Stack>
+      )}
 
       {nextRunTimes && nextRunTimes.length > 0 && (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, pl: 0.25 }}>

--- a/frontend/src/components/shared/SchedulePicker.tsx
+++ b/frontend/src/components/shared/SchedulePicker.tsx
@@ -123,41 +123,43 @@ const SchedulePicker: React.FC<SchedulePickerProps> = ({
         />
       )}
 
-      <>
-        <CronExpressionInput
-          value={cronExpression}
-          onChange={(cron) => onChange({ cronExpression: cron })}
-          label={cronLabel ?? t('wizard.scheduleWizard.config.scheduleLabel')}
-          helperText={cronHelperText ?? t('wizard.scheduleWizard.config.scheduleHelper')}
-          required={required}
-          disabled={disabled}
-          size={size}
-        />
+      {scheduleMode === 'cron' && (
+        <>
+          <CronExpressionInput
+            value={cronExpression}
+            onChange={(cron) => onChange({ cronExpression: cron })}
+            label={cronLabel ?? t('wizard.scheduleWizard.config.scheduleLabel')}
+            helperText={cronHelperText ?? t('wizard.scheduleWizard.config.scheduleHelper')}
+            required={required}
+            disabled={disabled}
+            size={size}
+          />
 
-        <Autocomplete
-          options={timezoneOptions}
-          value={effectiveTimezone}
-          onChange={(_, value) => {
-            if (value) onChange({ timezone: value })
-          }}
-          disableClearable
-          disabled={disabled}
-          fullWidth
-          size={size}
-          autoHighlight
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label={
-                timezoneLabel ??
-                t('wizard.scheduleWizard.config.timezoneLabel', { defaultValue: 'Timezone' })
-              }
-              required={required}
-              placeholder="Asia/Kolkata"
-            />
-          )}
-        />
-      </>
+          <Autocomplete
+            options={timezoneOptions}
+            value={effectiveTimezone}
+            onChange={(_, value) => {
+              if (value) onChange({ timezone: value })
+            }}
+            disableClearable
+            disabled={disabled}
+            fullWidth
+            size={size}
+            autoHighlight
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label={
+                  timezoneLabel ??
+                  t('wizard.scheduleWizard.config.timezoneLabel', { defaultValue: 'Timezone' })
+                }
+                required={required}
+                placeholder="Asia/Kolkata"
+              />
+            )}
+          />
+        </>
+      )}
 
       {scheduleMode === 'availability' && (
         <Stack spacing={2}>
@@ -197,10 +199,10 @@ const SchedulePicker: React.FC<SchedulePickerProps> = ({
             value={minimumSuccessIntervalHours}
             onChange={(event) =>
               onChange({
-                minimumSuccessIntervalHours: Math.max(1, Number(event.target.value) || 1),
+                minimumSuccessIntervalHours: Math.max(0, Number(event.target.value) || 0),
               })
             }
-            inputProps={{ min: 1 }}
+            inputProps={{ min: 0, step: 'any' }}
             required={required}
             disabled={disabled}
             size={size}

--- a/frontend/src/components/shared/__tests__/SchedulePicker.test.tsx
+++ b/frontend/src/components/shared/__tests__/SchedulePicker.test.tsx
@@ -41,4 +41,24 @@ describe('SchedulePicker', () => {
     render(<SchedulePicker {...defaultProps} cronLabel="Custom cron label" />)
     expect(screen.getByRole('textbox', { name: /Custom cron label/i })).toBeInTheDocument()
   })
+
+  it('shows availability controls and emits availability policy updates', () => {
+    const onChange = vi.fn()
+    render(
+      <SchedulePicker
+        {...defaultProps}
+        onChange={onChange}
+        showTriggerMode
+        scheduleMode="availability"
+        availabilityCheckIntervalMinutes={30}
+        minimumSuccessIntervalHours={20}
+      />
+    )
+
+    expect(screen.getByDisplayValue('0 2 * * *')).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText(/check every/i), { target: { value: '45' } })
+    expect(onChange).toHaveBeenCalledWith({ availabilityCheckIntervalMinutes: 45 })
+    fireEvent.change(screen.getByLabelText(/minimum interval/i), { target: { value: '24' } })
+    expect(onChange).toHaveBeenCalledWith({ minimumSuccessIntervalHours: 24 })
+  })
 })

--- a/frontend/src/components/shared/__tests__/SchedulePicker.test.tsx
+++ b/frontend/src/components/shared/__tests__/SchedulePicker.test.tsx
@@ -55,7 +55,8 @@ describe('SchedulePicker', () => {
       />
     )
 
-    expect(screen.getByDisplayValue('0 2 * * *')).toBeInTheDocument()
+    expect(screen.queryByDisplayValue('0 2 * * *')).not.toBeInTheDocument()
+    expect(screen.queryByDisplayValue('UTC')).not.toBeInTheDocument()
     fireEvent.change(screen.getByLabelText(/check every/i), { target: { value: '45' } })
     expect(onChange).toHaveBeenCalledWith({ availabilityCheckIntervalMinutes: 45 })
     fireEvent.change(screen.getByLabelText(/minimum interval/i), { target: { value: '24' } })

--- a/frontend/src/components/wizard/schedule/WizardStepScheduleConfig.tsx
+++ b/frontend/src/components/wizard/schedule/WizardStepScheduleConfig.tsx
@@ -7,6 +7,9 @@ import ArchiveNameTemplateInput from '../../ArchiveNameTemplateInput'
 interface WizardStepScheduleConfigData {
   cronExpression: string
   timezone?: string
+  scheduleMode?: 'cron' | 'availability'
+  availabilityCheckIntervalMinutes?: number
+  minimumSuccessIntervalHours?: number
   archiveNameTemplate: string
 }
 
@@ -29,6 +32,10 @@ const WizardStepScheduleConfig: React.FC<WizardStepScheduleConfigProps> = ({
         cronExpression={data.cronExpression}
         timezone={data.timezone || 'UTC'}
         onChange={(updates) => onChange(updates)}
+        scheduleMode={data.scheduleMode}
+        availabilityCheckIntervalMinutes={data.availabilityCheckIntervalMinutes}
+        minimumSuccessIntervalHours={data.minimumSuccessIntervalHours}
+        showTriggerMode
         required
         size="medium"
         cronLabel={t('wizard.scheduleWizard.config.scheduleLabel')}

--- a/frontend/src/components/wizard/schedule/WizardStepScheduleReview.tsx
+++ b/frontend/src/components/wizard/schedule/WizardStepScheduleReview.tsx
@@ -12,6 +12,9 @@ interface WizardStepScheduleReviewProps {
     repositoryIds: number[]
     cronExpression: string
     timezone?: string
+    scheduleMode?: 'cron' | 'availability'
+    availabilityCheckIntervalMinutes?: number
+    minimumSuccessIntervalHours?: number
     archiveNameTemplate: string
     preBackupScriptId: number | null
     postBackupScriptId: number | null
@@ -268,12 +271,42 @@ const WizardStepScheduleReview: React.FC<WizardStepScheduleReviewProps> = ({
               </Typography>
             </AttrRow>
           )}
-          <AttrRow label={t('wizard.scheduleWizard.review.schedule')}>
-            <CodePill>{data.cronExpression}</CodePill>
-          </AttrRow>
-          <AttrRow label={t('wizard.scheduleWizard.review.timezone', { defaultValue: 'Timezone' })}>
-            <CodePill>{data.timezone || 'UTC'}</CodePill>
-          </AttrRow>
+          {data.scheduleMode === 'availability' ? (
+            <>
+              <AttrRow label={t('schedule.trigger.label', { defaultValue: 'Run trigger' })}>
+                <Typography variant="body2" fontSize="0.75rem" fontWeight={600}>
+                  {t('schedule.trigger.whenAvailable', {
+                    defaultValue: 'When source is available',
+                  })}
+                </Typography>
+              </AttrRow>
+              <AttrRow
+                label={t('schedule.trigger.checkInterval', {
+                  defaultValue: 'Check every (minutes)',
+                })}
+              >
+                <CodePill>{data.availabilityCheckIntervalMinutes ?? 30} min</CodePill>
+              </AttrRow>
+              <AttrRow
+                label={t('schedule.trigger.minimumInterval', {
+                  defaultValue: 'Minimum interval after a successful run (hours)',
+                })}
+              >
+                <CodePill>{data.minimumSuccessIntervalHours ?? 20} h</CodePill>
+              </AttrRow>
+            </>
+          ) : (
+            <>
+              <AttrRow label={t('wizard.scheduleWizard.review.schedule')}>
+                <CodePill>{data.cronExpression}</CodePill>
+              </AttrRow>
+              <AttrRow
+                label={t('wizard.scheduleWizard.review.timezone', { defaultValue: 'Timezone' })}
+              >
+                <CodePill>{data.timezone || 'UTC'}</CodePill>
+              </AttrRow>
+            </>
+          )}
           <AttrRow label={t('wizard.scheduleWizard.review.archiveNameTemplate')}>
             <CodePill>{data.archiveNameTemplate}</CodePill>
           </AttrRow>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -361,7 +361,8 @@
     "failed": "Fehlgeschlagen",
     "running": "Läuft",
     "pending": "Ausstehend",
-    "cancelled": "Abgebrochen"
+    "cancelled": "Abgebrochen",
+    "skipped": "Übersprungen"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -555,7 +556,7 @@
     "tabs": {
       "ariaLabel": "Art des Sicherungsvorgangs",
       "backupPlans": "Backup-Pläne",
-      "legacyBackup": "Legacy-Sicherung"
+      "legacyBackup": "Backup-Automatisierungen"
     },
     "planRun": {
       "title": "Backup-Plan ausführen",
@@ -691,7 +692,7 @@
     "createBackup": "Sicherungszeitplan erstellen",
     "createBackupPlan": "Backup-Plan erstellen",
     "createSchedule": "Zeitplan erstellen",
-    "createLegacySchedule": "Legacy-Zeitplan erstellen",
+    "createLegacySchedule": "Backup-Automatisierung erstellen",
     "addCheck": "Überprüfungszeitplan hinzufügen",
     "addRestoreCheck": "Restore-Prüfung hinzufügen",
     "tabs": {
@@ -726,8 +727,19 @@
       "runCheckTip": "Integritätsprüfung läuft nach jedem Backup (zusätzlich zu geplanten Prüfungen unten)"
     },
     "noRepositories": "Du musst mindestens ein Repository erstellen, bevor du Sicherungen planst.",
-    "legacyBackupSchedulesTitle": "Legacy-Sicherungszeitpläne",
-    "legacyBackupSchedulesDescription": "Bestehende Repository-basierte Zeitpläne laufen hier weiter. Neue geplante Sicherungen sollten als Backup-Pläne erstellt werden.",
+    "legacyBackupSchedulesTitle": "Backup-Automatisierungen",
+    "legacyBackupSchedulesDescription": "Benutzerdefinierte Repository-basierte Backup-Automatisierungen, einschließlich zeitgesteuerter und verfügbarkeitsbasierter Ausführungen.",
+    "trigger": {
+      "catchUp": "Verpasste Sicherungen ausführen, wenn die Quelle verfügbar wird",
+      "label": "Auslöser",
+      "fixedTime": "Zu einer festen Zeit",
+      "whenAvailable": "Wenn die Quelle verfügbar ist",
+      "availabilityDescription": "Borg UI prüft eine erreichbare Quelle und führt die Sicherung nach Ablauf des Mindestintervalls aus.",
+      "checkInterval": "Prüfen alle (Minuten)",
+      "checkIntervalHelper": "Wie oft Borg UI prüft, ob die Quelle verfügbar ist.",
+      "minimumInterval": "Mindestintervall nach erfolgreicher Ausführung (Stunden)",
+      "minimumIntervalHelper": "Borg UI startet keine weitere Sicherung, bevor dieses Intervall abgelaufen ist."
+    },
     "confirmRunNow": "\"{{name}}\" jetzt ausführen?",
     "maintenance": {
       "pruning": "Archive werden bereinigt...",
@@ -1536,7 +1548,8 @@
         "package": "Paket",
         "rcloneSync": "Cloud-Sync",
         "rcloneHydrate": "Cloud-Hydratisierung",
-        "scriptExecution": "Skript"
+        "scriptExecution": "Skript",
+        "availabilityCheck": "Verfügbarkeitsprüfung"
       },
       "statuses": {
         "completed": "Abgeschlossen",
@@ -1544,12 +1557,19 @@
         "needsBackup": "Backup erforderlich",
         "failed": "Fehlgeschlagen",
         "running": "Läuft",
-        "pending": "Ausstehend"
+        "pending": "Ausstehend",
+        "skipped": "Übersprungen"
       }
     },
     "empty": {
       "title": "Keine Aktivität gefunden",
       "message": "Es gibt keine Vorgänge, die deinen Filtern entsprechen"
+    }
+  },
+  "availabilitySchedule": {
+    "skipReasons": {
+      "minimumIntervalNotElapsed": "Mindestintervall noch nicht erreicht",
+      "sourceUnavailable": "Quelle nicht verfügbar"
     }
   },
   "cloudStorageJobs": {
@@ -2234,8 +2254,8 @@
       "rcloneHydrate": "Lokalen Cache hydratisieren",
       "enableCloudMirror": "Cloud-Spiegelung aktivieren",
       "backupNow": "Jetzt sichern",
-      "legacyBackup": "Legacy-Sicherung",
-      "legacyBackupTooltip": "Führe die alte repositorybasierte Sicherung mit den Legacy-Quellpfaden dieses Repositorys aus",
+      "legacyBackup": "Backup-Automatisierung ausführen",
+      "legacyBackupTooltip": "Führe die repositorybasierte Backup-Automatisierung mit den konfigurierten Quellpfaden dieses Repositorys aus",
       "backupPlanRequired": "Erstelle einen Backup-Plan, um Quellen zu definieren",
       "viewArchives": "Archive anzeigen",
       "viewBackupPlans": "Verknüpfte Backup-Pläne anzeigen",
@@ -2589,7 +2609,8 @@
       "package": "Paketinstallation",
       "rcloneSync": "Cloud-Sync",
       "rcloneHydrate": "Cloud-Hydratisierung",
-      "scriptExecution": "Skript"
+      "scriptExecution": "Skript",
+      "availabilityCheck": "Verfügbarkeitsprüfung"
     },
     "scheduledById": "Geplant (ID: {{id}})",
     "backupPlanByName": "Backup-Plan: {{name}}",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -361,7 +361,8 @@
     "failed": "Failed",
     "running": "Running",
     "pending": "Pending",
-    "cancelled": "Cancelled"
+    "cancelled": "Cancelled",
+    "skipped": "Skipped"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -555,7 +556,7 @@
     "tabs": {
       "ariaLabel": "Backup operation type",
       "backupPlans": "Backup Plans",
-      "legacyBackup": "Legacy Backup"
+      "legacyBackup": "Backup automations"
     },
     "planRun": {
       "title": "Run a Backup Plan",
@@ -691,7 +692,7 @@
     "createBackup": "Create Backup Schedule",
     "createBackupPlan": "Create Backup Plan",
     "createSchedule": "Create Schedule",
-    "createLegacySchedule": "Create legacy schedule",
+    "createLegacySchedule": "Create backup automation",
     "addCheck": "Add Check Schedule",
     "addRestoreCheck": "Add Restore Check",
     "tabs": {
@@ -726,8 +727,19 @@
       "runCheckTip": "Integrity check runs after each backup (in addition to any scheduled check below)"
     },
     "noRepositories": "You need to create at least one repository before scheduling backups.",
-    "legacyBackupSchedulesTitle": "Legacy Backup Schedules",
-    "legacyBackupSchedulesDescription": "Existing repository-based schedules continue to run here. New scheduled backups should be created as Backup Plans.",
+    "legacyBackupSchedulesTitle": "Backup automations",
+    "legacyBackupSchedulesDescription": "Custom repository-based backup automations, including fixed-time and availability-triggered runs.",
+    "trigger": {
+      "catchUp": "Run missed backups when the source becomes available",
+      "label": "Run trigger",
+      "fixedTime": "At a fixed time",
+      "whenAvailable": "When source is available",
+      "availabilityDescription": "Borg UI checks for a reachable source and runs after the minimum interval has elapsed.",
+      "checkInterval": "Check every (minutes)",
+      "checkIntervalHelper": "How often Borg UI checks whether the source is available.",
+      "minimumInterval": "Minimum interval after a successful run (hours)",
+      "minimumIntervalHelper": "Borg UI will not start another backup before this interval has elapsed."
+    },
     "confirmRunNow": "Run \"{{name}}\" now?",
     "maintenance": {
       "pruning": "Pruning archives...",
@@ -1536,7 +1548,8 @@
         "package": "Package",
         "rcloneSync": "Cloud Sync",
         "rcloneHydrate": "Cloud Hydrate",
-        "scriptExecution": "Script"
+        "scriptExecution": "Script",
+        "availabilityCheck": "Availability check"
       },
       "statuses": {
         "completed": "Completed",
@@ -1544,12 +1557,19 @@
         "needsBackup": "Needs backup",
         "failed": "Failed",
         "running": "Running",
-        "pending": "Pending"
+        "pending": "Pending",
+        "skipped": "Skipped"
       }
     },
     "empty": {
       "title": "No activity found",
       "message": "There are no operations matching your filters"
+    }
+  },
+  "availabilitySchedule": {
+    "skipReasons": {
+      "minimumIntervalNotElapsed": "Minimum interval not elapsed",
+      "sourceUnavailable": "Source unavailable"
     }
   },
   "cloudStorageJobs": {
@@ -2234,8 +2254,8 @@
       "rcloneHydrate": "Hydrate local cache",
       "enableCloudMirror": "Enable cloud mirror",
       "backupNow": "Backup Now",
-      "legacyBackup": "Legacy Backup",
-      "legacyBackupTooltip": "Run the old repository-based backup using this repository's legacy source paths",
+      "legacyBackup": "Run backup automation",
+      "legacyBackupTooltip": "Run the repository-based backup automation using this repository's configured source paths",
       "backupPlanRequired": "Create a Backup Plan to define sources",
       "viewArchives": "View Archives",
       "viewBackupPlans": "View linked backup plans",
@@ -2589,7 +2609,8 @@
       "package": "Package Install",
       "rcloneSync": "Cloud Sync",
       "rcloneHydrate": "Cloud Hydrate",
-      "scriptExecution": "Script"
+      "scriptExecution": "Script",
+      "availabilityCheck": "Availability check"
     },
     "scheduledById": "Scheduled (ID: {{id}})",
     "backupPlanByName": "Backup Plan: {{name}}",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -734,7 +734,7 @@
       "label": "Activador de ejecución",
       "fixedTime": "A una hora fija",
       "whenAvailable": "Cuando la fuente esté disponible",
-      "availabilityDescription": "Borg UI busca una fuente accesible y se ejecuta cuando ha transcurrido el intervalo mínimo.",
+      "availabilityDescription": "Borg UI comprueba si la fuente está accesible y ejecuta la copia cuando ha transcurrido el intervalo mínimo.",
       "checkInterval": "Comprobar cada (minutos)",
       "checkIntervalHelper": "Con qué frecuencia Borg UI comprueba si la fuente está disponible.",
       "minimumInterval": "Intervalo mínimo después de una ejecución correcta (horas)",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -361,7 +361,8 @@
     "failed": "Fallido",
     "running": "En ejecución",
     "pending": "Pendiente",
-    "cancelled": "Cancelado"
+    "cancelled": "Cancelado",
+    "skipped": "Omitido"
   },
   "dashboard": {
     "title": "Panel",
@@ -555,7 +556,7 @@
     "tabs": {
       "ariaLabel": "Tipo de operación de copia de seguridad",
       "backupPlans": "Planes de copia",
-      "legacyBackup": "Copia heredada"
+      "legacyBackup": "Automatizaciones de copia de seguridad"
     },
     "planRun": {
       "title": "Ejecutar un plan de copia",
@@ -691,7 +692,7 @@
     "createBackup": "Crear programación de copia de seguridad",
     "createBackupPlan": "Crear plan de copia",
     "createSchedule": "Crear programación",
-    "createLegacySchedule": "Crear programación heredada",
+    "createLegacySchedule": "Crear automatización de copia de seguridad",
     "addCheck": "Agregar comprobación programada",
     "addRestoreCheck": "Agregar comprobación de restauración",
     "tabs": {
@@ -726,8 +727,19 @@
       "runCheckTip": "La comprobación de integridad se ejecuta después de cada copia (además de cualquier comprobación programada abajo)"
     },
     "noRepositories": "Necesitas crear al menos un repositorio antes de programar copias de seguridad.",
-    "legacyBackupSchedulesTitle": "Programaciones de copia heredadas",
-    "legacyBackupSchedulesDescription": "Las programaciones existentes basadas en repositorio siguen ejecutándose aquí. Las nuevas copias programadas deberían crearse como planes de copia.",
+    "legacyBackupSchedulesTitle": "Automatizaciones de copia de seguridad",
+    "legacyBackupSchedulesDescription": "Automatizaciones de copia basadas en repositorios personalizados, incluidas ejecuciones programadas y por disponibilidad.",
+    "trigger": {
+      "catchUp": "Ejecutar copias omitidas cuando la fuente esté disponible",
+      "label": "Activador de ejecución",
+      "fixedTime": "A una hora fija",
+      "whenAvailable": "Cuando la fuente esté disponible",
+      "availabilityDescription": "Borg UI busca una fuente accesible y se ejecuta cuando ha transcurrido el intervalo mínimo.",
+      "checkInterval": "Comprobar cada (minutos)",
+      "checkIntervalHelper": "Con qué frecuencia Borg UI comprueba si la fuente está disponible.",
+      "minimumInterval": "Intervalo mínimo después de una ejecución correcta (horas)",
+      "minimumIntervalHelper": "Borg UI no inicia otra copia hasta que haya transcurrido este intervalo."
+    },
     "confirmRunNow": "¿Ejecutar \"{{name}}\" ahora?",
     "maintenance": {
       "pruning": "Podando archivos...",
@@ -1536,7 +1548,8 @@
         "package": "Paquete",
         "rcloneSync": "Sincronización en la nube",
         "rcloneHydrate": "Hidratación en la nube",
-        "scriptExecution": "Script"
+        "scriptExecution": "Script",
+        "availabilityCheck": "Comprobación de disponibilidad"
       },
       "statuses": {
         "completed": "Completado",
@@ -1544,12 +1557,19 @@
         "needsBackup": "Necesita copia",
         "failed": "Fallido",
         "running": "En ejecución",
-        "pending": "Pendiente"
+        "pending": "Pendiente",
+        "skipped": "Omitido"
       }
     },
     "empty": {
       "title": "Sin actividad",
       "message": "No hay operaciones que coincidan con tus filtros"
+    }
+  },
+  "availabilitySchedule": {
+    "skipReasons": {
+      "minimumIntervalNotElapsed": "El intervalo mínimo no ha transcurrido",
+      "sourceUnavailable": "Fuente no disponible"
     }
   },
   "cloudStorageJobs": {
@@ -2234,8 +2254,8 @@
       "rcloneHydrate": "Hidratar caché local",
       "enableCloudMirror": "Activar réplica en la nube",
       "backupNow": "Copia ahora",
-      "legacyBackup": "Copia heredada",
-      "legacyBackupTooltip": "Ejecuta la copia antigua basada en repositorio usando las rutas de origen heredadas de este repositorio",
+      "legacyBackup": "Ejecutar automatización de copia",
+      "legacyBackupTooltip": "Ejecutar la automatización de copia basada en repositorio usando las rutas de origen configuradas de este repositorio",
       "backupPlanRequired": "Crea un plan de copia para definir fuentes",
       "viewArchives": "Ver archivos",
       "viewBackupPlans": "Ver planes de copia vinculados",
@@ -2589,7 +2609,8 @@
       "package": "Instalación de paquete",
       "rcloneSync": "Sincronización en la nube",
       "rcloneHydrate": "Hidratación en la nube",
-      "scriptExecution": "Script"
+      "scriptExecution": "Script",
+      "availabilityCheck": "Comprobación de disponibilidad"
     },
     "scheduledById": "Programado (ID: {{id}})",
     "backupPlanByName": "Plan de copia: {{name}}",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -361,7 +361,8 @@
     "failed": "Fallito",
     "running": "In esecuzione",
     "pending": "In attesa",
-    "cancelled": "Annullato"
+    "cancelled": "Annullato",
+    "skipped": "Ignorato"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -555,7 +556,7 @@
     "tabs": {
       "ariaLabel": "Tipo di operazione di backup",
       "backupPlans": "Piani di backup",
-      "legacyBackup": "Backup legacy"
+      "legacyBackup": "Automazioni di backup"
     },
     "planRun": {
       "title": "Esegui un piano di backup",
@@ -691,7 +692,7 @@
     "createBackup": "Crea Pianificazione Backup",
     "createBackupPlan": "Crea piano di backup",
     "createSchedule": "Crea pianificazione",
-    "createLegacySchedule": "Crea pianificazione legacy",
+    "createLegacySchedule": "Crea automazione di backup",
     "addCheck": "Aggiungi Pianificazione Controllo",
     "addRestoreCheck": "Aggiungi controllo di ripristino",
     "tabs": {
@@ -726,8 +727,19 @@
       "runCheckTip": "Il controllo di integrità viene eseguito dopo ogni backup (oltre a qualsiasi controllo pianificato qui sotto)"
     },
     "noRepositories": "Devi creare almeno un repository prima di pianificare i backup.",
-    "legacyBackupSchedulesTitle": "Pianificazioni backup legacy",
-    "legacyBackupSchedulesDescription": "Le pianificazioni esistenti basate su repository continuano a essere eseguite qui. I nuovi backup pianificati dovrebbero essere creati come piani di backup.",
+    "legacyBackupSchedulesTitle": "Automazioni di backup",
+    "legacyBackupSchedulesDescription": "Automazioni di backup personalizzate basate su repository, incluse esecuzioni a orario fisso e in base alla disponibilità.",
+    "trigger": {
+      "catchUp": "Esegui i backup mancati quando la sorgente diventa disponibile",
+      "label": "Attivatore di esecuzione",
+      "fixedTime": "A un orario fisso",
+      "whenAvailable": "Quando la sorgente è disponibile",
+      "availabilityDescription": "Borg UI controlla una sorgente raggiungibile ed esegue il backup quando è trascorso l'intervallo minimo.",
+      "checkInterval": "Controlla ogni (minuti)",
+      "checkIntervalHelper": "Con quale frequenza Borg UI controlla se la sorgente è disponibile.",
+      "minimumInterval": "Intervallo minimo dopo un'esecuzione riuscita (ore)",
+      "minimumIntervalHelper": "Borg UI non avvierà un altro backup prima che questo intervallo sia trascorso."
+    },
     "confirmRunNow": "Eseguire \"{{name}}\" ora?",
     "maintenance": {
       "pruning": "Pulizia archivi in corso...",
@@ -1536,7 +1548,8 @@
         "package": "Pacchetto",
         "rcloneSync": "Sync cloud",
         "rcloneHydrate": "Idratazione cloud",
-        "scriptExecution": "Script"
+        "scriptExecution": "Script",
+        "availabilityCheck": "Verifica disponibilità"
       },
       "statuses": {
         "completed": "Completato",
@@ -1544,12 +1557,19 @@
         "needsBackup": "Backup richiesto",
         "failed": "Fallito",
         "running": "In Esecuzione",
-        "pending": "In Attesa"
+        "pending": "In Attesa",
+        "skipped": "Ignorato"
       }
     },
     "empty": {
       "title": "Nessuna attività trovata",
       "message": "Non ci sono operazioni corrispondenti ai tuoi filtri"
+    }
+  },
+  "availabilitySchedule": {
+    "skipReasons": {
+      "minimumIntervalNotElapsed": "Intervallo minimo non ancora trascorso",
+      "sourceUnavailable": "Origine non disponibile"
     }
   },
   "cloudStorageJobs": {
@@ -2234,8 +2254,8 @@
       "rcloneHydrate": "Idrata cache locale",
       "enableCloudMirror": "Abilita mirror cloud",
       "backupNow": "Backup Ora",
-      "legacyBackup": "Backup legacy",
-      "legacyBackupTooltip": "Esegui il vecchio backup basato sul repository usando i percorsi sorgente legacy di questo repository",
+      "legacyBackup": "Esegui automazione di backup",
+      "legacyBackupTooltip": "Esegui l'automazione di backup basata sul repository usando i percorsi sorgente configurati del repository",
       "backupPlanRequired": "Crea un piano di backup per definire le sorgenti",
       "viewArchives": "Visualizza Archivi",
       "viewBackupPlans": "Visualizza piani di backup collegati",
@@ -2589,7 +2609,8 @@
       "package": "Installazione Pacchetto",
       "rcloneSync": "Sync cloud",
       "rcloneHydrate": "Idratazione cloud",
-      "scriptExecution": "Script"
+      "scriptExecution": "Script",
+      "availabilityCheck": "Verifica disponibilità"
     },
     "scheduledById": "Pianificato (ID: {{id}})",
     "backupPlanByName": "Piano di backup: {{name}}",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -362,7 +362,7 @@
     "running": "In esecuzione",
     "pending": "In attesa",
     "cancelled": "Annullato",
-    "skipped": "Ignorato"
+    "skipped": "Saltato"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -1558,7 +1558,7 @@
         "failed": "Fallito",
         "running": "In Esecuzione",
         "pending": "In Attesa",
-        "skipped": "Ignorato"
+        "skipped": "Saltato"
       }
     },
     "empty": {

--- a/frontend/src/pages/Activity.tsx
+++ b/frontend/src/pages/Activity.tsx
@@ -13,6 +13,7 @@ import RunningCloudStorageJobsSection from '../components/RunningCloudStorageJob
 import { ActivityFilters } from './activity/ActivityFilters'
 
 export interface ActivityItem {
+  activity_key?: string | null
   id: number
   type: string
   status: string
@@ -139,7 +140,7 @@ export function ActivityContent({
           canBreakLocks={canBreakLockForActivity}
           lockBreakingEnabled={lockBreakingEnabled}
           canDeleteJobs={canManageActivityJobs}
-          getRowKey={(activity) => `${activity.type}-${activity.id}`}
+          getRowKey={(activity) => activity.activity_key ?? `${activity.type}-${activity.id}`}
           headerBgColor="background.default"
           enableHover={true}
           tableId="activity"
@@ -160,7 +161,7 @@ export function ActivityContent({
           canBreakLocks={canBreakLockForActivity}
           lockBreakingEnabled={lockBreakingEnabled}
           canDeleteJobs={canManageActivityJobs}
-          getRowKey={(activity) => `${activity.type}-${activity.id}`}
+          getRowKey={(activity) => activity.activity_key ?? `${activity.type}-${activity.id}`}
           headerBgColor="background.default"
           enableHover={true}
           tableId="activity"

--- a/frontend/src/pages/Activity.tsx
+++ b/frontend/src/pages/Activity.tsx
@@ -31,6 +31,7 @@ export interface ActivityItem {
   backup_plan_id?: number | null
   backup_plan_run_id?: number | null
   backup_plan_name?: string | null
+  skip_reason?: 'minimum_interval_not_elapsed' | 'source_unavailable' | null
   has_logs?: boolean
 }
 

--- a/frontend/src/pages/Schedule.tsx
+++ b/frontend/src/pages/Schedule.tsx
@@ -540,7 +540,7 @@ const Schedule: React.FC = () => {
               sx={{ width: { xs: '100%', sm: 'auto' } }}
             >
               {t('schedule.createLegacySchedule', {
-                defaultValue: 'Create legacy schedule',
+                defaultValue: 'Create backup automation',
               })}
             </Button>
             <Button

--- a/frontend/src/pages/__tests__/Backup.test.tsx
+++ b/frontend/src/pages/__tests__/Backup.test.tsx
@@ -42,8 +42,8 @@ let backupPlansPayload: Array<Record<string, unknown>> = []
 let backupPlanRunsPayload: Array<Record<string, unknown>> = []
 let backupQueryClients: QueryClient[] = []
 
-async function openLegacyBackupTab(user: ReturnType<typeof userEvent.setup>) {
-  await user.click(await screen.findByRole('tab', { name: /legacy backup/i }))
+async function openBackupAutomationsTab(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(await screen.findByRole('tab', { name: /backup automations/i }))
 }
 
 async function selectBackupPlan(user: ReturnType<typeof userEvent.setup>, name: RegExp | string) {
@@ -279,7 +279,7 @@ describe('Backup page', () => {
     backupPlansRetryRunMock.mockImplementation(() => Promise.resolve({ data: {} }))
   })
 
-  it('defaults to the backup plans tab and keeps legacy backup separate', async () => {
+  it('defaults to the backup plans tab and keeps backup automations separate', async () => {
     const user = userEvent.setup()
 
     renderBackup()
@@ -291,9 +291,9 @@ describe('Backup page', () => {
     expect(await screen.findByRole('button', { name: /create backup plan/i })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /choose primary repo/i })).not.toBeInTheDocument()
 
-    await openLegacyBackupTab(user)
+    await openBackupAutomationsTab(user)
 
-    expect(screen.getByRole('tab', { name: /legacy backup/i })).toHaveAttribute(
+    expect(screen.getByRole('tab', { name: /backup automations/i })).toHaveAttribute(
       'aria-selected',
       'true'
     )
@@ -307,7 +307,7 @@ describe('Backup page', () => {
 
     renderBackup()
 
-    expect(await screen.findByRole('tab', { name: /legacy backup/i })).toHaveAttribute(
+    expect(await screen.findByRole('tab', { name: /backup automations/i })).toHaveAttribute(
       'aria-selected',
       'true'
     )
@@ -358,7 +358,7 @@ describe('Backup page', () => {
     const user = userEvent.setup()
 
     renderBackup()
-    await openLegacyBackupTab(user)
+    await openBackupAutomationsTab(user)
 
     expect(await screen.findByText('choose Primary Repo')).toBeInTheDocument()
     expect(screen.queryByText('choose Observe Repo')).not.toBeInTheDocument()
@@ -617,7 +617,7 @@ describe('Backup page', () => {
       expect(getManualJobsMock).not.toHaveBeenCalled()
     })
 
-    await openLegacyBackupTab(user)
+    await openBackupAutomationsTab(user)
     await user.click(await screen.findByRole('button', { name: /choose primary repo/i }))
 
     await waitFor(() => {
@@ -645,7 +645,7 @@ describe('Backup page', () => {
 
     renderBackup()
 
-    await openLegacyBackupTab(user)
+    await openBackupAutomationsTab(user)
     await user.click(await screen.findByRole('button', { name: /choose primary repo/i }))
 
     await waitFor(() => {
@@ -678,7 +678,7 @@ describe('Backup page', () => {
     const user = userEvent.setup()
 
     renderBackup()
-    await openLegacyBackupTab(user)
+    await openBackupAutomationsTab(user)
 
     expect(await screen.findByText('Recent Manual Jobs')).toBeInTheDocument()
     expect(
@@ -690,7 +690,7 @@ describe('Backup page', () => {
     const user = userEvent.setup()
     const { unmount } = renderBackup()
 
-    await openLegacyBackupTab(user)
+    await openBackupAutomationsTab(user)
     await user.click(await screen.findByRole('button', { name: /choose primary repo/i }))
 
     expect(trackBackup).toHaveBeenCalledWith(
@@ -705,7 +705,7 @@ describe('Backup page', () => {
     canDoBackup = false
     unmount()
     renderBackup()
-    await openLegacyBackupTab(user)
+    await openBackupAutomationsTab(user)
 
     expect(screen.queryByRole('button', { name: /choose primary repo/i })).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: /start backup/i })).toBeDisabled()
@@ -716,7 +716,7 @@ describe('Backup page', () => {
 
     renderBackup()
 
-    await openLegacyBackupTab(user)
+    await openBackupAutomationsTab(user)
     await user.click(await screen.findByRole('button', { name: /choose primary repo/i }))
 
     expect(await screen.findByText(/borg create/i)).toBeInTheDocument()

--- a/frontend/src/pages/__tests__/BackupPlans.test.tsx
+++ b/frontend/src/pages/__tests__/BackupPlans.test.tsx
@@ -41,6 +41,26 @@ describe('BackupPlans API', () => {
   })
 })
 
+describe('Backup plan availability scheduling', () => {
+  it('serializes availability policy values in backend minutes', () => {
+    const payload = buildBackupPlanPayload(
+      createPayloadState({
+        scheduleEnabled: true,
+        scheduleMode: 'availability',
+        availabilityCheckIntervalMinutes: 30,
+        minimumSuccessIntervalHours: 20,
+      })
+    )
+
+    expect(payload).toMatchObject({
+      schedule_mode: 'availability',
+      cron_expression: null,
+      availability_check_interval_minutes: 30,
+      min_success_interval_minutes: 1200,
+    })
+  })
+})
+
 describe('BackupPlans repository selection gating', () => {
   it('limits Community plans to the first selected repository', () => {
     expect(applyRepositorySelectionLimit([10, 20], false)).toEqual({

--- a/frontend/src/pages/activity/ActivityFilters.tsx
+++ b/frontend/src/pages/activity/ActivityFilters.tsx
@@ -36,6 +36,9 @@ export function ActivityFilters({
         <MenuItem value="rclone_sync">{t('activity.filters.types.rcloneSync')}</MenuItem>
         <MenuItem value="rclone_hydrate">{t('activity.filters.types.rcloneHydrate')}</MenuItem>
         <MenuItem value="script_execution">{t('activity.filters.types.scriptExecution')}</MenuItem>
+        <MenuItem value="availability_check">
+          {t('activity.filters.types.availabilityCheck')}
+        </MenuItem>
       </Select>
 
       <Select
@@ -54,6 +57,7 @@ export function ActivityFilters({
         <MenuItem value="failed">{t('activity.filters.statuses.failed')}</MenuItem>
         <MenuItem value="running">{t('activity.filters.statuses.running')}</MenuItem>
         <MenuItem value="pending">{t('activity.filters.statuses.pending')}</MenuItem>
+        <MenuItem value="skipped">{t('activity.filters.statuses.skipped')}</MenuItem>
       </Select>
     </Box>
   )

--- a/frontend/src/pages/backup-plans/state.ts
+++ b/frontend/src/pages/backup-plans/state.ts
@@ -30,8 +30,11 @@ export const createInitialState = (): WizardState => ({
   maxParallelRepositories: 1,
   failureBehavior: 'continue',
   scheduleEnabled: false,
+  scheduleMode: 'cron',
   cronExpression: '0 21 * * *',
   timezone: getBrowserTimeZone(),
+  availabilityCheckIntervalMinutes: 30,
+  minimumSuccessIntervalHours: 20,
   preBackupScriptId: null,
   postBackupScriptId: null,
   preBackupScriptParameters: {},
@@ -350,8 +353,14 @@ export function planToState(plan: BackupPlan): WizardState {
     maxParallelRepositories: plan.max_parallel_repositories || 1,
     failureBehavior: plan.failure_behavior || 'continue',
     scheduleEnabled: Boolean(plan.schedule_enabled),
+    scheduleMode: plan.schedule_mode || 'cron',
     cronExpression: plan.cron_expression || '0 21 * * *',
     timezone: plan.timezone || getBrowserTimeZone(),
+    availabilityCheckIntervalMinutes: plan.availability_check_interval_minutes ?? 30,
+    minimumSuccessIntervalHours: Math.max(
+      1,
+      Math.round((plan.min_success_interval_minutes ?? 20 * 60) / 60)
+    ),
     preBackupScriptId: firstPreHook?.script_id ?? plan.pre_backup_script_id ?? null,
     postBackupScriptId: firstPostHook?.script_id ?? plan.post_backup_script_id ?? null,
     preBackupScriptParameters:

--- a/frontend/src/pages/backup-plans/state.ts
+++ b/frontend/src/pages/backup-plans/state.ts
@@ -357,10 +357,7 @@ export function planToState(plan: BackupPlan): WizardState {
     cronExpression: plan.cron_expression || '0 21 * * *',
     timezone: plan.timezone || getBrowserTimeZone(),
     availabilityCheckIntervalMinutes: plan.availability_check_interval_minutes ?? 30,
-    minimumSuccessIntervalHours: Math.max(
-      1,
-      Math.round((plan.min_success_interval_minutes ?? 20 * 60) / 60)
-    ),
+    minimumSuccessIntervalHours: (plan.min_success_interval_minutes ?? 20 * 60) / 60,
     preBackupScriptId: firstPreHook?.script_id ?? plan.pre_backup_script_id ?? null,
     postBackupScriptId: firstPostHook?.script_id ?? plan.post_backup_script_id ?? null,
     preBackupScriptParameters:

--- a/frontend/src/pages/backup-plans/wizard-step/ReviewStep.tsx
+++ b/frontend/src/pages/backup-plans/wizard-step/ReviewStep.tsx
@@ -535,14 +535,42 @@ export function ReviewStep({
           }
         >
           {wizardState.scheduleEnabled ? (
-            <>
-              <ReviewAttrRow label={t('backupPlans.wizard.fields.cronExpression')}>
-                <ReviewCodePill>{wizardState.cronExpression}</ReviewCodePill>
-              </ReviewAttrRow>
-              <ReviewAttrRow label={t('backupPlans.wizard.fields.timezone')}>
-                <ReviewCodePill maxChars={20}>{wizardState.timezone}</ReviewCodePill>
-              </ReviewAttrRow>
-            </>
+            wizardState.scheduleMode === 'availability' ? (
+              <>
+                <ReviewAttrRow label={t('schedule.trigger.label', { defaultValue: 'Run trigger' })}>
+                  <Typography variant="body2" fontSize="0.75rem" fontWeight={600}>
+                    {t('schedule.trigger.whenAvailable', {
+                      defaultValue: 'When source is available',
+                    })}
+                  </Typography>
+                </ReviewAttrRow>
+                <ReviewAttrRow
+                  label={t('schedule.trigger.checkInterval', {
+                    defaultValue: 'Check every (minutes)',
+                  })}
+                >
+                  <ReviewCodePill>
+                    {wizardState.availabilityCheckIntervalMinutes} min
+                  </ReviewCodePill>
+                </ReviewAttrRow>
+                <ReviewAttrRow
+                  label={t('schedule.trigger.minimumInterval', {
+                    defaultValue: 'Minimum interval after a successful run (hours)',
+                  })}
+                >
+                  <ReviewCodePill>{wizardState.minimumSuccessIntervalHours} h</ReviewCodePill>
+                </ReviewAttrRow>
+              </>
+            ) : (
+              <>
+                <ReviewAttrRow label={t('backupPlans.wizard.fields.cronExpression')}>
+                  <ReviewCodePill>{wizardState.cronExpression}</ReviewCodePill>
+                </ReviewAttrRow>
+                <ReviewAttrRow label={t('backupPlans.wizard.fields.timezone')}>
+                  <ReviewCodePill maxChars={20}>{wizardState.timezone}</ReviewCodePill>
+                </ReviewAttrRow>
+              </>
+            )
           ) : (
             <Typography
               variant="caption"

--- a/frontend/src/pages/backup-plans/wizard-step/ScheduleStep.stories.tsx
+++ b/frontend/src/pages/backup-plans/wizard-step/ScheduleStep.stories.tsx
@@ -59,3 +59,22 @@ export const CheckFlagConflict: Story = {
     </Box>
   ),
 }
+
+export const WhenAvailable: Story = {
+  render: () => (
+    <Box sx={{ width: 720, maxWidth: 'calc(100vw - 32px)' }}>
+      <ScheduleStep
+        wizardState={{
+          ...createInitialState(),
+          scheduleEnabled: true,
+          scheduleMode: 'availability',
+          availabilityCheckIntervalMinutes: 30,
+          minimumSuccessIntervalHours: 20,
+        }}
+        updateState={() => {}}
+        handlePruneSettingsChange={() => {}}
+        t={t}
+      />
+    </Box>
+  ),
+}

--- a/frontend/src/pages/backup-plans/wizard-step/ScheduleStep.tsx
+++ b/frontend/src/pages/backup-plans/wizard-step/ScheduleStep.tsx
@@ -76,6 +76,10 @@ export function ScheduleStep({
             cronExpression={wizardState.cronExpression}
             timezone={wizardState.timezone}
             onChange={(updates) => updateState(updates)}
+            scheduleMode={wizardState.scheduleMode}
+            availabilityCheckIntervalMinutes={wizardState.availabilityCheckIntervalMinutes}
+            minimumSuccessIntervalHours={wizardState.minimumSuccessIntervalHours}
+            showTriggerMode
             required
             size="medium"
             cronLabel={t('backupPlans.wizard.fields.cronExpression')}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -319,8 +319,11 @@ export interface BackupPlan {
   max_parallel_repositories: number
   failure_behavior: 'continue' | 'stop'
   schedule_enabled: boolean
+  schedule_mode?: 'cron' | 'availability'
   cron_expression?: string | null
   timezone: string
+  availability_check_interval_minutes?: number | null
+  min_success_interval_minutes?: number | null
   last_run?: string | null
   next_run?: string | null
   repository_count: number
@@ -383,6 +386,7 @@ export interface BackupPlanRun {
   started_at?: string | null
   completed_at?: string | null
   error_message?: string | null
+  skip_reason?: 'minimum_interval_not_elapsed' | 'source_unavailable' | null
   created_at?: string | null
   retry_attempt?: number | null
   retry_original_run_id?: number | null
@@ -412,8 +416,11 @@ export interface BackupPlanData {
   max_parallel_repositories: number
   failure_behavior: 'continue' | 'stop'
   schedule_enabled: boolean
+  schedule_mode?: 'cron' | 'availability'
   cron_expression?: string | null
   timezone: string
+  availability_check_interval_minutes?: number | null
+  min_success_interval_minutes?: number | null
   pre_backup_script_id?: number | null
   post_backup_script_id?: number | null
   pre_backup_script_parameters?: Record<string, string> | null

--- a/frontend/src/types/jobs.ts
+++ b/frontend/src/types/jobs.ts
@@ -19,6 +19,7 @@ export interface Job {
   started_at?: string | null
   completed_at?: string | null
   error_message?: string | null
+  skip_reason?: 'minimum_interval_not_elapsed' | 'source_unavailable' | null
   archive_name?: string | null
   package_name?: string | null
   has_logs?: boolean

--- a/frontend/src/utils/backupPlanPayload.ts
+++ b/frontend/src/utils/backupPlanPayload.ts
@@ -409,7 +409,9 @@ export function buildBackupPlanPayload(
     availability_check_interval_minutes:
       state.scheduleMode === 'availability' ? (state.availabilityCheckIntervalMinutes ?? 30) : null,
     min_success_interval_minutes:
-      state.scheduleMode === 'availability' ? (state.minimumSuccessIntervalHours ?? 20) * 60 : null,
+      state.scheduleMode === 'availability'
+        ? Math.round((state.minimumSuccessIntervalHours ?? 20) * 60)
+        : null,
     pre_backup_script_id: firstPreHook?.script_id ?? state.preBackupScriptId,
     post_backup_script_id: firstPostHook?.script_id ?? state.postBackupScriptId,
     pre_backup_script_parameters:

--- a/frontend/src/utils/backupPlanPayload.ts
+++ b/frontend/src/utils/backupPlanPayload.ts
@@ -35,8 +35,11 @@ export interface BackupPlanPayloadState {
   maxParallelRepositories: number
   failureBehavior: 'continue' | 'stop'
   scheduleEnabled: boolean
+  scheduleMode?: 'cron' | 'availability'
   cronExpression: string
   timezone: string
+  availabilityCheckIntervalMinutes?: number
+  minimumSuccessIntervalHours?: number
   preBackupScriptId: number | null
   postBackupScriptId: number | null
   preBackupScriptParameters: Record<string, string>
@@ -397,8 +400,16 @@ export function buildBackupPlanPayload(
       state.repositoryRunMode === 'parallel' ? state.maxParallelRepositories : 1,
     failure_behavior: state.failureBehavior,
     schedule_enabled: state.scheduleEnabled,
-    cron_expression: state.scheduleEnabled ? state.cronExpression : null,
+    schedule_mode: state.scheduleMode || 'cron',
+    cron_expression:
+      state.scheduleEnabled && (state.scheduleMode || 'cron') === 'cron'
+        ? state.cronExpression
+        : null,
     timezone: state.timezone,
+    availability_check_interval_minutes:
+      state.scheduleMode === 'availability' ? (state.availabilityCheckIntervalMinutes ?? 30) : null,
+    min_success_interval_minutes:
+      state.scheduleMode === 'availability' ? (state.minimumSuccessIntervalHours ?? 20) * 60 : null,
     pre_backup_script_id: firstPreHook?.script_id ?? state.preBackupScriptId,
     post_backup_script_id: firstPostHook?.script_id ?? state.postBackupScriptId,
     pre_backup_script_parameters:

--- a/tests/unit/test_api_activity.py
+++ b/tests/unit/test_api_activity.py
@@ -135,6 +135,72 @@ class TestActivityLogDownloads:
 class TestRecentActivityEndpoint:
     """Test the aggregated recent activity feed."""
 
+    def test_recent_activity_includes_durable_availability_skips(
+        self, test_client, admin_headers, test_db
+    ):
+        from app.database.models import (
+            AvailabilityScheduleSkip,
+            BackupPlan,
+            BackupPlanRun,
+            ScheduledJob,
+        )
+
+        occurred_at = datetime(2026, 8, 13, 12, 0, 0)
+        plan = BackupPlan(
+            name="Availability plan",
+            source_directories='["/srv/availability"]',
+            schedule_enabled=True,
+            schedule_mode="availability",
+        )
+        automation = ScheduledJob(
+            name="Availability automation",
+            schedule_mode="availability",
+            enabled=True,
+        )
+        test_db.add_all([plan, automation])
+        test_db.flush()
+        test_db.add_all(
+            [
+                BackupPlanRun(
+                    backup_plan_id=plan.id,
+                    trigger="availability",
+                    status="skipped",
+                    skip_reason="minimum_interval_not_elapsed",
+                    error_message="Minimum interval after the last successful backup has not elapsed.",
+                    started_at=occurred_at,
+                    completed_at=occurred_at,
+                    created_at=occurred_at,
+                ),
+                AvailabilityScheduleSkip(
+                    scheduled_job_id=automation.id,
+                    reason="source_unavailable",
+                    detail="The backup source is unavailable.",
+                    occurred_at=occurred_at + timedelta(minutes=1),
+                ),
+            ]
+        )
+        test_db.commit()
+
+        response = test_client.get(
+            "/api/activity/recent?job_type=availability_check&status=skipped",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        activity = response.json()
+        assert len(activity) == 2
+        assert all(item["type"] == "availability_check" for item in activity)
+        assert all(item["status"] == "skipped" for item in activity)
+        assert all(item["has_logs"] is False for item in activity)
+        assert {item["skip_reason"] for item in activity} == {
+            "minimum_interval_not_elapsed",
+            "source_unavailable",
+        }
+        assert {item["repository"] for item in activity} == {
+            plan.name,
+            automation.name,
+        }
+
     def test_recent_activity_aggregates_job_types_and_schedule_metadata(
         self, test_client, admin_headers, test_db
     ):

--- a/tests/unit/test_api_backup_plans.py
+++ b/tests/unit/test_api_backup_plans.py
@@ -325,6 +325,50 @@ class TestBackupPlanRoutes:
         )
         assert get_response.status_code == 404
 
+    def test_create_plan_with_availability_trigger_persists_policy(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        repo = _create_repo(test_db, "Primary", "/repos/primary")
+
+        response = test_client.post(
+            "/api/backup-plans/",
+            json=_payload(
+                [repo.id],
+                schedule_enabled=True,
+                schedule_mode="availability",
+                availability_check_interval_minutes=15,
+                min_success_interval_minutes=20 * 60,
+                cron_expression=None,
+            ),
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 201
+        created = response.json()
+        assert created["schedule_mode"] == "availability"
+        assert created["availability_check_interval_minutes"] == 15
+        assert created["min_success_interval_minutes"] == 20 * 60
+        assert created["cron_expression"] is None
+        assert created["next_run"] is not None
+
+    def test_create_plan_rejects_invalid_availability_interval(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        repo = _create_repo(test_db, "Primary", "/repos/primary")
+
+        response = test_client.post(
+            "/api/backup-plans/",
+            json=_payload(
+                [repo.id],
+                schedule_enabled=True,
+                schedule_mode="availability",
+                availability_check_interval_minutes=0,
+            ),
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 422
+
     def test_create_plan_persists_upload_ratelimit_schedule_policies(
         self, test_client: TestClient, admin_headers, test_db
     ):
@@ -2494,6 +2538,42 @@ class TestBackupPlanRoutes:
         run = test_db.query(BackupPlanRun).filter_by(backup_plan_id=plan.id).one()
         assert run.trigger == "schedule"
         assert run.status == "pending"
+
+    def test_availability_plan_records_minimum_interval_skip(self, test_db):
+        repo = _create_repo(test_db, "Primary", "/repos/primary")
+        now = datetime(2026, 1, 2, 12, 0)
+        plan = _create_scheduled_plan(
+            test_db,
+            [repo],
+            next_run=now - timedelta(minutes=1),
+        )
+        plan.schedule_mode = "availability"
+        plan.availability_check_interval_minutes = 30
+        plan.min_success_interval_minutes = 20 * 60
+        test_db.add(
+            BackupPlanRun(
+                backup_plan_id=plan.id,
+                trigger="schedule",
+                status="completed",
+                started_at=now - timedelta(hours=1, minutes=5),
+                completed_at=now - timedelta(hours=1),
+                created_at=now - timedelta(hours=1, minutes=5),
+            )
+        )
+        test_db.commit()
+
+        dispatched = backup_plan_execution_service.dispatch_due_runs(test_db, now)
+
+        assert dispatched == 0
+        skipped = (
+            test_db.query(BackupPlanRun)
+            .filter_by(backup_plan_id=plan.id, status="skipped")
+            .one()
+        )
+        assert skipped.trigger == "availability"
+        assert skipped.skip_reason == "minimum_interval_not_elapsed"
+        assert len(skipped.repositories) == 1
+        assert skipped.repositories[0].status == "skipped"
 
     def test_dispatch_due_runs_skips_and_advances_paid_only_plan_after_downgrade(
         self, test_db

--- a/tests/unit/test_api_backup_plans.py
+++ b/tests/unit/test_api_backup_plans.py
@@ -338,7 +338,7 @@ class TestBackupPlanRoutes:
                 schedule_mode="availability",
                 availability_check_interval_minutes=15,
                 min_success_interval_minutes=20 * 60,
-                cron_expression=None,
+                cron_expression="not a valid cron expression",
             ),
             headers=admin_headers,
         )
@@ -368,6 +368,10 @@ class TestBackupPlanRoutes:
         )
 
         assert response.status_code == 422
+        assert (
+            response.json()["detail"]["key"]
+            == "backend.errors.schedule.invalidAvailabilityInterval"
+        )
 
     def test_create_plan_persists_upload_ratelimit_schedule_policies(
         self, test_client: TestClient, admin_headers, test_db
@@ -2507,7 +2511,8 @@ class TestBackupPlanRoutes:
         assert plan.enabled is False
         assert plan.next_run is None
 
-    def test_dispatch_due_runs_starts_scheduled_plan_and_advances_next_run(
+    @pytest.mark.asyncio
+    async def test_dispatch_due_runs_starts_scheduled_plan_and_advances_next_run(
         self, test_db
     ):
         _set_plan(test_db, "community")
@@ -2527,7 +2532,9 @@ class TestBackupPlanRoutes:
             "app.services.backup_plan_execution_service.asyncio.create_task",
             side_effect=close_background_task,
         ) as mock_create_task:
-            dispatched = backup_plan_execution_service.dispatch_due_runs(test_db, now)
+            dispatched = await backup_plan_execution_service.dispatch_due_runs(
+                test_db, now
+            )
 
         assert dispatched == 1
         mock_create_task.assert_called_once()
@@ -2539,7 +2546,8 @@ class TestBackupPlanRoutes:
         assert run.trigger == "schedule"
         assert run.status == "pending"
 
-    def test_availability_plan_records_minimum_interval_skip(self, test_db):
+    @pytest.mark.asyncio
+    async def test_availability_plan_records_minimum_interval_skip(self, test_db):
         repo = _create_repo(test_db, "Primary", "/repos/primary")
         now = datetime(2026, 1, 2, 12, 0)
         plan = _create_scheduled_plan(
@@ -2562,7 +2570,7 @@ class TestBackupPlanRoutes:
         )
         test_db.commit()
 
-        dispatched = backup_plan_execution_service.dispatch_due_runs(test_db, now)
+        dispatched = await backup_plan_execution_service.dispatch_due_runs(test_db, now)
 
         assert dispatched == 0
         skipped = (
@@ -2575,7 +2583,8 @@ class TestBackupPlanRoutes:
         assert len(skipped.repositories) == 1
         assert skipped.repositories[0].status == "skipped"
 
-    def test_dispatch_due_runs_skips_and_advances_paid_only_plan_after_downgrade(
+    @pytest.mark.asyncio
+    async def test_dispatch_due_runs_skips_and_advances_paid_only_plan_after_downgrade(
         self, test_db
     ):
         _set_plan(test_db, "community")
@@ -2591,7 +2600,9 @@ class TestBackupPlanRoutes:
         with patch(
             "app.services.backup_plan_execution_service.asyncio.create_task"
         ) as mock_create_task:
-            dispatched = backup_plan_execution_service.dispatch_due_runs(test_db, now)
+            dispatched = await backup_plan_execution_service.dispatch_due_runs(
+                test_db, now
+            )
 
         assert dispatched == 0
         mock_create_task.assert_not_called()
@@ -2602,7 +2613,8 @@ class TestBackupPlanRoutes:
         assert plan.last_run is None
         assert plan.next_run > now
 
-    def test_dispatch_due_runs_skips_plan_with_active_run(self, test_db):
+    @pytest.mark.asyncio
+    async def test_dispatch_due_runs_skips_plan_with_active_run(self, test_db):
         repo = _create_repo(test_db, "Primary", "/repos/primary")
         now = datetime(2026, 1, 1, 2, 0)
         plan = _create_scheduled_plan(
@@ -2622,7 +2634,9 @@ class TestBackupPlanRoutes:
         with patch(
             "app.services.backup_plan_execution_service.asyncio.create_task"
         ) as mock_create_task:
-            dispatched = backup_plan_execution_service.dispatch_due_runs(test_db, now)
+            dispatched = await backup_plan_execution_service.dispatch_due_runs(
+                test_db, now
+            )
 
         assert dispatched == 0
         mock_create_task.assert_not_called()
@@ -2630,7 +2644,8 @@ class TestBackupPlanRoutes:
             test_db.query(BackupPlanRun).filter_by(backup_plan_id=plan.id).count() == 1
         )
 
-    def test_dispatch_due_runs_ignores_disabled_plan_schedule(self, test_db):
+    @pytest.mark.asyncio
+    async def test_dispatch_due_runs_ignores_disabled_plan_schedule(self, test_db):
         repo = _create_repo(test_db, "Primary", "/repos/primary")
         now = datetime(2026, 1, 1, 2, 0)
         _create_scheduled_plan(
@@ -2643,7 +2658,9 @@ class TestBackupPlanRoutes:
         with patch(
             "app.services.backup_plan_execution_service.asyncio.create_task"
         ) as mock_create_task:
-            dispatched = backup_plan_execution_service.dispatch_due_runs(test_db, now)
+            dispatched = await backup_plan_execution_service.dispatch_due_runs(
+                test_db, now
+            )
 
         assert dispatched == 0
         mock_create_task.assert_not_called()

--- a/tests/unit/test_api_schedule_routes.py
+++ b/tests/unit/test_api_schedule_routes.py
@@ -53,6 +53,32 @@ def _create_schedule(
 
 @pytest.mark.unit
 class TestScheduleRouteContracts:
+    def test_create_availability_schedule_without_cron_expression(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        repository = _create_repo(test_db, "Availability Repo", "/repos/availability")
+
+        response = test_client.post(
+            "/api/schedule/",
+            json={
+                "name": "Availability backup",
+                "schedule_mode": "availability",
+                "availability_check_interval_minutes": 30,
+                "min_success_interval_minutes": 20 * 60,
+                "cron_expression": None,
+                "timezone": "UTC",
+                "repository_id": repository.id,
+                "enabled": True,
+            },
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        created = response.json()["job"]
+        assert created["schedule_mode"] == "availability"
+        assert created["cron_expression"] is None
+        assert created["next_run"] is not None
+
     def test_list_schedules_includes_deduped_repository_ids(
         self, test_client: TestClient, admin_headers, test_db
     ):

--- a/tests/unit/test_schedulers.py
+++ b/tests/unit/test_schedulers.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 
 from app.database.models import (
     BackupJob,
+    AvailabilityScheduleSkip,
     CheckJob,
     Repository,
     RestoreCheckJob,
@@ -24,6 +25,33 @@ from app.services.mqtt_sync_scheduler import (
 from app.services.stats_refresh_scheduler import StatsRefreshScheduler
 from app.api import schedule as schedule_api
 from app.api.schedule import check_scheduled_jobs, dispatch_due_scheduled_backups
+
+
+@pytest.mark.unit
+def test_availability_automation_skip_is_durable_and_neutral(db_session):
+    job = ScheduledJob(
+        name="Availability automation",
+        schedule_mode="availability",
+        enabled=True,
+    )
+    db_session.add(job)
+    db_session.commit()
+
+    now = datetime.now(timezone.utc)
+    job.next_run = now + timedelta(minutes=30)
+    schedule_api._record_availability_skip(
+        db_session,
+        job,
+        now,
+        reason="minimum_interval_not_elapsed",
+        detail="Minimum interval after the last successful backup has not elapsed.",
+    )
+    db_session.commit()
+
+    skip = db_session.query(AvailabilityScheduleSkip).one()
+    assert skip.scheduled_job_id == job.id
+    assert skip.reason == "minimum_interval_not_elapsed"
+    assert skip.next_check_at == job.next_run
 
 
 @pytest.mark.unit

--- a/tests/unit/test_schedulers.py
+++ b/tests/unit/test_schedulers.py
@@ -36,6 +36,7 @@ def test_availability_automation_skip_is_durable_and_neutral(db_session):
     )
     db_session.add(job)
     db_session.commit()
+    db_session.expire_all()
 
     now = datetime.now(timezone.utc)
     job.next_run = now + timedelta(minutes=30)
@@ -51,6 +52,10 @@ def test_availability_automation_skip_is_durable_and_neutral(db_session):
     skip = db_session.query(AvailabilityScheduleSkip).one()
     assert skip.scheduled_job_id == job.id
     assert skip.reason == "minimum_interval_not_elapsed"
+    assert (
+        skip.detail
+        == "Minimum interval after the last successful backup has not elapsed."
+    )
     assert skip.next_check_at == job.next_run
 
 


### PR DESCRIPTION
## Description

Adds an availability trigger for Backup Plans and Backup Automations. Users can configure a source polling interval and a minimum interval after a successful backup.

Skipped availability decisions are persisted as neutral history records with a reason and are shown in Activity and Backup Plan run history.

## Related Issue

Fixes #714

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass

Ran:

- Targeted availability scheduler, plan, automation, and Activity tests
- `ruff check` and `ruff format --check`
- Frontend locale parity, typecheck, lint, and production build
- Full unit suite: completed with existing baseline failures; the availability-plan route failure found during the run was fixed and rerun successfully.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Storybook coverage was added for the skipped availability state.

## Additional Context

Availability schedules do not create Borg jobs when the minimum interval has not elapsed or the source is unavailable. These are visible as neutral Skipped entries and do not trigger failure alerts, logs, or retries.

---

By submitting this pull request, you agree that your contributions will be licensed under the GNU Affero General Public License v3.0 (AGPL-3.0), the same license as this project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added availability-based scheduling for backup plans and automations.
  * Configure availability-check intervals and minimum time between successful backups.
  * Runs can be deferred when sources are unavailable or the minimum interval has not elapsed.
  * Added skipped-run history with reasons and next-check details.

* **Improvements**
  * Activity and job views display availability checks, skipped statuses, and localized reasons.
  * Added filters for availability checks and skipped activity.
  * Existing cron scheduling remains supported.
  * Updated scheduling controls and summaries for both trigger modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 12 changed, 6 added, 0 removed, 440 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-804/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/31677790566
<details>
<summary>Changed files</summary>
- `components-repositorycard--default.png` (10.56%)
- `components-repositorycard--enable-cloud-mirror-for-ssh.png` (10.78%)
- `components-repositorycard--enable-cloud-mirror.png` (10.64%)
- `components-repositorycard--managed-agent-mirror-pending.png` (0.80%)
- `components-repositorycard--rclone-failed.png` (0.78%)
- `components-repositorycard--rclone-hydration-required.png` (0.78%)
- `components-repositorycard--rclone-scheduled-failed.png` (0.78%)
- `components-repositorycard--rclone-scheduled.png` (0.80%)
- `components-repositorycard--rclone-synced.png` (0.78%)
- `components-repositorycard--remote-repository-without-permanent-delete.png` (10.81%)
- `components-repositorycard--with-upload-limit.png` (10.94%)
- `components-repositorycard--without-break-lock-access.png` (10.56%)
</details>
<details>
<summary>New screenshots</summary>
- `backup-plans-schedulestep--when-available--mobile.png`
- `backup-plans-schedulestep--when-available.png`
- `components-backupplanrunspanel--skipped-availability-check--mobile.png`
- `components-backupplanrunspanel--skipped-availability-check.png`
- `shared-schedulepicker--availability-trigger--mobile.png`
- `shared-schedulepicker--availability-trigger.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->