### PR TITLE
fix(auth): resolve endpoint policy from concrete request path (unblocks fastapi 0.141)

### DIFF
--- a/app/core/authorization.py
+++ b/app/core/authorization.py
@@ -1,5 +1,6 @@
+import re
 from dataclasses import dataclass
-from typing import Dict, Tuple
+from typing import Dict, List, Optional, Pattern, Tuple
 
 from fastapi import Depends, Request
 from sqlalchemy.orm import Session
@@ -18,6 +19,37 @@ def _normalize_path(path: str) -> str:
     if path != "/" and path.endswith("/"):
         return path.rstrip("/")
     return path
+
+
+def _strip_root_path(path: str, root_path: str) -> str:
+    """Drop the mount prefix so matching is done on the app-relative path.
+
+    Under a non-empty ``BASE_PATH`` (``FastAPI(root_path=...)``), the ASGI
+    server can leave ``request.url.path`` carrying the mount prefix while
+    ``scope["root_path"]`` holds it separately. Stripping it on a path-segment
+    boundary keeps the policy lookup working — otherwise the prefixed path
+    misses every template and the guard is skipped. A no-op when no prefix is
+    present.
+    """
+    root_path = root_path.rstrip("/")
+    if not root_path:
+        return path
+    if path == root_path:
+        return "/"
+    if path.startswith(root_path + "/"):
+        return path[len(root_path) :]
+    return path
+
+
+def _template_to_regex(path: str) -> Pattern[str]:
+    """Compile a policy path template into an anchored regex.
+
+    ``/api/repositories/{repo_id}/wipe-jobs/{job_id}`` becomes
+    ``^/api/repositories/[^/]+/wipe-jobs/[^/]+$``. Splitting on ``{...}`` also
+    absorbs converter forms such as ``{repo_id:int}``.
+    """
+    parts = re.split(r"\{[^/]+\}", path)
+    return re.compile("^" + "[^/]+".join(re.escape(part) for part in parts) + "$")
 
 
 ENDPOINT_POLICIES: Dict[Tuple[str, str], EndpointPolicy] = {
@@ -170,13 +202,89 @@ ENDPOINT_POLICIES: Dict[Tuple[str, str], EndpointPolicy] = {
 }
 
 
+def _is_param_segment(segment: str) -> bool:
+    return segment.startswith("{") and segment.endswith("}")
+
+
+def _templates_overlap(a: str, b: str) -> bool:
+    """True when some concrete path would match both templates.
+
+    They overlap iff they have the same number of segments and, at every
+    position, the segments are equal or at least one is a ``{param}``.
+    """
+    seg_a = a.strip("/").split("/")
+    seg_b = b.strip("/").split("/")
+    if len(seg_a) != len(seg_b):
+        return False
+    return all(
+        _is_param_segment(x) or _is_param_segment(y) or x == y
+        for x, y in zip(seg_a, seg_b)
+    )
+
+
+def _assert_unambiguous_policies() -> None:
+    """No two same-method templates may match the same concrete path.
+
+    FastAPI does not reject overlapping routes — it resolves them by declaration
+    order — so the guard must not rely on that. Enforcing uniqueness here keeps a
+    single match per request: a future overlap fails loudly at import instead of
+    silently resolving to the wrong policy.
+    """
+    by_method: Dict[str, List[str]] = {}
+    for method, path in ENDPOINT_POLICIES:
+        by_method.setdefault(method, []).append(path)
+    for method, paths in by_method.items():
+        for index, first in enumerate(paths):
+            for second in paths[index + 1 :]:
+                if _templates_overlap(first, second):
+                    raise ValueError(
+                        f"Ambiguous authorization policies for {method}: "
+                        f"{first!r} overlaps {second!r}"
+                    )
+
+
+_assert_unambiguous_policies()
+
+# Policies compiled once at import, matched against the concrete request path.
+# Uniqueness is enforced above, so the first regex match is the only match.
+_COMPILED_POLICIES: List[Tuple[str, Pattern[str], EndpointPolicy]] = [
+    (method, _template_to_regex(path), policy)
+    for (method, path), policy in ENDPOINT_POLICIES.items()
+]
+
+
+def _match_policy(method: str, path: str) -> Optional[EndpointPolicy]:
+    """Resolve the policy for a request from its concrete path.
+
+    Matching the concrete ``request.url.path`` against our own templates keeps
+    authorization independent of how FastAPI names the matched route: since
+    0.141 a router-level dependency sees the router-relative ``route.path``
+    (``/{job_id}``) rather than the full path, which silently defeated a lookup
+    keyed on the full template.
+    """
+    path = _normalize_path(path)
+    for policy_method, pattern, policy in _COMPILED_POLICIES:
+        if policy_method == method and pattern.match(path):
+            return policy
+    return None
+
+
 async def authorize_request(
     request: Request,
     db: Session = Depends(get_db),
 ) -> None:
-    route = request.scope.get("route")
-    route_path = _normalize_path(getattr(route, "path", request.url.path))
-    policy = ENDPOINT_POLICIES.get((request.method.upper(), route_path))
+    method = request.method.upper()
+    # Match the path as received first; only if that misses retry with the
+    # BASE_PATH/root_path prefix stripped. As-is-first never breaks a path that
+    # already matches, so a mount prefix that happens to prefix a real route
+    # cannot cause a wrongful strip.
+    policy = _match_policy(method, request.url.path)
+    if policy is None:
+        stripped = _strip_root_path(
+            request.url.path, request.scope.get("root_path") or ""
+        )
+        if stripped != request.url.path:
+            policy = _match_policy(method, stripped)
     if policy is None:
         return
 

--- a/docs/engineering/specs/2026-08-13-authz-path-resolution.md
+++ b/docs/engineering/specs/2026-08-13-authz-path-resolution.md
@@ -1,0 +1,100 @@
+# Version-robust endpoint authorization
+
+Status: implemented. Concerns how `authorize_request` resolves which endpoint a
+request hit, and why that resolution must not depend on FastAPI's internal route
+naming. Unblocks the `fastapi` 0.136 -> 0.141 upgrade held back in the
+`backend-minor-patch` dependency group.
+
+## Problem
+
+Role and authentication guards are enforced in one place: `authorize_request`, a
+router-level dependency in `app/core/authorization.py`. It looks up an
+`EndpointPolicy` in `ENDPOINT_POLICIES`, a table keyed on
+`(method, full_path_template)` — e.g. `("PUT", "/api/schedule/{job_id}")` requires
+`admin` or `operator`. If no policy matches, the request is allowed through (the
+endpoint is public or guards itself).
+
+The endpoint was identified by reading `request.scope["route"].path` — the full
+path template. That is an implicit dependency on a FastAPI internal, and the
+internal changed:
+
+| | FastAPI 0.136.3 | FastAPI 0.141.1 |
+| --- | --- | --- |
+| `scope["route"].path` seen by a router-level dependency | `/api/schedule/{job_id}` (full) | `/{job_id}` (router-relative) |
+| `root_path` | `""` | `""` (does not carry the prefix) |
+
+Under 0.141 every lookup misses, `policy` is `None`, and the guard returns without
+checking — **silently turning every role and auth guard into a no-op**. A viewer
+could create, modify, and delete schedules; unauthenticated requests reached admin
+endpoints (200 where 401/403 was due). `main` was not affected while pinned to
+0.136.3; the upgrade is what would have exposed it. This was reproduced and
+bisected: `fastapi` alone flips the behaviour, with `starlette` (1.6.0) and
+`pydantic` (2.13.4) unchanged.
+
+## The fix: resolve from the concrete path
+
+The guard must not depend on *how* FastAPI names the matched route. The only
+stable, version-independent input is the concrete request path
+(`request.url.path`, e.g. `/api/schedule/1`). We already own the path templates —
+the `ENDPOINT_POLICIES` keys — so we compile those into anchored regexes once and
+match the concrete path against them:
+
+```python
+def _template_to_regex(path: str) -> Pattern[str]:
+    # "/api/repositories/{repo_id}/wipe-jobs/{job_id}"
+    #   -> ^/api/repositories/[^/]+/wipe-jobs/[^/]+$
+    parts = re.split(r"\{[^/]+\}", path)
+    return re.compile("^" + "[^/]+".join(re.escape(part) for part in parts) + "$")
+```
+
+`_match_policy(method, path)` normalises the trailing slash (unchanged
+`_normalize_path`) and returns the first compiled policy whose method and pattern
+match. `authorize_request` calls it with `request.url.path`; `scope["route"]` is no
+longer read. The `EndpointPolicy` / `ENDPOINT_POLICIES` data is untouched — only
+the lookup changed.
+
+For this to have a single, well-defined answer, no two same-method templates may
+match the same concrete path. FastAPI does *not* enforce that — it allows
+overlapping routes and resolves them by declaration order — so the guard cannot
+rely on it. `_assert_unambiguous_policies` enforces it here instead, at import: an
+overlapping pair fails loudly at startup rather than silently resolving to the
+wrong policy. With uniqueness guaranteed, the first regex match is the only match
+and match order is irrelevant.
+
+### Mounted under a base path
+
+The policy templates are app-relative (`/api/...`), so matching must be too. When
+the app is served under a non-empty `BASE_PATH` (`FastAPI(root_path=...)`), the
+ASGI server can leave `request.url.path` carrying the mount prefix while
+`scope["root_path"]` holds it separately — a prefixed path (`/borgui/api/...`)
+would then miss every template and skip the guard, the same failure in a different
+guise. `_strip_root_path` removes the prefix on a path-segment boundary (so
+`/borgui` is not stripped from `/borguix/...`) before matching; it is a no-op when
+no prefix is present.
+
+## Alternatives considered
+
+- **Repair `route.path` / use `root_path`.** Rejected: `root_path` is empty
+  (measured), and `route.path` is exactly the value that shifted between versions.
+- **Per-route dependencies** (`Depends(require_roles(...))` on each of ~50
+  endpoints instead of the central table). This is the most idiomatic FastAPI
+  shape and is immune to path semantics, but it means touching every router and
+  giving up the single auditable policy table. Noted as a possible future
+  direction; out of scope for restoring correctness under the version bump.
+
+## Verification
+
+Two guarantees, both enforced in CI:
+
+- **Cross-version.** The nine guard tests (`test_api_schedule::TestScheduleRoleGuard`,
+  the `test_api_settings` unauthenticated / non-admin cases, and
+  `test_api_repository_wipe::test_preview_requires_global_admin`) pass on both
+  fastapi 0.136.3 and 0.141.1.
+- **Resolution invariant.** `tests/unit/test_authorization_policy.py` drives
+  `_match_policy` directly. Its central test fills every `ENDPOINT_POLICIES`
+  template with a concrete value and asserts it resolves back to exactly that
+  policy — a single check that no template, static/parameterised sibling, or
+  future addition can be misresolved, independent of the FastAPI version.
+- **Base path.** The same file covers `_strip_root_path` (prefix removal,
+  segment-boundary safety) and drives `authorize_request` end-to-end under
+  `root_path=/borgui`: a viewer is rejected with 403 and an admin is allowed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ coverage[toml]==7.14.1
 croniter==6.2.2
 cryptography==50.0.0
 fastapi-cache2==0.2.2
-fastapi==0.136.3
+fastapi==0.141.1
 gunicorn==26.0.0
 httpx==0.28.1
 psutil==7.2.2

--- a/tests/unit/test_authorization_policy.py
+++ b/tests/unit/test_authorization_policy.py
@@ -1,0 +1,190 @@
+"""Unit tests for endpoint-policy resolution in ``app.core.authorization``.
+
+The role/auth guards are keyed on the request's endpoint. Resolution must work
+from the concrete request path alone — not from ``request.scope["route"].path``,
+whose meaning changed in FastAPI 0.141 (a router-level dependency now sees the
+router-relative path, e.g. ``/{job_id}`` instead of ``/api/schedule/{job_id}``).
+That regression silently turned every guard into a no-op; these tests pin the
+version-independent behaviour, including resolution under a non-empty
+``BASE_PATH`` (``root_path``).
+"""
+
+import re
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app.core import authorization as authz
+from app.core.authorization import (
+    ENDPOINT_POLICIES,
+    _assert_unambiguous_policies,
+    _match_policy,
+    _strip_root_path,
+    _templates_overlap,
+    authorize_request,
+)
+
+
+def _request(method: str, path: str, root_path: str = "") -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": method,
+            "path": path,
+            "raw_path": path.encode(),
+            "root_path": root_path,
+            "headers": [],
+            "query_string": b"",
+            "scheme": "http",
+            "server": ("test", 80),
+        }
+    )
+
+
+def _fill(template: str) -> str:
+    """Turn a policy template into a concrete path (``{param}`` -> ``1``)."""
+    return re.sub(r"\{[^/]+\}", "1", template)
+
+
+def test_every_policy_resolves_from_its_concrete_path():
+    # For each declared policy, the concrete path it governs must resolve back
+    # to exactly that policy — the core invariant the guard relies on.
+    for (method, template), policy in ENDPOINT_POLICIES.items():
+        resolved = _match_policy(method, _fill(template))
+        assert resolved is policy, f"{method} {template} resolved to {resolved!r}"
+
+
+def test_resolves_parameterised_path():
+    policy = _match_policy("PUT", "/api/schedule/42")
+    assert policy is not None
+    assert policy.detail_key == "backend.errors.schedule.operatorAccessRequired"
+    assert policy.roles == ("admin", "operator")
+
+
+def test_resolves_deep_multi_param_path():
+    policy = _match_policy("GET", "/api/repositories/7/wipe-jobs/9")
+    assert policy is not None
+    assert policy.detail_key == "backend.errors.repo.adminAccessRequired"
+
+
+def test_trailing_slash_is_normalised():
+    assert _match_policy("POST", "/api/schedule/") is _match_policy(
+        "POST", "/api/schedule"
+    )
+    assert _match_policy("POST", "/api/schedule") is not None
+
+
+def test_method_is_significant():
+    # No policy governs GET on a single schedule; it must not borrow PUT's.
+    assert _match_policy("GET", "/api/schedule/1") is None
+
+
+def test_static_and_parameterised_siblings_do_not_collide():
+    # A concrete path must resolve to its own entry, not fall through to a
+    # parameterised sibling of a different shape.
+    assert (
+        _match_policy("GET", "/api/packages/jobs")
+        is ENDPOINT_POLICIES[("GET", "/api/packages/jobs")]
+    )
+    assert (
+        _match_policy("GET", "/api/packages/jobs/5")
+        is ENDPOINT_POLICIES[("GET", "/api/packages/jobs/{job_id}")]
+    )
+
+
+def test_unlisted_path_has_no_policy():
+    assert _match_policy("GET", "/api/health") is None
+    assert _match_policy("GET", "/api/schedule") is None
+
+
+# --- policy uniqueness ------------------------------------------------------
+
+
+def test_declared_policies_are_unambiguous():
+    # The real table must never let two same-method templates match one path.
+    _assert_unambiguous_policies()
+
+
+def test_templates_overlap_detects_static_vs_param():
+    assert _templates_overlap("/api/x/{id}", "/api/x/static") is True
+
+
+def test_templates_overlap_ignores_different_lengths():
+    assert _templates_overlap("/api/x", "/api/x/{id}") is False
+
+
+def test_templates_overlap_ignores_distinct_literals():
+    assert _templates_overlap("/api/a", "/api/b") is False
+
+
+# --- BASE_PATH / root_path handling -----------------------------------------
+
+
+def test_prefixed_path_misses_without_stripping():
+    # The bug the strip closes: a mount-prefixed path matches no template.
+    assert _match_policy("PUT", "/borgui/api/schedule/1") is None
+
+
+def test_strip_root_path_removes_prefix():
+    assert _strip_root_path("/borgui/api/schedule/1", "/borgui") == "/api/schedule/1"
+    assert _strip_root_path("/borgui/api/schedule/1", "/borgui/") == "/api/schedule/1"
+
+
+def test_strip_root_path_is_noop_without_prefix():
+    assert _strip_root_path("/api/schedule/1", "") == "/api/schedule/1"
+
+
+def test_strip_root_path_only_on_segment_boundary():
+    # "/borgui" must not be stripped from "/borguix/...".
+    assert _strip_root_path("/borguix/api", "/borgui") == "/borguix/api"
+
+
+def test_strip_root_path_exact_match_becomes_root():
+    assert _strip_root_path("/borgui", "/borgui") == "/"
+
+
+def test_policy_resolves_after_stripping_prefix():
+    stripped = _strip_root_path("/borgui/api/schedule/1", "/borgui")
+    assert (
+        _match_policy("PUT", stripped)
+        is ENDPOINT_POLICIES[("PUT", "/api/schedule/{job_id}")]
+    )
+
+
+async def test_authorize_request_enforces_under_root_path(monkeypatch):
+    async def fake_current_user(request, db):
+        return SimpleNamespace(role="viewer")
+
+    monkeypatch.setattr(authz, "get_current_user", fake_current_user)
+
+    # Viewer hitting an operator-only endpoint behind BASE_PATH=/borgui.
+    request = _request("POST", "/borgui/api/schedule", root_path="/borgui")
+    with pytest.raises(HTTPException) as exc:
+        await authorize_request(request, db=None)
+    assert exc.value.status_code == 403
+
+
+async def test_authorize_request_allows_admin_under_root_path(monkeypatch):
+    async def fake_current_user(request, db):
+        return SimpleNamespace(role="admin")
+
+    monkeypatch.setattr(authz, "get_current_user", fake_current_user)
+
+    request = _request("POST", "/borgui/api/schedule", root_path="/borgui")
+    assert await authorize_request(request, db=None) is None
+
+
+async def test_authorize_request_prefers_path_as_received(monkeypatch):
+    # A received path that already matches must win, even when root_path happens
+    # to prefix a real route — the strip must not fire and drop enforcement.
+    async def fake_current_user(request, db):
+        return SimpleNamespace(role="viewer")
+
+    monkeypatch.setattr(authz, "get_current_user", fake_current_user)
+
+    request = _request("POST", "/api/schedule", root_path="/api")
+    with pytest.raises(HTTPException) as exc:
+        await authorize_request(request, db=None)
+    assert exc.value.status_code == 403


