### PR TITLE
fix(auth): reject passwords over bcrypt's 72-byte limit

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -53,6 +53,7 @@ from app.core.oidc import (
 )
 from app.core.security import (
     authenticate_user,
+    BcryptPassword,
     create_access_token,
     create_login_challenge_token,
     create_totp_setup_token,
@@ -151,7 +152,7 @@ class OidcLinkStartResponse(BaseModel):
 
 class UserCreate(BaseModel):
     username: str
-    password: str
+    password: BcryptPassword
     email: Optional[str] = None
     is_admin: bool = False
     role: Optional[str] = None
@@ -166,7 +167,7 @@ class UserUpdate(BaseModel):
 
 class PasswordChange(BaseModel):
     current_password: str
-    new_password: str
+    new_password: BcryptPassword
 
 
 class PasswordSetupCompleteResponse(BaseModel):

--- a/app/api/settings.py
+++ b/app/api/settings.py
@@ -11,6 +11,7 @@ from app.database.models import User, Repository, SystemSettings
 from app.services import backup_monitoring_service
 from app.core.authorization import authorize_request
 from app.core.security import (
+    BcryptPassword,
     encrypt_secret,
     get_current_user,
     get_password_hash,
@@ -167,7 +168,7 @@ from pydantic import BaseModel
 
 class UserCreate(BaseModel):
     username: str
-    password: str
+    password: BcryptPassword
     email: Optional[str] = None
     role: str = "viewer"
     full_name: Optional[str] = None
@@ -185,11 +186,11 @@ class UserUpdate(BaseModel):
 
 class PasswordChange(BaseModel):
     current_password: str
-    new_password: str
+    new_password: BcryptPassword
 
 
 class PasswordReset(BaseModel):
-    new_password: str
+    new_password: BcryptPassword
 
 
 class UserPreferencesUpdate(BaseModel):

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,8 +1,9 @@
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Annotated, Optional
 import jwt
 from jwt.exceptions import PyJWTError as JWTError
 import bcrypt
+from pydantic import AfterValidator
 import hashlib
 from fastapi import HTTPException, status, Depends, Request
 from fastapi.security import HTTPBearer
@@ -76,6 +77,26 @@ def verify_password(plain_password: str, hashed_password: Optional[str]) -> bool
 def get_password_hash(password: str) -> str:
     """Hash a password"""
     return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+
+# bcrypt hashes at most 72 bytes of input; bcrypt 5 raises ValueError on longer
+# input rather than truncating it. Left unchecked that surfaces as a 500 when a
+# user sets a long (or multibyte) password. Validating at the request boundary
+# turns it into a clean 422 on registration, password change, and reset.
+BCRYPT_MAX_PASSWORD_BYTES = 72
+
+
+def enforce_bcrypt_password_length(password: str) -> str:
+    if len(password.encode("utf-8")) > BCRYPT_MAX_PASSWORD_BYTES:
+        raise ValueError(
+            f"Password must not exceed {BCRYPT_MAX_PASSWORD_BYTES} bytes when "
+            "UTF-8 encoded"
+        )
+    return password
+
+
+# Use on request-model password fields that are hashed with get_password_hash.
+BcryptPassword = Annotated[str, AfterValidator(enforce_bcrypt_password_length)]
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):

--- a/tests/unit/test_password_length.py
+++ b/tests/unit/test_password_length.py
@@ -1,0 +1,65 @@
+"""bcrypt hashes at most 72 bytes and (since bcrypt 5) raises on longer input.
+
+Password fields that are hashed with ``get_password_hash`` must reject over-limit
+input at the request boundary, so registration / password change / reset return a
+clean 422 instead of a 500. These tests pin that on the shared validator and on
+every model that carries a hashed password field.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.api import auth as auth_api
+from app.api import settings as settings_api
+from app.core.security import (
+    BCRYPT_MAX_PASSWORD_BYTES,
+    enforce_bcrypt_password_length,
+)
+
+AT_LIMIT = "a" * BCRYPT_MAX_PASSWORD_BYTES  # 72 ASCII bytes
+OVER_LIMIT = "a" * (BCRYPT_MAX_PASSWORD_BYTES + 1)  # 73 bytes
+MULTIBYTE_AT_LIMIT = "é" * (BCRYPT_MAX_PASSWORD_BYTES // 2)  # 36 chars = 72 bytes
+MULTIBYTE_OVER_LIMIT = "é" * (BCRYPT_MAX_PASSWORD_BYTES // 2) + "a"  # 73 bytes
+
+
+def test_validator_accepts_at_limit():
+    assert enforce_bcrypt_password_length(AT_LIMIT) == AT_LIMIT
+    assert enforce_bcrypt_password_length(MULTIBYTE_AT_LIMIT) == MULTIBYTE_AT_LIMIT
+
+
+def test_validator_rejects_over_limit():
+    with pytest.raises(ValueError):
+        enforce_bcrypt_password_length(OVER_LIMIT)
+
+
+def test_validator_counts_bytes_not_characters():
+    # 37 two-byte characters are only 37 characters but 74 bytes.
+    with pytest.raises(ValueError):
+        enforce_bcrypt_password_length(MULTIBYTE_OVER_LIMIT)
+
+
+# (model, kwargs-builder) for every model carrying a hashed password field.
+_MODELS = [
+    (auth_api.UserCreate, lambda pw: {"username": "u", "password": pw}),
+    (auth_api.PasswordChange, lambda pw: {"current_password": "x", "new_password": pw}),
+    (settings_api.UserCreate, lambda pw: {"username": "u", "password": pw}),
+    (
+        settings_api.PasswordChange,
+        lambda pw: {"current_password": "x", "new_password": pw},
+    ),
+    (settings_api.PasswordReset, lambda pw: {"new_password": pw}),
+]
+
+
+@pytest.mark.parametrize("model, build", _MODELS)
+def test_models_accept_at_limit(model, build):
+    model(**build(AT_LIMIT))
+    model(**build(MULTIBYTE_AT_LIMIT))
+
+
+@pytest.mark.parametrize("model, build", _MODELS)
+def test_models_reject_over_limit(model, build):
+    with pytest.raises(ValidationError):
+        model(**build(OVER_LIMIT))
+    with pytest.raises(ValidationError):
+        model(**build(MULTIBYTE_OVER_LIMIT))

--- a/tests/unit/test_password_length.py
+++ b/tests/unit/test_password_length.py
@@ -19,7 +19,7 @@ from app.core.security import (
 AT_LIMIT = "a" * BCRYPT_MAX_PASSWORD_BYTES  # 72 ASCII bytes
 OVER_LIMIT = "a" * (BCRYPT_MAX_PASSWORD_BYTES + 1)  # 73 bytes
 MULTIBYTE_AT_LIMIT = "é" * (BCRYPT_MAX_PASSWORD_BYTES // 2)  # 36 chars = 72 bytes
-MULTIBYTE_OVER_LIMIT = "é" * (BCRYPT_MAX_PASSWORD_BYTES // 2) + "a"  # 73 bytes
+MULTIBYTE_OVER_LIMIT = "é" * (BCRYPT_MAX_PASSWORD_BYTES // 2 + 1)  # 37 chars = 74 bytes
 
 
 def test_validator_accepts_at_limit():


### PR DESCRIPTION
Rejects passwords bcrypt cannot hash, with a clean 422 instead of a 500.

### Why
`get_password_hash` calls `bcrypt.hashpw` directly. bcrypt hashes at most 72 bytes and — since bcrypt 5 (pinned on `main`) — **raises `ValueError` on longer input** rather than truncating it. A password over 72 UTF-8 bytes (easy to hit with multibyte characters: 37 `é` = 74 bytes) therefore surfaced as an unhandled 500 during registration, password change, and reset.

Raised by CodeRabbit on #807. It is pre-existing on `main` (bcrypt 5.0.0 is unchanged there), not caused by that dependency bump — hence a standalone fix.

### Scope
The verify side already fails closed: `verify_password` catches the `ValueError` and returns `False`, so login and API/agent-token verification return a clean 401/auth-failure, not a 500. Only the **hashing** path was unguarded.

### What
- `app/core/security.py`: a shared `BcryptPassword` type (`Annotated[str, AfterValidator(...)]`) rejecting input over `BCRYPT_MAX_PASSWORD_BYTES` (72) UTF-8 bytes.
- Applied to every request field that is hashed with `get_password_hash`: `UserCreate.password`, `PasswordChange.new_password`, and `PasswordReset.new_password` in both `app/api/auth.py` and `app/api/settings.py`. Over-limit input now fails Pydantic validation → **422**.
- `tests/unit/test_password_length.py`: the validator (72/73 bytes, byte-vs-character counting) and every model (at-limit accepted, over-limit rejected, ASCII and multibyte).

### Verification
New test: 13 passed. No regressions: `test_api_auth.py` + `test_api_settings.py` 164 passed. `ruff check` + `ruff format --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password validation to enforce bcrypt’s 72-byte limit.
  * Applied the validation consistently to account creation, password changes, and password resets.
  * Multibyte passwords are measured by UTF-8 byte length.

* **Bug Fixes**
  * Prevented oversized passwords from being accepted by authentication and settings forms.

* **Tests**
  * Added coverage for boundary-length, multibyte, valid, and oversized passwords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->