### PR TITLE
fix(backup): keep a strong reference to background backup tasks

### DIFF
--- a/app/api/backup.py
+++ b/app/api/backup.py
@@ -51,6 +51,18 @@ router = APIRouter()
 
 RETRYABLE_BACKUP_STATUSES = {"failed", "cancelled"}
 
+# asyncio keeps only a weak reference to a bare create_task() result, so a
+# fire-and-forget backup task can be garbage-collected mid-execution — leaving
+# the job stuck in "pending". Hold a strong reference until the task finishes.
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _run_in_background(coro) -> asyncio.Task:
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task
+
 
 def _get_job_repository(
     db: Session, repository_path: Optional[str]
@@ -435,7 +447,7 @@ async def _start_backup_impl(
                     repository_id=repo_record.id,
                 )
             else:
-                asyncio.create_task(
+                _run_in_background(
                     backup_service.execute_backup(
                         backup_job.id,
                         backup_request.repository,
@@ -582,7 +594,7 @@ async def retry_backup_job(
     )
     db.commit()
     db.refresh(retry_job)
-    asyncio.create_task(
+    _run_in_background(
         backup_service.execute_backup(
             retry_job.id,
             repo.path,

--- a/tests/unit/test_api_backup.py
+++ b/tests/unit/test_api_backup.py
@@ -68,7 +68,7 @@ class TestBackupStart:
             patch(
                 "app.api.backup.backup_service.execute_backup", return_value=object()
             ),
-            patch("app.api.backup.asyncio.create_task"),
+            patch("app.api.backup._run_in_background") as run_background,
         ):
             response = test_client.post(
                 "/api/backup/start",
@@ -80,6 +80,9 @@ class TestBackupStart:
             data = response.json()
             assert "job_id" in data
             assert data["status"] == "pending"
+            # The happy path must actually dispatch the backup, not just create
+            # the pending row.
+            run_background.assert_called_once()
 
     def test_run_backup_alias_success(
         self, test_client: TestClient, admin_headers, test_db
@@ -275,7 +278,7 @@ class TestBackupStart:
             patch(
                 "app.api.backup.backup_service.execute_backup", new_callable=AsyncMock
             ) as execute_backup,
-            patch("app.api.backup.asyncio.create_task") as create_task,
+            patch("app.api.backup._run_in_background") as run_background,
         ):
             response = test_client.post(
                 "/api/backup/start",
@@ -289,7 +292,7 @@ class TestBackupStart:
             == "backend.errors.backup.concurrentLimitReached"
         )
         execute_backup.assert_not_called()
-        create_task.assert_not_called()
+        run_background.assert_not_called()
         assert test_db.query(BackupJob).filter_by(repository=repo.path).count() == 1
 
     def test_start_backup_multiple_sources(
@@ -738,9 +741,9 @@ class TestBackupRetry:
                 new_callable=AsyncMock,
             ) as execute_backup,
             patch(
-                "app.api.backup.asyncio.create_task",
+                "app.api.backup._run_in_background",
                 side_effect=_close_background_task,
-            ) as create_task,
+            ) as run_background,
         ):
             response = test_client.post(
                 f"/api/backup/jobs/{source_job.id}/retry", headers=admin_headers
@@ -794,7 +797,7 @@ class TestBackupRetry:
         assert snapshot["backup"]["custom_flags"] == "--one-file-system"
 
         execute_backup.assert_called_once()
-        create_task.assert_called_once()
+        run_background.assert_called_once()
 
     def test_retry_failed_agent_backup_creates_agent_job_with_lineage(
         self, test_client: TestClient, admin_headers, test_db
@@ -1017,7 +1020,7 @@ class TestBackupRetry:
                 new_callable=AsyncMock,
             ),
             patch(
-                "app.api.backup.asyncio.create_task",
+                "app.api.backup._run_in_background",
                 side_effect=_close_background_task,
             ),
         ):

--- a/tests/unit/test_backup_background_tasks.py
+++ b/tests/unit/test_backup_background_tasks.py
@@ -1,0 +1,41 @@
+"""A fire-and-forget backup task must not vanish mid-execution.
+
+asyncio keeps only a weak reference to a bare ``create_task()`` result, so an
+unreferenced backup task can be garbage-collected before it runs — leaving the
+job stuck in ``pending`` (the root cause of a flaky backup integration test).
+``app.api.backup._run_in_background`` holds a strong reference until the task
+finishes; these tests pin that contract.
+"""
+
+import asyncio
+
+import pytest
+
+from app.api.backup import _background_tasks, _run_in_background
+
+
+async def test_reference_held_during_execution_and_released_after():
+    release = asyncio.Event()
+    running = asyncio.Event()
+
+    async def work():
+        running.set()
+        await release.wait()
+
+    task = _run_in_background(work())
+    await running.wait()
+    assert task in _background_tasks  # strong reference retained while running
+
+    release.set()
+    await task
+    assert task not in _background_tasks  # discarded once done
+
+
+async def test_reference_released_even_when_task_raises():
+    async def boom():
+        raise RuntimeError("backup blew up")
+
+    task = _run_in_background(boom())
+    with pytest.raises(RuntimeError):
+        await task
+    assert task not in _background_tasks  # no leak on failure


### PR DESCRIPTION
Fixes a fire-and-forget backup task that could vanish mid-execution.

### Root cause
`start_backup` and the retry path launched `backup_service.execute_backup(...)` with a bare `asyncio.create_task(...)` whose result was never stored. Per the asyncio docs, the event loop keeps only a **weak** reference to a task, so an unreferenced task can be garbage-collected before it runs. Under GC pressure the backup coroutine is collected and the job stays in `pending` (`started_at=None`) forever.

This surfaced as a **flaky integration test** — `tests/integration/test_api_backup_integration.py::TestBackupCreationIntegration::test_download_backup_logs_for_failed_backup_job` timed out waiting for a job that never left `pending` (~2 of 3 CI runs on identical code). It is also a latent **production** bug: a manual backup could silently never run.

### Fix
Route both `create_task` sites through `_run_in_background`, which adds the task to a module-level set and discards it via `add_done_callback` on completion — a strong reference for the task's whole lifetime, released afterwards (including on failure, so the set does not leak).

### Verification
- New unit tests (`tests/unit/test_backup_background_tasks.py`): the reference is retained while the task runs and released once it is done or raises.
- `ruff check` + `ruff format --check` clean.
- The previously-flaky integration test exercises the real path in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of background backup operations by ensuring tasks remain active until completion.
  * Ensured backup tasks are properly cleaned up after successful completion or failure.
  * Improved reliability for manual backups and local backup retries, including operations that encounter errors or concurrency limits.

* **Tests**
  * Added coverage for task retention and cleanup during successful and failed backup operations.
  * Expanded validation for backup dispatch and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->