### PR TITLE
fix(runtime-base): rclone --version env collision aborts the image build

### DIFF
--- a/Dockerfile.runtime-base
+++ b/Dockerfile.runtime-base
@@ -82,7 +82,10 @@ RUN set -eux; \
     sha256sum -c /tmp/rclone.sha256; \
     unzip -j -o /tmp/rclone.zip "*/rclone" -d /out; \
     chmod 0755 /out/rclone; \
-    /out/rclone version; \
+    # rclone reads RCLONE_* env vars as flags, and BuildKit exposes these ARGs
+    # as env vars in RUN, so RCLONE_VERSION collides with the --version flag —
+    # clear them for the verification call (the final runtime image sets none).
+    env -u RCLONE_VERSION -u RCLONE_SHA256_AMD64 -u RCLONE_SHA256_ARM64 /out/rclone version; \
     rm -f /tmp/rclone.zip /tmp/rclone.sha256
 
 # --- runtime-base: slim image, no compilers — runtime libs + operational tools -


### PR DESCRIPTION
## What this fixes

Since #802, every `Dockerfile.runtime-base` build aborts in the builder stage — including the "Trivy Docker Image Scan" job of **Security Scan on `main`**, which builds the runtime base directly.

The static-rclone step verifies the download with `rclone version`. But rclone reads `RCLONE_*` environment variables as flags, and BuildKit exposes the `RCLONE_VERSION` build ARG as an environment variable inside `RUN` — so the verification call resolves `RCLONE_VERSION` to the boolean `--version` flag and dies:

```
CRITICAL: Invalid value when setting --version from environment variable
RCLONE_VERSION="1.75.0": invalid argument "1.75.0" for "--version" flag:
strconv.ParseBool: parsing "1.75.0": invalid syntax
```

The download, checksum verification and unzip all succeed; only the `rclone version` sanity call trips over the collision.

## The fix

Clear the colliding `RCLONE_*` vars for the verification call only:

```dockerfile
env -u RCLONE_VERSION -u RCLONE_SHA256_AMD64 -u RCLONE_SHA256_ARM64 /out/rclone version
```

The download/checksum logic is untouched, and the final runtime image sets none of these as env, so runtime `rclone` invocations were never affected.

## Verification

Built `--target builder` for `Dockerfile.runtime-base` locally (arm64) — the step now prints `rclone v1.75.0` and the build completes. hadolint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rclone version verification during container builds by preventing build-time environment variables from being misinterpreted as command-line options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->