### PR DESCRIPTION
Makes `authorize_request` version-robust and bumps `fastapi` 0.136.3 -> 0.141.1. This is the fastapi half held back in #807 (which bumps the rest of the `backend-minor-patch` group and pins fastapi at 0.136.3).

### Why
FastAPI 0.141 changes `request.scope["route"].path` inside a **router-level dependency** from the full path (`/api/schedule/{job_id}`) to the router-relative path (`/{job_id}`). `authorize_request` keyed its `ENDPOINT_POLICIES` lookup on the full template, so every lookup missed, `policy` was `None`, and the guard returned without checking — **silently turning all role/auth guards into no-ops** (viewers could write; unauthenticated requests reached admin endpoints). `main` is unaffected while pinned to 0.136.3; the bump is what would expose it. Verified by bisection: fastapi alone flips it (starlette 1.6.0, pydantic 2.13.4 unchanged).

### What
- `authorize_request` resolves the policy by matching the concrete `request.url.path` against the `ENDPOINT_POLICIES` templates (compiled once to anchored regexes), instead of reading `scope["route"].path`. The policy data is unchanged — only the lookup.
- `requirements.txt`: fastapi 0.141.1.
- `tests/unit/test_authorization_policy.py`: drives `_match_policy`; the central test fills every policy template with a concrete value and asserts it resolves back to exactly that policy.
- `docs/engineering/specs/2026-08-13-authz-path-resolution.md`: the design and the FastAPI version coupling, so this is not reintroduced.

### Verification
The nine guard tests + the new unit test pass on **both** fastapi 0.136.3 and 0.141.1 (cross-version). Affected files: 112 passed. `ruff check` + `ruff format --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved endpoint authorization for URLs containing one or more path parameters.
  - Correctly distinguishes static and parameterized paths, HTTP methods, and trailing-slash variants.
  - Added support for deployments using a base path.
  - Prevented ambiguous policies and access to unlisted paths.
  - Preserved role validation and authorization detail handling across supported framework versions.

- **Documentation**
  - Added technical documentation covering authorization behavior, security considerations, and verification coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->