### PR TITLE
fix(i18n): localize audited frontend strings

### DIFF
--- a/docs/engineering/plans/2026-08-13-frontend-i18n-hardcoded-strings.md
+++ b/docs/engineering/plans/2026-08-13-frontend-i18n-hardcoded-strings.md
@@ -1,0 +1,34 @@
+# Frontend I18n Hardcoded Strings Plan
+
+## Goal
+
+Remove the remaining user-facing English literals identified in issue #775 from
+application components and pages, and make locale use regressions visible in
+CI.
+
+## Scope
+
+- Replace user-facing literals in `frontend/src/components` and
+  `frontend/src/pages` with translation keys.
+- Add matching English, German, Italian, and Spanish messages with interpolation
+  where values are dynamic.
+- Centralize common action labels when they are reused.
+- Add scoped linting that rejects new user-facing literal strings without
+  applying it to tests, stories, data, command text, or non-UI code.
+
+## Delivery
+
+Keep this as one PR with logical commits by surface:
+
+1. Managed Agents.
+2. API tokens and authentication.
+3. Shared wizard and layout components.
+4. Remaining pages and components.
+5. Locale guard and full verification.
+
+## Verification
+
+- Targeted Vitest coverage for changed components.
+- `npm run check:locales`.
+- Frontend lint, typecheck, and build.
+- Run the literal-string guard and inspect its exceptions for false positives.

--- a/frontend/src/components/AccountPasswordDialog.tsx
+++ b/frontend/src/components/AccountPasswordDialog.tsx
@@ -7,6 +7,7 @@ import {
   Stack,
   TextField,
 } from '@mui/material'
+import { useTranslation } from 'react-i18next'
 import ResponsiveDialog from './shared/ResponsiveDialog'
 
 interface AccountPasswordDialogProps {
@@ -36,11 +37,12 @@ export default function AccountPasswordDialog({
   onFormChange,
   onSubmit,
 }: AccountPasswordDialogProps) {
+  const { t } = useTranslation()
   const passwordsMismatch = confirmPassword !== '' && newPassword !== confirmPassword
 
   return (
     <ResponsiveDialog open={open} onClose={(_, reason) => onClose(reason)} maxWidth="sm" fullWidth>
-      <DialogTitle>Change password</DialogTitle>
+      <DialogTitle>{t('accountPassword.title')}</DialogTitle>
       <form
         onSubmit={(e) => {
           e.preventDefault()
@@ -50,7 +52,7 @@ export default function AccountPasswordDialog({
         <DialogContent>
           <Stack spacing={2}>
             <TextField
-              label="Current password"
+              label={t('accountPassword.current')}
               type="password"
               value={currentPassword}
               onChange={(e) => onFormChange({ current_password: e.target.value })}
@@ -59,7 +61,7 @@ export default function AccountPasswordDialog({
               size="small"
             />
             <TextField
-              label="New password"
+              label={t('accountPassword.new')}
               type="password"
               value={newPassword}
               onChange={(e) => onFormChange({ new_password: e.target.value })}
@@ -68,7 +70,7 @@ export default function AccountPasswordDialog({
               size="small"
             />
             <TextField
-              label="Confirm password"
+              label={t('accountPassword.confirm')}
               type="password"
               value={confirmPassword}
               onChange={(e) => onFormChange({ confirm_password: e.target.value })}
@@ -76,19 +78,19 @@ export default function AccountPasswordDialog({
               fullWidth
               size="small"
               error={passwordsMismatch}
-              helperText={passwordsMismatch ? 'Passwords do not match' : ''}
+              helperText={passwordsMismatch ? t('accountPassword.mismatch') : ''}
             />
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => onClose('closeButton')}>Cancel</Button>
+          <Button onClick={() => onClose('closeButton')}>{t('common.buttons.cancel')}</Button>
           <Button
             type="submit"
             variant="contained"
             disabled={isSubmitting}
             startIcon={isSubmitting ? <CircularProgress size={14} /> : null}
           >
-            {isSubmitting ? 'Saving' : 'Update password'}
+            {isSubmitting ? t('accountPassword.saving') : t('accountPassword.update')}
           </Button>
         </DialogActions>
       </form>

--- a/frontend/src/components/ActiveBackupPlanRunCard.tsx
+++ b/frontend/src/components/ActiveBackupPlanRunCard.tsx
@@ -48,8 +48,8 @@ function isActive(status?: string): boolean {
   return status === 'pending' || status === 'running'
 }
 
-function getRepositoryLabel(runRepository: BackupPlanRunRepository): string {
-  return runRepository.repository?.name || runRepository.backup_job?.repository || 'Repository'
+function getRepositoryLabel(runRepository: BackupPlanRunRepository, fallback: string): string {
+  return runRepository.repository?.name || runRepository.backup_job?.repository || fallback
 }
 
 function aggregateStats(run: BackupPlanRun) {
@@ -195,13 +195,13 @@ const ActiveBackupPlanRunCard: React.FC<ActiveBackupPlanRunCardProps> = ({
   visibleStats.push({
     key: 'speed',
     label: t('backup.runningJobs.progress.speed'),
-    value: stats.hasSpeed ? `${stats.speed.toFixed(2)} MB/s` : 'N/A',
+    value: stats.hasSpeed ? `${stats.speed.toFixed(2)} MB/s` : t('common.na'),
     valueColor: undefined,
   })
   visibleStats.push({
     key: 'eta',
     label: t('backup.runningJobs.progress.eta'),
-    value: stats.hasEta ? formatDurationSeconds(stats.eta) : 'N/A',
+    value: stats.hasEta ? formatDurationSeconds(stats.eta) : t('common.na'),
     valueColor: undefined,
   })
 
@@ -553,7 +553,7 @@ const ActiveBackupPlanRunCard: React.FC<ActiveBackupPlanRunCardProps> = ({
                     noWrap
                     sx={{ flex: 1, minWidth: 0 }}
                   >
-                    {getRepositoryLabel(repoRun)}
+                    {getRepositoryLabel(repoRun, t('backupPlans.status.repositoryFallback'))}
                   </Typography>
                   <Typography
                     variant="caption"

--- a/frontend/src/components/AnnouncementModal.tsx
+++ b/frontend/src/components/AnnouncementModal.tsx
@@ -148,7 +148,7 @@ export default function AnnouncementModal({
               {announcement.type === 'update_available' ? (
                 <Chip
                   size="small"
-                  label="Latest release"
+                  label={t('announcements.latestRelease')}
                   sx={{
                     height: 24,
                     bgcolor: alpha(accentColor, 0.16),
@@ -183,7 +183,7 @@ export default function AnnouncementModal({
             <IconButton
               onClick={onAcknowledge}
               size="small"
-              aria-label="Close announcement"
+              aria-label={t('announcements.close')}
               sx={{
                 color: secondaryText,
                 border: `1px solid ${borderAlpha}`,

--- a/frontend/src/components/ApiTokensSection.tsx
+++ b/frontend/src/components/ApiTokensSection.tsx
@@ -17,6 +17,7 @@ import {
 } from '@mui/material'
 import { Plus, Trash2, Key, Copy, Check } from 'lucide-react'
 import { toast } from 'react-hot-toast'
+import { useTranslation } from 'react-i18next'
 import { tokensAPI } from '../services/api'
 import { formatDateShort } from '../utils/dateUtils'
 import EmptyStateCard from './EmptyStateCard'
@@ -30,6 +31,7 @@ interface Token {
 }
 
 export default function ApiTokensSection() {
+  const { t } = useTranslation()
   const queryClient = useQueryClient()
   const [generateOpen, setGenerateOpen] = useState(false)
   const [tokenName, setTokenName] = useState('')
@@ -51,7 +53,7 @@ export default function ApiTokensSection() {
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onError: (error: any) => {
-      toast.error(error.response?.data?.detail || 'Failed to generate token')
+      toast.error(error.response?.data?.detail || t('apiTokens.errors.generate'))
     },
   })
 
@@ -59,11 +61,11 @@ export default function ApiTokensSection() {
     mutationFn: (id: number) => tokensAPI.revoke(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['api-tokens'] })
-      toast.success('Token revoked')
+      toast.success(t('apiTokens.revoked'))
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onError: (error: any) => {
-      toast.error(error.response?.data?.detail || 'Failed to revoke token')
+      toast.error(error.response?.data?.detail || t('apiTokens.errors.revoke'))
     },
   })
 
@@ -112,10 +114,10 @@ export default function ApiTokensSection() {
         >
           <Box>
             <Typography variant="body2" fontWeight={600}>
-              API Tokens
+              {t('apiTokens.title')}
             </Typography>
             <Typography variant="caption" color="text.secondary">
-              Programmatic access — shown only once when generated
+              {t('apiTokens.description')}
             </Typography>
           </Box>
           <Button
@@ -125,7 +127,7 @@ export default function ApiTokensSection() {
             onClick={() => setGenerateOpen(true)}
             sx={{ width: { xs: '100%', sm: 'auto' } }}
           >
-            Generate
+            {t('common.buttons.generate')}
           </Button>
         </Box>
 
@@ -135,12 +137,18 @@ export default function ApiTokensSection() {
               <CircularProgress size={24} />
             </Box>
           ) : tokens.length === 0 ? (
-            <EmptyStateCard inline icon={<Key size={32} />} title="No tokens yet" />
+            <EmptyStateCard inline icon={<Key size={32} />} title={t('apiTokens.empty')} />
           ) : (
             <Box component="table" sx={{ width: '100%', borderCollapse: 'collapse' }}>
               <Box component="thead">
                 <Box component="tr" sx={{ borderBottom: '1px solid', borderColor: 'divider' }}>
-                  {['Name', 'Prefix', 'Created', 'Last used', ''].map((h) => (
+                  {[
+                    t('common.name'),
+                    t('apiTokens.prefix'),
+                    t('apiTokens.created'),
+                    t('apiTokens.lastUsed'),
+                    '',
+                  ].map((h) => (
                     <Box
                       key={h}
                       component="th"
@@ -188,11 +196,13 @@ export default function ApiTokensSection() {
                     </Box>
                     <Box component="td" sx={{ p: 1.5 }}>
                       <Typography variant="body2" color="text.secondary">
-                        {token.last_used_at ? formatDateShort(token.last_used_at) : 'Never'}
+                        {token.last_used_at
+                          ? formatDateShort(token.last_used_at)
+                          : t('common.never')}
                       </Typography>
                     </Box>
                     <Box component="td" sx={{ p: 1.5, textAlign: 'right' }}>
-                      <Tooltip title="Revoke token">
+                      <Tooltip title={t('apiTokens.revoke')}>
                         <IconButton
                           size="small"
                           color="error"
@@ -218,7 +228,7 @@ export default function ApiTokensSection() {
         maxWidth="sm"
         fullWidth
       >
-        <DialogTitle>Generate API Token</DialogTitle>
+        <DialogTitle>{t('apiTokens.generateTitle')}</DialogTitle>
         <form
           onSubmit={(e) => {
             e.preventDefault()
@@ -227,23 +237,27 @@ export default function ApiTokensSection() {
         >
           <DialogContent>
             <TextField
-              label="Token name"
+              label={t('apiTokens.name')}
               value={tokenName}
               onChange={(e) => setTokenName(e.target.value)}
-              placeholder="e.g. CI deploy, Home automation"
+              placeholder={t('apiTokens.namePlaceholder')}
               required
               fullWidth
               autoFocus
             />
           </DialogContent>
           <DialogActions>
-            <Button onClick={() => setGenerateOpen(false)}>Cancel</Button>
+            <Button onClick={() => setGenerateOpen(false)}>{t('common.buttons.cancel')}</Button>
             <Button
               type="submit"
               variant="contained"
               disabled={generateMutation.isPending || !tokenName.trim()}
             >
-              {generateMutation.isPending ? <CircularProgress size={16} /> : 'Generate'}
+              {generateMutation.isPending ? (
+                <CircularProgress size={16} />
+              ) : (
+                t('common.buttons.generate')
+              )}
             </Button>
           </DialogActions>
         </form>
@@ -251,10 +265,10 @@ export default function ApiTokensSection() {
 
       {/* One-time token copy dialog */}
       <Dialog open={!!newToken} onClose={handleCloseCopyModal} maxWidth="sm" fullWidth>
-        <DialogTitle>Your new API token</DialogTitle>
+        <DialogTitle>{t('apiTokens.newTokenTitle')}</DialogTitle>
         <DialogContent>
           <Alert severity="warning" sx={{ mb: 2 }}>
-            Copy this token now. You won't be able to see it again.
+            {t('apiTokens.copyWarning')}
           </Alert>
           <Stack direction="row" spacing={1} alignItems="center">
             <TextField
@@ -263,7 +277,7 @@ export default function ApiTokensSection() {
               InputProps={{ readOnly: true, sx: { fontFamily: 'monospace', fontSize: '0.8rem' } }}
               onClick={(e) => (e.target as HTMLInputElement).select()}
             />
-            <Tooltip title={copied ? 'Copied!' : 'Copy to clipboard'}>
+            <Tooltip title={copied ? t('apiTokens.copied') : t('apiTokens.copyToClipboard')}>
               <IconButton onClick={handleCopy} color={copied ? 'success' : 'default'}>
                 {copied ? <Check size={18} /> : <Copy size={18} />}
               </IconButton>
@@ -272,7 +286,7 @@ export default function ApiTokensSection() {
         </DialogContent>
         <DialogActions>
           <Button onClick={handleCloseCopyModal} variant="contained">
-            Done
+            {t('common.buttons.finish')}
           </Button>
         </DialogActions>
       </Dialog>
@@ -284,14 +298,12 @@ export default function ApiTokensSection() {
         maxWidth="xs"
         fullWidth
       >
-        <DialogTitle>Close without copying?</DialogTitle>
+        <DialogTitle>{t('apiTokens.closeWithoutCopyingTitle')}</DialogTitle>
         <DialogContent>
-          <Typography variant="body2">
-            You haven't copied the token. Once you close this dialog, the token cannot be retrieved.
-          </Typography>
+          <Typography variant="body2">{t('apiTokens.closeWithoutCopyingDescription')}</Typography>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setCloseConfirmOpen(false)}>Go back</Button>
+          <Button onClick={() => setCloseConfirmOpen(false)}>{t('common.buttons.back')}</Button>
           <Button
             color="error"
             onClick={() => {
@@ -300,7 +312,7 @@ export default function ApiTokensSection() {
               setGenerateOpen(false)
             }}
           >
-            Close anyway
+            {t('apiTokens.closeAnyway')}
           </Button>
         </DialogActions>
       </Dialog>

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -57,7 +57,7 @@ export default function AppHeader({ onToggleMobileMenu }: AppHeaderProps) {
   const roleBadgeStyles = getRoleBadgeStyles(roleLabel, isDark)
   const companyLabel =
     user?.deployment_type === 'enterprise'
-      ? user.enterprise_name?.trim() || 'Enterprise deployment'
+      ? user.enterprise_name?.trim() || t('navigation.menu.enterpriseDeployment')
       : ''
 
   const isFullAccess = entitlement?.is_full_access && entitlement.status === 'active'
@@ -100,7 +100,7 @@ export default function AppHeader({ onToggleMobileMenu }: AppHeaderProps) {
       >
         <IconButton
           color="inherit"
-          aria-label="open drawer"
+          aria-label={t('navigation.menu.openDrawer')}
           edge="start"
           onClick={onToggleMobileMenu}
           sx={{ mr: 2, display: { sm: 'none' } }}
@@ -120,7 +120,7 @@ export default function AppHeader({ onToggleMobileMenu }: AppHeaderProps) {
             setAnchorEl(e.currentTarget)
             trackNavigation(EventAction.VIEW, { surface: 'user_menu' })
           }}
-          aria-label="User menu"
+          aria-label={t('navigation.menu.userMenu')}
           aria-haspopup="true"
           aria-expanded={open}
           sx={{

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -520,7 +520,7 @@ export default function AppSidebar({ mobileOpen, onClose }: AppSidebarProps) {
                             textTransform: 'uppercase',
                           }}
                         >
-                          {t('navigation.badges.new', { defaultValue: 'New' })}
+                          {t('navigation.badges.new')}
                         </Box>
                       ) : undefined
                     }

--- a/frontend/src/components/ArchivesList.tsx
+++ b/frontend/src/components/ArchivesList.tsx
@@ -202,10 +202,10 @@ export default function ArchivesList({
         color: 'text.disabled',
       }}
     >
-      <span>{t('archivesList.columnArchive', 'Archive')}</span>
-      <span>{t('archivesList.columnType', 'Type')}</span>
-      <span>{t('archivesList.columnDate', 'Date')}</span>
-      <Box sx={{ textAlign: 'right' }}>{t('archivesList.columnActions', 'Actions')}</Box>
+      <span>{t('archivesList.columnArchive')}</span>
+      <span>{t('archivesList.columnType')}</span>
+      <span>{t('archivesList.columnDate')}</span>
+      <Box sx={{ textAlign: 'right' }}>{t('archivesList.columnActions')}</Box>
     </Box>
   )
 
@@ -309,7 +309,7 @@ export default function ArchivesList({
       >
         <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.25, flexShrink: 0 }}>
           <Typography variant="h6" fontWeight={700} sx={{ fontSize: '0.95rem' }}>
-            Archives
+            {t('archivesList.archives')}
           </Typography>
           <Typography
             variant="body2"

--- a/frontend/src/components/BackupPlanRunsPanel.tsx
+++ b/frontend/src/components/BackupPlanRunsPanel.tsx
@@ -61,8 +61,8 @@ function runStatusColor(status?: string): 'default' | 'primary' | 'success' | 'w
   return 'default'
 }
 
-function formatRunStatus(status?: string): string {
-  if (!status) return 'Unknown'
+function formatRunStatus(status?: string, unknownLabel = 'Unknown'): string {
+  if (!status) return unknownLabel
   return status.replace(/_/g, ' ')
 }
 
@@ -92,8 +92,11 @@ function getTransportLabel(
   return null
 }
 
-function getRepositoryLabel(runRepository: BackupPlanRunRepository): string {
-  return runRepository.repository?.name || runRepository.backup_job?.repository || 'Repository'
+function getRepositoryLabel(
+  runRepository: BackupPlanRunRepository,
+  fallback = 'Repository'
+): string {
+  return runRepository.repository?.name || runRepository.backup_job?.repository || fallback
 }
 
 function getRepositoryPath(runRepository: BackupPlanRunRepository): string {
@@ -170,7 +173,7 @@ function RepositoryRunRow({
   const progressDetails = job?.progress_details
   const maintenanceStatus = job?.maintenance_status
   const statusLabel = t(`backupPlans.statuses.${runRepository.status}`, {
-    defaultValue: formatRunStatus(runRepository.status),
+    defaultValue: formatRunStatus(runRepository.status, t('common.unknown')),
   })
   const transportLabel = getTransportLabel(runRepository, t)
 
@@ -192,7 +195,9 @@ function RepositoryRunRow({
           justifyContent="space-between"
         >
           <Box sx={{ minWidth: 0 }}>
-            <Typography variant="subtitle2">{getRepositoryLabel(runRepository)}</Typography>
+            <Typography variant="subtitle2">
+              {getRepositoryLabel(runRepository, t('backupPlans.status.repositoryFallback'))}
+            </Typography>
             <Typography variant="caption" color="text.secondary" noWrap component="div">
               {getRepositoryPath(runRepository)}
             </Typography>
@@ -212,7 +217,7 @@ function RepositoryRunRow({
                 color={maintenanceStatus.includes('failed') ? 'warning' : 'default'}
                 label={t('backupPlans.runsDialog.maintenanceStatus', {
                   status: t(`backupPlans.statuses.${maintenanceStatus}`, {
-                    defaultValue: formatRunStatus(maintenanceStatus),
+                    defaultValue: formatRunStatus(maintenanceStatus, t('common.unknown')),
                   }),
                 })}
               />
@@ -364,7 +369,7 @@ export function BackupPlanRunCard({
   const active = isActiveRun(run.status)
   const progress = getRunProgress(run)
   const statusLabel = t(`backupPlans.statuses.${run.status}`, {
-    defaultValue: formatRunStatus(run.status),
+    defaultValue: formatRunStatus(run.status, t('common.unknown')),
   })
   const planName =
     plan?.name ||

--- a/frontend/src/components/BackupPlanRunsPanel.tsx
+++ b/frontend/src/components/BackupPlanRunsPanel.tsx
@@ -61,7 +61,7 @@ function runStatusColor(status?: string): 'default' | 'primary' | 'success' | 'w
   return 'default'
 }
 
-function formatRunStatus(status?: string, unknownLabel = 'Unknown'): string {
+function formatRunStatus(status: string | undefined, unknownLabel: string): string {
   if (!status) return unknownLabel
   return status.replace(/_/g, ' ')
 }
@@ -92,10 +92,7 @@ function getTransportLabel(
   return null
 }
 
-function getRepositoryLabel(
-  runRepository: BackupPlanRunRepository,
-  fallback = 'Repository'
-): string {
+function getRepositoryLabel(runRepository: BackupPlanRunRepository, fallback: string): string {
   return runRepository.repository?.name || runRepository.backup_job?.repository || fallback
 }
 
@@ -135,10 +132,10 @@ function getStartedAt(run: BackupPlanRun): string | null {
   return run.started_at || run.created_at || null
 }
 
-function getPrimaryRepositoryName(run: BackupPlanRun): string {
+function getPrimaryRepositoryName(run: BackupPlanRun, fallback: string): string {
   const firstRepository = run.repositories[0]
   if (!firstRepository) return '-'
-  return getRepositoryLabel(firstRepository)
+  return getRepositoryLabel(firstRepository, fallback)
 }
 
 function getPrimaryRepositoryPath(run: BackupPlanRun): string {
@@ -561,7 +558,10 @@ export default function BackupPlanRunsPanel({
             {getPlanName(run)}
           </Typography>
           <RepositoryCell
-            repositoryName={getPrimaryRepositoryName(run)}
+            repositoryName={getPrimaryRepositoryName(
+              run,
+              t('backupPlans.status.repositoryFallback')
+            )}
             repositoryPath={getPrimaryRepositoryPath(run)}
             withIcon={false}
           />

--- a/frontend/src/components/CacheManagementTab.tsx
+++ b/frontend/src/components/CacheManagementTab.tsx
@@ -211,12 +211,12 @@ const CacheManagementTab: React.FC = () => {
   const formatTtl = (minutes: number) => {
     if (minutes >= 1440) {
       const days = Math.floor(minutes / 1440)
-      return `${days} day${days > 1 ? 's' : ''}`
+      return t('cache.durationDays', { count: days })
     } else if (minutes >= 60) {
       const hours = Math.floor(minutes / 60)
-      return `${hours} hour${hours > 1 ? 's' : ''}`
+      return t('cache.durationHours', { count: hours })
     } else {
-      return `${minutes} minute${minutes > 1 ? 's' : ''}`
+      return t('cache.durationMinutes', { count: minutes })
     }
   }
 
@@ -275,7 +275,7 @@ const CacheManagementTab: React.FC = () => {
               </Box>
               {stats && (
                 <Chip
-                  label={stats.backend === 'redis' ? 'Redis' : 'In-Memory'}
+                  label={stats.backend === 'redis' ? t('cache.redis') : t('cache.inMemory')}
                   color={stats.backend === 'redis' ? 'success' : 'warning'}
                   size="small"
                   icon={stats.backend === 'redis' ? <Database size={16} /> : <Zap size={16} />}
@@ -287,9 +287,9 @@ const CacheManagementTab: React.FC = () => {
             {stats && stats.connection_info && (
               <Alert severity="info" sx={{ py: 0.5 }}>
                 <Typography variant="caption">
-                  <strong>Connection:</strong> {stats.connection_info}
-                  {stats.connection_type === 'external_url' && ' (External Redis)'}
-                  {stats.connection_type === 'local' && ' (Local Docker)'}
+                  <strong>{t('cache.connection')}:</strong> {stats.connection_info}
+                  {stats.connection_type === 'external_url' && ` (${t('cache.externalRedis')})`}
+                  {stats.connection_type === 'local' && ` (${t('cache.localDocker')})`}
                 </Typography>
               </Alert>
             )}
@@ -336,7 +336,9 @@ const CacheManagementTab: React.FC = () => {
 
               <Box sx={{ textAlign: 'center', p: 2, bgcolor: 'action.hover', borderRadius: 1 }}>
                 <Typography variant="h4" color="primary">
-                  {stats ? formatTtl(stats.cache_ttl_minutes) : '2 hours'}
+                  {stats
+                    ? formatTtl(stats.cache_ttl_minutes)
+                    : t('cache.durationHours', { count: 2 })}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
                   {t('cache.cacheTtl')}

--- a/frontend/src/components/FileExplorerDialog.tsx
+++ b/frontend/src/components/FileExplorerDialog.tsx
@@ -456,8 +456,7 @@ export default function FileExplorerDialog({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: any) {
       console.error('Failed to create folder:', err)
-      const errorMessage =
-        err.response?.data?.detail || err.message || t('fileExplorer.createFailed')
+      const errorMessage = err.response?.data?.detail || t('fileExplorer.createFailed')
       // Handle validation errors from FastAPI
       if (typeof errorMessage === 'object') {
         setError(JSON.stringify(errorMessage))

--- a/frontend/src/components/FileExplorerDialog.tsx
+++ b/frontend/src/components/FileExplorerDialog.tsx
@@ -201,7 +201,7 @@ export default function FileExplorerDialog({
       try {
         if (useConnectionType === 'agent') {
           if (!agentId) {
-            setError(t('fileExplorer.selectAgentFirst', 'Select an agent before browsing.'))
+            setError(t('fileExplorer.selectAgentFirst'))
             setItems([])
             return
           }
@@ -255,7 +255,7 @@ export default function FileExplorerDialog({
 
         if (useConnectionType === 'rclone') {
           if (!rcloneRemoteId) {
-            setError(t('wizard.cloudMirror.selectRemoteFirst', 'Select a rclone remote first.'))
+            setError(t('fileExplorer.selectRemoteFirst'))
             setItems([])
             return
           }
@@ -456,7 +456,8 @@ export default function FileExplorerDialog({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: any) {
       console.error('Failed to create folder:', err)
-      const errorMessage = err.response?.data?.detail || err.message || 'Failed to create folder'
+      const errorMessage =
+        err.response?.data?.detail || err.message || t('fileExplorer.createFailed')
       // Handle validation errors from FastAPI
       if (typeof errorMessage === 'object') {
         setError(JSON.stringify(errorMessage))

--- a/frontend/src/components/MountSuccessToast.tsx
+++ b/frontend/src/components/MountSuccessToast.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Box, Typography, IconButton, alpha, useTheme } from '@mui/material'
 import { HardDrive, Copy, Check, X } from 'lucide-react'
 import { toast } from 'react-hot-toast'
+import { useTranslation } from 'react-i18next'
 
 interface MountSuccessToastProps {
   toastId: string
@@ -9,6 +10,7 @@ interface MountSuccessToastProps {
 }
 
 export default function MountSuccessToast({ toastId, command }: MountSuccessToastProps) {
+  const { t } = useTranslation()
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
   const [copied, setCopied] = useState(false)
@@ -62,10 +64,10 @@ export default function MountSuccessToast({ toastId, command }: MountSuccessToas
             fontWeight={600}
             sx={{ fontSize: '0.82rem', lineHeight: 1.3 }}
           >
-            Archive Mounted
+            {t('mountSuccess.title')}
           </Typography>
           <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.72rem' }}>
-            Access via Docker:
+            {t('mountSuccess.accessViaDocker')}
           </Typography>
         </Box>
         <IconButton
@@ -107,7 +109,7 @@ export default function MountSuccessToast({ toastId, command }: MountSuccessToas
         <IconButton
           size="small"
           onClick={handleCopy}
-          title={copied ? 'Copied!' : 'Copy command'}
+          title={copied ? t('mountSuccess.copied') : t('mountSuccess.copyCommand')}
           sx={{
             flexShrink: 0,
             color: copied ? 'success.main' : 'text.disabled',

--- a/frontend/src/components/NavGroup.tsx
+++ b/frontend/src/components/NavGroup.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import {
   Box,
   Collapse,
@@ -40,6 +41,7 @@ export default function NavGroup({
   currentPath,
   navLabel,
 }: NavGroupProps) {
+  const { t } = useTranslation()
   const isAnySubItemActive = subItems.some((sub) => sub.href && currentPath.startsWith(sub.href))
 
   return (
@@ -144,7 +146,7 @@ export default function NavGroup({
             return (
               <ListItem key={subItem.name} disablePadding>
                 {isDisabled ? (
-                  <Tooltip title="Coming soon" arrow placement="right">
+                  <Tooltip title={t('navigation.comingSoon')} arrow placement="right">
                     <Box sx={{ width: '100%' }}>{button}</Box>
                   </Tooltip>
                 ) : (

--- a/frontend/src/components/NotificationCard.tsx
+++ b/frontend/src/components/NotificationCard.tsx
@@ -56,26 +56,28 @@ interface NotificationCardProps {
   isTesting?: boolean
 }
 
-function getServiceType(url: string): string {
+function getServiceType(url: string, t: (key: string) => string): string {
   const match = url.match(/^([a-z]+):\/\//)
-  if (!match) return 'Webhook'
+  if (!match) return t('notifications.card.serviceTypes.webhook')
   const scheme = match[1].toLowerCase()
   const map: Record<string, string> = {
-    slack: 'Slack',
-    discord: 'Discord',
-    tgram: 'Telegram',
-    tgrams: 'Telegram',
-    mailto: 'Email',
-    msteams: 'Teams',
-    pover: 'Pushover',
-    ntfy: 'Ntfy',
-    json: 'Webhook',
-    xml: 'Webhook',
-    form: 'Webhook',
-    gotify: 'Gotify',
-    matrix: 'Matrix',
+    slack: 'slack',
+    discord: 'discord',
+    tgram: 'telegram',
+    tgrams: 'telegram',
+    mailto: 'email',
+    msteams: 'teams',
+    pover: 'pushover',
+    ntfy: 'ntfy',
+    json: 'webhook',
+    xml: 'webhook',
+    form: 'webhook',
+    gotify: 'gotify',
+    matrix: 'matrix',
   }
-  return map[scheme] ?? scheme.charAt(0).toUpperCase() + scheme.slice(1)
+  return map[scheme]
+    ? t(`notifications.card.serviceTypes.${map[scheme]}`)
+    : scheme.charAt(0).toUpperCase() + scheme.slice(1)
 }
 
 export default function NotificationCard({
@@ -110,7 +112,7 @@ export default function NotificationCard({
     {
       icon: <Bell size={11} />,
       label: t('notifications.card.stats.service'),
-      value: getServiceType(notification.service_url),
+      value: getServiceType(notification.service_url, t),
       color: 'primary',
     },
     {

--- a/frontend/src/components/PlanScheduleCard.tsx
+++ b/frontend/src/components/PlanScheduleCard.tsx
@@ -93,7 +93,10 @@ const PlanScheduleCard: React.FC<PlanScheduleCardProps> = ({
         role="button"
         tabIndex={0}
         aria-expanded={expanded}
-        aria-label={`${expanded ? 'Collapse' : 'Expand'} ${plan.name}`}
+        aria-label={t('schedule.byPlan.togglePlan', {
+          action: expanded ? t('schedule.byPlan.collapse') : t('schedule.byPlan.expand'),
+          name: plan.name,
+        })}
         onClick={() => setExpanded((v) => !v)}
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
@@ -155,7 +158,7 @@ const PlanScheduleCard: React.FC<PlanScheduleCardProps> = ({
         {!plan.enabled && (
           <Chip
             size="small"
-            label={t('schedule.byPlan.paused', { defaultValue: 'Paused' })}
+            label={t('schedule.byPlan.paused')}
             sx={{
               height: 20,
               fontSize: '0.65rem',
@@ -168,18 +171,14 @@ const PlanScheduleCard: React.FC<PlanScheduleCardProps> = ({
           />
         )}
         {canManagePlan && (
-          <Tooltip
-            title={t('schedule.byPlan.editPlan', { defaultValue: 'Edit plan' })}
-            arrow
-            placement="left"
-          >
+          <Tooltip title={t('schedule.byPlan.editPlan')} arrow placement="left">
             <IconButton
               size="small"
               onClick={(e) => {
                 e.stopPropagation()
                 onEditPlan(plan.id)
               }}
-              aria-label={t('schedule.byPlan.editPlan', { defaultValue: 'Edit plan' })}
+              aria-label={t('schedule.byPlan.editPlan')}
               sx={{
                 width: 28,
                 height: 28,
@@ -232,7 +231,7 @@ const PlanScheduleCard: React.FC<PlanScheduleCardProps> = ({
             flexShrink: 0,
           }}
         >
-          {t('schedule.byPlan.backup', { defaultValue: 'Backup' })}
+          {t('schedule.byPlan.backup')}
         </Typography>
         {hasBackupSchedule ? (
           <Typography variant="body2" sx={{ flex: 1, minWidth: 0 }} noWrap>
@@ -252,10 +251,8 @@ const PlanScheduleCard: React.FC<PlanScheduleCardProps> = ({
           <Box sx={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 0.75 }}>
             <Typography variant="body2" sx={{ fontStyle: 'italic' }} color="text.disabled" noWrap>
               {plan.schedule_enabled
-                ? t('schedule.byPlan.notScheduled', { defaultValue: 'Not scheduled' })
-                : t('schedule.byPlan.scheduleDisabled', {
-                    defaultValue: 'Schedule disabled',
-                  })}
+                ? t('schedule.byPlan.notScheduled')
+                : t('schedule.byPlan.scheduleDisabled')}
             </Typography>
             {canManagePlan && (
               <Button
@@ -275,7 +272,7 @@ const PlanScheduleCard: React.FC<PlanScheduleCardProps> = ({
                   },
                 }}
               >
-                {t('schedule.byPlan.setSchedule', { defaultValue: 'Set schedule' })}
+                {t('schedule.byPlan.setSchedule')}
               </Button>
             )}
           </Box>
@@ -325,51 +322,35 @@ const PlanScheduleCard: React.FC<PlanScheduleCardProps> = ({
                   flexShrink: 0,
                 }}
               >
-                {t('schedule.byPlan.afterLabel', { defaultValue: 'After backup' })}
+                {t('schedule.byPlan.afterLabel')}
               </Typography>
               <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
                 {plan.run_prune_after && (
-                  <Tooltip
-                    title={t('schedule.byPlan.runPruneTip', {
-                      defaultValue: 'Old archives are pruned after each backup',
-                    })}
-                    arrow
-                  >
+                  <Tooltip title={t('schedule.byPlan.runPruneTip')} arrow>
                     <Chip
                       size="small"
                       icon={<Scissors size={11} aria-hidden />}
-                      label={t('schedule.byPlan.runPrune', { defaultValue: 'Prune' })}
+                      label={t('schedule.byPlan.runPrune')}
                       sx={chipSxFor(pruneColor)}
                     />
                   </Tooltip>
                 )}
                 {plan.run_compact_after && (
-                  <Tooltip
-                    title={t('schedule.byPlan.runCompactTip', {
-                      defaultValue: 'Repository is compacted after each backup',
-                    })}
-                    arrow
-                  >
+                  <Tooltip title={t('schedule.byPlan.runCompactTip')} arrow>
                     <Chip
                       size="small"
                       icon={<Archive size={11} aria-hidden />}
-                      label={t('schedule.byPlan.runCompact', { defaultValue: 'Compact' })}
+                      label={t('schedule.byPlan.runCompact')}
                       sx={chipSxFor(compactColor)}
                     />
                   </Tooltip>
                 )}
                 {plan.run_check_after && (
-                  <Tooltip
-                    title={t('schedule.byPlan.runCheckTip', {
-                      defaultValue:
-                        'Integrity check runs after each backup (in addition to any scheduled check below)',
-                    })}
-                    arrow
-                  >
+                  <Tooltip title={t('schedule.byPlan.runCheckTip')} arrow>
                     <Chip
                       size="small"
                       icon={<ShieldCheck size={11} aria-hidden />}
-                      label={t('schedule.byPlan.runCheck', { defaultValue: 'Check' })}
+                      label={t('schedule.byPlan.runCheck')}
                       sx={chipSxFor(checkColor)}
                     />
                   </Tooltip>
@@ -391,9 +372,7 @@ const PlanScheduleCard: React.FC<PlanScheduleCardProps> = ({
             }}
           >
             <Typography variant="body2" color="text.secondary">
-              {t('schedule.byPlan.noRepos', {
-                defaultValue: 'No repositories attached to this plan.',
-              })}
+              {t('schedule.byPlan.noRepos')}
             </Typography>
           </Box>
         ) : (

--- a/frontend/src/components/RepoMenuItem.tsx
+++ b/frontend/src/components/RepoMenuItem.tsx
@@ -1,5 +1,6 @@
 import { Box, Chip, Stack, Typography } from '@mui/material'
 import { Database } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import BorgVersionChip from './BorgVersionChip'
 
 interface RepoMenuItemProps {
@@ -32,6 +33,7 @@ export default function RepoMenuItem({
   maintenanceLabel = 'maintenance running',
   hidePath = false,
 }: RepoMenuItemProps) {
+  const { t } = useTranslation()
   return (
     <Stack direction="row" spacing={1} alignItems="center" sx={{ minWidth: 0, overflow: 'hidden' }}>
       <Database size={16} style={{ flexShrink: 0 }} />
@@ -41,7 +43,9 @@ export default function RepoMenuItem({
             {name}
           </Typography>
           <BorgVersionChip borgVersion={borgVersion} compact />
-          {mode === 'observe' && <Chip label="Observe Only" size="small" sx={observeChipSx} />}
+          {mode === 'observe' && (
+            <Chip label={t('repositories.observeOnly')} size="small" sx={observeChipSx} />
+          )}
           {hasRunningMaintenance && (
             <Typography component="span" variant="caption" color="warning.main">
               {maintenanceLabel}

--- a/frontend/src/components/RepoScheduleRow.tsx
+++ b/frontend/src/components/RepoScheduleRow.tsx
@@ -215,27 +215,27 @@ const RepoScheduleRow: React.FC<RepoScheduleRowProps> = ({
       <Box sx={{ pl: 2.5 }}>
         <ScheduleLine
           kind="check"
-          label={t('schedule.byPlan.check', { defaultValue: 'Check' })}
+          label={t('schedule.byPlan.check')}
           cron={checkCron}
           timezone={checkTimezone}
           enabled={checkEnabled}
           onClick={() => onEditCheck(repositoryId)}
           canManage={canManage}
-          setLabel={t('schedule.byPlan.setSchedule', { defaultValue: 'Set schedule' })}
-          editLabel={t('schedule.byPlan.edit', { defaultValue: 'Edit' })}
-          pausedLabel={t('schedule.byPlan.paused', { defaultValue: 'Paused' })}
+          setLabel={t('schedule.byPlan.setSchedule')}
+          editLabel={t('schedule.byPlan.edit')}
+          pausedLabel={t('schedule.byPlan.paused')}
         />
         <ScheduleLine
           kind="restore"
-          label={t('schedule.byPlan.restore', { defaultValue: 'Restore' })}
+          label={t('schedule.byPlan.restore')}
           cron={restoreCron}
           timezone={restoreTimezone}
           enabled={restoreEnabled}
           onClick={() => onEditRestore(repositoryId)}
           canManage={canManage}
-          setLabel={t('schedule.byPlan.setSchedule', { defaultValue: 'Set schedule' })}
-          editLabel={t('schedule.byPlan.edit', { defaultValue: 'Edit' })}
-          pausedLabel={t('schedule.byPlan.paused', { defaultValue: 'Paused' })}
+          setLabel={t('schedule.byPlan.setSchedule')}
+          editLabel={t('schedule.byPlan.edit')}
+          pausedLabel={t('schedule.byPlan.paused')}
         />
       </Box>
     </Box>

--- a/frontend/src/components/RepoSelect.tsx
+++ b/frontend/src/components/RepoSelect.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   FormControl,
   InputLabel,
@@ -43,9 +44,9 @@ export default function RepoSelect({
   onChange,
   loading = false,
   valueKey = 'path',
-  label = 'Repository',
-  loadingLabel = 'Loading…',
-  placeholderLabel = 'Select a repository',
+  label,
+  loadingLabel,
+  placeholderLabel,
   fallbackDisplayValue,
   maintenanceLabel,
   size = 'medium',
@@ -55,7 +56,11 @@ export default function RepoSelect({
   fullWidth = true,
   sx,
 }: RepoSelectProps) {
+  const { t } = useTranslation()
   const theme = useTheme()
+  const resolvedLabel = label ?? t('repoSelect.label')
+  const resolvedLoadingLabel = loadingLabel ?? t('common.loading')
+  const resolvedPlaceholderLabel = placeholderLabel ?? t('repoSelect.placeholder')
 
   // Find selected repo for rich renderValue
   const selectedRepo =
@@ -87,18 +92,18 @@ export default function RepoSelect({
       size={size}
       sx={{ minWidth: { xs: '100%', sm: 300 }, ...sx }}
     >
-      {label && <InputLabel>{label}</InputLabel>}
+      {resolvedLabel && <InputLabel>{resolvedLabel}</InputLabel>}
       <Select
         value={value}
         onChange={(e) => onChange(e.target.value as number | string)}
-        label={label || undefined}
+        label={resolvedLabel || undefined}
         disabled={disabled || loading}
         sx={selectSx}
         renderValue={(val) => {
           if (loading) {
             return (
               <Typography variant="body2" color="text.secondary">
-                {loadingLabel}
+                {resolvedLoadingLabel}
               </Typography>
             )
           }
@@ -112,7 +117,7 @@ export default function RepoSelect({
             }
             return (
               <Typography variant="body2" color="text.disabled">
-                {placeholderLabel}
+                {resolvedPlaceholderLabel}
               </Typography>
             )
           }
@@ -168,7 +173,7 @@ export default function RepoSelect({
         {prefixItems}
         {!prefixItems && (
           <MenuItem value="" disabled>
-            {loading ? loadingLabel : placeholderLabel}
+            {loading ? resolvedLoadingLabel : resolvedPlaceholderLabel}
           </MenuItem>
         )}
         {repositories.map((repo) => (

--- a/frontend/src/components/RepositoryScriptsTab.tsx
+++ b/frontend/src/components/RepositoryScriptsTab.tsx
@@ -376,7 +376,9 @@ export default function RepositoryScriptsTab({
                   })}
                 >
                   <Chip
-                    label={`${script.parameters.length} param${script.parameters.length > 1 ? 's' : ''}`}
+                    label={t('repositoryScripts.parameterCount', {
+                      count: script.parameters.length,
+                    })}
                     size="small"
                     color="info"
                     variant="outlined"
@@ -439,7 +441,7 @@ export default function RepositoryScriptsTab({
 
               {/* Actions */}
               <Box sx={{ display: 'flex', gap: 0.25, ml: 'auto' }}>
-                <Tooltip title={t('repositoryScripts.tooltips.testScript', 'Test run this script')}>
+                <Tooltip title={t('repositoryScripts.tooltips.testScript')}>
                   <IconButton
                     size="small"
                     onClick={() => handleTestScript(script)}
@@ -601,7 +603,7 @@ function RepositoryScriptDialog({
         <Box sx={{ pt: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
           {isPreBackup && hasInlineScript && scriptsCount === 0 && (
             <Alert severity="warning">
-              Adding a library script will replace your current inline script for this hook.
+              {t('repositoryScripts.dialog.inlineScriptReplacementWarning')}
             </Alert>
           )}
           <FormControl fullWidth>
@@ -796,7 +798,9 @@ function ScriptTestDialog({ open, onClose, scriptName, running, result }: Script
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
       <DialogTitle>
         <Box display="flex" alignItems="center" justifyContent="space-between">
-          <Typography variant="h6">Test: {scriptName}</Typography>
+          <Typography variant="h6">
+            {t('repositoryScripts.testDialog.title', { scriptName })}
+          </Typography>
           {running && <CircularProgress size={20} />}
           {result && (
             <Box display="flex" alignItems="center" gap={1}>
@@ -806,12 +810,14 @@ function ScriptTestDialog({ open, onClose, scriptName, running, result }: Script
                 <XCircle size={20} color="#f44336" />
               )}
               <Chip
-                label={`Exit: ${result.exit_code}`}
+                label={t('repositoryScripts.testDialog.exitCode', { code: result.exit_code })}
                 size="small"
                 color={result.exit_code === 0 ? 'success' : 'error'}
               />
               <Chip
-                label={`${result.execution_time.toFixed(2)}s`}
+                label={t('repositoryScripts.testDialog.duration', {
+                  seconds: result.execution_time.toFixed(2),
+                })}
                 size="small"
                 variant="outlined"
               />

--- a/frontend/src/components/RunningBackupsSection.tsx
+++ b/frontend/src/components/RunningBackupsSection.tsx
@@ -85,7 +85,7 @@ const RunningBackupsSection: React.FC<RunningBackupsSectionProps> = ({
         label: t('backup.runningJobs.progress.originalSize'),
         value: job.progress_details?.original_size
           ? formatBytesUtil(job.progress_details.original_size)
-          : job.processed_size || 'Unknown',
+          : job.processed_size || t('common.unknown'),
       },
       {
         key: 'compressed',
@@ -110,7 +110,7 @@ const RunningBackupsSection: React.FC<RunningBackupsSectionProps> = ({
         value:
           job.progress_details?.total_expected_size && job.progress_details.total_expected_size > 0
             ? formatBytesUtil(job.progress_details.total_expected_size)
-            : 'Unknown',
+            : t('common.unknown'),
         valueColor: 'success.main',
       },
       {
@@ -119,7 +119,7 @@ const RunningBackupsSection: React.FC<RunningBackupsSectionProps> = ({
         value:
           job.status === 'running' && job.progress_details?.backup_speed
             ? `${job.progress_details.backup_speed.toFixed(2)} MB/s`
-            : 'N/A',
+            : t('common.na'),
         valueColor: 'primary.main',
       },
       {
@@ -128,7 +128,7 @@ const RunningBackupsSection: React.FC<RunningBackupsSectionProps> = ({
         value:
           (job.progress_details?.estimated_time_remaining || 0) > 0
             ? formatDurationSeconds(job.progress_details?.estimated_time_remaining || 0)
-            : 'N/A',
+            : t('common.na'),
         valueColor: 'success.main',
       },
     ].filter((stat) => stat.value !== null)

--- a/frontend/src/components/ScheduledChecksSection.tsx
+++ b/frontend/src/components/ScheduledChecksSection.tsx
@@ -199,7 +199,7 @@ const ScheduledChecksSection = forwardRef<ScheduledChecksSectionRef, {}>((_, ref
     mutationFn: async (check: ScheduledCheck) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const repo = repositories.find((r: any) => r.id === check.repository_id)
-      if (!repo) throw new Error('Repository not found')
+      if (!repo) throw new Error(t('scheduledChecks.repositoryNotFound'))
       return new BorgApiClient(repo).checkRepository({
         maxDuration: check.check_max_duration,
         checkExtraFlags: check.check_extra_flags || '',
@@ -454,8 +454,8 @@ const ScheduledChecksSection = forwardRef<ScheduledChecksSectionRef, {}>((_, ref
               <MenuItem value="all">{t('scheduledChecks.allStatus')}</MenuItem>
               <MenuItem value="completed">{t('backupHistory.completed')}</MenuItem>
               <MenuItem value="failed">{t('backupHistory.failed')}</MenuItem>
-              <MenuItem value="cancelled">Cancelled</MenuItem>
-              <MenuItem value="running">Running</MenuItem>
+              <MenuItem value="cancelled">{t('scheduledChecks.status.cancelled')}</MenuItem>
+              <MenuItem value="running">{t('scheduledChecks.status.running')}</MenuItem>
             </Select>
           </Box>
 

--- a/frontend/src/components/ScheduledRestoreChecksSection.tsx
+++ b/frontend/src/components/ScheduledRestoreChecksSection.tsx
@@ -317,8 +317,8 @@ const ScheduledRestoreChecksSection = forwardRef<ScheduledRestoreChecksSectionRe
             title={
               <ScheduledInstantTooltip
                 display={startedDisplay}
-                scheduledLabel="Stored UTC"
-                localLabel="Your local timezone"
+                scheduledLabel={t('scheduledRestoreChecks.timeLabels.storedUtc')}
+                localLabel={t('scheduledRestoreChecks.timeLabels.localTimezone')}
               />
             }
             arrow

--- a/frontend/src/components/UnassignedReposSection.tsx
+++ b/frontend/src/components/UnassignedReposSection.tsx
@@ -52,12 +52,15 @@ const UnassignedReposSection: React.FC<UnassignedReposSectionProps> = ({
         }}
         onClick={() => setExpanded((v) => !v)}
       >
-        <IconButton size="small" sx={{ ml: -0.5 }} aria-label={expanded ? 'Collapse' : 'Expand'}>
+        <IconButton
+          size="small"
+          sx={{ ml: -0.5 }}
+          aria-label={expanded ? t('common.buttons.collapse') : t('common.buttons.expand')}
+        >
           {expanded ? <ChevronDown size={18} /> : <ChevronRight size={18} />}
         </IconButton>
         <Typography variant="subtitle2" fontWeight={700} sx={{ flex: 1 }}>
           {t('schedule.byPlan.unassignedTitle', {
-            defaultValue: 'Repositories not in any plan ({{count}})',
             count: repositories.length,
           })}
         </Typography>

--- a/frontend/src/components/UpcomingJobsTable.tsx
+++ b/frontend/src/components/UpcomingJobsTable.tsx
@@ -48,7 +48,7 @@ const UpcomingJobsTable: React.FC<UpcomingJobsTableProps> = ({
       return t('upcomingJobs.repositories', { count: job.repository_ids.length })
     }
     if (job.repository_id) {
-      return repositories.find((r) => r.id === job.repository_id)?.name || 'Unknown'
+      return repositories.find((r) => r.id === job.repository_id)?.name || t('common.unknown')
     }
     return getRepositoryName(job.repository || '')
   }
@@ -87,9 +87,7 @@ const UpcomingJobsTable: React.FC<UpcomingJobsTableProps> = ({
           const isPlan = job.type === 'backup_plan'
           const accent = isPlan ? ACCENT_PLAN : ACCENT_SCHEDULE
           const isClickable = isPlan && Boolean(onPlanClick)
-          const typeLabel = isPlan
-            ? t('upcomingJobs.types.plan', { defaultValue: 'Plan' })
-            : t('upcomingJobs.types.schedule', { defaultValue: 'Schedule' })
+          const typeLabel = isPlan ? t('upcomingJobs.types.plan') : t('upcomingJobs.types.schedule')
           const TypeIcon = isPlan ? ListChecks : CalendarClock
 
           const rowContent = (

--- a/frontend/src/components/__tests__/ArchivesList.test.tsx
+++ b/frontend/src/components/__tests__/ArchivesList.test.tsx
@@ -68,7 +68,7 @@ describe('ArchivesList', () => {
       />
     )
 
-    expect(screen.getByText('Archives')).toBeInTheDocument()
+    expect(screen.getByText('archives')).toBeInTheDocument()
     expect(screen.getByText('3')).toBeInTheDocument()
   })
 

--- a/frontend/src/components/__tests__/RunningBackupsSection.test.tsx
+++ b/frontend/src/components/__tests__/RunningBackupsSection.test.tsx
@@ -21,6 +21,7 @@ vi.mock('react-i18next', () => ({
         'backup.runningJobs.progress.initializing': 'Initializing',
         'backup.runningJobs.progress.processing': 'Processing',
         'backup.runningJobs.progress.finalizing': 'Finalizing',
+        'common.na': 'N/A',
       }
       if (key === 'backup.runningJobs.jobTitle') return `Backup Job ${opts?.id}`
       return map[key] ?? key

--- a/frontend/src/components/shared/BackupPlanSelect.tsx
+++ b/frontend/src/components/shared/BackupPlanSelect.tsx
@@ -1,5 +1,6 @@
 import { Alert, type AlertColor, Chip, type SxProps, type Theme } from '@mui/material'
 import { CalendarCheck } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import type { SourceType } from '../../types'
 import RichSelect, { type RichSelectOption } from './RichSelect'
 
@@ -47,22 +48,26 @@ export default function BackupPlanSelect({
   hideEmptyAlert,
   emptySeverity = 'info',
   sx,
-  formatSecondary = formatBackupPlanSecondary,
-  getIndicatorLabel = getDefaultIndicatorLabel,
+  formatSecondary,
+  getIndicatorLabel,
 }: BackupPlanSelectProps) {
+  const { t } = useTranslation()
+
   if (!Array.isArray(plans) || plans.length === 0) {
     if (hideEmptyAlert) return null
     return <Alert severity={emptySeverity}>{emptyMessage}</Alert>
   }
 
   const options: RichSelectOption[] = plans.map((plan) => {
-    const indicatorLabel = getIndicatorLabel(plan)
+    const indicatorLabel = getIndicatorLabel
+      ? getIndicatorLabel(plan)
+      : getDefaultIndicatorLabel(plan, t)
 
     return {
       value: String(plan.id),
       icon: <CalendarCheck size={16} />,
       primary: plan.name,
-      secondary: formatSecondary(plan),
+      secondary: formatSecondary?.(plan) ?? formatBackupPlanSecondary(plan, t),
       indicator: indicatorLabel ? (
         <Chip
           size="small"
@@ -91,21 +96,27 @@ export default function BackupPlanSelect({
   )
 }
 
-function formatBackupPlanSecondary(plan: BackupPlanSummary): string {
-  return `${formatSourceType(plan.source_type)} · ${formatRepositoryCount(plan.repository_count)}`
+function formatBackupPlanSecondary(
+  plan: BackupPlanSummary,
+  t: (key: string, options?: Record<string, unknown>) => string
+): string {
+  return `${formatSourceType(plan.source_type, t)} · ${formatRepositoryCount(plan.repository_count, t)}`
 }
 
-function formatSourceType(sourceType: SourceType): string {
-  if (sourceType === 'remote') return 'Remote source'
-  if (sourceType === 'agent') return 'Managed agent'
-  if (sourceType === 'mixed') return 'Multiple sources'
-  return 'Local source'
+function formatSourceType(sourceType: SourceType, t: (key: string) => string): string {
+  if (sourceType === 'remote') return t('backupPlans.select.source.remote')
+  if (sourceType === 'agent') return t('backupPlans.select.source.agent')
+  if (sourceType === 'mixed') return t('backupPlans.select.source.mixed')
+  return t('backupPlans.select.source.local')
 }
 
-function formatRepositoryCount(count: number): string {
-  return count === 1 ? '1 repository' : `${count} repositories`
+function formatRepositoryCount(
+  count: number,
+  t: (key: string, options?: Record<string, unknown>) => string
+): string {
+  return t('backupPlans.select.repositories', { count })
 }
 
-function getDefaultIndicatorLabel(plan: BackupPlanSummary): string {
-  return plan.schedule_enabled ? 'Scheduled' : 'Manual'
+function getDefaultIndicatorLabel(plan: BackupPlanSummary, t: (key: string) => string): string {
+  return plan.schedule_enabled ? t('backupPlans.select.scheduled') : t('backupPlans.select.manual')
 }

--- a/frontend/src/components/shared/RichSelect.tsx
+++ b/frontend/src/components/shared/RichSelect.tsx
@@ -15,6 +15,7 @@ import type { SystemStyleObject } from '@mui/system'
 import { Search } from 'lucide-react'
 import type { KeyboardEvent, MouseEvent, ReactNode } from 'react'
 import { useId, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import RichSelectRow from './RichSelectRow'
 
 export interface RichSelectOption {
@@ -58,18 +59,21 @@ export default function RichSelect({
   required,
   placeholder,
   searchEnabled = false,
-  searchPlaceholder = 'Search',
-  noResultsText = 'No results found',
+  searchPlaceholder,
+  noResultsText,
   sx,
   selectSx,
   menuPaperSx,
 }: RichSelectProps) {
+  const { t } = useTranslation()
   const generatedId = useId()
   const resolvedLabelId = labelId ?? `${generatedId}-label`
   const rootRef = useRef<HTMLDivElement | null>(null)
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuWidth, setMenuWidth] = useState<number | null>(null)
   const [search, setSearch] = useState('')
+  const resolvedSearchPlaceholder = searchPlaceholder ?? t('common.search')
+  const resolvedNoResultsText = noResultsText ?? t('common.noResults')
   const selectSxList = toSxArray(selectSx)
   const menuPaperSxList = toSxArray(menuPaperSx)
 
@@ -204,7 +208,7 @@ export default function RichSelect({
               fullWidth
               size="small"
               value={search}
-              placeholder={searchPlaceholder}
+              placeholder={resolvedSearchPlaceholder}
               onChange={(event) => setSearch(event.target.value)}
               onClick={handleSearchClick}
               onMouseDown={handleSearchClick}
@@ -259,7 +263,7 @@ export default function RichSelect({
         ) : (
           <MenuItem disabled sx={menuItemSx}>
             <Typography variant="body2" color="text.secondary" noWrap>
-              {noResultsText}
+              {resolvedNoResultsText}
             </Typography>
           </MenuItem>
         )}

--- a/frontend/src/components/shared/WizardStepIndicator.tsx
+++ b/frontend/src/components/shared/WizardStepIndicator.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { Box, Typography, alpha, useTheme, useMediaQuery } from '@mui/material'
 import { getWizardStepColor } from './wizardStepColors'
 
@@ -19,6 +20,7 @@ export default function WizardStepIndicator({
   currentStep,
   onStepClick,
 }: WizardStepIndicatorProps) {
+  const { t } = useTranslation()
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
   const isMobile = useMediaQuery(theme.breakpoints.down('md'))
@@ -55,7 +57,10 @@ export default function WizardStepIndicator({
           }}
         >
           <Typography variant="caption" sx={{ color: 'text.secondary', fontWeight: 500 }}>
-            {`Step ${currentStep + 1} / ${steps.length}`}
+            {t('wizard.scheduleWizard.stepIndicator.progress', {
+              current: currentStep + 1,
+              total: steps.length,
+            })}
           </Typography>
           <Typography variant="caption" sx={{ color: activeColor, fontWeight: 600 }}>
             {activeStep?.label}
@@ -74,7 +79,10 @@ export default function WizardStepIndicator({
                 onClick={() => onStepClick?.(index)}
                 data-testid={`step-circle-${step.key}`}
                 role="button"
-                aria-label={`Go to step ${index + 1}: ${step.label}`}
+                aria-label={t('wizard.scheduleWizard.stepIndicator.goToStep', {
+                  step: index + 1,
+                  label: step.label,
+                })}
                 sx={{
                   display: 'flex',
                   alignItems: 'center',

--- a/frontend/src/components/wizard/RcloneRemoteDialog.tsx
+++ b/frontend/src/components/wizard/RcloneRemoteDialog.tsx
@@ -73,11 +73,11 @@ interface RcloneRemoteDialogProps {
   ) => Promise<unknown> | unknown
 }
 
-const DEFAULT_PROVIDERS: RcloneProvider[] = [
+const getDefaultProviders = (t: (key: string) => string): RcloneProvider[] => [
   {
     type: 'local',
-    label: 'Local filesystem',
-    description: 'Local path remote.',
+    label: t('wizard.location.rcloneDefaultProviders.localLabel'),
+    description: t('wizard.location.rcloneDefaultProviders.localDescription'),
     auth_type: 'none',
     type_editable: false,
     docs_url: 'https://rclone.org/local/',
@@ -86,8 +86,8 @@ const DEFAULT_PROVIDERS: RcloneProvider[] = [
   },
   {
     type: 'custom',
-    label: 'Custom rclone backend',
-    description: 'Manual setup for any rclone backend.',
+    label: t('wizard.location.rcloneDefaultProviders.customLabel'),
+    description: t('wizard.location.rcloneDefaultProviders.customDescription'),
     auth_type: 'manual',
     type_editable: true,
     docs_url: 'https://rclone.org/docs/',
@@ -160,7 +160,7 @@ export default function RcloneRemoteDialog({
   isCreating = false,
   error = null,
   disablePortal = false,
-  providers = DEFAULT_PROVIDERS,
+  providers = [],
   onClose,
   onCreate,
   onStartOAuth,
@@ -168,6 +168,7 @@ export default function RcloneRemoteDialog({
   onSaveOAuthCredentials,
 }: RcloneRemoteDialogProps) {
   const { t } = useTranslation()
+  const defaultProviders = useMemo(() => getDefaultProviders(t), [t])
   const [name, setName] = useState('')
   const [providerType, setProviderType] = useState('local')
   const [customProvider, setCustomProvider] = useState('')
@@ -190,7 +191,7 @@ export default function RcloneRemoteDialog({
   const resolvedProviderRef = useRef('local')
   const initializedRemoteKeyRef = useRef<string | null>(null)
 
-  const providerOptions = providers.length ? providers : DEFAULT_PROVIDERS
+  const providerOptions = providers.length ? providers : defaultProviders
   const sortedProviderOptions = useMemo(
     () => sortRcloneProviders(providerOptions),
     [providerOptions]

--- a/frontend/src/components/wizard/RepositoryEncryptionFields.tsx
+++ b/frontend/src/components/wizard/RepositoryEncryptionFields.tsx
@@ -28,32 +28,13 @@ interface RepositoryEncryptionFieldsProps {
   onChange: (data: Partial<RepositoryEncryptionData>) => void
 }
 
-const BORG1_ENCRYPTION_OPTIONS = [
-  { value: 'repokey', label: 'Repository Key', desc: 'Key stored in repository (recommended)' },
-  { value: 'repokey-blake2', label: 'Repository Key (BLAKE2)', desc: 'Faster hashing variant' },
-  { value: 'keyfile', label: 'Key File', desc: 'Key stored in a separate file' },
-  { value: 'keyfile-blake2', label: 'Key File (BLAKE2)', desc: 'Key file with faster hashing' },
-  { value: 'none', label: 'None', desc: 'No encryption (not recommended)' },
-]
-
+const BORG1_ENCRYPTION_OPTIONS = ['repokey', 'repokey-blake2', 'keyfile', 'keyfile-blake2', 'none']
 const BORG2_ENCRYPTION_OPTIONS = [
-  {
-    value: 'repokey-aes-ocb',
-    label: 'Repository Key (AES-OCB)',
-    desc: 'Default for Borg 2 · recommended',
-  },
-  {
-    value: 'repokey-chacha20-poly1305',
-    label: 'Repository Key (ChaCha20)',
-    desc: 'Alternative AEAD cipher',
-  },
-  { value: 'keyfile-aes-ocb', label: 'Key File (AES-OCB)', desc: 'Key stored in a separate file' },
-  {
-    value: 'keyfile-chacha20-poly1305',
-    label: 'Key File (ChaCha20)',
-    desc: 'Key file with ChaCha20',
-  },
-  { value: 'none', label: 'None', desc: 'No encryption (not recommended)' },
+  'repokey-aes-ocb',
+  'repokey-chacha20-poly1305',
+  'keyfile-aes-ocb',
+  'keyfile-chacha20-poly1305',
+  'none',
 ]
 
 export default function RepositoryEncryptionFields({
@@ -81,13 +62,13 @@ export default function RepositoryEncryptionFields({
               onChange={(e) => onChange({ encryption: e.target.value })}
             >
               {encryptionOptions.map((opt) => (
-                <MenuItem key={opt.value} value={opt.value}>
+                <MenuItem key={opt} value={opt}>
                   <Box>
                     <Typography variant="body2" fontWeight={600}>
-                      {opt.label}
+                      {t(`wizard.security.options.${opt}.label`)}
                     </Typography>
                     <Typography variant="caption" color="text.secondary">
-                      {opt.desc}
+                      {t(`wizard.security.options.${opt}.description`)}
                     </Typography>
                   </Box>
                 </MenuItem>
@@ -146,7 +127,11 @@ export default function RepositoryEncryptionFields({
             endAdornment: (
               <InputAdornment position="end">
                 <IconButton
-                  aria-label={showPassphrase ? 'Hide passphrase' : 'Show passphrase'}
+                  aria-label={
+                    showPassphrase
+                      ? t('wizard.review.hidePassphrase')
+                      : t('wizard.review.showPassphrase')
+                  }
                   onClick={() => setShowPassphrase((v) => !v)}
                   edge="end"
                   size="small"

--- a/frontend/src/components/wizard/WizardStepDataSource.tsx
+++ b/frontend/src/components/wizard/WizardStepDataSource.tsx
@@ -361,7 +361,7 @@ export default function WizardStepDataSource({
 
           <Alert severity="info">
             <Typography variant="body2">
-              <strong>Note:</strong> {t('wizard.dataSource.remoteSshNote')}
+              <strong>{t('wizard.dataSource.note')}</strong> {t('wizard.dataSource.remoteSshNote')}
             </Typography>
           </Alert>
         </>

--- a/frontend/src/components/wizard/WizardStepLocation.tsx
+++ b/frontend/src/components/wizard/WizardStepLocation.tsx
@@ -250,7 +250,7 @@ export default function WizardStepLocation({
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
               <Typography variant="body2" color="text.secondary" sx={{ flexShrink: 0 }}>
-                Borg Version
+                {t('wizard.location.borgVersion')}
               </Typography>
               <Box
                 sx={{
@@ -289,7 +289,7 @@ export default function WizardStepLocation({
               {(data.borgVersion ?? 1) === 2 && (
                 <Tooltip title={t('wizard.location.borgV2Warning')} arrow placement="right">
                   <Chip
-                    label="Beta"
+                    label={t('wizard.location.beta')}
                     size="small"
                     color="warning"
                     variant="outlined"
@@ -432,7 +432,7 @@ export default function WizardStepLocation({
               {t('wizard.location.directRcloneAdvancedTitle')}
             </Typography>
             <Chip
-              label="Borg 2"
+              label={t('wizard.location.borg2')}
               size="small"
               variant="outlined"
               color="warning"

--- a/frontend/src/components/wizard/WizardStepRestoreDestination.tsx
+++ b/frontend/src/components/wizard/WizardStepRestoreDestination.tsx
@@ -289,7 +289,7 @@ export default function WizardStepRestoreDestination({
                           {conn.username}@{conn.host}
                         </Typography>
                         <Typography variant="caption" color="text.secondary">
-                          Port {conn.port}
+                          {t('wizard.restoreDestination.port', { port: conn.port })}
                           {conn.mount_point && ` • ${conn.mount_point}`}
                         </Typography>
                       </Box>
@@ -301,7 +301,7 @@ export default function WizardStepRestoreDestination({
                             borderRadius: '50%',
                             bgcolor: 'success.main',
                           }}
-                          title="Connected"
+                          title={t('wizard.restoreDestination.connected')}
                         />
                       )}
                     </Box>

--- a/frontend/src/components/wizard/WizardStepReview.tsx
+++ b/frontend/src/components/wizard/WizardStepReview.tsx
@@ -205,7 +205,7 @@ export default function WizardStepReview({
           <Tooltip title={t('wizard.review.repositoryInitialized')} placement="top" arrow>
             <Chip
               icon={<Rocket size={11} />}
-              label="Ready to Initialize"
+              label={t('wizard.review.readyToInitialize')}
               size="small"
               sx={{
                 height: 20,
@@ -398,9 +398,19 @@ export default function WizardStepReview({
                 >
                   {showPassphrase ? data.passphrase : '••••••••'}
                 </Typography>
-                <Tooltip title={showPassphrase ? 'Hide passphrase' : 'Show passphrase'}>
+                <Tooltip
+                  title={
+                    showPassphrase
+                      ? t('wizard.review.hidePassphrase')
+                      : t('wizard.review.showPassphrase')
+                  }
+                >
                   <IconButton
-                    aria-label={showPassphrase ? 'Hide passphrase' : 'Show passphrase'}
+                    aria-label={
+                      showPassphrase
+                        ? t('wizard.review.hidePassphrase')
+                        : t('wizard.review.showPassphrase')
+                    }
                     onClick={() => setShowPassphrase((v) => !v)}
                     size="small"
                     sx={{ p: 0.2 }}

--- a/frontend/src/components/wizard/schedule/WizardStepMaintenance.tsx
+++ b/frontend/src/components/wizard/schedule/WizardStepMaintenance.tsx
@@ -114,7 +114,8 @@ const WizardStepMaintenance: React.FC<WizardStepMaintenanceProps> = ({ data, onC
             />
             <Alert severity="warning" sx={{ mt: 2, py: 0.5 }}>
               <Typography variant="caption">
-                <strong>Caution:</strong> {t('wizard.scheduleWizard.maintenance.pruneCaution')}
+                <strong>{t('wizard.scheduleWizard.maintenance.caution')}</strong>{' '}
+                {t('wizard.scheduleWizard.maintenance.pruneCaution')}
               </Typography>
             </Alert>
           </Box>

--- a/frontend/src/components/wizard/schedule/WizardStepScheduleReview.tsx
+++ b/frontend/src/components/wizard/schedule/WizardStepScheduleReview.tsx
@@ -212,7 +212,7 @@ const WizardStepScheduleReview: React.FC<WizardStepScheduleReviewProps> = ({
         <Tooltip title={t('wizard.scheduleWizard.review.readyToCreate')} placement="top" arrow>
           <Chip
             icon={<Rocket size={11} />}
-            label="Ready"
+            label={t('wizard.scheduleWizard.review.ready')}
             size="small"
             sx={{
               height: 20,
@@ -273,25 +273,15 @@ const WizardStepScheduleReview: React.FC<WizardStepScheduleReviewProps> = ({
           )}
           {data.scheduleMode === 'availability' ? (
             <>
-              <AttrRow label={t('schedule.trigger.label', { defaultValue: 'Run trigger' })}>
+              <AttrRow label={t('schedule.trigger.label')}>
                 <Typography variant="body2" fontSize="0.75rem" fontWeight={600}>
-                  {t('schedule.trigger.whenAvailable', {
-                    defaultValue: 'When source is available',
-                  })}
+                  {t('schedule.trigger.whenAvailable')}
                 </Typography>
               </AttrRow>
-              <AttrRow
-                label={t('schedule.trigger.checkInterval', {
-                  defaultValue: 'Check every (minutes)',
-                })}
-              >
+              <AttrRow label={t('schedule.trigger.checkInterval')}>
                 <CodePill>{data.availabilityCheckIntervalMinutes ?? 30} min</CodePill>
               </AttrRow>
-              <AttrRow
-                label={t('schedule.trigger.minimumInterval', {
-                  defaultValue: 'Minimum interval after a successful run (hours)',
-                })}
-              >
+              <AttrRow label={t('schedule.trigger.minimumInterval')}>
                 <CodePill>{data.minimumSuccessIntervalHours ?? 20} h</CodePill>
               </AttrRow>
             </>
@@ -300,9 +290,7 @@ const WizardStepScheduleReview: React.FC<WizardStepScheduleReviewProps> = ({
               <AttrRow label={t('wizard.scheduleWizard.review.schedule')}>
                 <CodePill>{data.cronExpression}</CodePill>
               </AttrRow>
-              <AttrRow
-                label={t('wizard.scheduleWizard.review.timezone', { defaultValue: 'Timezone' })}
-              >
+              <AttrRow label={t('wizard.scheduleWizard.review.timezone')}>
                 <CodePill>{data.timezone || 'UTC'}</CodePill>
               </AttrRow>
             </>
@@ -397,7 +385,7 @@ const WizardStepScheduleReview: React.FC<WizardStepScheduleReviewProps> = ({
             />
           </AttrRow>
           {data.runPruneAfter && (
-            <AttrRow label="Keep:">
+            <AttrRow label={t('wizard.scheduleWizard.review.keep')}>
               <CodePill>{pruneKeeps}</CodePill>
             </AttrRow>
           )}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -25,9 +25,16 @@
       "clear": "Leeren",
       "reset": "Zurücksetzen",
       "deploy": "Bereitstellen",
-      "view": "Ansehen"
+      "view": "Ansehen",
+      "collapse": "Einklappen",
+      "expand": "Ausklappen"
     },
     "status": "Status",
+    "loading": "Lädt...",
+    "password": {
+      "show": "Passwort anzeigen",
+      "hide": "Passwort ausblenden"
+    },
     "never": "Nie",
     "na": "N/V",
     "unknown": "Unbekannt",
@@ -148,6 +155,9 @@
       "beta": "Beta"
     },
     "menu": {
+      "openDrawer": "Navigation öffnen",
+      "userMenu": "Benutzermenü",
+      "enterpriseDeployment": "Enterprise-Bereitstellung",
       "accountAndSecurityDesc": "Profil, Passwort, 2FA, Passkeys",
       "appearanceDesc": "Design",
       "notificationsDesc": "Benachrichtigungen & Einstellungen",
@@ -257,7 +267,245 @@
   "managedAgents": {
     "planGate": {
       "message": "Managed Agents benötigen Pro oder Enterprise. Führe ein Upgrade durch, um entfernte Maschinen zu registrieren und Agent-Jobs auszuführen."
+    },
+    "agent": "Agent",
+    "page": {
+      "title": "Verwaltete Agenten",
+      "subtitle": "Leichtgewichtige Maschinen, die mit diesem Borg-UI-Server verbunden sind",
+      "refresh": "Aktualisieren",
+      "refreshing": "Agenten werden aktualisiert",
+      "addAgent": "Agent hinzufügen",
+      "unknownAgent": "Unbekannter Agent",
+      "never": "Nie",
+      "none": "Keine",
+      "noneReported": "Keine gemeldet",
+      "notReported": "Nicht gemeldet",
+      "os": "Betriebssystem",
+      "lastSeen": "Zuletzt gesehen",
+      "agentVersion": "Agent-Version",
+      "borg": "Borg",
+      "capabilities": "Funktionen",
+      "emptyAgents": "Keine Agenten registriert.",
+      "emptyJobs": "Noch keine Agent-Jobs.",
+      "emptyTokens": "Keine Registrierungstoken erstellt.",
+      "tabs": { "agents": "Agenten", "jobs": "Jobs", "tokens": "Registrierungstoken" },
+      "toasts": {
+        "tokenCreated": "Registrierungstoken erstellt",
+        "tokenRevoked": "Registrierungstoken widerrufen",
+        "agentRevoked": "Agent widerrufen",
+        "agentDeleted": "Agent gelöscht",
+        "cancellationRequested": "Abbruch angefordert",
+        "copied": "Kopiert"
+      },
+      "errors": {
+        "revokeToken": "Registrierungstoken konnte nicht widerrufen werden",
+        "revokeAgent": "Agent konnte nicht widerrufen werden",
+        "deleteAgent": "Agent konnte nicht gelöscht werden",
+        "cancelJob": "Job konnte nicht abgebrochen werden",
+        "runDiagnostics": "Diagnose konnte nicht ausgeführt werden"
+      },
+      "table": {
+        "job": "Job",
+        "status": "Status",
+        "progress": "Fortschritt",
+        "updated": "Aktualisiert",
+        "actions": "Aktionen",
+        "name": "Name",
+        "prefix": "Präfix",
+        "expires": "Läuft ab"
+      },
+      "actions": {
+        "runDiagnostics": "Diagnose ausführen",
+        "viewAgentLogs": "Agent-Protokolle anzeigen",
+        "reinstallAgent": "Agent neu installieren",
+        "revokeAccess": "Zugriff widerrufen",
+        "revokeAgent": "Agent widerrufen",
+        "deleteAgent": "Agent löschen",
+        "viewLogs": "Protokolle anzeigen",
+        "cancelJob": "Job abbrechen",
+        "revokeToken": "Token widerrufen"
+      },
+      "noBorg": {
+        "title": "Keine verwendbare Borg-Binärdatei gemeldet",
+        "description": "Installieren Sie Borg auf diesem Agenten oder erstellen Sie den Einrichtungsbefehl mit aktivierter Borg-Installation neu."
+      },
+      "deleteDialog": {
+        "title": "Agent löschen",
+        "confirm": "Agent löschen",
+        "description": "Dadurch wird der Agent aus der Flottenliste entfernt. Der lokale Dienst läuft möglicherweise weiter, bis er auf dem Client entfernt wird."
+      },
+      "reinstallDialog": {
+        "title": "Agent neu installieren",
+        "copyCommand": "Neuinstallationsbefehl kopieren",
+        "description": "Führen Sie dies auf dem registrierten Rechner aus, um das Borg-UI-Agent-Paket zu aktualisieren und den systemd-Dienst neu zu starten. Kein Registrierungstoken oder Registrierungsschritt erforderlich.",
+        "configPreserved": "Das Skript behält die vorhandene Agent-Konfiguration bei unter"
+      },
+      "logs": {
+        "agent": "Agent-Protokolle",
+        "agentTitle": "Agent-Protokolle - {{name}}",
+        "job": "Agent-Job",
+        "jobTitle": "Agent-Job-Protokolle - Job #{{id}}"
+      },
+      "diagnostics": {
+        "title": "Agent-Diagnose",
+        "running": "Diagnose wird ausgeführt",
+        "runCheck": "Prüfung ausführen",
+        "description": "Überprüfen Sie die ausgehende Agent-Sitzung und testen Sie optional ein TCP-Ziel vom Agent-Host.",
+        "invalidPort": "Geben Sie einen TCP-Port zwischen 1 und 65535 ein.",
+        "invalidTimeout": "Geben Sie ein Zeitlimit zwischen 0,5 und 10 Sekunden ein.",
+        "advancedSummary": "Erweitert: anderen Dienst testen",
+        "advancedDescription": "Prüft, ob dieser Agent einen separaten Dienst erreichen kann. Für die normale Diagnose leer lassen.",
+        "serviceHost": "Dienst-Host",
+        "serviceHostHelper": "Optionaler Dienst, der von diesem Agenten getestet wird",
+        "servicePort": "Dienst-Port",
+        "timeout": "Zeitlimit",
+        "seconds": "Sekunden",
+        "timeoutRange": "0,5-10 Sekunden",
+        "sessionHealthy": "Sitzung fehlerfrei",
+        "agentOffline": "Agent offline",
+        "timedOut": "Zeitüberschreitung",
+        "sessionFailed": "Sitzung fehlgeschlagen",
+        "tcpReachable": "TCP erreichbar",
+        "tcpFailed": "TCP fehlgeschlagen",
+        "emptyResult": "Führen Sie eine Prüfung aus, um die aktive Agent-Sitzung zu bestätigen. Fügen Sie Host und Port hinzu, um die TCP-Erreichbarkeit vom Agent-Host zu testen.",
+        "unavailable": "Diagnosen sind in dieser Story- oder Testansicht nicht verfügbar."
+      }
+    },
+    "installCommand": {
+      "title": "Installationsbefehl",
+      "copy": "Installationsbefehl kopieren",
+      "description": "Führen Sie den Befehl auf dem Linux-Rechner aus. Das Installationsprogramm registriert den Agenten und aktiviert standardmäßig den systemd-Dienst.",
+      "connected": "{{name}} verbunden",
+      "waiting": "Warte auf die Verbindung des Agenten…",
+      "connectedDescription": "Sie können diesen Dialog schließen; der Agent läuft weiter.",
+      "waitingDescription": "Diese Seite wird nach Abschluss der Installation automatisch aktualisiert."
+    },
+    "setupGuide": {
+      "summary": "Führen Sie dies auf einem entfernten Rechner aus, um ihn bei diesem Borg-UI-Server zu registrieren.",
+      "help": "Einrichtungshilfe",
+      "title": "Hilfe zur Agenteneinrichtung",
+      "copySetupCommand": "Einrichtungsbefehl kopieren",
+      "copyInstallCommands": "Installationsbefehle kopieren",
+      "copyStatusCommand": "Statusbefehl kopieren",
+      "copySystemdCommands": "systemd-Befehle kopieren",
+      "steps": {
+        "install": {
+          "title": "1. Linux-Installationsprogramm ausführen",
+          "description": "Führen Sie dies auf dem Linux-Rechner aus, der die zu sichernden Dateien besitzt. Das Installationsprogramm installiert Abhängigkeiten, registriert den Agenten und aktiviert den systemd-Dienst. Standardmäßig läuft der Dienst als Benutzer, der sudo aufgerufen hat. Repository- und Quellpfade müssen für diesen Benutzer zugänglich sein."
+        },
+        "server": {
+          "title": "2. Server-URL und Token",
+          "description": "Die Server-URL muss vom Client-Rechner erreichbar sein. localhost funktioniert nur, wenn Agent und Borg UI auf demselben Rechner laufen. Entfernte Clients sollten einen erreichbaren Borg-UI-Hostnamen, eine IP-Adresse oder HTTPS-URL verwenden. Registrierungstoken sind temporäre Einrichtungsanmeldedaten; der registrierte Agent behält seine eigenen Anmeldedaten bis zum Widerruf oder Löschen."
+        },
+        "troubleshooting": {
+          "title": "3. Manuelle Fehlerbehebung",
+          "descriptionPrefix": "Die manuelle Installation ist weiterhin für die Fehlerbehebung hilfreich. Der Agent-Quellcode befindet sich im",
+          "link": "Borg-UI-Agentenverzeichnis"
+        },
+        "service": {
+          "title": "4. Dienstprüfungen",
+          "description": "Das Installationsprogramm aktiviert systemd standardmäßig, damit der Agent Neustarts übersteht. Verwenden Sie diese Befehle nur zum Prüfen oder Reparieren einer manuellen Installation."
+        }
+      }
+    },
+    "add": {
+      "title": "Agent hinzufügen",
+      "steps": { "target": "Ziel", "details": "Details", "install": "Installieren" },
+      "errors": { "createToken": "Registrierungstoken konnte nicht erstellt werden" },
+      "platform": "Plattform",
+      "platforms": { "linux": "Linux", "macos": "macOS", "windows": "Windows" },
+      "selected": "Ausgewählt",
+      "comingLater": "Demnächst verfügbar",
+      "serverUrl": "Server-URL",
+      "localhostWarning": "localhost funktioniert nur, wenn Agent und Borg UI auf demselben Rechner laufen. Entfernte Rechner benötigen einen erreichbaren Hostnamen, eine IP-Adresse oder HTTPS-URL.",
+      "serverUrlHelper": "Diese URL muss vom Agentenrechner erreichbar sein.",
+      "agentName": "Agentenname",
+      "defaultPath": "Standardpfad",
+      "defaultPathHelper": "Startverzeichnis zum Durchsuchen der Dateien dieses Agenten.",
+      "tokenExpiry": "Token-Ablauf",
+      "expiry": {
+        "1h": "1 Stunde",
+        "24h": "24 Stunden",
+        "7d": "7 Tage",
+        "30d": "30 Tage",
+        "never": "Nie"
+      },
+      "serviceUser": "Dienstbenutzer",
+      "serviceUsers": {
+        "current": {
+          "label": "Installierender Benutzer",
+          "description": "Der Agent kann auf dieselben Dateien wie der Benutzer zugreifen, der das Installationsprogramm ausführt."
+        },
+        "dedicated": {
+          "label": "Eigener borg-ui-agent-Benutzer",
+          "description": "Verwenden Sie ein separates Konto mit geringen Rechten für eine stärkere Isolation."
+        },
+        "root": {
+          "label": "Root",
+          "description": "Nur verwenden, wenn der Agent Root-Dateipfade sichern muss."
+        }
+      },
+      "rootWarning": "Der Root-Modus erlaubt diesem Agenten Borg-Operationen mit Root-Rechten. Verwenden Sie ihn nur für Root-Dateipfade.",
+      "borgInstallation": "Borg-Installation",
+      "borgOptions": {
+        "borg1": {
+          "label": "Borg 1.x",
+          "description": "Standard. Installiert oder prüft Borg 1 als 'borg'."
+        },
+        "borg2": {
+          "label": "Nur Borg 2.x Beta",
+          "description": "Erweiterte experimentelle Option. Installiert oder prüft Borg 2 als 'borg2'."
+        },
+        "both": {
+          "label": "Borg 1.x und Borg 2.x Beta",
+          "description": "Erweiterte experimentelle Option. Behält Borg 1 als 'borg' und Borg 2 als 'borg2'."
+        },
+        "skip": {
+          "label": "Borg-Installation überspringen",
+          "description": "Verwenden Sie dies, wenn Borg auf dem Agentenrechner separat verwaltet wird."
+        }
+      },
+      "generateInstallCommand": "Installationsbefehl erstellen"
     }
+  },
+  "apiTokens": {
+    "title": "API-Token",
+    "description": "Programmgesteuerter Zugriff, nur einmal beim Erstellen sichtbar",
+    "empty": "Noch keine Token",
+    "prefix": "Präfix",
+    "created": "Erstellt",
+    "lastUsed": "Zuletzt verwendet",
+    "revoke": "Token widerrufen",
+    "revoked": "Token widerrufen",
+    "name": "Tokenname",
+    "namePlaceholder": "z. B. CI-Bereitstellung, Hausautomatisierung",
+    "generateTitle": "API-Token erstellen",
+    "newTokenTitle": "Ihr neuer API-Token",
+    "copyWarning": "Kopieren Sie diesen Token jetzt. Sie können ihn nicht erneut anzeigen.",
+    "copied": "Kopiert!",
+    "copyToClipboard": "In Zwischenablage kopieren",
+    "closeWithoutCopyingTitle": "Ohne Kopieren schließen?",
+    "closeWithoutCopyingDescription": "Sie haben den Token nicht kopiert. Nach dem Schließen dieses Dialogs kann er nicht abgerufen werden.",
+    "closeAnyway": "Trotzdem schließen",
+    "errors": {
+      "generate": "Token konnte nicht erstellt werden",
+      "revoke": "Token konnte nicht widerrufen werden"
+    }
+  },
+  "accountPassword": {
+    "title": "Passwort ändern",
+    "current": "Aktuelles Passwort",
+    "new": "Neues Passwort",
+    "confirm": "Passwort bestätigen",
+    "mismatch": "Passwörter stimmen nicht überein",
+    "saving": "Wird gespeichert",
+    "update": "Passwort aktualisieren"
+  },
+  "mountSuccess": {
+    "title": "Archiv eingebunden",
+    "accessViaDocker": "Zugriff über Docker:",
+    "copied": "Kopiert!",
+    "copyCommand": "Befehl kopieren"
   },
   "cloudStorage": {
     "title": "Cloud-Speicher",
@@ -286,6 +534,9 @@
     "storagePercentUsed": "{{value}}% belegt",
     "noStorageInfo": "Keine Speicherinfo",
     "configSourceLabel": "Konfiguration",
+    "configSource": {
+      "managed": "Verwaltet"
+    },
     "managedConfig": "Serververwaltete rclone.conf",
     "editRemote": "Remote bearbeiten",
     "deleteRemote": "Remote löschen",
@@ -724,7 +975,10 @@
       "runCompact": "Komprimieren",
       "runCompactTip": "Repository wird nach jedem Backup komprimiert",
       "runCheck": "Prüfen",
-      "runCheckTip": "Integritätsprüfung läuft nach jedem Backup (zusätzlich zu geplanten Prüfungen unten)"
+      "runCheckTip": "Integritätsprüfung läuft nach jedem Backup (zusätzlich zu geplanten Prüfungen unten)",
+      "collapse": "Einklappen",
+      "expand": "Ausklappen",
+      "togglePlan": "{{action}} {{name}}"
     },
     "noRepositories": "Du musst mindestens ein Repository erstellen, bevor du Sicherungen planst.",
     "legacyBackupSchedulesTitle": "Backup-Automatisierungen",
@@ -833,6 +1087,18 @@
     "title": "Backup-Pläne",
     "subtitle": "Definiere Quellen, Einstellungen, Zeitpläne und die Repositories, in die jede Sicherung schreibt.",
     "loading": "Backup-Pläne werden geladen...",
+    "select": {
+      "source": {
+        "local": "Lokale Quelle",
+        "remote": "Remote-Quelle",
+        "agent": "Verwalteter Agent",
+        "mixed": "Mehrere Quellen"
+      },
+      "repositories_one": "{{count}} Repository",
+      "repositories_other": "{{count}} Repositories",
+      "scheduled": "Geplant",
+      "manual": "Manuell"
+    },
     "runTooltipPro": "Dieser Plan verwendet mehrere Repositories oder parallele Ausführung. Bearbeite ihn oder upgrade auf Pro, um ihn auszuführen.",
     "runTooltipProFeature": "Dieser Plan verwendet {{feature}}, wofür Pro erforderlich ist. Bearbeite ihn oder upgrade auf Pro, um ihn auszuführen.",
     "runTooltipProFeatures": "Dieser Plan verwendet reine Pro-Funktionen: {{features}}. Bearbeite ihn oder upgrade auf Pro, um ihn auszuführen.",
@@ -1460,6 +1726,7 @@
       "encryption": "Verschlüsselung"
     },
     "observeOnly": "Nur Beobachtung",
+    "deleteConfirmation": "Möchtest du das Repository \"{{name}}\" wirklich löschen?",
     "buttons": {
       "info": "Info",
       "check": "Prüfen",
@@ -1943,6 +2210,7 @@
     },
     "systemKey": {
       "title": "System-SSH-Schlüssel",
+      "defaultDescription": "System-SSH-Schlüssel für alle Remote-Verbindungen",
       "noKey": "Kein System-SSH-Schlüssel gefunden. Generiere einen neuen oder importiere einen vorhandenen.",
       "generate": "System-SSH-Schlüssel generieren",
       "import": "Vorhandenen Schlüssel importieren",
@@ -3497,6 +3765,8 @@
     "noScheduledChecks": "Keine geplanten Überprüfungen",
     "noScheduledChecksDesc": "Konfiguriere automatische Repository-Überprüfungen, um die Datenintegrität sicherzustellen",
     "needRepository": "Du musst mindestens ein Repository erstellen, bevor du Überprüfungen planst.",
+    "repositoryNotFound": "Repository nicht gefunden",
+    "status": { "cancelled": "Abgebrochen", "running": "Wird ausgeführt" },
     "historyTitle": "Verlauf geplanter Überprüfungen",
     "historyShowing": "Zeige {{filtered}} von {{total}} geplanten Überprüfungsjobs",
     "historyShowingFiltered": "Zeige {{filtered}} von {{total}} geplanten Überprüfungsjobs (gefiltert)",
@@ -3705,6 +3975,9 @@
       "remoteSshNote": "Der Borg-UI-Server stellt eine SSH-Verbindung zur Remote-Maschine her, um die ausgewählten Verzeichnisse zu durchsuchen und zu sichern. Stelle sicher, dass die SSH-Verbindung mit den erforderlichen Berechtigungen ordnungsgemäß konfiguriert ist."
     },
     "location": {
+      "borgVersion": "Borg-Version",
+      "beta": "Beta",
+      "borg2": "Borg 2",
       "repositoryNameLabel": "Repository-Name",
       "repositoryNameHelper": "Ein aussagekräftiger Name zur Identifizierung dieses Repositorys",
       "repositoryModeLabel": "Repository-Modus",
@@ -4002,6 +4275,9 @@
       "compression": "Komprimierung",
       "customFlags": "Benutzerdefinierte Flags",
       "repositoryInitialized": "Repository wird initialisiert",
+      "readyToInitialize": "Bereit zur Initialisierung",
+      "hidePassphrase": "Passphrase ausblenden",
+      "showPassphrase": "Passphrase anzeigen",
       "repositoryImportNote": "Das Repository wird vor dem Import überprüft. Stelle sicher, dass die Passphrase korrekt ist.",
       "repositoryEditNote": "Änderungen werden in der Repository-Konfiguration gespeichert."
     },
@@ -4022,6 +4298,41 @@
       "passphrasePlaceholderCreate": "Passphrase eingeben",
       "passphraseHelperEdit": "Optional - leer lassen, um die zuletzt gespeicherte Passphrase beizubehalten",
       "passphraseHelperCreate": "Sicher aufbewahren - ohne sie kannst du nicht auf Sicherungen zugreifen!",
+      "options": {
+        "repokey": {
+          "label": "Repository-Schlüssel",
+          "description": "Im Repository gespeicherter Schlüssel (empfohlen)"
+        },
+        "repokey-blake2": {
+          "label": "Repository-Schlüssel (BLAKE2)",
+          "description": "Schnellere Hashing-Variante"
+        },
+        "keyfile": {
+          "label": "Schlüsseldatei",
+          "description": "In einer separaten Datei gespeicherter Schlüssel"
+        },
+        "keyfile-blake2": {
+          "label": "Schlüsseldatei (BLAKE2)",
+          "description": "Schlüsseldatei mit schnellerem Hashing"
+        },
+        "repokey-aes-ocb": {
+          "label": "Repository-Schlüssel (AES-OCB)",
+          "description": "Standard für Borg 2 · empfohlen"
+        },
+        "repokey-chacha20-poly1305": {
+          "label": "Repository-Schlüssel (ChaCha20)",
+          "description": "Alternativer AEAD-Chiffrierer"
+        },
+        "keyfile-aes-ocb": {
+          "label": "Schlüsseldatei (AES-OCB)",
+          "description": "In einer separaten Datei gespeicherter Schlüssel"
+        },
+        "keyfile-chacha20-poly1305": {
+          "label": "Schlüsseldatei (ChaCha20)",
+          "description": "Schlüsseldatei mit ChaCha20"
+        },
+        "none": { "label": "Keine", "description": "Keine Verschlüsselung (nicht empfohlen)" }
+      },
       "borgKeyfileTitle": "Borg-Schlüsseldatei (Optional)",
       "borgKeyfileDesc": "Borg-Schlüsseldateien werden typischerweise ohne Dateiendung in ~/.config/borg/keys/ gespeichert",
       "uploadFile": "Datei hochladen",
@@ -4063,6 +4374,8 @@
       },
       "review": {
         "readyToCreate": "Bereit, Zeitplan zu erstellen!",
+        "ready": "Bereit",
+        "keep": "Behalten:",
         "reviewAndConfirm": "Unten überprüfen und bestätigen.",
         "jobSummary": "Aufgabenübersicht",
         "name": "Name",
@@ -4452,6 +4765,17 @@
     "selectPath": "Pfad auswählen"
   },
   "cache": {
+    "redis": "Redis",
+    "inMemory": "Im Speicher",
+    "connection": "Verbindung",
+    "externalRedis": "Externes Redis",
+    "localDocker": "Lokales Docker",
+    "durationDays_one": "{{count}} Tag",
+    "durationDays_other": "{{count}} Tage",
+    "durationHours_one": "{{count}} Stunde",
+    "durationHours_other": "{{count}} Stunden",
+    "durationMinutes_one": "{{count}} Minute",
+    "durationMinutes_other": "{{count}} Minuten",
     "subtitle": "Redis-basiertes Archiv-Caching-System für schnelleres Durchsuchen überwachen und konfigurieren",
     "cacheStatus": "Cache-Status",
     "cachedArchives": "Gecachte Einträge",
@@ -4570,6 +4894,8 @@
     },
     "confirmRemove": "Dieses Skript aus dem Repository entfernen?",
     "parametersConfigured": "{{count}} Parameter konfiguriert",
+    "parameterCount_one": "{{count}} Parameter",
+    "parameterCount_other": "{{count}} Parameter",
     "tooltips": {
       "testScript": "Dieses Skript testweise ausführen",
       "parametersOutOfSync": "Parameter benötigen Aufmerksamkeit - Skriptdefinition hat sich geändert",
@@ -4588,7 +4914,13 @@
       "continueOnErrorHelperText": "Standard überschreiben: Wenn aktiviert, wird die Sicherung auch bei Skriptfehler fortgesetzt.",
       "cancel": "Abbrechen",
       "assignScript": "Skript zuweisen",
-      "onFailureLabel": "Wenn dieses Skript fehlschlägt:"
+      "onFailureLabel": "Wenn dieses Skript fehlschlägt:",
+      "inlineScriptReplacementWarning": "Das Hinzufügen eines Bibliotheksskripts ersetzt das aktuelle Inline-Skript für diesen Hook."
+    },
+    "testDialog": {
+      "title": "Test: {{scriptName}}",
+      "exitCode": "Exit: {{code}}",
+      "duration": "{{seconds}}s"
     },
     "parametersDialog": {
       "title": "Skriptparameter konfigurieren: {{scriptName}}",
@@ -5289,6 +5621,8 @@
     "learnMore": "See what's included →"
   },
   "announcements": {
+    "latestRelease": "Neueste Version",
+    "close": "Ankündigung schließen",
     "highlights": "What's new",
     "viewDetails": "View details",
     "remindLater": "Remind me later",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -31,6 +31,8 @@
     },
     "status": "Status",
     "loading": "Lädt...",
+    "search": "Suchen",
+    "noResults": "Keine Ergebnisse gefunden",
     "password": {
       "show": "Passwort anzeigen",
       "hide": "Passwort ausblenden"
@@ -131,6 +133,7 @@
     "badges": {
       "new": "Neu"
     },
+    "comingSoon": "Demnächst verfügbar",
     "settings": {
       "personal": "Persönlich",
       "system": "System",
@@ -1005,6 +1008,18 @@
       "completed": "Wartung abgeschlossen"
     },
     "card": {
+      "serviceTypes": {
+        "webhook": "Webhook",
+        "slack": "Slack",
+        "discord": "Discord",
+        "telegram": "Telegram",
+        "email": "E-Mail",
+        "teams": "Teams",
+        "pushover": "Pushover",
+        "ntfy": "Ntfy",
+        "gotify": "Gotify",
+        "matrix": "Matrix"
+      },
       "stats": {
         "schedule": "Schedule",
         "repository": "Repository",
@@ -3864,6 +3879,10 @@
     "canaryModeHint": "Der Canary-Modus fügt künftigen Sicherungen eine winzige Borg UI-Canary-Datei hinzu, solange er aktiviert ist, und prüft sie aus dem neuesten Archiv. Er funktioniert nach der nächsten Sicherung.",
     "canaryUnavailableObserveOnly": "Der Canary-Modus ist für Observe-only-Repositories nicht verfügbar, weil Borg UI deren Backups nicht erstellt. Nutze ausgewählte Probe-Pfade oder einen vollständigen Archiv-Drill.",
     "noBackupYet": "Noch keine Sicherung",
+    "timeLabels": {
+      "storedUtc": "Gespeichert in UTC",
+      "localTimezone": "Deine lokale Zeitzone"
+    },
     "probeModeHint": "Der Probe-Pfad-Modus stellt echte von dir gewählte Dateien wieder her. Nutze ihn für aussagekräftigere Prüfungen kritischer Pfade ohne das gesamte Archiv zu extrahieren.",
     "fullArchiveWarning": "Vollständige Archiv-Drills können bei großen Repositories teuer sein. Nutze sie sparsam und nur mit ausreichend temporärem Speicher und Wartungsfenster."
   },
@@ -3957,6 +3976,7 @@
       "remoteSshfsNote": "Remote-Verzeichnisse werden über SSHFS eingehängt und behalten ihre ursprünglichen Pfade bei. Ausschlussmuster funktionieren genauso wie bei lokalen Quellen (z.B. */var/cache/*)."
     },
     "dataSource": {
+      "note": "Hinweis:",
       "title": "Wo befinden sich die Daten, die du sichern möchtest?",
       "localDescription": "Daten von diesem Server sichern (lokale oder eingehängte Dateisysteme)",
       "agentLocalDescription": "Pfade aus dem Dateisystem des ausgewählten verwalteten Agenten sichern",
@@ -4023,6 +4043,12 @@
       "rcloneOAuthBorgUiHelper": "Borg UI empfängt den Provider-Callback serverseitig. Nachdem der Provider die Autorisierung als abgeschlossen meldet, kehre hierher zurück; dieser Dialog prüft automatisch.",
       "rcloneOAuthLoopbackHelper": "rclone verwendet seinen lokalen Loopback-Callback. Verwende dies nur, wenn dein Browser denselben Host wie der rclone-Prozess erreichen kann.",
       "rcloneOAuthSetupMissing": "Borg UI-eigenes OAuth ist für diesen Provider nicht konfiguriert.",
+      "rcloneDefaultProviders": {
+        "localLabel": "Lokales Dateisystem",
+        "localDescription": "Remote für lokale Pfade.",
+        "customLabel": "Benutzerdefiniertes rclone-Backend",
+        "customDescription": "Manuelle Einrichtung für jedes rclone-Backend."
+      },
       "rcloneOAuthCallbackUrl": "Borg UI-Callback: {{url}}",
       "rcloneOAuthModeBorgUi": "Borg UI-Callback",
       "rcloneOAuthModeLoopback": "rclone-Loopback",
@@ -4140,6 +4166,8 @@
       "useFolder": "Ordner verwenden"
     },
     "restoreDestination": {
+      "port": "Port {{port}}",
+      "connected": "Verbunden",
       "title": "Wohin sollen Dateien wiederhergestellt werden?",
       "subtitle": "Wähle Ziel und Speicherort für die wiederhergestellten Dateien",
       "borgUiServerDesc": "Im lokalen Speicher dieses Servers wiederherstellen",
@@ -4356,6 +4384,7 @@
         "selectAtLeastOne": "Wähle mindestens ein Repository aus, um fortzufahren."
       },
       "maintenance": {
+        "caution": "Achtung:",
         "title": "Wartungsoptionen",
         "subtitle": "Bereinigung und Komprimierung nach Sicherungen ausführen, um Speicherplatz zu verwalten.",
         "info": "Bereinigung entfernt alte Archive. Komprimierung gibt Speicherplatz frei.",
@@ -4365,6 +4394,10 @@
         "compactAfterPrune": "Komprimierung nach Bereinigung ausführen",
         "compactAfterPruneDesc": "Speicherplatz durch Freigabe von Segmenten zurückgewinnen",
         "compactInfo": "Komprimierung gibt nach der Bereinigung Speicherplatz frei. Kann bei großen Repositories Zeit in Anspruch nehmen."
+      },
+      "stepIndicator": {
+        "progress": "Schritt {{current}} / {{total}}",
+        "goToStep": "Zu Schritt {{step}}: {{label}}"
       },
       "config": {
         "scheduleLabel": "Zeitplan (Cron-Ausdruck)",
@@ -4749,11 +4782,18 @@
     "creating": "Erstellt...",
     "create": "Erstellen",
     "failedToLoad": "Verzeichnis konnte nicht geladen werden",
+    "selectAgentFirst": "Wähle vor dem Durchsuchen einen Agenten aus.",
+    "selectRemoteFirst": "Wähle zuerst ein Rclone-Remote aus.",
+    "createFailed": "Ordner konnte nicht erstellt werden",
     "chips": {
       "remote": "Remote",
       "host": "Host",
       "borg": "Borg"
     }
+  },
+  "repoSelect": {
+    "label": "Repository",
+    "placeholder": "Repository auswählen"
   },
   "cronExpressionInput": {
     "label": "Zeitplan"

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -4043,6 +4043,8 @@
       "rcloneOAuthBorgUiHelper": "Borg UI empfängt den Provider-Callback serverseitig. Nachdem der Provider die Autorisierung als abgeschlossen meldet, kehre hierher zurück; dieser Dialog prüft automatisch.",
       "rcloneOAuthLoopbackHelper": "rclone verwendet seinen lokalen Loopback-Callback. Verwende dies nur, wenn dein Browser denselben Host wie der rclone-Prozess erreichen kann.",
       "rcloneOAuthSetupMissing": "Borg UI-eigenes OAuth ist für diesen Provider nicht konfiguriert.",
+      "rcloneProviderSearchPlaceholder": "Provider suchen",
+      "rcloneProviderSearchNoResults": "Keine Provider gefunden",
       "rcloneDefaultProviders": {
         "localLabel": "Lokales Dateisystem",
         "localDescription": "Remote für lokale Pfade.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -4040,6 +4040,8 @@
       "rcloneOAuthBorgUiHelper": "Borg UI receives the provider callback server-side. After the provider says authorization is complete, return here; this dialog checks automatically.",
       "rcloneOAuthLoopbackHelper": "rclone will use its local loopback callback. Use this only when your browser can reach the same host as the rclone process.",
       "rcloneOAuthSetupMissing": "Borg UI-owned OAuth is not configured for this provider.",
+      "rcloneProviderSearchPlaceholder": "Search providers",
+      "rcloneProviderSearchNoResults": "No providers found",
       "rcloneDefaultProviders": {
         "localLabel": "Local filesystem",
         "localDescription": "Local path remote.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -31,6 +31,8 @@
     },
     "status": "Status",
     "loading": "Loading...",
+    "search": "Search",
+    "noResults": "No results found",
     "password": {
       "show": "Show password",
       "hide": "Hide password"
@@ -131,6 +133,7 @@
     "badges": {
       "new": "New"
     },
+    "comingSoon": "Coming soon",
     "settings": {
       "personal": "Personal",
       "system": "System",
@@ -1016,6 +1019,18 @@
       "never": "Never"
     },
     "card": {
+      "serviceTypes": {
+        "webhook": "Webhook",
+        "slack": "Slack",
+        "discord": "Discord",
+        "telegram": "Telegram",
+        "email": "Email",
+        "teams": "Teams",
+        "pushover": "Pushover",
+        "ntfy": "Ntfy",
+        "gotify": "Gotify",
+        "matrix": "Matrix"
+      },
       "stats": {
         "schedule": "Schedule",
         "repository": "Repository",
@@ -3861,6 +3876,10 @@
     "canaryModeHint": "Canary mode adds a tiny Borg UI canary file to future backups while enabled, then verifies it from the latest archive. It works after the next backup.",
     "canaryUnavailableObserveOnly": "Canary mode is unavailable for observe-only repositories because Borg UI does not create their backups. Use selected probe paths or a full archive drill.",
     "noBackupYet": "No backup yet",
+    "timeLabels": {
+      "storedUtc": "Stored UTC",
+      "localTimezone": "Your local timezone"
+    },
     "probeModeHint": "Probe-path mode restores real files you choose. Use it for higher-confidence checks on critical paths without extracting the full archive.",
     "fullArchiveWarning": "Full archive drills can be expensive on large repositories. Use this sparingly, and only when you have enough temporary storage and maintenance window budget."
   },
@@ -3954,6 +3973,7 @@
       "remoteSshfsNote": "Remote directories are mounted via SSHFS preserving their original paths. Exclude patterns work the same as local sources (e.g., */var/cache/*)."
     },
     "dataSource": {
+      "note": "Note:",
       "title": "Where is the data you want to back up?",
       "localDescription": "Back up data from this server (local or mounted filesystems)",
       "agentLocalDescription": "Back up paths from the selected managed agent filesystem",
@@ -4020,6 +4040,12 @@
       "rcloneOAuthBorgUiHelper": "Borg UI receives the provider callback server-side. After the provider says authorization is complete, return here; this dialog checks automatically.",
       "rcloneOAuthLoopbackHelper": "rclone will use its local loopback callback. Use this only when your browser can reach the same host as the rclone process.",
       "rcloneOAuthSetupMissing": "Borg UI-owned OAuth is not configured for this provider.",
+      "rcloneDefaultProviders": {
+        "localLabel": "Local filesystem",
+        "localDescription": "Local path remote.",
+        "customLabel": "Custom rclone backend",
+        "customDescription": "Manual setup for any rclone backend."
+      },
       "rcloneOAuthCallbackUrl": "Borg UI callback: {{url}}",
       "rcloneOAuthModeBorgUi": "Borg UI callback",
       "rcloneOAuthModeLoopback": "rclone loopback",
@@ -4137,6 +4163,8 @@
       "useFolder": "Use folder"
     },
     "restoreDestination": {
+      "port": "Port {{port}}",
+      "connected": "Connected",
       "title": "Where should files be restored?",
       "subtitle": "Select the destination and location for your restored files",
       "borgUiServerDesc": "Restore to this server's local storage",
@@ -4350,6 +4378,7 @@
         "selectAtLeastOne": "Select at least one repository to continue."
       },
       "maintenance": {
+        "caution": "Caution:",
         "title": "Maintenance Options",
         "subtitle": "Run prune and compact after backups to manage disk space.",
         "info": "Prune removes old archives. Compact reclaims disk space.",
@@ -4359,6 +4388,10 @@
         "compactAfterPrune": "Run compact after prune",
         "compactAfterPruneDesc": "Reclaim disk space by freeing segments",
         "compactInfo": "Compact reclaims disk space after prune. May take time on large repositories."
+      },
+      "stepIndicator": {
+        "progress": "Step {{current}} / {{total}}",
+        "goToStep": "Go to step {{step}}: {{label}}"
       },
       "config": {
         "scheduleLabel": "Schedule (Cron Expression)",
@@ -4743,11 +4776,18 @@
     "creating": "Creating...",
     "create": "Create",
     "failedToLoad": "Failed to load directory",
+    "selectAgentFirst": "Select an agent before browsing.",
+    "selectRemoteFirst": "Select a rclone remote first.",
+    "createFailed": "Failed to create folder",
     "chips": {
       "remote": "Remote",
       "host": "Host",
       "borg": "Borg"
     }
+  },
+  "repoSelect": {
+    "label": "Repository",
+    "placeholder": "Select a repository"
   },
   "cronExpressionInput": {
     "label": "Schedule"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -25,9 +25,16 @@
       "clear": "Clear",
       "reset": "Reset",
       "deploy": "Deploy",
-      "view": "View"
+      "view": "View",
+      "collapse": "Collapse",
+      "expand": "Expand"
     },
     "status": "Status",
+    "loading": "Loading...",
+    "password": {
+      "show": "Show password",
+      "hide": "Hide password"
+    },
     "never": "Never",
     "na": "N/A",
     "unknown": "Unknown",
@@ -148,6 +155,9 @@
       "beta": "Beta"
     },
     "menu": {
+      "openDrawer": "Open navigation",
+      "userMenu": "User menu",
+      "enterpriseDeployment": "Enterprise deployment",
       "accountAndSecurityDesc": "Profile, password, 2FA, passkeys",
       "appearanceDesc": "Theme",
       "notificationsDesc": "Alerts & preferences",
@@ -257,7 +267,242 @@
   "managedAgents": {
     "planGate": {
       "message": "Managed Agents need Pro or Enterprise. Upgrade to enroll remote machines and run agent-backed jobs."
+    },
+    "agent": "Agent",
+    "page": {
+      "title": "Managed Agents",
+      "subtitle": "Lightweight machines connected to this Borg UI server",
+      "refresh": "Refresh",
+      "refreshing": "Refreshing agents",
+      "addAgent": "Add Agent",
+      "unknownAgent": "Unknown agent",
+      "never": "Never",
+      "none": "None",
+      "noneReported": "None reported",
+      "notReported": "Not reported",
+      "os": "OS",
+      "lastSeen": "Last seen",
+      "agentVersion": "Agent version",
+      "borg": "Borg",
+      "capabilities": "Capabilities",
+      "emptyAgents": "No agents enrolled.",
+      "emptyJobs": "No agent jobs yet.",
+      "emptyTokens": "No enrollment tokens created.",
+      "tabs": { "agents": "Agents", "jobs": "Jobs", "tokens": "Enrollment Tokens" },
+      "toasts": {
+        "tokenCreated": "Enrollment token created",
+        "tokenRevoked": "Enrollment token revoked",
+        "agentRevoked": "Agent revoked",
+        "agentDeleted": "Agent deleted",
+        "cancellationRequested": "Cancellation requested",
+        "copied": "Copied"
+      },
+      "errors": {
+        "revokeToken": "Failed to revoke enrollment token",
+        "revokeAgent": "Failed to revoke agent",
+        "deleteAgent": "Failed to delete agent",
+        "cancelJob": "Failed to cancel job",
+        "runDiagnostics": "Failed to run diagnostics"
+      },
+      "table": {
+        "job": "Job",
+        "status": "Status",
+        "progress": "Progress",
+        "updated": "Updated",
+        "actions": "Actions",
+        "name": "Name",
+        "prefix": "Prefix",
+        "expires": "Expires"
+      },
+      "actions": {
+        "runDiagnostics": "Run diagnostics",
+        "viewAgentLogs": "View agent logs",
+        "reinstallAgent": "Reinstall agent",
+        "revokeAccess": "Revoke access",
+        "revokeAgent": "Revoke agent",
+        "deleteAgent": "Delete agent",
+        "viewLogs": "View logs",
+        "cancelJob": "Cancel job",
+        "revokeToken": "Revoke token"
+      },
+      "noBorg": {
+        "title": "No usable Borg binary reported",
+        "description": "Install Borg on this agent or regenerate the setup command with Borg installation enabled."
+      },
+      "deleteDialog": {
+        "title": "Delete agent",
+        "confirm": "Delete agent",
+        "description": "Deleting removes it from the fleet list. The local service may still run until removed on the client."
+      },
+      "reinstallDialog": {
+        "title": "Reinstall agent",
+        "copyCommand": "Copy reinstall command",
+        "description": "Run this on the enrolled machine to update the Borg UI agent package and restart the systemd service. No enrollment token or registration step is required.",
+        "configPreserved": "The script preserves the existing agent config at"
+      },
+      "logs": {
+        "agent": "Agent Logs",
+        "agentTitle": "Agent Logs - {{name}}",
+        "job": "Agent Job",
+        "jobTitle": "Agent Job Logs - Job #{{id}}"
+      },
+      "diagnostics": {
+        "title": "Agent diagnostics",
+        "running": "Running diagnostics",
+        "runCheck": "Run check",
+        "description": "Verify the outbound agent session and optionally test a TCP target from the agent host.",
+        "invalidPort": "Enter a TCP port between 1 and 65535.",
+        "invalidTimeout": "Enter a timeout between 0.5 and 10 seconds.",
+        "advancedSummary": "Advanced: test another service",
+        "advancedDescription": "Checks whether this agent can reach a separate service. Leave blank for normal diagnostics.",
+        "serviceHost": "Service host",
+        "serviceHostHelper": "Optional service to test from this agent",
+        "servicePort": "Service port",
+        "timeout": "Timeout",
+        "seconds": "Seconds",
+        "timeoutRange": "0.5-10 seconds",
+        "sessionHealthy": "Session healthy",
+        "agentOffline": "Agent offline",
+        "timedOut": "Timed out",
+        "sessionFailed": "Session failed",
+        "tcpReachable": "TCP reachable",
+        "tcpFailed": "TCP failed",
+        "emptyResult": "Run a check to verify the active agent session. Add a host and port to test TCP reachability from the agent host.",
+        "unavailable": "Diagnostics are unavailable in this story or test surface."
+      }
+    },
+    "installCommand": {
+      "title": "Install command",
+      "copy": "Copy install command",
+      "description": "Run the command on the Linux machine. The installer registers the agent and enables the systemd service by default.",
+      "connected": "{{name}} connected",
+      "waiting": "Waiting for agent to connect…",
+      "connectedDescription": "You can close this dialog; the agent will keep running.",
+      "waitingDescription": "This page will update automatically once the install completes."
+    },
+    "setupGuide": {
+      "summary": "Run this on a remote machine to register it with this Borg UI server.",
+      "help": "Setup Help",
+      "title": "Agent Setup Help",
+      "copySetupCommand": "Copy setup command",
+      "copyInstallCommands": "Copy install commands",
+      "copyStatusCommand": "Copy status command",
+      "copySystemdCommands": "Copy systemd commands",
+      "steps": {
+        "install": {
+          "title": "1. Run the Linux installer",
+          "description": "Run this on the Linux machine that owns the files Borg should back up. The installer installs dependencies, registers the agent, and enables the systemd service. By default, the service runs as the user who invoked sudo, so repository and source paths must be accessible to that user."
+        },
+        "server": {
+          "title": "2. Server URL and token",
+          "description": "The server URL must be reachable from the client machine. localhost only works when the agent and Borg UI are on the same machine; remote clients should use the Borg UI host name, IP address, or HTTPS URL they can reach. Enrollment tokens are temporary setup credentials; the enrolled agent keeps its own credential until revoked or deleted."
+        },
+        "troubleshooting": {
+          "title": "3. Manual troubleshooting",
+          "descriptionPrefix": "Manual installation remains useful for troubleshooting. The agent source is in the",
+          "link": "Borg UI agent directory"
+        },
+        "service": {
+          "title": "4. Service checks",
+          "description": "The installer enables systemd by default so the agent survives reboot. Use these commands only when inspecting or repairing a manual installation."
+        }
+      }
+    },
+    "add": {
+      "title": "Add Agent",
+      "steps": { "target": "Target", "details": "Details", "install": "Install" },
+      "errors": { "createToken": "Failed to create enrollment token" },
+      "platform": "Platform",
+      "platforms": { "linux": "Linux", "macos": "macOS", "windows": "Windows" },
+      "selected": "Selected",
+      "comingLater": "Coming later",
+      "serverUrl": "Server URL",
+      "localhostWarning": "localhost only works when the agent runs on the same machine as Borg UI. Remote machines need a reachable host name, IP, or HTTPS URL.",
+      "serverUrlHelper": "This URL must be reachable from the agent machine.",
+      "agentName": "Agent name",
+      "defaultPath": "Default path",
+      "defaultPathHelper": "Starting directory for browsing this agent's files.",
+      "tokenExpiry": "Token expiry",
+      "expiry": {
+        "1h": "1 hour",
+        "24h": "24 hours",
+        "7d": "7 days",
+        "30d": "30 days",
+        "never": "Never"
+      },
+      "serviceUser": "Service user",
+      "serviceUsers": {
+        "current": {
+          "label": "Installing user",
+          "description": "The agent can access the same files as the user running the installer."
+        },
+        "dedicated": {
+          "label": "Dedicated borg-ui-agent user",
+          "description": "Use a separate low-privilege service account for stricter isolation."
+        },
+        "root": {
+          "label": "Root",
+          "description": "Use only when the agent must back up root-owned paths."
+        }
+      },
+      "rootWarning": "Root mode lets this agent run root-level Borg operations. Use it only for root-owned paths.",
+      "borgInstallation": "Borg installation",
+      "borgOptions": {
+        "borg1": {
+          "label": "Borg 1.x",
+          "description": "Default. Installs or verifies Borg 1 as 'borg'."
+        },
+        "borg2": {
+          "label": "Borg 2.x beta only",
+          "description": "Advanced experimental option. Installs or verifies Borg 2 as 'borg2'."
+        },
+        "both": {
+          "label": "Borg 1.x and Borg 2.x beta",
+          "description": "Advanced experimental option. Keeps Borg 1 as 'borg' and Borg 2 as 'borg2'."
+        },
+        "skip": {
+          "label": "Skip Borg install",
+          "description": "Use this when Borg is managed separately on the agent machine."
+        }
+      },
+      "generateInstallCommand": "Generate install command"
     }
+  },
+  "apiTokens": {
+    "title": "API Tokens",
+    "description": "Programmatic access, shown only once when generated",
+    "empty": "No tokens yet",
+    "prefix": "Prefix",
+    "created": "Created",
+    "lastUsed": "Last used",
+    "revoke": "Revoke token",
+    "revoked": "Token revoked",
+    "name": "Token name",
+    "namePlaceholder": "e.g. CI deploy, Home automation",
+    "generateTitle": "Generate API Token",
+    "newTokenTitle": "Your new API token",
+    "copyWarning": "Copy this token now. You won't be able to see it again.",
+    "copied": "Copied!",
+    "copyToClipboard": "Copy to clipboard",
+    "closeWithoutCopyingTitle": "Close without copying?",
+    "closeWithoutCopyingDescription": "You haven't copied the token. Once you close this dialog, the token cannot be retrieved.",
+    "closeAnyway": "Close anyway",
+    "errors": { "generate": "Failed to generate token", "revoke": "Failed to revoke token" }
+  },
+  "accountPassword": {
+    "title": "Change password",
+    "current": "Current password",
+    "new": "New password",
+    "confirm": "Confirm password",
+    "mismatch": "Passwords do not match",
+    "saving": "Saving",
+    "update": "Update password"
+  },
+  "mountSuccess": {
+    "title": "Archive Mounted",
+    "accessViaDocker": "Access via Docker:",
+    "copied": "Copied!",
+    "copyCommand": "Copy command"
   },
   "cloudStorage": {
     "title": "Cloud Storage",
@@ -286,6 +531,9 @@
     "storagePercentUsed": "{{value}}% used",
     "noStorageInfo": "No storage info",
     "configSourceLabel": "Config",
+    "configSource": {
+      "managed": "Managed"
+    },
     "managedConfig": "Server-managed rclone.conf",
     "editRemote": "Edit remote",
     "deleteRemote": "Delete remote",
@@ -724,7 +972,10 @@
       "runCompact": "Compact",
       "runCompactTip": "Repository is compacted after each backup",
       "runCheck": "Check",
-      "runCheckTip": "Integrity check runs after each backup (in addition to any scheduled check below)"
+      "runCheckTip": "Integrity check runs after each backup (in addition to any scheduled check below)",
+      "collapse": "Collapse",
+      "expand": "Expand",
+      "togglePlan": "{{action}} {{name}}"
     },
     "noRepositories": "You need to create at least one repository before scheduling backups.",
     "legacyBackupSchedulesTitle": "Backup automations",
@@ -833,6 +1084,18 @@
     "title": "Backup Plans",
     "subtitle": "Define sources, settings, schedules, and the repositories each backup writes to.",
     "loading": "Loading backup plans...",
+    "select": {
+      "source": {
+        "local": "Local source",
+        "remote": "Remote source",
+        "agent": "Managed agent",
+        "mixed": "Multiple sources"
+      },
+      "repositories_one": "{{count}} repository",
+      "repositories_other": "{{count}} repositories",
+      "scheduled": "Scheduled",
+      "manual": "Manual"
+    },
     "runTooltipPro": "This plan uses multiple repositories or parallel execution. Edit it or upgrade to Pro to run it.",
     "runTooltipProFeature": "This plan uses {{feature}}, which requires Pro. Edit it or upgrade to Pro to run it.",
     "runTooltipProFeatures": "This plan uses Pro-only features: {{features}}. Edit it or upgrade to Pro to run it.",
@@ -1460,6 +1723,7 @@
       "encryption": "Encryption"
     },
     "observeOnly": "Observe Only",
+    "deleteConfirmation": "Are you sure you want to delete repository \"{{name}}\"?",
     "buttons": {
       "info": "Info",
       "check": "Check",
@@ -1943,6 +2207,7 @@
     },
     "systemKey": {
       "title": "System SSH Key",
+      "defaultDescription": "System SSH key for all remote connections",
       "noKey": "No system SSH key found. Generate a new one or import an existing one.",
       "generate": "Generate System SSH Key",
       "import": "Import Existing Key",
@@ -3497,6 +3762,8 @@
     "noScheduledChecks": "No scheduled checks",
     "noScheduledChecksDesc": "Configure automatic repository checks to ensure data integrity",
     "needRepository": "You need to create at least one repository before scheduling checks.",
+    "repositoryNotFound": "Repository not found",
+    "status": { "cancelled": "Cancelled", "running": "Running" },
     "historyTitle": "Scheduled Check History",
     "historyShowing": "Showing {{filtered}} of {{total}} scheduled check jobs",
     "historyShowingFiltered": "Showing {{filtered}} of {{total}} scheduled check jobs (filtered)",
@@ -3705,6 +3972,9 @@
       "remoteSshNote": "The Borg UI server will SSH into the remote machine to browse and back up the selected directories. Ensure the SSH connection is properly configured with the necessary permissions."
     },
     "location": {
+      "borgVersion": "Borg Version",
+      "beta": "Beta",
+      "borg2": "Borg 2",
       "repositoryNameLabel": "Repository Name",
       "repositoryNameHelper": "A friendly name to identify this repository",
       "repositoryModeLabel": "Repository Mode",
@@ -4002,6 +4272,9 @@
       "compression": "Compression",
       "customFlags": "Custom Flags",
       "repositoryInitialized": "Repository will be initialized",
+      "readyToInitialize": "Ready to Initialize",
+      "hidePassphrase": "Hide passphrase",
+      "showPassphrase": "Show passphrase",
       "repositoryImportNote": "Repository will be verified before import. Ensure the passphrase is correct.",
       "repositoryEditNote": "Changes will be saved to the repository configuration."
     },
@@ -4022,6 +4295,38 @@
       "passphrasePlaceholderCreate": "Enter passphrase",
       "passphraseHelperEdit": "Optional - leave blank to keep last saved passphrase",
       "passphraseHelperCreate": "Keep this safe - you cannot access backups without it!",
+      "options": {
+        "repokey": {
+          "label": "Repository Key",
+          "description": "Key stored in repository (recommended)"
+        },
+        "repokey-blake2": {
+          "label": "Repository Key (BLAKE2)",
+          "description": "Faster hashing variant"
+        },
+        "keyfile": { "label": "Key File", "description": "Key stored in a separate file" },
+        "keyfile-blake2": {
+          "label": "Key File (BLAKE2)",
+          "description": "Key file with faster hashing"
+        },
+        "repokey-aes-ocb": {
+          "label": "Repository Key (AES-OCB)",
+          "description": "Default for Borg 2 · recommended"
+        },
+        "repokey-chacha20-poly1305": {
+          "label": "Repository Key (ChaCha20)",
+          "description": "Alternative AEAD cipher"
+        },
+        "keyfile-aes-ocb": {
+          "label": "Key File (AES-OCB)",
+          "description": "Key stored in a separate file"
+        },
+        "keyfile-chacha20-poly1305": {
+          "label": "Key File (ChaCha20)",
+          "description": "Key file with ChaCha20"
+        },
+        "none": { "label": "None", "description": "No encryption (not recommended)" }
+      },
       "borgKeyfileTitle": "Borg Keyfile (Optional)",
       "borgKeyfileDesc": "Borg keyfiles are typically stored without a file extension in ~/.config/borg/keys/",
       "uploadFile": "Upload File",
@@ -4063,6 +4368,8 @@
       },
       "review": {
         "readyToCreate": "Ready to create schedule!",
+        "ready": "Ready",
+        "keep": "Keep:",
         "reviewAndConfirm": "Review and confirm below.",
         "jobSummary": "Job Summary",
         "name": "Name",
@@ -4452,6 +4759,17 @@
     "selectPath": "Select Path"
   },
   "cache": {
+    "redis": "Redis",
+    "inMemory": "In-Memory",
+    "connection": "Connection",
+    "externalRedis": "External Redis",
+    "localDocker": "Local Docker",
+    "durationDays_one": "{{count}} day",
+    "durationDays_other": "{{count}} days",
+    "durationHours_one": "{{count}} hour",
+    "durationHours_other": "{{count}} hours",
+    "durationMinutes_one": "{{count}} minute",
+    "durationMinutes_other": "{{count}} minutes",
     "subtitle": "Monitor and configure the Redis-based archive caching system for faster browsing",
     "cacheStatus": "Cache Status",
     "cachedArchives": "Cached Entities",
@@ -4570,6 +4888,8 @@
     },
     "confirmRemove": "Remove this script from the repository?",
     "parametersConfigured": "{{count}} parameter(s) configured",
+    "parameterCount_one": "{{count}} parameter",
+    "parameterCount_other": "{{count}} parameters",
     "tooltips": {
       "testScript": "Test run this script",
       "parametersOutOfSync": "Parameters need attention - script definition has changed",
@@ -4588,7 +4908,13 @@
       "continueOnErrorHelperText": "Override default: If checked, the backup will proceed even if this script fails.",
       "onFailureLabel": "If this script fails:",
       "cancel": "Cancel",
-      "assignScript": "Assign Script"
+      "assignScript": "Assign Script",
+      "inlineScriptReplacementWarning": "Adding a library script will replace the current inline script for this hook."
+    },
+    "testDialog": {
+      "title": "Test: {{scriptName}}",
+      "exitCode": "Exit: {{code}}",
+      "duration": "{{seconds}}s"
     },
     "parametersDialog": {
       "title": "Configure Script Parameters: {{scriptName}}",
@@ -5289,6 +5615,8 @@
     "learnMore": "See what's included →"
   },
   "announcements": {
+    "latestRelease": "Latest release",
+    "close": "Close announcement",
     "highlights": "What's new",
     "viewDetails": "View details",
     "remindLater": "Remind me later",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -31,6 +31,8 @@
     },
     "status": "Estado",
     "loading": "Cargando...",
+    "search": "Buscar",
+    "noResults": "No se encontraron resultados",
     "password": {
       "show": "Mostrar contraseña",
       "hide": "Ocultar contraseña"
@@ -131,6 +133,7 @@
     "badges": {
       "new": "Nuevo"
     },
+    "comingSoon": "Próximamente",
     "settings": {
       "personal": "Personal",
       "system": "Sistema",
@@ -1002,6 +1005,18 @@
       "completed": "Mantenimiento completado"
     },
     "card": {
+      "serviceTypes": {
+        "webhook": "Webhook",
+        "slack": "Slack",
+        "discord": "Discord",
+        "telegram": "Telegram",
+        "email": "Correo electrónico",
+        "teams": "Teams",
+        "pushover": "Pushover",
+        "ntfy": "Ntfy",
+        "gotify": "Gotify",
+        "matrix": "Matrix"
+      },
       "stats": {
         "schedule": "Schedule",
         "repository": "Repository",
@@ -3861,6 +3876,10 @@
     "canaryModeHint": "El modo canario añade un pequeño archivo canario de Borg UI a las copias de seguridad futuras mientras esté activado, y luego lo verifica desde el archivo más reciente. Funciona después de la próxima copia de seguridad.",
     "canaryUnavailableObserveOnly": "El modo canario no está disponible para repositorios solo de observación porque Borg UI no crea sus copias. Usa rutas de prueba seleccionadas o una prueba de archivo completo.",
     "noBackupYet": "Aún no hay copia",
+    "timeLabels": {
+      "storedUtc": "Guardado en UTC",
+      "localTimezone": "Tu zona horaria local"
+    },
     "probeModeHint": "El modo de rutas de prueba restaura archivos reales que tú eliges. Úsalo para comprobaciones más profundas de rutas críticas sin extraer el archivo completo.",
     "fullArchiveWarning": "Las pruebas de archivo completo pueden ser costosas en repositorios grandes. Úsalas con moderación y solo cuando tengas almacenamiento temporal y ventana de mantenimiento suficientes."
   },
@@ -3954,6 +3973,7 @@
       "remoteSshfsNote": "Los directorios remotos se montan mediante SSHFS preservando sus rutas originales. Los patrones de exclusión funcionan igual que con fuentes locales (ej., */var/cache/*)."
     },
     "dataSource": {
+      "note": "Nota:",
       "title": "¿Dónde están los datos que deseas respaldar?",
       "localDescription": "Respaldar datos de este servidor (sistemas de archivos locales o montados)",
       "agentLocalDescription": "Respaldar rutas del sistema de archivos del agente gestionado seleccionado",
@@ -4020,6 +4040,12 @@
       "rcloneOAuthBorgUiHelper": "Borg UI recibe el callback del proveedor en el servidor. Cuando el proveedor indique que la autorización terminó, vuelve aquí; este diálogo comprobará automáticamente.",
       "rcloneOAuthLoopbackHelper": "rclone usará su callback loopback local. Úsalo solo cuando el navegador pueda llegar al mismo host que el proceso rclone.",
       "rcloneOAuthSetupMissing": "El OAuth gestionado por Borg UI no está configurado para este proveedor.",
+      "rcloneDefaultProviders": {
+        "localLabel": "Sistema de archivos local",
+        "localDescription": "Remoto de ruta local.",
+        "customLabel": "Backend rclone personalizado",
+        "customDescription": "Configuración manual para cualquier backend de rclone."
+      },
       "rcloneOAuthCallbackUrl": "Callback de Borg UI: {{url}}",
       "rcloneOAuthModeBorgUi": "Callback de Borg UI",
       "rcloneOAuthModeLoopback": "loopback de rclone",
@@ -4137,6 +4163,8 @@
       "useFolder": "Usar carpeta"
     },
     "restoreDestination": {
+      "port": "Puerto {{port}}",
+      "connected": "Conectado",
       "title": "¿Dónde deben restaurarse los archivos?",
       "subtitle": "Selecciona el destino y la ubicación para los archivos restaurados",
       "borgUiServerDesc": "Restaurar en el almacenamiento local de este servidor",
@@ -4353,6 +4381,7 @@
         "selectAtLeastOne": "Selecciona al menos un repositorio para continuar."
       },
       "maintenance": {
+        "caution": "Precaución:",
         "title": "Opciones de mantenimiento",
         "subtitle": "Ejecutar poda y compactación tras las copias de seguridad para gestionar el espacio en disco.",
         "info": "La poda elimina archivos antiguos. La compactación recupera espacio en disco.",
@@ -4362,6 +4391,10 @@
         "compactAfterPrune": "Ejecutar compactación tras la poda",
         "compactAfterPruneDesc": "Recuperar espacio en disco liberando segmentos",
         "compactInfo": "La compactación recupera espacio en disco tras la poda. Puede llevar tiempo en repositorios grandes."
+      },
+      "stepIndicator": {
+        "progress": "Paso {{current}} / {{total}}",
+        "goToStep": "Ir al paso {{step}}: {{label}}"
       },
       "config": {
         "scheduleLabel": "Programación (Expresión Cron)",
@@ -4746,11 +4779,18 @@
     "creating": "Creando...",
     "create": "Crear",
     "failedToLoad": "Error al cargar el directorio",
+    "selectAgentFirst": "Selecciona un agente antes de explorar.",
+    "selectRemoteFirst": "Selecciona primero un remoto de rclone.",
+    "createFailed": "No se pudo crear la carpeta",
     "chips": {
       "remote": "Remoto",
       "host": "Host",
       "borg": "Borg"
     }
+  },
+  "repoSelect": {
+    "label": "Repositorio",
+    "placeholder": "Selecciona un repositorio"
   },
   "cronExpressionInput": {
     "label": "Programación"

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -4040,6 +4040,8 @@
       "rcloneOAuthBorgUiHelper": "Borg UI recibe el callback del proveedor en el servidor. Cuando el proveedor indique que la autorización terminó, vuelve aquí; este diálogo comprobará automáticamente.",
       "rcloneOAuthLoopbackHelper": "rclone usará su callback loopback local. Úsalo solo cuando el navegador pueda llegar al mismo host que el proceso rclone.",
       "rcloneOAuthSetupMissing": "El OAuth gestionado por Borg UI no está configurado para este proveedor.",
+      "rcloneProviderSearchPlaceholder": "Buscar proveedores",
+      "rcloneProviderSearchNoResults": "No se encontraron proveedores",
       "rcloneDefaultProviders": {
         "localLabel": "Sistema de archivos local",
         "localDescription": "Remoto de ruta local.",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -25,9 +25,16 @@
       "clear": "Limpiar",
       "reset": "Restablecer",
       "deploy": "Desplegar",
-      "view": "Ver"
+      "view": "Ver",
+      "collapse": "Contraer",
+      "expand": "Expandir"
     },
     "status": "Estado",
+    "loading": "Cargando...",
+    "password": {
+      "show": "Mostrar contraseña",
+      "hide": "Ocultar contraseña"
+    },
     "never": "Nunca",
     "na": "N/D",
     "unknown": "Desconocido",
@@ -148,6 +155,9 @@
       "beta": "Beta"
     },
     "menu": {
+      "openDrawer": "Abrir navegación",
+      "userMenu": "Menú de usuario",
+      "enterpriseDeployment": "Implementación Enterprise",
       "accountAndSecurityDesc": "Perfil, contraseña, 2FA, passkeys",
       "appearanceDesc": "Tema",
       "notificationsDesc": "Alertas y preferencias",
@@ -257,7 +267,242 @@
   "managedAgents": {
     "planGate": {
       "message": "Los agentes gestionados requieren Pro o Enterprise. Actualiza para registrar máquinas remotas y ejecutar jobs con agentes."
+    },
+    "agent": "Agente",
+    "page": {
+      "title": "Agentes gestionados",
+      "subtitle": "Máquinas ligeras conectadas a este servidor de Borg UI",
+      "refresh": "Actualizar",
+      "refreshing": "Actualizando agentes",
+      "addAgent": "Añadir agente",
+      "unknownAgent": "Agente desconocido",
+      "never": "Nunca",
+      "none": "Ninguno",
+      "noneReported": "No informado",
+      "notReported": "No informado",
+      "os": "SO",
+      "lastSeen": "Visto por última vez",
+      "agentVersion": "Versión del agente",
+      "borg": "Borg",
+      "capabilities": "Capacidades",
+      "emptyAgents": "No hay agentes registrados.",
+      "emptyJobs": "Aún no hay trabajos de agente.",
+      "emptyTokens": "No se han creado tokens de registro.",
+      "tabs": { "agents": "Agentes", "jobs": "Trabajos", "tokens": "Tokens de registro" },
+      "toasts": {
+        "tokenCreated": "Token de registro creado",
+        "tokenRevoked": "Token de registro revocado",
+        "agentRevoked": "Agente revocado",
+        "agentDeleted": "Agente eliminado",
+        "cancellationRequested": "Cancelación solicitada",
+        "copied": "Copiado"
+      },
+      "errors": {
+        "revokeToken": "No se pudo revocar el token de registro",
+        "revokeAgent": "No se pudo revocar el agente",
+        "deleteAgent": "No se pudo eliminar el agente",
+        "cancelJob": "No se pudo cancelar el trabajo",
+        "runDiagnostics": "No se pudieron ejecutar los diagnósticos"
+      },
+      "table": {
+        "job": "Trabajo",
+        "status": "Estado",
+        "progress": "Progreso",
+        "updated": "Actualizado",
+        "actions": "Acciones",
+        "name": "Nombre",
+        "prefix": "Prefijo",
+        "expires": "Caduca"
+      },
+      "actions": {
+        "runDiagnostics": "Ejecutar diagnósticos",
+        "viewAgentLogs": "Ver registros del agente",
+        "reinstallAgent": "Reinstalar agente",
+        "revokeAccess": "Revocar acceso",
+        "revokeAgent": "Revocar agente",
+        "deleteAgent": "Eliminar agente",
+        "viewLogs": "Ver registros",
+        "cancelJob": "Cancelar trabajo",
+        "revokeToken": "Revocar token"
+      },
+      "noBorg": {
+        "title": "No se informó de un binario Borg utilizable",
+        "description": "Instale Borg en este agente o genere de nuevo el comando de configuración con la instalación de Borg activada."
+      },
+      "deleteDialog": {
+        "title": "Eliminar agente",
+        "confirm": "Eliminar agente",
+        "description": "Al eliminarlo, se quita de la lista de flota. El servicio local puede seguir ejecutándose hasta eliminarse en el cliente."
+      },
+      "reinstallDialog": {
+        "title": "Reinstalar agente",
+        "copyCommand": "Copiar comando de reinstalación",
+        "description": "Ejecute esto en la máquina registrada para actualizar el paquete del agente Borg UI y reiniciar el servicio systemd. No se requiere token ni paso de registro.",
+        "configPreserved": "El script conserva la configuración existente del agente en"
+      },
+      "logs": {
+        "agent": "Registros del agente",
+        "agentTitle": "Registros del agente - {{name}}",
+        "job": "Trabajo de agente",
+        "jobTitle": "Registros del trabajo de agente - Trabajo #{{id}}"
+      },
+      "diagnostics": {
+        "title": "Diagnósticos del agente",
+        "running": "Ejecutando diagnósticos",
+        "runCheck": "Ejecutar comprobación",
+        "description": "Verifique la sesión saliente del agente y, opcionalmente, pruebe un destino TCP desde el host del agente.",
+        "invalidPort": "Introduzca un puerto TCP entre 1 y 65535.",
+        "invalidTimeout": "Introduzca un tiempo de espera entre 0,5 y 10 segundos.",
+        "advancedSummary": "Avanzado: probar otro servicio",
+        "advancedDescription": "Comprueba si este agente puede alcanzar un servicio independiente. Déjelo vacío para los diagnósticos normales.",
+        "serviceHost": "Host del servicio",
+        "serviceHostHelper": "Servicio opcional para probar desde este agente",
+        "servicePort": "Puerto del servicio",
+        "timeout": "Tiempo de espera",
+        "seconds": "Segundos",
+        "timeoutRange": "0,5-10 segundos",
+        "sessionHealthy": "Sesión correcta",
+        "agentOffline": "Agente sin conexión",
+        "timedOut": "Tiempo agotado",
+        "sessionFailed": "Sesión fallida",
+        "tcpReachable": "TCP accesible",
+        "tcpFailed": "TCP falló",
+        "emptyResult": "Ejecute una comprobación para verificar la sesión activa del agente. Añada un host y un puerto para probar la conectividad TCP desde el host del agente.",
+        "unavailable": "Los diagnósticos no están disponibles en esta vista de historia o prueba."
+      }
+    },
+    "installCommand": {
+      "title": "Comando de instalación",
+      "copy": "Copiar comando de instalación",
+      "description": "Ejecuta el comando en el equipo Linux. El instalador registra el agente y habilita el servicio systemd de forma predeterminada.",
+      "connected": "{{name}} conectado",
+      "waiting": "Esperando a que el agente se conecte…",
+      "connectedDescription": "Puedes cerrar este diálogo; el agente seguirá funcionando.",
+      "waitingDescription": "Esta página se actualizará automáticamente cuando termine la instalación."
+    },
+    "setupGuide": {
+      "summary": "Ejecuta esto en un equipo remoto para registrarlo con este servidor Borg UI.",
+      "help": "Ayuda de configuración",
+      "title": "Ayuda de configuración del agente",
+      "copySetupCommand": "Copiar comando de configuración",
+      "copyInstallCommands": "Copiar comandos de instalación",
+      "copyStatusCommand": "Copiar comando de estado",
+      "copySystemdCommands": "Copiar comandos systemd",
+      "steps": {
+        "install": {
+          "title": "1. Ejecutar el instalador de Linux",
+          "description": "Ejecuta esto en el equipo Linux que posee los archivos que Borg debe respaldar. El instalador instala dependencias, registra el agente y habilita el servicio systemd. De forma predeterminada, el servicio se ejecuta como el usuario que invocó sudo, por lo que las rutas del repositorio y del origen deben ser accesibles para ese usuario."
+        },
+        "server": {
+          "title": "2. URL del servidor y token",
+          "description": "La URL del servidor debe ser accesible desde el equipo cliente. localhost solo funciona cuando el agente y Borg UI están en el mismo equipo. Los clientes remotos deben usar un nombre de host, una dirección IP o una URL HTTPS de Borg UI accesible. Los tokens de inscripción son credenciales temporales de configuración; el agente inscrito conserva su propia credencial hasta que se revoca o elimina."
+        },
+        "troubleshooting": {
+          "title": "3. Solución manual de problemas",
+          "descriptionPrefix": "La instalación manual sigue siendo útil para solucionar problemas. El código fuente del agente está en el",
+          "link": "directorio del agente de Borg UI"
+        },
+        "service": {
+          "title": "4. Comprobaciones del servicio",
+          "description": "El instalador habilita systemd de forma predeterminada para que el agente sobreviva a los reinicios. Usa estos comandos solo al inspeccionar o reparar una instalación manual."
+        }
+      }
+    },
+    "add": {
+      "title": "Añadir agente",
+      "steps": { "target": "Destino", "details": "Detalles", "install": "Instalar" },
+      "errors": { "createToken": "No se pudo crear el token de inscripción" },
+      "platform": "Plataforma",
+      "platforms": { "linux": "Linux", "macos": "macOS", "windows": "Windows" },
+      "selected": "Seleccionado",
+      "comingLater": "Próximamente",
+      "serverUrl": "URL del servidor",
+      "localhostWarning": "localhost solo funciona cuando el agente y Borg UI se ejecutan en el mismo equipo. Los equipos remotos necesitan un nombre de host, una dirección IP o una URL HTTPS accesible.",
+      "serverUrlHelper": "Esta URL debe ser accesible desde el equipo del agente.",
+      "agentName": "Nombre del agente",
+      "defaultPath": "Ruta predeterminada",
+      "defaultPathHelper": "Directorio inicial para explorar los archivos de este agente.",
+      "tokenExpiry": "Caducidad del token",
+      "expiry": {
+        "1h": "1 hora",
+        "24h": "24 horas",
+        "7d": "7 días",
+        "30d": "30 días",
+        "never": "Nunca"
+      },
+      "serviceUser": "Usuario del servicio",
+      "serviceUsers": {
+        "current": {
+          "label": "Usuario de instalación",
+          "description": "El agente puede acceder a los mismos archivos que el usuario que ejecuta el instalador."
+        },
+        "dedicated": {
+          "label": "Usuario dedicado borg-ui-agent",
+          "description": "Usa una cuenta independiente con pocos privilegios para un aislamiento más estricto."
+        },
+        "root": {
+          "label": "Root",
+          "description": "Úsalo solo cuando el agente deba respaldar rutas propiedad de root."
+        }
+      },
+      "rootWarning": "El modo root permite que este agente ejecute operaciones de Borg con privilegios de root. Úsalo solo para rutas propiedad de root.",
+      "borgInstallation": "Instalación de Borg",
+      "borgOptions": {
+        "borg1": {
+          "label": "Borg 1.x",
+          "description": "Predeterminado. Instala o verifica Borg 1 como 'borg'."
+        },
+        "borg2": {
+          "label": "Solo Borg 2.x beta",
+          "description": "Opción experimental avanzada. Instala o verifica Borg 2 como 'borg2'."
+        },
+        "both": {
+          "label": "Borg 1.x y Borg 2.x beta",
+          "description": "Opción experimental avanzada. Mantiene Borg 1 como 'borg' y Borg 2 como 'borg2'."
+        },
+        "skip": {
+          "label": "Omitir instalación de Borg",
+          "description": "Usa esta opción cuando Borg se gestione por separado en el equipo del agente."
+        }
+      },
+      "generateInstallCommand": "Generar comando de instalación"
     }
+  },
+  "apiTokens": {
+    "title": "Tokens de API",
+    "description": "Acceso programático, se muestra solo una vez al generarlo",
+    "empty": "Aún no hay tokens",
+    "prefix": "Prefijo",
+    "created": "Creado",
+    "lastUsed": "Último uso",
+    "revoke": "Revocar token",
+    "revoked": "Token revocado",
+    "name": "Nombre del token",
+    "namePlaceholder": "p. ej. despliegue CI, automatización del hogar",
+    "generateTitle": "Generar token de API",
+    "newTokenTitle": "Tu nuevo token de API",
+    "copyWarning": "Copia este token ahora. No podrás volver a verlo.",
+    "copied": "¡Copiado!",
+    "copyToClipboard": "Copiar al portapapeles",
+    "closeWithoutCopyingTitle": "¿Cerrar sin copiar?",
+    "closeWithoutCopyingDescription": "No has copiado el token. Una vez que cierres este diálogo, no podrá recuperarse.",
+    "closeAnyway": "Cerrar de todos modos",
+    "errors": { "generate": "No se pudo generar el token", "revoke": "No se pudo revocar el token" }
+  },
+  "accountPassword": {
+    "title": "Cambiar contraseña",
+    "current": "Contraseña actual",
+    "new": "Nueva contraseña",
+    "confirm": "Confirmar contraseña",
+    "mismatch": "Las contraseñas no coinciden",
+    "saving": "Guardando",
+    "update": "Actualizar contraseña"
+  },
+  "mountSuccess": {
+    "title": "Archivo montado",
+    "accessViaDocker": "Acceso mediante Docker:",
+    "copied": "¡Copiado!",
+    "copyCommand": "Copiar comando"
   },
   "cloudStorage": {
     "title": "Almacenamiento cloud",
@@ -286,6 +531,9 @@
     "storagePercentUsed": "{{value}}% usado",
     "noStorageInfo": "Sin información de almacenamiento",
     "configSourceLabel": "Configuración",
+    "configSource": {
+      "managed": "Gestionada"
+    },
     "managedConfig": "rclone.conf gestionado por el servidor",
     "editRemote": "Editar remoto",
     "deleteRemote": "Eliminar remoto",
@@ -724,7 +972,10 @@
       "runCompact": "Compactar",
       "runCompactTip": "El repositorio se compacta después de cada copia",
       "runCheck": "Comprobar",
-      "runCheckTip": "La comprobación de integridad se ejecuta después de cada copia (además de cualquier comprobación programada abajo)"
+      "runCheckTip": "La comprobación de integridad se ejecuta después de cada copia (además de cualquier comprobación programada abajo)",
+      "collapse": "Contraer",
+      "expand": "Expandir",
+      "togglePlan": "{{action}} {{name}}"
     },
     "noRepositories": "Necesitas crear al menos un repositorio antes de programar copias de seguridad.",
     "legacyBackupSchedulesTitle": "Automatizaciones de copia de seguridad",
@@ -833,6 +1084,18 @@
     "title": "Planes de copia",
     "subtitle": "Define orígenes, ajustes, programaciones y los repositorios donde escribe cada copia.",
     "loading": "Cargando planes de copia...",
+    "select": {
+      "source": {
+        "local": "Fuente local",
+        "remote": "Fuente remota",
+        "agent": "Agente gestionado",
+        "mixed": "Varias fuentes"
+      },
+      "repositories_one": "{{count}} repositorio",
+      "repositories_other": "{{count}} repositorios",
+      "scheduled": "Programado",
+      "manual": "Manual"
+    },
     "runTooltipPro": "Este plan usa varios repositorios o ejecución en paralelo. Edítalo o actualiza a Pro para ejecutarlo.",
     "runTooltipProFeature": "Este plan usa {{feature}}, que requiere Pro. Edítalo o actualiza a Pro para ejecutarlo.",
     "runTooltipProFeatures": "Este plan usa funciones solo Pro: {{features}}. Edítalo o actualiza a Pro para ejecutarlo.",
@@ -1460,6 +1723,7 @@
       "encryption": "Cifrado"
     },
     "observeOnly": "Solo observación",
+    "deleteConfirmation": "¿Seguro que quieres eliminar el repositorio \"{{name}}\"?",
     "buttons": {
       "info": "Info",
       "check": "Comprobar",
@@ -1943,6 +2207,7 @@
     },
     "systemKey": {
       "title": "Clave SSH del sistema",
+      "defaultDescription": "Clave SSH del sistema para todas las conexiones remotas",
       "noKey": "No se encontró clave SSH del sistema. Genera una nueva o importa una existente.",
       "generate": "Generar clave SSH del sistema",
       "import": "Importar clave existente",
@@ -3497,6 +3762,8 @@
     "noScheduledChecks": "Sin comprobaciones programadas",
     "noScheduledChecksDesc": "Configura comprobaciones automáticas del repositorio para garantizar la integridad de los datos",
     "needRepository": "Necesitas crear al menos un repositorio antes de programar comprobaciones.",
+    "repositoryNotFound": "Repositorio no encontrado",
+    "status": { "cancelled": "Cancelado", "running": "En ejecución" },
     "historyTitle": "Historial de comprobaciones programadas",
     "historyShowing": "Mostrando {{filtered}} de {{total}} trabajos de comprobación programada",
     "historyShowingFiltered": "Mostrando {{filtered}} de {{total}} trabajos de comprobación programada (filtrados)",
@@ -3705,6 +3972,9 @@
       "remoteSshNote": "El servidor Borg UI se conectará por SSH a la máquina remota para explorar y respaldar los directorios seleccionados. Asegúrate de que la conexión SSH esté correctamente configurada con los permisos necesarios."
     },
     "location": {
+      "borgVersion": "Versión de Borg",
+      "beta": "Beta",
+      "borg2": "Borg 2",
       "repositoryNameLabel": "Nombre del repositorio",
       "repositoryNameHelper": "Un nombre descriptivo para identificar este repositorio",
       "repositoryModeLabel": "Modo del repositorio",
@@ -4002,6 +4272,9 @@
       "compression": "Compresión",
       "customFlags": "Indicadores personalizados",
       "repositoryInitialized": "El repositorio será inicializado",
+      "readyToInitialize": "Listo para inicializar",
+      "hidePassphrase": "Ocultar frase de contraseña",
+      "showPassphrase": "Mostrar frase de contraseña",
       "repositoryImportNote": "El repositorio será verificado antes de importar. Asegúrate de que la frase de contraseña sea correcta.",
       "repositoryEditNote": "Los cambios se guardarán en la configuración del repositorio."
     },
@@ -4022,6 +4295,41 @@
       "passphrasePlaceholderCreate": "Introduce la frase de contraseña",
       "passphraseHelperEdit": "Opcional - dejar en blanco para mantener la última frase guardada",
       "passphraseHelperCreate": "¡Guárdala de forma segura - no podrás acceder a las copias de seguridad sin ella!",
+      "options": {
+        "repokey": {
+          "label": "Clave del repositorio",
+          "description": "Clave almacenada en el repositorio (recomendado)"
+        },
+        "repokey-blake2": {
+          "label": "Clave del repositorio (BLAKE2)",
+          "description": "Variante de hash más rápida"
+        },
+        "keyfile": {
+          "label": "Archivo de clave",
+          "description": "Clave almacenada en un archivo separado"
+        },
+        "keyfile-blake2": {
+          "label": "Archivo de clave (BLAKE2)",
+          "description": "Archivo de clave con hash más rápido"
+        },
+        "repokey-aes-ocb": {
+          "label": "Clave del repositorio (AES-OCB)",
+          "description": "Predeterminado para Borg 2 · recomendado"
+        },
+        "repokey-chacha20-poly1305": {
+          "label": "Clave del repositorio (ChaCha20)",
+          "description": "Cifrado AEAD alternativo"
+        },
+        "keyfile-aes-ocb": {
+          "label": "Archivo de clave (AES-OCB)",
+          "description": "Clave almacenada en un archivo separado"
+        },
+        "keyfile-chacha20-poly1305": {
+          "label": "Archivo de clave (ChaCha20)",
+          "description": "Archivo de clave con ChaCha20"
+        },
+        "none": { "label": "Ninguna", "description": "Sin cifrado (no recomendado)" }
+      },
       "borgKeyfileTitle": "Archivo de clave Borg (Opcional)",
       "borgKeyfileDesc": "Los archivos de clave Borg se almacenan típicamente sin extensión de archivo en ~/.config/borg/keys/",
       "uploadFile": "Subir archivo",
@@ -4063,6 +4371,8 @@
       },
       "review": {
         "readyToCreate": "¡Listo para crear la programación!",
+        "ready": "Listo",
+        "keep": "Conservar:",
         "reviewAndConfirm": "Revisa y confirma a continuación.",
         "jobSummary": "Resumen del trabajo",
         "name": "Nombre",
@@ -4452,6 +4762,17 @@
     "selectPath": "Seleccionar ruta"
   },
   "cache": {
+    "redis": "Redis",
+    "inMemory": "En memoria",
+    "connection": "Conexión",
+    "externalRedis": "Redis externo",
+    "localDocker": "Docker local",
+    "durationDays_one": "{{count}} día",
+    "durationDays_other": "{{count}} días",
+    "durationHours_one": "{{count}} hora",
+    "durationHours_other": "{{count}} horas",
+    "durationMinutes_one": "{{count}} minuto",
+    "durationMinutes_other": "{{count}} minutos",
     "subtitle": "Monitoriza y configura el sistema de caché de archivos basado en Redis para una navegación más rápida",
     "cacheStatus": "Estado de la caché",
     "cachedArchives": "Entidades en caché",
@@ -4570,6 +4891,8 @@
     },
     "confirmRemove": "¿Eliminar este script del repositorio?",
     "parametersConfigured": "{{count}} parámetro(s) configurado(s)",
+    "parameterCount_one": "{{count}} parámetro",
+    "parameterCount_other": "{{count}} parámetros",
     "tooltips": {
       "testScript": "Probar este script",
       "parametersOutOfSync": "Los parámetros necesitan atención - la definición del script ha cambiado",
@@ -4588,7 +4911,13 @@
       "continueOnErrorHelperText": "Anular predeterminado: Si está marcado, la copia de seguridad continuará aunque falle este script.",
       "cancel": "Cancelar",
       "assignScript": "Asignar script",
-      "onFailureLabel": "Si este script falla:"
+      "onFailureLabel": "Si este script falla:",
+      "inlineScriptReplacementWarning": "Añadir un script de la biblioteca sustituirá el script integrado actual de este hook."
+    },
+    "testDialog": {
+      "title": "Prueba: {{scriptName}}",
+      "exitCode": "Salida: {{code}}",
+      "duration": "{{seconds}}s"
     },
     "parametersDialog": {
       "title": "Configurar parámetros del script: {{scriptName}}",
@@ -5289,6 +5618,8 @@
     "learnMore": "See what's included →"
   },
   "announcements": {
+    "latestRelease": "Última versión",
+    "close": "Cerrar anuncio",
     "highlights": "What's new",
     "viewDetails": "View details",
     "remindLater": "Remind me later",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -31,6 +31,8 @@
     },
     "status": "Stato",
     "loading": "Caricamento...",
+    "search": "Cerca",
+    "noResults": "Nessun risultato trovato",
     "password": {
       "show": "Mostra password",
       "hide": "Nascondi password"
@@ -131,6 +133,7 @@
     "badges": {
       "new": "Nuovo"
     },
+    "comingSoon": "Prossimamente",
     "settings": {
       "personal": "Personali",
       "system": "Sistema",
@@ -1005,6 +1008,18 @@
       "completed": "Manutenzione completata"
     },
     "card": {
+      "serviceTypes": {
+        "webhook": "Webhook",
+        "slack": "Slack",
+        "discord": "Discord",
+        "telegram": "Telegram",
+        "email": "Email",
+        "teams": "Teams",
+        "pushover": "Pushover",
+        "ntfy": "Ntfy",
+        "gotify": "Gotify",
+        "matrix": "Matrix"
+      },
       "stats": {
         "schedule": "Pianificazione",
         "repository": "Repository",
@@ -3864,6 +3879,10 @@
     "canaryModeHint": "La modalità canary aggiunge un piccolo file canary di Borg UI ai backup futuri finché è attiva, poi lo verifica dall'archivio più recente. Funziona dopo il prossimo backup.",
     "canaryUnavailableObserveOnly": "La modalità canary non è disponibile per i repository solo osservazione perché Borg UI non crea i loro backup. Usa percorsi di prova selezionati o una verifica dell'intero archivio.",
     "noBackupYet": "Nessun backup",
+    "timeLabels": {
+      "storedUtc": "Memorizzato in UTC",
+      "localTimezone": "Il tuo fuso orario locale"
+    },
     "probeModeHint": "La modalità percorsi di prova ripristina file reali che scegli tu. Usala per verifiche più approfondite su percorsi critici senza estrarre l'intero archivio.",
     "fullArchiveWarning": "Le verifiche dell'intero archivio possono essere costose su repository grandi. Usale raramente e solo se hai spazio temporaneo e una finestra di manutenzione adeguata."
   },
@@ -3957,6 +3976,7 @@
       "remoteSshfsNote": "Le directory remote vengono montate tramite SSHFS preservando i loro percorsi originali. I pattern di esclusione funzionano come per le sorgenti locali (es., */var/cache/*)."
     },
     "dataSource": {
+      "note": "Nota:",
       "title": "Dove si trovano i dati di cui vuoi fare il backup?",
       "localDescription": "Backup dei dati da questo server (filesystem locali o montati)",
       "agentLocalDescription": "Esegui il backup dei percorsi dal filesystem dell'agente gestito selezionato",
@@ -4023,6 +4043,12 @@
       "rcloneOAuthBorgUiHelper": "Borg UI riceve il callback del provider lato server. Quando il provider indica che l'autorizzazione è completa, torna qui; questa finestra controllerà automaticamente.",
       "rcloneOAuthLoopbackHelper": "rclone userà il proprio callback loopback locale. Usalo solo quando il browser può raggiungere lo stesso host del processo rclone.",
       "rcloneOAuthSetupMissing": "L'OAuth gestito da Borg UI non è configurato per questo provider.",
+      "rcloneDefaultProviders": {
+        "localLabel": "File system locale",
+        "localDescription": "Remoto per percorso locale.",
+        "customLabel": "Backend rclone personalizzato",
+        "customDescription": "Configurazione manuale per qualsiasi backend rclone."
+      },
       "rcloneOAuthCallbackUrl": "Callback Borg UI: {{url}}",
       "rcloneOAuthModeBorgUi": "Callback Borg UI",
       "rcloneOAuthModeLoopback": "loopback rclone",
@@ -4140,6 +4166,8 @@
       "useFolder": "Usa cartella"
     },
     "restoreDestination": {
+      "port": "Porta {{port}}",
+      "connected": "Connesso",
       "title": "Dove devono essere ripristinati i file?",
       "subtitle": "Seleziona la destinazione e la posizione per i tuoi file ripristinati",
       "borgUiServerDesc": "Ripristina sull'archiviazione locale di questo server",
@@ -4356,6 +4384,7 @@
         "selectAtLeastOne": "Seleziona almeno un repository per continuare."
       },
       "maintenance": {
+        "caution": "Attenzione:",
         "title": "Opzioni Manutenzione",
         "subtitle": "Esegui pulizia e compattazione dopo i backup per gestire lo spazio su disco.",
         "info": "La pulizia rimuove gli archivi vecchi. La compattazione recupera spazio su disco.",
@@ -4365,6 +4394,10 @@
         "compactAfterPrune": "Esegui compattazione dopo la pulizia",
         "compactAfterPruneDesc": "Recupera spazio su disco liberando segmenti",
         "compactInfo": "La compattazione recupera spazio su disco dopo la pulizia. Potrebbe richiedere tempo su repository di grandi dimensioni."
+      },
+      "stepIndicator": {
+        "progress": "Passaggio {{current}} / {{total}}",
+        "goToStep": "Vai al passaggio {{step}}: {{label}}"
       },
       "config": {
         "scheduleLabel": "Pianificazione (Espressione Cron)",
@@ -4749,11 +4782,18 @@
     "creating": "Creazione in corso...",
     "create": "Crea",
     "failedToLoad": "Impossibile caricare la directory",
+    "selectAgentFirst": "Seleziona un agente prima di esplorare.",
+    "selectRemoteFirst": "Seleziona prima un remoto rclone.",
+    "createFailed": "Impossibile creare la cartella",
     "chips": {
       "remote": "Remoto",
       "host": "Host",
       "borg": "Borg"
     }
+  },
+  "repoSelect": {
+    "label": "Repository",
+    "placeholder": "Seleziona un repository"
   },
   "cronExpressionInput": {
     "label": "Pianificazione"

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -25,9 +25,16 @@
       "clear": "Pulisci",
       "reset": "Reimposta",
       "deploy": "Distribuisci",
-      "view": "Visualizza"
+      "view": "Visualizza",
+      "collapse": "Comprimi",
+      "expand": "Espandi"
     },
     "status": "Stato",
+    "loading": "Caricamento...",
+    "password": {
+      "show": "Mostra password",
+      "hide": "Nascondi password"
+    },
     "never": "Mai",
     "na": "N/D",
     "unknown": "Sconosciuto",
@@ -148,6 +155,9 @@
       "beta": "Beta"
     },
     "menu": {
+      "openDrawer": "Apri navigazione",
+      "userMenu": "Menu utente",
+      "enterpriseDeployment": "Distribuzione Enterprise",
       "accountAndSecurityDesc": "Profilo, password, 2FA, passkey",
       "appearanceDesc": "Tema",
       "notificationsDesc": "Avvisi e preferenze",
@@ -257,7 +267,245 @@
   "managedAgents": {
     "planGate": {
       "message": "Gli agenti gestiti richiedono Pro o Enterprise. Effettua l'upgrade per registrare macchine remote ed eseguire job con agenti."
+    },
+    "agent": "Agente",
+    "page": {
+      "title": "Agenti gestiti",
+      "subtitle": "Macchine leggere connesse a questo server Borg UI",
+      "refresh": "Aggiorna",
+      "refreshing": "Aggiornamento degli agenti",
+      "addAgent": "Aggiungi agente",
+      "unknownAgent": "Agente sconosciuto",
+      "never": "Mai",
+      "none": "Nessuno",
+      "noneReported": "Nessuno segnalato",
+      "notReported": "Non segnalato",
+      "os": "SO",
+      "lastSeen": "Ultimo accesso",
+      "agentVersion": "Versione agente",
+      "borg": "Borg",
+      "capabilities": "Capacità",
+      "emptyAgents": "Nessun agente registrato.",
+      "emptyJobs": "Nessun processo agente ancora.",
+      "emptyTokens": "Nessun token di registrazione creato.",
+      "tabs": { "agents": "Agenti", "jobs": "Processi", "tokens": "Token di registrazione" },
+      "toasts": {
+        "tokenCreated": "Token di registrazione creato",
+        "tokenRevoked": "Token di registrazione revocato",
+        "agentRevoked": "Agente revocato",
+        "agentDeleted": "Agente eliminato",
+        "cancellationRequested": "Annullamento richiesto",
+        "copied": "Copiato"
+      },
+      "errors": {
+        "revokeToken": "Impossibile revocare il token di registrazione",
+        "revokeAgent": "Impossibile revocare l'agente",
+        "deleteAgent": "Impossibile eliminare l'agente",
+        "cancelJob": "Impossibile annullare il processo",
+        "runDiagnostics": "Impossibile eseguire la diagnostica"
+      },
+      "table": {
+        "job": "Processo",
+        "status": "Stato",
+        "progress": "Avanzamento",
+        "updated": "Aggiornato",
+        "actions": "Azioni",
+        "name": "Nome",
+        "prefix": "Prefisso",
+        "expires": "Scade"
+      },
+      "actions": {
+        "runDiagnostics": "Esegui diagnostica",
+        "viewAgentLogs": "Visualizza registri agente",
+        "reinstallAgent": "Reinstalla agente",
+        "revokeAccess": "Revoca accesso",
+        "revokeAgent": "Revoca agente",
+        "deleteAgent": "Elimina agente",
+        "viewLogs": "Visualizza registri",
+        "cancelJob": "Annulla processo",
+        "revokeToken": "Revoca token"
+      },
+      "noBorg": {
+        "title": "Nessun binario Borg utilizzabile segnalato",
+        "description": "Installa Borg su questo agente oppure rigenera il comando di configurazione con l'installazione di Borg abilitata."
+      },
+      "deleteDialog": {
+        "title": "Elimina agente",
+        "confirm": "Elimina agente",
+        "description": "L'eliminazione lo rimuove dall'elenco della flotta. Il servizio locale potrebbe continuare a essere eseguito finché non viene rimosso sul client."
+      },
+      "reinstallDialog": {
+        "title": "Reinstalla agente",
+        "copyCommand": "Copia comando di reinstallazione",
+        "description": "Esegui questo comando sulla macchina registrata per aggiornare il pacchetto dell'agente Borg UI e riavviare il servizio systemd. Non sono richiesti token o passaggi di registrazione.",
+        "configPreserved": "Lo script conserva la configurazione dell'agente esistente in"
+      },
+      "logs": {
+        "agent": "Registri agente",
+        "agentTitle": "Registri agente - {{name}}",
+        "job": "Processo agente",
+        "jobTitle": "Registri processo agente - Processo #{{id}}"
+      },
+      "diagnostics": {
+        "title": "Diagnostica agente",
+        "running": "Diagnostica in esecuzione",
+        "runCheck": "Esegui controllo",
+        "description": "Verifica la sessione agente in uscita e, facoltativamente, prova una destinazione TCP dall'host dell'agente.",
+        "invalidPort": "Inserisci una porta TCP compresa tra 1 e 65535.",
+        "invalidTimeout": "Inserisci un timeout compreso tra 0,5 e 10 secondi.",
+        "advancedSummary": "Avanzato: prova un altro servizio",
+        "advancedDescription": "Verifica se questo agente può raggiungere un servizio separato. Lascia vuoto per la diagnostica normale.",
+        "serviceHost": "Host del servizio",
+        "serviceHostHelper": "Servizio facoltativo da testare da questo agente",
+        "servicePort": "Porta del servizio",
+        "timeout": "Timeout",
+        "seconds": "Secondi",
+        "timeoutRange": "0,5-10 secondi",
+        "sessionHealthy": "Sessione integra",
+        "agentOffline": "Agente offline",
+        "timedOut": "Tempo scaduto",
+        "sessionFailed": "Sessione non riuscita",
+        "tcpReachable": "TCP raggiungibile",
+        "tcpFailed": "TCP non riuscito",
+        "emptyResult": "Esegui un controllo per verificare la sessione agente attiva. Aggiungi un host e una porta per testare la raggiungibilità TCP dall'host dell'agente.",
+        "unavailable": "La diagnostica non è disponibile in questa superficie di storia o test."
+      }
+    },
+    "installCommand": {
+      "title": "Comando di installazione",
+      "copy": "Copia comando di installazione",
+      "description": "Esegui il comando sul computer Linux. Il programma di installazione registra l'agente e abilita il servizio systemd per impostazione predefinita.",
+      "connected": "{{name}} connesso",
+      "waiting": "In attesa della connessione dell'agente…",
+      "connectedDescription": "Puoi chiudere questa finestra; l'agente continuerà a funzionare.",
+      "waitingDescription": "Questa pagina si aggiornerà automaticamente al termine dell'installazione."
+    },
+    "setupGuide": {
+      "summary": "Esegui questa operazione su un computer remoto per registrarlo con questo server Borg UI.",
+      "help": "Guida alla configurazione",
+      "title": "Guida alla configurazione dell'agente",
+      "copySetupCommand": "Copia comando di configurazione",
+      "copyInstallCommands": "Copia comandi di installazione",
+      "copyStatusCommand": "Copia comando di stato",
+      "copySystemdCommands": "Copia comandi systemd",
+      "steps": {
+        "install": {
+          "title": "1. Esegui il programma di installazione Linux",
+          "description": "Esegui questa operazione sul computer Linux che possiede i file di cui Borg deve eseguire il backup. Il programma di installazione installa le dipendenze, registra l'agente e abilita il servizio systemd. Per impostazione predefinita, il servizio viene eseguito come l'utente che ha invocato sudo, quindi i percorsi del repository e delle origini devono essere accessibili a tale utente."
+        },
+        "server": {
+          "title": "2. URL del server e token",
+          "description": "L'URL del server deve essere raggiungibile dal computer client. localhost funziona solo quando l'agente e Borg UI sono sullo stesso computer. I client remoti devono usare un nome host Borg UI, un indirizzo IP o un URL HTTPS raggiungibile. I token di registrazione sono credenziali temporanee di configurazione; l'agente registrato conserva le proprie credenziali fino alla revoca o all'eliminazione."
+        },
+        "troubleshooting": {
+          "title": "3. Risoluzione manuale dei problemi",
+          "descriptionPrefix": "L'installazione manuale rimane utile per la risoluzione dei problemi. Il codice sorgente dell'agente si trova nella",
+          "link": "directory dell'agente Borg UI"
+        },
+        "service": {
+          "title": "4. Controlli del servizio",
+          "description": "Il programma di installazione abilita systemd per impostazione predefinita, così l'agente sopravvive al riavvio. Usa questi comandi solo quando controlli o ripari un'installazione manuale."
+        }
+      }
+    },
+    "add": {
+      "title": "Aggiungi agente",
+      "steps": { "target": "Destinazione", "details": "Dettagli", "install": "Installa" },
+      "errors": { "createToken": "Impossibile creare il token di registrazione" },
+      "platform": "Piattaforma",
+      "platforms": { "linux": "Linux", "macos": "macOS", "windows": "Windows" },
+      "selected": "Selezionato",
+      "comingLater": "Disponibile in seguito",
+      "serverUrl": "URL del server",
+      "localhostWarning": "localhost funziona solo quando l'agente e Borg UI sono sullo stesso computer. I computer remoti richiedono un nome host, un indirizzo IP o un URL HTTPS raggiungibile.",
+      "serverUrlHelper": "Questo URL deve essere raggiungibile dal computer dell'agente.",
+      "agentName": "Nome agente",
+      "defaultPath": "Percorso predefinito",
+      "defaultPathHelper": "Directory iniziale per esplorare i file di questo agente.",
+      "tokenExpiry": "Scadenza del token",
+      "expiry": {
+        "1h": "1 ora",
+        "24h": "24 ore",
+        "7d": "7 giorni",
+        "30d": "30 giorni",
+        "never": "Mai"
+      },
+      "serviceUser": "Utente del servizio",
+      "serviceUsers": {
+        "current": {
+          "label": "Utente di installazione",
+          "description": "L'agente può accedere agli stessi file dell'utente che esegue il programma di installazione."
+        },
+        "dedicated": {
+          "label": "Utente borg-ui-agent dedicato",
+          "description": "Usa un account separato con privilegi ridotti per un isolamento più rigoroso."
+        },
+        "root": {
+          "label": "Root",
+          "description": "Usa questa opzione solo quando l'agente deve eseguire il backup di percorsi di proprietà di root."
+        }
+      },
+      "rootWarning": "La modalità root consente a questo agente di eseguire operazioni Borg a livello root. Usala solo per percorsi di proprietà di root.",
+      "borgInstallation": "Installazione di Borg",
+      "borgOptions": {
+        "borg1": {
+          "label": "Borg 1.x",
+          "description": "Predefinito. Installa o verifica Borg 1 come 'borg'."
+        },
+        "borg2": {
+          "label": "Solo Borg 2.x beta",
+          "description": "Opzione sperimentale avanzata. Installa o verifica Borg 2 come 'borg2'."
+        },
+        "both": {
+          "label": "Borg 1.x e Borg 2.x beta",
+          "description": "Opzione sperimentale avanzata. Mantiene Borg 1 come 'borg' e Borg 2 come 'borg2'."
+        },
+        "skip": {
+          "label": "Salta installazione Borg",
+          "description": "Usa questa opzione quando Borg è gestito separatamente sul computer dell'agente."
+        }
+      },
+      "generateInstallCommand": "Genera comando di installazione"
     }
+  },
+  "apiTokens": {
+    "title": "Token API",
+    "description": "Accesso programmatico, mostrato una sola volta alla creazione",
+    "empty": "Nessun token",
+    "prefix": "Prefisso",
+    "created": "Creato",
+    "lastUsed": "Ultimo utilizzo",
+    "revoke": "Revoca token",
+    "revoked": "Token revocato",
+    "name": "Nome token",
+    "namePlaceholder": "ad es. distribuzione CI, domotica",
+    "generateTitle": "Genera token API",
+    "newTokenTitle": "Il tuo nuovo token API",
+    "copyWarning": "Copia ora questo token. Non potrai più visualizzarlo.",
+    "copied": "Copiato!",
+    "copyToClipboard": "Copia negli appunti",
+    "closeWithoutCopyingTitle": "Chiudere senza copiare?",
+    "closeWithoutCopyingDescription": "Non hai copiato il token. Dopo la chiusura di questa finestra non potrà essere recuperato.",
+    "closeAnyway": "Chiudi comunque",
+    "errors": {
+      "generate": "Impossibile generare il token",
+      "revoke": "Impossibile revocare il token"
+    }
+  },
+  "accountPassword": {
+    "title": "Cambia password",
+    "current": "Password attuale",
+    "new": "Nuova password",
+    "confirm": "Conferma password",
+    "mismatch": "Le password non corrispondono",
+    "saving": "Salvataggio",
+    "update": "Aggiorna password"
+  },
+  "mountSuccess": {
+    "title": "Archivio montato",
+    "accessViaDocker": "Accesso tramite Docker:",
+    "copied": "Copiato!",
+    "copyCommand": "Copia comando"
   },
   "cloudStorage": {
     "title": "Archiviazione cloud",
@@ -286,6 +534,9 @@
     "storagePercentUsed": "{{value}}% usato",
     "noStorageInfo": "Nessuna info storage",
     "configSourceLabel": "Configurazione",
+    "configSource": {
+      "managed": "Gestita"
+    },
     "managedConfig": "rclone.conf gestito dal server",
     "editRemote": "Modifica remoto",
     "deleteRemote": "Elimina remoto",
@@ -724,7 +975,10 @@
       "runCompact": "Compatta",
       "runCompactTip": "Il repository viene compattato dopo ogni backup",
       "runCheck": "Controlla",
-      "runCheckTip": "Il controllo di integrità viene eseguito dopo ogni backup (oltre a qualsiasi controllo pianificato qui sotto)"
+      "runCheckTip": "Il controllo di integrità viene eseguito dopo ogni backup (oltre a qualsiasi controllo pianificato qui sotto)",
+      "collapse": "Comprimi",
+      "expand": "Espandi",
+      "togglePlan": "{{action}} {{name}}"
     },
     "noRepositories": "Devi creare almeno un repository prima di pianificare i backup.",
     "legacyBackupSchedulesTitle": "Automazioni di backup",
@@ -833,6 +1087,18 @@
     "title": "Piani di backup",
     "subtitle": "Definisci sorgenti, impostazioni, pianificazioni e i repository in cui ogni backup scrive.",
     "loading": "Caricamento piani di backup...",
+    "select": {
+      "source": {
+        "local": "Sorgente locale",
+        "remote": "Sorgente remota",
+        "agent": "Agente gestito",
+        "mixed": "Più sorgenti"
+      },
+      "repositories_one": "{{count}} repository",
+      "repositories_other": "{{count}} repository",
+      "scheduled": "Pianificato",
+      "manual": "Manuale"
+    },
     "runTooltipPro": "Questo piano usa più repository o esecuzione parallela. Modificalo o passa a Pro per eseguirlo.",
     "runTooltipProFeature": "Questo piano usa {{feature}}, che richiede Pro. Modificalo o passa a Pro per eseguirlo.",
     "runTooltipProFeatures": "Questo piano usa funzioni solo Pro: {{features}}. Modificalo o passa a Pro per eseguirlo.",
@@ -1460,6 +1726,7 @@
       "encryption": "Crittografia"
     },
     "observeOnly": "Solo Osservazione",
+    "deleteConfirmation": "Vuoi davvero eliminare il repository \"{{name}}\"?",
     "buttons": {
       "info": "Info",
       "check": "Controlla",
@@ -1943,6 +2210,7 @@
     },
     "systemKey": {
       "title": "Chiave SSH di Sistema",
+      "defaultDescription": "Chiave SSH di sistema per tutte le connessioni remote",
       "noKey": "Nessuna chiave SSH di sistema trovata. Generane una nuova o importane una esistente.",
       "generate": "Genera Chiave SSH di Sistema",
       "import": "Importa Chiave Esistente",
@@ -3497,6 +3765,8 @@
     "noScheduledChecks": "Nessun controllo pianificato",
     "noScheduledChecksDesc": "Configura controlli automatici del repository per garantire l'integrità dei dati",
     "needRepository": "Devi creare almeno un repository prima di pianificare i controlli.",
+    "repositoryNotFound": "Repository non trovato",
+    "status": { "cancelled": "Annullato", "running": "In esecuzione" },
     "historyTitle": "Cronologia controlli pianificati",
     "historyShowing": "Mostra {{filtered}} di {{total}} job di controllo pianificato",
     "historyShowingFiltered": "Mostra {{filtered}} di {{total}} job di controllo pianificato (filtrati)",
@@ -3705,6 +3975,9 @@
       "remoteSshNote": "Il server Borg UI si connetterà via SSH alla macchina remota per sfogliare e fare il backup delle directory selezionate. Assicurati che la connessione SSH sia configurata correttamente con i permessi necessari."
     },
     "location": {
+      "borgVersion": "Versione di Borg",
+      "beta": "Beta",
+      "borg2": "Borg 2",
       "repositoryNameLabel": "Nome Repository",
       "repositoryNameHelper": "Un nome descrittivo per identificare questo repository",
       "repositoryModeLabel": "Modalità Repository",
@@ -4002,6 +4275,9 @@
       "compression": "Compressione",
       "customFlags": "Flag Personalizzati",
       "repositoryInitialized": "Il repository verrà inizializzato",
+      "readyToInitialize": "Pronto per l'inizializzazione",
+      "hidePassphrase": "Nascondi passphrase",
+      "showPassphrase": "Mostra passphrase",
       "repositoryImportNote": "Il repository verrà verificato prima dell'importazione. Assicurati che la passphrase sia corretta.",
       "repositoryEditNote": "Le modifiche verranno salvate nella configurazione del repository."
     },
@@ -4022,6 +4298,41 @@
       "passphrasePlaceholderCreate": "Inserisci passphrase",
       "passphraseHelperEdit": "Opzionale - lascia vuoto per mantenere l'ultima passphrase salvata",
       "passphraseHelperCreate": "Conservala al sicuro - senza di essa non puoi accedere ai backup!",
+      "options": {
+        "repokey": {
+          "label": "Chiave del repository",
+          "description": "Chiave memorizzata nel repository (consigliato)"
+        },
+        "repokey-blake2": {
+          "label": "Chiave del repository (BLAKE2)",
+          "description": "Variante di hashing più veloce"
+        },
+        "keyfile": {
+          "label": "File chiave",
+          "description": "Chiave memorizzata in un file separato"
+        },
+        "keyfile-blake2": {
+          "label": "File chiave (BLAKE2)",
+          "description": "File chiave con hashing più veloce"
+        },
+        "repokey-aes-ocb": {
+          "label": "Chiave del repository (AES-OCB)",
+          "description": "Predefinito per Borg 2 · consigliato"
+        },
+        "repokey-chacha20-poly1305": {
+          "label": "Chiave del repository (ChaCha20)",
+          "description": "Cifrario AEAD alternativo"
+        },
+        "keyfile-aes-ocb": {
+          "label": "File chiave (AES-OCB)",
+          "description": "Chiave memorizzata in un file separato"
+        },
+        "keyfile-chacha20-poly1305": {
+          "label": "File chiave (ChaCha20)",
+          "description": "File chiave con ChaCha20"
+        },
+        "none": { "label": "Nessuna", "description": "Nessuna crittografia (non consigliato)" }
+      },
       "borgKeyfileTitle": "File Chiave Borg (Opzionale)",
       "borgKeyfileDesc": "I file chiave Borg sono tipicamente archiviati senza estensione in ~/.config/borg/keys/",
       "uploadFile": "Carica File",
@@ -4063,6 +4374,8 @@
       },
       "review": {
         "readyToCreate": "Pronto per creare la pianificazione!",
+        "ready": "Pronto",
+        "keep": "Conserva:",
         "reviewAndConfirm": "Rivedi e conferma qui sotto.",
         "jobSummary": "Riepilogo Job",
         "name": "Nome",
@@ -4452,6 +4765,17 @@
     "selectPath": "Seleziona Percorso"
   },
   "cache": {
+    "redis": "Redis",
+    "inMemory": "In memoria",
+    "connection": "Connessione",
+    "externalRedis": "Redis esterno",
+    "localDocker": "Docker locale",
+    "durationDays_one": "{{count}} giorno",
+    "durationDays_other": "{{count}} giorni",
+    "durationHours_one": "{{count}} ora",
+    "durationHours_other": "{{count}} ore",
+    "durationMinutes_one": "{{count}} minuto",
+    "durationMinutes_other": "{{count}} minuti",
     "subtitle": "Monitora e configura il sistema di cache degli archivi basato su Redis per una navigazione più veloce",
     "cacheStatus": "Stato Cache",
     "cachedArchives": "Entità in cache",
@@ -4570,6 +4894,8 @@
     },
     "confirmRemove": "Rimuovere questo script dal repository?",
     "parametersConfigured": "{{count}} parametro(i) configurati",
+    "parameterCount_one": "{{count}} parametro",
+    "parameterCount_other": "{{count}} parametri",
     "tooltips": {
       "testScript": "Esegui il test di questo script",
       "parametersOutOfSync": "I parametri necessitano attenzione - la definizione dello script è cambiata",
@@ -4588,7 +4914,13 @@
       "continueOnErrorHelperText": "Sovrascrivi predefinito: Se selezionato, il backup procederà anche se questo script fallisce.",
       "onFailureLabel": "Se questo script fallisce:",
       "cancel": "Annulla",
-      "assignScript": "Assegna Script"
+      "assignScript": "Assegna Script",
+      "inlineScriptReplacementWarning": "L'aggiunta di uno script dalla libreria sostituirà lo script inline corrente per questo hook."
+    },
+    "testDialog": {
+      "title": "Test: {{scriptName}}",
+      "exitCode": "Uscita: {{code}}",
+      "duration": "{{seconds}}s"
     },
     "parametersDialog": {
       "title": "Configura Parametri Script: {{scriptName}}",
@@ -5289,6 +5621,8 @@
     "learnMore": "Scopri cosa include →"
   },
   "announcements": {
+    "latestRelease": "Ultima versione",
+    "close": "Chiudi annuncio",
     "highlights": "Novità",
     "viewDetails": "Visualizza dettagli",
     "remindLater": "Ricordamelo più tardi",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -4043,6 +4043,8 @@
       "rcloneOAuthBorgUiHelper": "Borg UI riceve il callback del provider lato server. Quando il provider indica che l'autorizzazione è completa, torna qui; questa finestra controllerà automaticamente.",
       "rcloneOAuthLoopbackHelper": "rclone userà il proprio callback loopback locale. Usalo solo quando il browser può raggiungere lo stesso host del processo rclone.",
       "rcloneOAuthSetupMissing": "L'OAuth gestito da Borg UI non è configurato per questo provider.",
+      "rcloneProviderSearchPlaceholder": "Cerca provider",
+      "rcloneProviderSearchNoResults": "Nessun provider trovato",
       "rcloneDefaultProviders": {
         "localLabel": "File system locale",
         "localDescription": "Remoto per percorso locale.",

--- a/frontend/src/pages/Archives.tsx
+++ b/frontend/src/pages/Archives.tsx
@@ -134,11 +134,11 @@ const Archives: React.FC = () => {
     if (responseStatus === 423 && selectedRepositoryId) {
       setLockError({
         repositoryId: selectedRepositoryId,
-        repositoryName: selectedRepository?.name || 'Unknown',
+        repositoryName: selectedRepository?.name || t('common.unknown'),
         borgVersion: getBorgVersion(selectedRepository),
       })
     }
-  }, [archivesError, selectedRepositoryId, selectedRepository])
+  }, [archivesError, selectedRepositoryId, selectedRepository, t])
 
   // Get restore jobs
   const { data: restoreJobsData } = useQuery({
@@ -153,11 +153,11 @@ const Archives: React.FC = () => {
     if (repoInfoError && (repoInfoError as any)?.response?.status === 423 && selectedRepositoryId) {
       setLockError({
         repositoryId: selectedRepositoryId,
-        repositoryName: selectedRepository?.name || 'Unknown',
+        repositoryName: selectedRepository?.name || t('common.unknown'),
         borgVersion: getBorgVersion(selectedRepository),
       })
     }
-  }, [repoInfoError, selectedRepositoryId, selectedRepository])
+  }, [repoInfoError, selectedRepositoryId, selectedRepository, t])
 
   // Delete archive mutation
   const deleteArchiveMutation = useMutation({

--- a/frontend/src/pages/Backup.tsx
+++ b/frontend/src/pages/Backup.tsx
@@ -446,9 +446,7 @@ const Backup: React.FC = () => {
                     onChange={setSelectedBackupPlanId}
                     plans={runnableBackupPlans}
                     emptyMessage={t('backup.planRun.empty')}
-                    placeholder={t('backup.planRun.selectPlaceholder', {
-                      defaultValue: 'Select a backup plan',
-                    })}
+                    placeholder={t('backup.planRun.selectPlaceholder')}
                     disabled={loadingBackupPlans || runnableBackupPlans.length === 0}
                     formatSecondary={(plan) => {
                       const sourceLabel =

--- a/frontend/src/pages/CloudStorage.tsx
+++ b/frontend/src/pages/CloudStorage.tsx
@@ -147,10 +147,6 @@ const getApiMessage = (error: unknown, fallback: string) => {
   return translateBackendKey(detail) || fallback
 }
 
-const formatStatus = (remote: RcloneRemote) => {
-  return remote.last_test_status || 'Not tested'
-}
-
 const statusColor = (
   status?: string | null
 ): 'default' | 'success' | 'error' | 'warning' | 'info' => {
@@ -225,7 +221,21 @@ function CloudStorageRemoteCard({
   const { t } = useTranslation()
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
-  const status = formatStatus(remote)
+  const status = (() => {
+    switch (remote.last_test_status) {
+      case 'connected':
+      case 'success':
+        return t('cloudStorage.groups.connected')
+      case 'failed':
+      case 'error':
+        return t('cloudStorage.groups.failed')
+      case 'pending':
+      case 'running':
+        return t('cloudStorage.groups.pending')
+      default:
+        return t('cloudStorage.groups.notTested')
+    }
+  })()
   const statusThemeColor = statusColor(remote.last_test_status)
   const usageCount = remote.usage_count ?? 0
   const deleteDisabled = usageCount > 0
@@ -611,7 +621,9 @@ function CloudStorageRemoteCard({
             <Typography
               sx={{ fontSize: '0.68rem', fontWeight: 600, color: 'text.secondary', lineHeight: 1 }}
             >
-              {remote.config_source || 'managed'}
+              {remote.config_source === 'managed' || !remote.config_source
+                ? t('cloudStorage.configSource.managed')
+                : remote.config_source}
             </Typography>
           </Box>
         </Box>
@@ -805,15 +817,15 @@ export function CloudStorageContent({
     switch (status) {
       case 'connected':
       case 'success':
-        return t('cloudStorage.groups.connected', { defaultValue: 'Connected' })
+        return t('cloudStorage.groups.connected')
       case 'failed':
       case 'error':
-        return t('cloudStorage.groups.failed', { defaultValue: 'Failed' })
+        return t('cloudStorage.groups.failed')
       case 'pending':
       case 'running':
-        return t('cloudStorage.groups.pending', { defaultValue: 'Pending' })
+        return t('cloudStorage.groups.pending')
       default:
-        return t('cloudStorage.groups.notTested', { defaultValue: 'Not tested' })
+        return t('cloudStorage.groups.notTested')
     }
   }
 
@@ -954,48 +966,46 @@ export function CloudStorageContent({
         <ListToolbar
           searchValue={searchQuery}
           onSearchChange={handleSearchChange}
-          searchPlaceholder={t('cloudStorage.search', {
-            defaultValue: 'Search cloud storage...',
-          })}
+          searchPlaceholder={t('cloudStorage.search')}
           sortValue={sortBy}
           onSortChange={handleSortChange}
           sortOptions={[
             {
               value: 'name-asc',
-              label: t('cloudStorage.sort.nameAZ', { defaultValue: 'Name A → Z' }),
+              label: t('cloudStorage.sort.nameAZ'),
             },
             {
               value: 'name-desc',
-              label: t('cloudStorage.sort.nameZA', { defaultValue: 'Name Z → A' }),
+              label: t('cloudStorage.sort.nameZA'),
             },
             {
               value: 'provider-asc',
-              label: t('cloudStorage.sort.provider', { defaultValue: 'Provider' }),
+              label: t('cloudStorage.sort.provider'),
             },
             {
               value: 'status',
-              label: t('cloudStorage.sort.status', { defaultValue: 'Status (connected first)' }),
+              label: t('cloudStorage.sort.status'),
             },
             {
               value: 'usage-desc',
-              label: t('cloudStorage.sort.usageMost', { defaultValue: 'Usage (most first)' }),
+              label: t('cloudStorage.sort.usageMost'),
             },
             {
               value: 'usage-asc',
-              label: t('cloudStorage.sort.usageLeast', { defaultValue: 'Usage (least first)' }),
+              label: t('cloudStorage.sort.usageLeast'),
             },
           ]}
           groupValue={groupBy}
           onGroupChange={handleGroupChange}
           groupOptions={[
-            { value: 'none', label: t('cloudStorage.group.none', { defaultValue: 'No grouping' }) },
+            { value: 'none', label: t('cloudStorage.group.none') },
             {
               value: 'status',
-              label: t('cloudStorage.group.status', { defaultValue: 'By status' }),
+              label: t('cloudStorage.group.status'),
             },
             {
               value: 'provider',
-              label: t('cloudStorage.group.provider', { defaultValue: 'By provider' }),
+              label: t('cloudStorage.group.provider'),
             },
           ]}
         />
@@ -1022,21 +1032,16 @@ export function CloudStorageContent({
         <EmptyStateCard
           centered={false}
           icon={<Cloud size={48} />}
-          title={t('cloudStorage.noMatch.title', { defaultValue: 'No matching remotes' })}
+          title={t('cloudStorage.noMatch.title')}
           description={
             searchQuery
-              ? t('cloudStorage.noMatch.message', {
-                  search: searchQuery,
-                  defaultValue: `No remotes match "${searchQuery}".`,
-                })
-              : t('cloudStorage.noMatch.fallback', {
-                  defaultValue: 'No remotes match the current filters.',
-                })
+              ? t('cloudStorage.noMatch.message', { search: searchQuery })
+              : t('cloudStorage.noMatch.fallback')
           }
           actions={
             searchQuery ? (
               <Button variant="outlined" onClick={() => setSearchQuery('')}>
-                {t('cloudStorage.noMatch.clearSearch', { defaultValue: 'Clear search' })}
+                {t('cloudStorage.noMatch.clearSearch')}
               </Button>
             ) : null
           }

--- a/frontend/src/pages/FirstLoginPasswordSetup.tsx
+++ b/frontend/src/pages/FirstLoginPasswordSetup.tsx
@@ -142,7 +142,7 @@ export default function PasswordSetupCard({ onComplete }: { onComplete: () => vo
               <button
                 type="button"
                 onClick={() => setShowNewPassword((v) => !v)}
-                aria-label={showNewPassword ? 'Hide password' : 'Show password'}
+                aria-label={showNewPassword ? t('common.password.hide') : t('common.password.show')}
                 style={{
                   position: 'absolute',
                   right: 12,
@@ -195,7 +195,9 @@ export default function PasswordSetupCard({ onComplete }: { onComplete: () => vo
               <button
                 type="button"
                 onClick={() => setShowConfirmPassword((v) => !v)}
-                aria-label={showConfirmPassword ? 'Hide password' : 'Show password'}
+                aria-label={
+                  showConfirmPassword ? t('common.password.hide') : t('common.password.show')
+                }
                 style={{
                   position: 'absolute',
                   right: 12,
@@ -299,7 +301,7 @@ export default function PasswordSetupCard({ onComplete }: { onComplete: () => vo
               fontFamily: 'inherit',
             }}
           >
-            {skipSetupMutation.isPending ? 'Loading...' : t('firstLoginSetup.skip')}
+            {skipSetupMutation.isPending ? t('common.loading') : t('firstLoginSetup.skip')}
           </button>
         </div>
       </form>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -420,7 +420,9 @@ export default function Login() {
                       <button
                         type="button"
                         onClick={() => setShowPassword((v) => !v)}
-                        aria-label={showPassword ? 'Hide password' : 'Show password'}
+                        aria-label={
+                          showPassword ? t('common.password.hide') : t('common.password.show')
+                        }
                         style={{
                           position: 'absolute',
                           right: 12,

--- a/frontend/src/pages/ManagedAgents.tsx
+++ b/frontend/src/pages/ManagedAgents.tsx
@@ -86,8 +86,8 @@ const EMPTY_TOKENS: AgentEnrollmentTokenSummary[] = []
 const EMPTY_JOBS: AgentJobResponse[] = []
 const EMPTY_LOG_RESULT = { lines: [], total_lines: 0, has_more: false }
 
-function formatDate(value?: string | null): string {
-  if (!value) return 'Never'
+function formatDate(value: string | null | undefined, neverLabel: string): string {
+  if (!value) return neverLabel
   return new Intl.DateTimeFormat(undefined, {
     dateStyle: 'medium',
     timeStyle: 'short',
@@ -118,8 +118,8 @@ function statusChipColor(
   }
 }
 
-function getAgentLabel(agent?: AgentMachineResponse): string {
-  if (!agent) return 'Unknown agent'
+function getAgentLabel(agent: AgentMachineResponse | undefined, unknownLabel: string): string {
+  if (!agent) return unknownLabel
   return agent.hostname || agent.name || agent.agent_id
 }
 
@@ -141,8 +141,8 @@ function formatBorgBinary(binary: Record<string, unknown>): string {
   return installSource ? `${label} (${installSource})` : label
 }
 
-function formatElapsedMs(value?: number | null): string {
-  if (typeof value !== 'number') return 'Not reported'
+function formatElapsedMs(value: number | null | undefined, notReportedLabel: string): string {
+  if (typeof value !== 'number') return notReportedLabel
   return `${Math.round(value)} ms`
 }
 
@@ -161,14 +161,15 @@ function parseDiagnosticsTimeout(value: string): number | null {
 function getDiagnosticsTargetError(
   hostValue: string,
   portValue: string,
-  timeoutValue: string
+  timeoutValue: string,
+  messages: { invalidPort: string; invalidTimeout: string }
 ): string | null {
   if (!hostValue.trim()) return null
   if (parseDiagnosticsPort(portValue) === null) {
-    return 'Enter a TCP port between 1 and 65535.'
+    return messages.invalidPort
   }
   if (parseDiagnosticsTimeout(timeoutValue) === null) {
-    return 'Enter a timeout between 0.5 and 10 seconds.'
+    return messages.invalidTimeout
   }
   return null
 }
@@ -193,21 +194,21 @@ function buildDiagnosticsPayload(
   }
 }
 
-function sessionStatusLabel(status: string): string {
+function sessionStatusLabel(status: string, labels: Record<string, string>): string {
   switch (status) {
     case 'success':
-      return 'Session healthy'
+      return labels.healthy
     case 'offline':
-      return 'Agent offline'
+      return labels.offline
     case 'timeout':
-      return 'Timed out'
+      return labels.timedOut
     default:
-      return 'Session failed'
+      return labels.failed
   }
 }
 
-function tcpStatusLabel(status: string): string {
-  return status === 'success' ? 'TCP reachable' : 'TCP failed'
+function tcpStatusLabel(status: string, labels: Record<string, string>): string {
+  return status === 'success' ? labels.reachable : labels.failed
 }
 
 export function ManagedAgentsPreview({
@@ -225,6 +226,7 @@ export function ManagedAgentsPreview({
   jobs?: AgentJobResponse[]
   isLoading?: boolean
 }) {
+  const { t } = useTranslation()
   const setupCommand = buildAgentInstallCommand(
     defaultAgentServerUrl,
     '<enrollment-token>',
@@ -237,15 +239,18 @@ export function ManagedAgentsPreview({
   return (
     <Box>
       <PageHeader
-        title="Managed Agents"
-        subtitle="Lightweight machines connected to this Borg UI server"
+        title={t('managedAgents.page.title')}
+        subtitle={t('managedAgents.page.subtitle')}
         actions={
           <>
-            <IconButton aria-label="Refresh" title="Refresh">
+            <IconButton
+              aria-label={t('managedAgents.page.refresh')}
+              title={t('managedAgents.page.refresh')}
+            >
               <RefreshCw size={20} />
             </IconButton>
             <Button variant="contained" startIcon={<Plus size={18} />}>
-              Add Agent
+              {t('managedAgents.page.addAgent')}
             </Button>
           </>
         }
@@ -254,9 +259,9 @@ export function ManagedAgentsPreview({
       <AgentSetupGuide command={setupCommand} onCopy={() => {}} />
 
       <PageTabs value={activeTab} onChange={() => {}}>
-        <Tab label="Agents" value="agents" />
-        <Tab label="Jobs" value="jobs" />
-        <Tab label="Enrollment Tokens" value="tokens" />
+        <Tab label={t('managedAgents.page.tabs.agents')} value="agents" />
+        <Tab label={t('managedAgents.page.tabs.jobs')} value="jobs" />
+        <Tab label={t('managedAgents.page.tabs.tokens')} value="tokens" />
       </PageTabs>
 
       {isLoading ? (
@@ -337,6 +342,7 @@ export function ManagedAgentsPlanGate({
 }
 
 export default function ManagedAgents() {
+  const { t } = useTranslation()
   const queryClient = useQueryClient()
   const { hasGlobalPermission } = useAuth()
   const { trackSystem, EventAction } = useAnalytics()
@@ -422,10 +428,10 @@ export default function ManagedAgents() {
         has_default_path: Boolean(payload.default_path),
         expires_never: Boolean(payload.expires_never),
       })
-      toast.success('Enrollment token created')
+      toast.success(t('managedAgents.page.toasts.tokenCreated'))
     },
     onError: (error: unknown) => {
-      toast.error(extractBackendMessage(error, 'Failed to create enrollment token'))
+      toast.error(extractBackendMessage(error, t('managedAgents.add.errors.createToken')))
     },
   })
 
@@ -441,10 +447,10 @@ export default function ManagedAgents() {
         surface: MANAGED_AGENTS_ANALYTICS_SECTION,
         operation: 'revoke_enrollment_token',
       })
-      toast.success('Enrollment token revoked')
+      toast.success(t('managedAgents.page.toasts.tokenRevoked'))
     },
     onError: (error: unknown) => {
-      toast.error(extractBackendMessage(error, 'Failed to revoke enrollment token'))
+      toast.error(extractBackendMessage(error, t('managedAgents.page.errors.revokeToken')))
     },
   })
 
@@ -460,10 +466,10 @@ export default function ManagedAgents() {
         surface: MANAGED_AGENTS_ANALYTICS_SECTION,
         operation: 'revoke_agent',
       })
-      toast.success('Agent revoked')
+      toast.success(t('managedAgents.page.toasts.agentRevoked'))
     },
     onError: (error: unknown) => {
-      toast.error(extractBackendMessage(error, 'Failed to revoke agent'))
+      toast.error(extractBackendMessage(error, t('managedAgents.page.errors.revokeAgent')))
     },
   })
 
@@ -479,10 +485,10 @@ export default function ManagedAgents() {
         surface: MANAGED_AGENTS_ANALYTICS_SECTION,
         operation: 'delete_agent',
       })
-      toast.success('Agent deleted')
+      toast.success(t('managedAgents.page.toasts.agentDeleted'))
     },
     onError: (error: unknown) => {
-      toast.error(extractBackendMessage(error, 'Failed to delete agent'))
+      toast.error(extractBackendMessage(error, t('managedAgents.page.errors.deleteAgent')))
     },
   })
 
@@ -500,10 +506,10 @@ export default function ManagedAgents() {
         operation: 'cancel_job',
         job_id_present: Boolean(jobId),
       })
-      toast.success('Cancellation requested')
+      toast.success(t('managedAgents.page.toasts.cancellationRequested'))
     },
     onError: (error: unknown) => {
-      toast.error(extractBackendMessage(error, 'Failed to cancel job'))
+      toast.error(extractBackendMessage(error, t('managedAgents.page.errors.cancelJob')))
     },
   })
 
@@ -536,7 +542,7 @@ export default function ManagedAgents() {
       operation: 'copy_command',
       source,
     })
-    toast.success('Copied')
+    toast.success(t('managedAgents.page.toasts.copied'))
   }
 
   const setupCommand = buildAgentInstallCommand(
@@ -548,14 +554,22 @@ export default function ManagedAgents() {
   return (
     <Box>
       <PageHeader
-        title="Managed Agents"
-        subtitle="Lightweight machines connected to this Borg UI server"
+        title={t('managedAgents.page.title')}
+        subtitle={t('managedAgents.page.subtitle')}
         actions={
           <>
             <IconButton
               onClick={() => void refreshAll()}
-              aria-label={manualRefreshInFlight ? 'Refreshing agents' : 'Refresh'}
-              title={manualRefreshInFlight ? 'Refreshing agents' : 'Refresh'}
+              aria-label={
+                manualRefreshInFlight
+                  ? t('managedAgents.page.refreshing')
+                  : t('managedAgents.page.refresh')
+              }
+              title={
+                manualRefreshInFlight
+                  ? t('managedAgents.page.refreshing')
+                  : t('managedAgents.page.refresh')
+              }
               disabled={manualRefreshInFlight}
             >
               <RefreshCw size={20} />
@@ -576,7 +590,7 @@ export default function ManagedAgents() {
               }}
               sx={{ width: { xs: '100%', md: 'auto' } }}
             >
-              Add Agent
+              {t('managedAgents.page.addAgent')}
             </Button>
           </>
         }
@@ -595,9 +609,9 @@ export default function ManagedAgents() {
           setActiveTab(value)
         }}
       >
-        <Tab label="Agents" value="agents" />
-        <Tab label="Jobs" value="jobs" />
-        <Tab label="Enrollment Tokens" value="tokens" />
+        <Tab label={t('managedAgents.page.tabs.agents')} value="agents" />
+        <Tab label={t('managedAgents.page.tabs.jobs')} value="jobs" />
+        <Tab label={t('managedAgents.page.tabs.tokens')} value="tokens" />
       </PageTabs>
 
       {isLoading ? (
@@ -708,6 +722,7 @@ export function AgentSetupGuide({
   command: string
   onCopy: (value: string) => void
 }) {
+  const { t } = useTranslation()
   const [helpOpen, setHelpOpen] = useState(false)
 
   return (
@@ -721,9 +736,7 @@ export function AgentSetupGuide({
       >
         <Stack direction="row" spacing={1} alignItems="center" color="text.secondary">
           <Terminal size={16} />
-          <Typography variant="body2">
-            Run this on a remote machine to register it with this Borg UI server.
-          </Typography>
+          <Typography variant="body2">{t('managedAgents.setupGuide.summary')}</Typography>
         </Stack>
         <Button
           variant="text"
@@ -731,23 +744,23 @@ export function AgentSetupGuide({
           startIcon={<Info size={16} />}
           onClick={() => setHelpOpen(true)}
         >
-          Setup Help
+          {t('managedAgents.setupGuide.help')}
         </Button>
       </Stack>
 
       <CopyableCodeBlock
         value={command}
-        copyLabel="Copy setup command"
+        copyLabel={t('managedAgents.setupGuide.copySetupCommand')}
         onCopy={() => onCopy(command)}
       />
 
       <Dialog open={helpOpen} onClose={() => setHelpOpen(false)} fullWidth maxWidth="md">
-        <DialogTitle>Agent Setup Help</DialogTitle>
+        <DialogTitle>{t('managedAgents.setupGuide.title')}</DialogTitle>
         <DialogContent>
           <AgentSetupHelpContent command={command} onCopy={onCopy} />
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setHelpOpen(false)}>Close</Button>
+          <Button onClick={() => setHelpOpen(false)}>{t('common.buttons.close')}</Button>
         </DialogActions>
       </Dialog>
     </Box>
@@ -761,6 +774,7 @@ export function AgentSetupHelpContent({
   command: string
   onCopy: (value: string) => void
 }) {
+  const { t } = useTranslation()
   const manualInstallCommand = [
     'git clone https://github.com/karanhudia/borg-ui.git',
     'cd borg-ui',
@@ -779,72 +793,65 @@ export function AgentSetupHelpContent({
     <Stack spacing={2.5} sx={{ mt: 1 }}>
       <Box>
         <Typography variant="subtitle2" fontWeight={700} gutterBottom>
-          1. Run the Linux installer
+          {t('managedAgents.setupGuide.steps.install.title')}
         </Typography>
         <Typography color="text.secondary" sx={{ mb: 1 }}>
-          Run this on the Linux machine that owns the files Borg should back up. The installer
-          installs dependencies, registers the agent, and enables the systemd service. By default,
-          the service runs as the user who invoked sudo, so repository and source paths must be
-          accessible to that user.
+          {t('managedAgents.setupGuide.steps.install.description')}
         </Typography>
         <CopyableCodeBlock
           value={command}
-          copyLabel="Copy install command"
+          copyLabel={t('managedAgents.installCommand.copy')}
           onCopy={() => onCopy(command)}
         />
       </Box>
 
       <Box>
         <Typography variant="subtitle2" fontWeight={700} gutterBottom>
-          2. Server URL and token
+          {t('managedAgents.setupGuide.steps.server.title')}
         </Typography>
         <Typography color="text.secondary" sx={{ mb: 1 }}>
-          The server URL must be reachable from the client machine. localhost only works when the
-          agent and Borg UI are on the same machine; remote clients should use the Borg UI host
-          name, IP address, or HTTPS URL they can reach. Enrollment tokens are temporary setup
-          credentials; the enrolled agent keeps its own credential until revoked or deleted.
+          {t('managedAgents.setupGuide.steps.server.description')}
         </Typography>
       </Box>
 
       <Box>
         <Typography variant="subtitle2" fontWeight={700} gutterBottom>
-          3. Manual troubleshooting
+          {t('managedAgents.setupGuide.steps.troubleshooting.title')}
         </Typography>
         <Typography color="text.secondary" sx={{ mb: 1 }}>
-          Manual installation remains useful for troubleshooting. The agent source is in the{' '}
+          {t('managedAgents.setupGuide.steps.troubleshooting.descriptionPrefix')}{' '}
           <MuiLink
             href="https://github.com/karanhudia/borg-ui/tree/main/agent"
             target="_blank"
             rel="noreferrer"
           >
-            Borg UI agent directory
+            {t('managedAgents.setupGuide.steps.troubleshooting.link')}
           </MuiLink>
           .
         </Typography>
         <CopyableCodeBlock
           value={manualInstallCommand}
-          copyLabel="Copy install commands"
+          copyLabel={t('managedAgents.setupGuide.copyInstallCommands')}
           onCopy={() => onCopy(manualInstallCommand)}
         />
       </Box>
 
       <Box>
         <Typography variant="subtitle2" fontWeight={700} gutterBottom>
-          4. Service checks
+          {t('managedAgents.setupGuide.steps.service.title')}
         </Typography>
         <Typography color="text.secondary" sx={{ mb: 1 }}>
-          The installer enables systemd by default so the agent survives reboot. Use these commands
-          only when inspecting or repairing a manual installation.
+          {t('managedAgents.setupGuide.steps.service.description')}
         </Typography>
         <CopyableCodeBlock
           value={runCommand}
-          copyLabel="Copy status command"
+          copyLabel={t('managedAgents.setupGuide.copyStatusCommand')}
           onCopy={() => onCopy(runCommand)}
         />
         <Box sx={{ mt: 1 }}>
           <CopyableCodeBlock
             value={linuxStartupCommand}
-            copyLabel="Copy systemd commands"
+            copyLabel={t('managedAgents.setupGuide.copySystemdCommands')}
             onCopy={() => onCopy(linuxStartupCommand)}
           />
         </Box>
@@ -952,13 +959,23 @@ export function AgentDiagnosticsDialog({
     payload: AgentDiagnosticsRequest
   ) => Promise<AgentDiagnosticsResponse>
 }) {
+  const { t } = useTranslation()
   const [targetHost, setTargetHost] = useState('')
   const [targetPort, setTargetPort] = useState('')
   const [targetTimeout, setTargetTimeout] = useState('3')
   const [result, setResult] = useState<AgentDiagnosticsResponse | null>(initialResult)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [running, setRunning] = useState(false)
-  const targetError = getDiagnosticsTargetError(targetHost, targetPort, targetTimeout)
+  const diagnosticsMessages = {
+    invalidPort: t('managedAgents.page.diagnostics.invalidPort'),
+    invalidTimeout: t('managedAgents.page.diagnostics.invalidTimeout'),
+  }
+  const targetError = getDiagnosticsTargetError(
+    targetHost,
+    targetPort,
+    targetTimeout,
+    diagnosticsMessages
+  )
   const hasTarget = Boolean(targetHost.trim())
   const portInvalid = hasTarget && parseDiagnosticsPort(targetPort) === null
   const timeoutInvalid = hasTarget && parseDiagnosticsTimeout(targetTimeout) === null
@@ -972,7 +989,12 @@ export function AgentDiagnosticsDialog({
 
   const runDiagnostics = async () => {
     if (!agent || !onRunDiagnostics) return
-    const validationError = getDiagnosticsTargetError(targetHost, targetPort, targetTimeout)
+    const validationError = getDiagnosticsTargetError(
+      targetHost,
+      targetPort,
+      targetTimeout,
+      diagnosticsMessages
+    )
     if (validationError) {
       setErrorMessage(validationError)
       return
@@ -986,7 +1008,7 @@ export function AgentDiagnosticsDialog({
       )
       setResult(nextResult)
     } catch (error) {
-      setErrorMessage(extractBackendMessage(error, 'Failed to run diagnostics'))
+      setErrorMessage(extractBackendMessage(error, t('managedAgents.page.errors.runDiagnostics')))
     } finally {
       setRunning(false)
     }
@@ -999,7 +1021,7 @@ export function AgentDiagnosticsDialog({
 
   const footer = (
     <DialogActions sx={{ px: 3, py: 2 }}>
-      <Button onClick={onClose}>Close</Button>
+      <Button onClick={onClose}>{t('common.buttons.close')}</Button>
       <Button
         variant="contained"
         onClick={() => void runDiagnostics()}
@@ -1008,21 +1030,24 @@ export function AgentDiagnosticsDialog({
           running ? <CircularProgress color="inherit" size={16} /> : <Activity size={16} />
         }
       >
-        {running ? 'Running diagnostics' : 'Run check'}
+        {running
+          ? t('managedAgents.page.diagnostics.running')
+          : t('managedAgents.page.diagnostics.runCheck')}
       </Button>
     </DialogActions>
   )
 
   return (
     <ResponsiveDialog open={open} onClose={onClose} fullWidth maxWidth="md" footer={footer}>
-      <DialogTitle>Agent diagnostics</DialogTitle>
+      <DialogTitle>{t('managedAgents.page.diagnostics.title')}</DialogTitle>
       <DialogContent>
         <Stack spacing={2.25} sx={{ pt: 0.5, pb: 1 }}>
           <Box>
-            <Typography fontWeight={700}>{getAgentLabel(agent || undefined)}</Typography>
+            <Typography fontWeight={700}>
+              {getAgentLabel(agent || undefined, t('managedAgents.page.unknownAgent'))}
+            </Typography>
             <Typography color="text.secondary" variant="body2" sx={{ mt: 0.25 }}>
-              Verify the outbound agent session and optionally test a TCP target from the agent
-              host.
+              {t('managedAgents.page.diagnostics.description')}
             </Typography>
           </Box>
 
@@ -1038,18 +1063,17 @@ export function AgentDiagnosticsDialog({
             timeoutInvalid={timeoutInvalid}
             timeoutInputProps={{ min: 0.5, max: 10, step: 0.5 }}
             labels={{
-              summary: 'Advanced: test another service',
-              description:
-                'Checks whether this agent can reach a separate service. Leave blank for normal diagnostics.',
-              host: 'Service host',
+              summary: t('managedAgents.page.diagnostics.advancedSummary'),
+              description: t('managedAgents.page.diagnostics.advancedDescription'),
+              host: t('managedAgents.page.diagnostics.serviceHost'),
               hostPlaceholder: 'postgres.internal',
-              hostHelper: 'Optional service to test from this agent',
-              port: 'Service port',
+              hostHelper: t('managedAgents.page.diagnostics.serviceHostHelper'),
+              port: t('managedAgents.page.diagnostics.servicePort'),
               portPlaceholder: '5432',
               portError: '1-65535',
-              timeout: 'Timeout',
-              timeoutHelper: 'Seconds',
-              timeoutError: '0.5-10 seconds',
+              timeout: t('managedAgents.page.diagnostics.timeout'),
+              timeoutHelper: t('managedAgents.page.diagnostics.seconds'),
+              timeoutError: t('managedAgents.page.diagnostics.timeoutRange'),
             }}
           />
 
@@ -1080,12 +1104,26 @@ export function AgentDiagnosticsDialog({
               }}
             >
               {[
-                ['Status', diagnosticAgent?.status ?? agent?.status ?? 'unknown'],
-                ['Last seen', formatDate(diagnosticAgent?.last_seen_at ?? agent?.last_seen_at)],
-                ['Agent version', diagnosticAgent?.agent_version ?? agent?.agent_version ?? '—'],
                 [
-                  'Borg',
-                  borgVersions.length ? borgVersions.map(formatBorgBinary).join(', ') : 'None',
+                  t('managedAgents.page.table.status'),
+                  diagnosticAgent?.status ?? agent?.status ?? 'unknown',
+                ],
+                [
+                  t('managedAgents.page.lastSeen'),
+                  formatDate(
+                    diagnosticAgent?.last_seen_at ?? agent?.last_seen_at,
+                    t('managedAgents.page.never')
+                  ),
+                ],
+                [
+                  t('managedAgents.page.agentVersion'),
+                  diagnosticAgent?.agent_version ?? agent?.agent_version ?? '—',
+                ],
+                [
+                  t('managedAgents.page.borg'),
+                  borgVersions.length
+                    ? borgVersions.map(formatBorgBinary).join(', ')
+                    : t('managedAgents.page.none'),
                 ],
               ].map(([label, value], index) => (
                 <Box
@@ -1112,7 +1150,7 @@ export function AgentDiagnosticsDialog({
 
           <Stack spacing={1}>
             <Typography variant="caption" color="text.secondary" fontWeight={700}>
-              Capabilities
+              {t('managedAgents.page.capabilities')}
             </Typography>
             <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap">
               {capabilities.length ? (
@@ -1120,7 +1158,11 @@ export function AgentDiagnosticsDialog({
                   <Chip key={capability} label={capability} size="small" variant="outlined" />
                 ))
               ) : (
-                <Chip label="None reported" size="small" variant="outlined" />
+                <Chip
+                  label={t('managedAgents.page.noneReported')}
+                  size="small"
+                  variant="outlined"
+                />
               )}
             </Stack>
           </Stack>
@@ -1134,7 +1176,12 @@ export function AgentDiagnosticsDialog({
           {result ? (
             <Stack spacing={1.25} aria-live="polite">
               <DiagnosticResultRow
-                title={sessionStatusLabel(result.session.status)}
+                title={sessionStatusLabel(result.session.status, {
+                  healthy: t('managedAgents.page.diagnostics.sessionHealthy'),
+                  offline: t('managedAgents.page.diagnostics.agentOffline'),
+                  timedOut: t('managedAgents.page.diagnostics.timedOut'),
+                  failed: t('managedAgents.page.diagnostics.sessionFailed'),
+                })}
                 elapsed={result.session.elapsed_ms}
                 error={result.session.error}
                 message={result.session.message}
@@ -1142,7 +1189,10 @@ export function AgentDiagnosticsDialog({
               />
               {result.tcp ? (
                 <DiagnosticResultRow
-                  title={tcpStatusLabel(result.tcp.status)}
+                  title={tcpStatusLabel(result.tcp.status, {
+                    reachable: t('managedAgents.page.diagnostics.tcpReachable'),
+                    failed: t('managedAgents.page.diagnostics.tcpFailed'),
+                  })}
                   elapsed={result.tcp.elapsed_ms}
                   target={`${result.tcp.target.host}:${result.tcp.target.port}`}
                   error={result.tcp.error}
@@ -1153,8 +1203,7 @@ export function AgentDiagnosticsDialog({
             </Stack>
           ) : (
             <Alert severity="info" sx={{ borderRadius: 1.5 }}>
-              Run a check to verify the active agent session. Add a host and port to test TCP
-              reachability from the agent host.
+              {t('managedAgents.page.diagnostics.emptyResult')}
             </Alert>
           )}
         </Stack>
@@ -1178,6 +1227,7 @@ function DiagnosticResultRow({
   target?: string
   severity: 'success' | 'warning' | 'error'
 }) {
+  const { t } = useTranslation()
   return (
     <Box
       sx={{
@@ -1199,7 +1249,11 @@ function DiagnosticResultRow({
           )}
           <Typography fontWeight={700}>{title}</Typography>
         </Stack>
-        <Chip label={formatElapsedMs(elapsed)} size="small" variant="outlined" />
+        <Chip
+          label={formatElapsedMs(elapsed, t('managedAgents.page.notReported'))}
+          size="small"
+          variant="outlined"
+        />
       </Stack>
       {target && (
         <Typography variant="body2" color="text.secondary" sx={{ mt: 0.75 }}>
@@ -1236,20 +1290,22 @@ export function AgentDeleteConfirmationDialog({
   onCancel: () => void
   onConfirm: (agent: AgentMachineResponse) => void
 }) {
+  const { t } = useTranslation()
   return (
     <Dialog open={open} onClose={onCancel} fullWidth maxWidth="xs">
-      <DialogTitle>Delete agent</DialogTitle>
+      <DialogTitle>{t('managedAgents.page.deleteDialog.title')}</DialogTitle>
       <DialogContent>
         <Stack spacing={1.5} sx={{ mt: 0.5 }}>
-          <Typography fontWeight={700}>{getAgentLabel(agent || undefined)}</Typography>
+          <Typography fontWeight={700}>
+            {getAgentLabel(agent || undefined, t('managedAgents.page.unknownAgent'))}
+          </Typography>
           <Typography color="text.secondary">
-            Deleting removes it from the fleet list. The local service may still run until removed
-            on the client.
+            {t('managedAgents.page.deleteDialog.description')}
           </Typography>
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel}>Cancel</Button>
+        <Button onClick={onCancel}>{t('common.buttons.cancel')}</Button>
         <Button
           color="error"
           variant="contained"
@@ -1259,7 +1315,7 @@ export function AgentDeleteConfirmationDialog({
             onConfirm(agent)
           }}
         >
-          Delete agent
+          {t('managedAgents.page.deleteDialog.confirm')}
         </Button>
       </DialogActions>
     </Dialog>
@@ -1279,33 +1335,35 @@ export function AgentReinstallDialog({
   onCancel: () => void
   onCopy: (value: string) => void
 }) {
+  const { t } = useTranslation()
   const command = buildAgentReinstallCommand(serverUrl)
 
   return (
     <Dialog open={open} onClose={onCancel} fullWidth maxWidth="md">
-      <DialogTitle>Reinstall agent</DialogTitle>
+      <DialogTitle>{t('managedAgents.page.reinstallDialog.title')}</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 0.5 }}>
           <Box>
-            <Typography fontWeight={700}>{getAgentLabel(agent || undefined)}</Typography>
+            <Typography fontWeight={700}>
+              {getAgentLabel(agent || undefined, t('managedAgents.page.unknownAgent'))}
+            </Typography>
             <Typography color="text.secondary" sx={{ mt: 0.5 }}>
-              Run this on the enrolled machine to update the Borg UI agent package and restart the
-              systemd service. No enrollment token or registration step is required.
+              {t('managedAgents.page.reinstallDialog.description')}
             </Typography>
           </Box>
           <CopyableCodeBlock
             value={command}
-            copyLabel="Copy reinstall command"
+            copyLabel={t('managedAgents.page.reinstallDialog.copyCommand')}
             onCopy={() => onCopy(command)}
           />
           <Alert severity="info" sx={{ borderRadius: 1.5 }}>
-            The script preserves the existing agent config at{' '}
+            {t('managedAgents.page.reinstallDialog.configPreserved')}{' '}
             <Box component="code">/etc/borg-ui-agent/config.toml</Box>.
           </Alert>
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel}>Close</Button>
+        <Button onClick={onCancel}>{t('common.buttons.close')}</Button>
       </DialogActions>
     </Dialog>
   )
@@ -1336,6 +1394,7 @@ export function AgentList({
   isDeleting: boolean
 }) {
   const theme = useTheme()
+  const { t } = useTranslation()
   const { trackSystem, EventAction } = useAnalytics()
   const isDark = theme.palette.mode === 'dark'
   const [deleteTarget, setDeleteTarget] = useState<AgentMachineResponse | null>(null)
@@ -1360,13 +1419,13 @@ export function AgentList({
         status: 'failed',
         elapsed_ms: null,
         error: 'diagnostics_unavailable',
-        message: 'Diagnostics are unavailable in this story or test surface.',
+        message: t('managedAgents.page.diagnostics.unavailable'),
       },
       tcp: null,
     }))
 
   if (!agents.length) {
-    return <Alert severity="info">No agents enrolled.</Alert>
+    return <Alert severity="info">{t('managedAgents.page.emptyAgents')}</Alert>
   }
 
   return (
@@ -1382,12 +1441,20 @@ export function AgentList({
           const accent = getAgentStatusAccent(agent.status)
           const borgVersions = agent.borg_versions ?? []
           const hasUsableBorg = borgVersions.length > 0
-          const borgValue = hasUsableBorg ? borgVersions.map(formatBorgBinary).join(', ') : 'None'
+          const borgValue = hasUsableBorg
+            ? borgVersions.map(formatBorgBinary).join(', ')
+            : t('managedAgents.page.none')
           const stats = [
-            { label: 'OS', value: [agent.os, agent.arch].filter(Boolean).join(' / ') || '—' },
-            { label: 'Agent', value: agent.agent_version || '—' },
-            { label: 'Last Seen', value: formatDate(agent.last_seen_at) },
-            { label: 'Borg', value: borgValue },
+            {
+              label: t('managedAgents.page.os'),
+              value: [agent.os, agent.arch].filter(Boolean).join(' / ') || '—',
+            },
+            { label: t('managedAgents.agent'), value: agent.agent_version || '—' },
+            {
+              label: t('managedAgents.page.lastSeen'),
+              value: formatDate(agent.last_seen_at, t('managedAgents.page.never')),
+            },
+            { label: t('managedAgents.page.borg'), value: borgValue },
           ]
 
           return (
@@ -1466,10 +1533,10 @@ export function AgentList({
                     variant="subtitle1"
                     fontWeight={700}
                     noWrap
-                    title={getAgentLabel(agent)}
+                    title={getAgentLabel(agent, t('managedAgents.page.unknownAgent'))}
                     sx={{ lineHeight: 1.3, mb: 0.25 }}
                   >
-                    {getAgentLabel(agent)}
+                    {getAgentLabel(agent, t('managedAgents.page.unknownAgent'))}
                   </Typography>
 
                   <Typography
@@ -1577,11 +1644,10 @@ export function AgentList({
                     }}
                   >
                     <Typography variant="body2" fontWeight={700}>
-                      No usable Borg binary reported
+                      {t('managedAgents.page.noBorg.title')}
                     </Typography>
                     <Typography variant="caption" color="text.secondary">
-                      Install Borg on this agent or regenerate the setup command with Borg
-                      installation enabled.
+                      {t('managedAgents.page.noBorg.description')}
                     </Typography>
                   </Alert>
                 )}
@@ -1598,10 +1664,10 @@ export function AgentList({
                     borderColor: isDark ? alpha('#fff', 0.06) : alpha('#000', 0.07),
                   }}
                 >
-                  <Tooltip title="Run diagnostics" arrow>
+                  <Tooltip title={t('managedAgents.page.actions.runDiagnostics')} arrow>
                     <IconButton
                       size="small"
-                      aria-label="Run diagnostics"
+                      aria-label={t('managedAgents.page.actions.runDiagnostics')}
                       onClick={() => {
                         trackSystem(EventAction.START, {
                           section: MANAGED_AGENTS_ANALYTICS_SECTION,
@@ -1624,10 +1690,10 @@ export function AgentList({
                       <Activity size={16} />
                     </IconButton>
                   </Tooltip>
-                  <Tooltip title="View agent logs" arrow>
+                  <Tooltip title={t('managedAgents.page.actions.viewAgentLogs')} arrow>
                     <IconButton
                       size="small"
-                      aria-label="View agent logs"
+                      aria-label={t('managedAgents.page.actions.viewAgentLogs')}
                       onClick={() => onViewLogs(agent)}
                       sx={{
                         width: { xs: 40, sm: 34 },
@@ -1643,10 +1709,10 @@ export function AgentList({
                       <Eye size={16} />
                     </IconButton>
                   </Tooltip>
-                  <Tooltip title="Reinstall agent" arrow>
+                  <Tooltip title={t('managedAgents.page.actions.reinstallAgent')} arrow>
                     <IconButton
                       size="small"
-                      aria-label="Reinstall agent"
+                      aria-label={t('managedAgents.page.actions.reinstallAgent')}
                       onClick={() => {
                         trackSystem(EventAction.VIEW, {
                           section: MANAGED_AGENTS_ANALYTICS_SECTION,
@@ -1670,11 +1736,11 @@ export function AgentList({
                       <RefreshCw size={16} />
                     </IconButton>
                   </Tooltip>
-                  <Tooltip title="Revoke access" arrow>
+                  <Tooltip title={t('managedAgents.page.actions.revokeAccess')} arrow>
                     <span>
                       <IconButton
                         size="small"
-                        aria-label="Revoke agent"
+                        aria-label={t('managedAgents.page.actions.revokeAgent')}
                         onClick={() => onRevoke(agent)}
                         disabled={isRevoking || agent.status === 'revoked'}
                         sx={{
@@ -1693,11 +1759,11 @@ export function AgentList({
                       </IconButton>
                     </span>
                   </Tooltip>
-                  <Tooltip title="Delete agent" arrow>
+                  <Tooltip title={t('managedAgents.page.actions.deleteAgent')} arrow>
                     <span>
                       <IconButton
                         size="small"
-                        aria-label="Delete agent"
+                        aria-label={t('managedAgents.page.actions.deleteAgent')}
                         onClick={() => setDeleteTarget(agent)}
                         disabled={isDeleting}
                         sx={{
@@ -1760,6 +1826,7 @@ export function AgentSessionLogsDialog({
   loading?: boolean
   onClose: () => void
 }) {
+  const { t } = useTranslation()
   const handleFetchLogs = useCallback<LogViewerFetchLogs>(
     async (offset: number) => {
       if (!agent || loading) return EMPTY_LOG_RESULT
@@ -1778,8 +1845,14 @@ export function AgentSessionLogsDialog({
       job={agent ? { id: agent.id, status, type: 'agent' } : null}
       open={!!agent}
       onClose={onClose}
-      title={agent ? `Agent Logs - ${getAgentLabel(agent)}` : 'Agent Logs'}
-      jobTypeLabel="Agent"
+      title={
+        agent
+          ? t('managedAgents.page.logs.agentTitle', {
+              name: getAgentLabel(agent, t('managedAgents.page.unknownAgent')),
+            })
+          : t('managedAgents.page.logs.agent')
+      }
+      jobTypeLabel={t('managedAgents.agent')}
       onFetchLogs={handleFetchLogs}
     />
   )
@@ -1794,6 +1867,7 @@ export function AgentJobLogsDialog({
   logs?: AgentJobLogEntryResponse[]
   onClose: () => void
 }) {
+  const { t } = useTranslation()
   const handleFetchLogs = useCallback<LogViewerFetchLogs>(
     async (offset: number) => {
       if (!job) return EMPTY_LOG_RESULT
@@ -1810,8 +1884,12 @@ export function AgentJobLogsDialog({
       job={job ? { ...job, type: 'agent job' } : null}
       open={!!job}
       onClose={onClose}
-      title={job ? `Agent Job Logs - Job #${job.id}` : 'Agent Job Logs'}
-      jobTypeLabel="Agent Job"
+      title={
+        job
+          ? t('managedAgents.page.logs.jobTitle', { id: job.id })
+          : t('managedAgents.page.logs.job')
+      }
+      jobTypeLabel={t('managedAgents.page.logs.job')}
       onFetchLogs={handleFetchLogs}
     />
   )
@@ -1830,8 +1908,9 @@ export function JobsTable({
   onViewLogs: (job: AgentJobResponse) => void
   isCanceling: boolean
 }) {
+  const { t } = useTranslation()
   if (!jobs.length) {
-    return <Alert severity="info">No agent jobs yet.</Alert>
+    return <Alert severity="info">{t('managedAgents.page.emptyJobs')}</Alert>
   }
 
   return (
@@ -1839,12 +1918,12 @@ export function JobsTable({
       <Table>
         <TableHead>
           <TableRow>
-            <TableCell>Job</TableCell>
-            <TableCell>Agent</TableCell>
-            <TableCell>Status</TableCell>
-            <TableCell>Progress</TableCell>
-            <TableCell>Updated</TableCell>
-            <TableCell align="right">Actions</TableCell>
+            <TableCell>{t('managedAgents.page.table.job')}</TableCell>
+            <TableCell>{t('managedAgents.agent')}</TableCell>
+            <TableCell>{t('managedAgents.page.table.status')}</TableCell>
+            <TableCell>{t('managedAgents.page.table.progress')}</TableCell>
+            <TableCell>{t('managedAgents.page.table.updated')}</TableCell>
+            <TableCell align="right">{t('managedAgents.page.table.actions')}</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -1859,7 +1938,7 @@ export function JobsTable({
                     {getJobKind(job)}
                   </Typography>
                 </TableCell>
-                <TableCell>{getAgentLabel(agent)}</TableCell>
+                <TableCell>{getAgentLabel(agent, t('managedAgents.page.unknownAgent'))}</TableCell>
                 <TableCell>
                   <Chip label={job.status} color={statusChipColor(job.status)} size="small" />
                 </TableCell>
@@ -1873,14 +1952,14 @@ export function JobsTable({
                     {Math.round(job.progress_percent ?? 0)}%
                   </Typography>
                 </TableCell>
-                <TableCell>{formatDate(job.updated_at)}</TableCell>
+                <TableCell>{formatDate(job.updated_at, t('managedAgents.page.never'))}</TableCell>
                 <TableCell align="right">
-                  <Tooltip title="View logs">
+                  <Tooltip title={t('managedAgents.page.actions.viewLogs')}>
                     <IconButton onClick={() => onViewLogs(job)}>
                       <Eye size={18} />
                     </IconButton>
                   </Tooltip>
-                  <Tooltip title="Cancel job">
+                  <Tooltip title={t('managedAgents.page.actions.cancelJob')}>
                     <span>
                       <IconButton
                         color="warning"
@@ -1917,8 +1996,9 @@ export function TokensTable({
   onRevoke: (tokenId: number) => void
   isRevoking: boolean
 }) {
+  const { t } = useTranslation()
   if (!tokens.length) {
-    return <Alert severity="info">No enrollment tokens created.</Alert>
+    return <Alert severity="info">{t('managedAgents.page.emptyTokens')}</Alert>
   }
 
   return (
@@ -1926,11 +2006,11 @@ export function TokensTable({
       <Table>
         <TableHead>
           <TableRow>
-            <TableCell>Name</TableCell>
-            <TableCell>Prefix</TableCell>
-            <TableCell>Status</TableCell>
-            <TableCell>Expires</TableCell>
-            <TableCell align="right">Actions</TableCell>
+            <TableCell>{t('managedAgents.page.table.name')}</TableCell>
+            <TableCell>{t('managedAgents.page.table.prefix')}</TableCell>
+            <TableCell>{t('managedAgents.page.table.status')}</TableCell>
+            <TableCell>{t('managedAgents.page.table.expires')}</TableCell>
+            <TableCell align="right">{t('managedAgents.page.table.actions')}</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -1956,9 +2036,9 @@ export function TokensTable({
                     size="small"
                   />
                 </TableCell>
-                <TableCell>{formatDate(token.expires_at)}</TableCell>
+                <TableCell>{formatDate(token.expires_at, t('managedAgents.page.never'))}</TableCell>
                 <TableCell align="right">
-                  <Tooltip title="Revoke token">
+                  <Tooltip title={t('managedAgents.page.actions.revokeToken')}>
                     <span>
                       <IconButton
                         color="error"

--- a/frontend/src/pages/ManagedAgents.tsx
+++ b/frontend/src/pages/ManagedAgents.tsx
@@ -10,7 +10,6 @@ import {
   Button,
   Chip,
   CircularProgress,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -754,15 +753,22 @@ export function AgentSetupGuide({
         onCopy={() => onCopy(command)}
       />
 
-      <Dialog open={helpOpen} onClose={() => setHelpOpen(false)} fullWidth maxWidth="md">
+      <ResponsiveDialog
+        open={helpOpen}
+        onClose={() => setHelpOpen(false)}
+        fullWidth
+        maxWidth="md"
+        footer={
+          <DialogActions>
+            <Button onClick={() => setHelpOpen(false)}>{t('common.buttons.close')}</Button>
+          </DialogActions>
+        }
+      >
         <DialogTitle>{t('managedAgents.setupGuide.title')}</DialogTitle>
         <DialogContent>
           <AgentSetupHelpContent command={command} onCopy={onCopy} />
         </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setHelpOpen(false)}>{t('common.buttons.close')}</Button>
-        </DialogActions>
-      </Dialog>
+      </ResponsiveDialog>
     </Box>
   )
 }
@@ -1292,7 +1298,28 @@ export function AgentDeleteConfirmationDialog({
 }) {
   const { t } = useTranslation()
   return (
-    <Dialog open={open} onClose={onCancel} fullWidth maxWidth="xs">
+    <ResponsiveDialog
+      open={open}
+      onClose={onCancel}
+      fullWidth
+      maxWidth="xs"
+      footer={
+        <DialogActions>
+          <Button onClick={onCancel}>{t('common.buttons.cancel')}</Button>
+          <Button
+            color="error"
+            variant="contained"
+            disabled={isDeleting || !agent}
+            onClick={() => {
+              if (!agent) return
+              onConfirm(agent)
+            }}
+          >
+            {t('managedAgents.page.deleteDialog.confirm')}
+          </Button>
+        </DialogActions>
+      }
+    >
       <DialogTitle>{t('managedAgents.page.deleteDialog.title')}</DialogTitle>
       <DialogContent>
         <Stack spacing={1.5} sx={{ mt: 0.5 }}>
@@ -1304,21 +1331,7 @@ export function AgentDeleteConfirmationDialog({
           </Typography>
         </Stack>
       </DialogContent>
-      <DialogActions>
-        <Button onClick={onCancel}>{t('common.buttons.cancel')}</Button>
-        <Button
-          color="error"
-          variant="contained"
-          disabled={isDeleting || !agent}
-          onClick={() => {
-            if (!agent) return
-            onConfirm(agent)
-          }}
-        >
-          {t('managedAgents.page.deleteDialog.confirm')}
-        </Button>
-      </DialogActions>
-    </Dialog>
+    </ResponsiveDialog>
   )
 }
 
@@ -1339,7 +1352,17 @@ export function AgentReinstallDialog({
   const command = buildAgentReinstallCommand(serverUrl)
 
   return (
-    <Dialog open={open} onClose={onCancel} fullWidth maxWidth="md">
+    <ResponsiveDialog
+      open={open}
+      onClose={onCancel}
+      fullWidth
+      maxWidth="md"
+      footer={
+        <DialogActions>
+          <Button onClick={onCancel}>{t('common.buttons.close')}</Button>
+        </DialogActions>
+      }
+    >
       <DialogTitle>{t('managedAgents.page.reinstallDialog.title')}</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 0.5 }}>
@@ -1362,10 +1385,7 @@ export function AgentReinstallDialog({
           </Alert>
         </Stack>
       </DialogContent>
-      <DialogActions>
-        <Button onClick={onCancel}>{t('common.buttons.close')}</Button>
-      </DialogActions>
-    </Dialog>
+    </ResponsiveDialog>
   )
 }
 

--- a/frontend/src/pages/Repositories.tsx
+++ b/frontend/src/pages/Repositories.tsx
@@ -566,7 +566,7 @@ export default function Repositories() {
 
   // Event handlers
   const handleDeleteRepository = (repository: Repository) => {
-    if (window.confirm(`Are you sure you want to delete repository "${repository.name}"?`)) {
+    if (window.confirm(t('repositories.deleteConfirmation', { name: repository.name }))) {
       deleteRepositoryMutation.mutate(repository.id)
     }
   }

--- a/frontend/src/pages/SSHConnectionsSingleKey.tsx
+++ b/frontend/src/pages/SSHConnectionsSingleKey.tsx
@@ -342,9 +342,9 @@ export default function SSHConnectionsSingleKey() {
   // Handlers
   const handleGenerateKey = () => {
     generateKeyMutation.mutate({
-      name: 'System SSH Key',
+      name: t('sshConnections.systemKey.title'),
       key_type: keyType,
-      description: 'System SSH key for all remote connections',
+      description: t('sshConnections.systemKey.defaultDescription'),
     })
   }
 

--- a/frontend/src/pages/Scripts.tsx
+++ b/frontend/src/pages/Scripts.tsx
@@ -603,12 +603,12 @@ export default function Scripts() {
                           <Box sx={{ display: 'flex', gap: 1, mt: 0.5 }}>
                             {param.default && (
                               <Typography variant="caption" color="text.secondary">
-                                Default: {param.default}
+                                {t('common.default')} {param.default}
                               </Typography>
                             )}
                             {param.required && (
                               <Chip
-                                label="Required"
+                                label={t('common.required')}
                                 size="small"
                                 color="error"
                                 variant="outlined"

--- a/frontend/src/pages/__tests__/CloudStorage.test.tsx
+++ b/frontend/src/pages/__tests__/CloudStorage.test.tsx
@@ -292,7 +292,7 @@ describe('CloudStorage', () => {
     expect(await screen.findByText('prod-s3')).toBeInTheDocument()
     const card = screen.getByTestId('cloud-storage-remote-prod-s3')
     expect(within(card).getByText('s3')).toBeInTheDocument()
-    expect(within(card).getAllByText('connected').length).toBeGreaterThan(0)
+    expect(within(card).getAllByText('Connected').length).toBeGreaterThan(0)
     expect(within(card).getByText('2 repositories')).toBeInTheDocument()
     expect(
       screen.getByText('Manage reusable rclone remotes for repository mirrors.')

--- a/frontend/src/pages/managed-agents/AddAgentDialog.tsx
+++ b/frontend/src/pages/managed-agents/AddAgentDialog.tsx
@@ -20,6 +20,7 @@ import {
   Typography,
 } from '@mui/material'
 import { AlertTriangle, Globe, Laptop, Monitor, Server, Settings, Terminal } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import WizardDialog, { type WizardStep } from '../../components/shared/WizardDialog'
 import type {
   AgentEnrollmentTokenCreate,
@@ -31,12 +32,6 @@ import type { AgentServiceUserMode, BorgInstallMode } from './agentInstallComman
 import { isLocalAgentServerUrl, normalizeAgentServerUrl } from './agentServerUrl'
 
 type WizardStepIndex = 0 | 1 | 2
-
-const wizardSteps: WizardStep[] = [
-  { key: 'location', label: 'Target', icon: <Globe size={16} /> },
-  { key: 'config', label: 'Details', icon: <Settings size={16} /> },
-  { key: 'review', label: 'Install', icon: <Terminal size={16} /> },
-]
 
 function InlineWarning({ children }: { children: ReactNode }) {
   return (
@@ -71,62 +66,11 @@ function InlineWarning({ children }: { children: ReactNode }) {
 
 type ExpiryOption = '1h' | '24h' | '7d' | '30d' | 'never'
 
-const expiryOptions: Array<{ value: ExpiryOption; label: string }> = [
-  { value: '1h', label: '1 hour' },
-  { value: '24h', label: '24 hours' },
-  { value: '7d', label: '7 days' },
-  { value: '30d', label: '30 days' },
-  { value: 'never', label: 'Never' },
-]
+const expiryOptions: ExpiryOption[] = ['1h', '24h', '7d', '30d', 'never']
 
-const borgInstallOptions: Array<{
-  value: BorgInstallMode
-  label: string
-  description: string
-}> = [
-  {
-    value: 'borg1',
-    label: 'Borg 1.x',
-    description: "Default. Installs or verifies Borg 1 as 'borg'.",
-  },
-  {
-    value: 'borg2',
-    label: 'Borg 2.x beta only',
-    description: "Advanced experimental option. Installs or verifies Borg 2 as 'borg2'.",
-  },
-  {
-    value: 'both',
-    label: 'Borg 1.x and Borg 2.x beta',
-    description: "Advanced experimental option. Keeps Borg 1 as 'borg' and Borg 2 as 'borg2'.",
-  },
-  {
-    value: 'skip',
-    label: 'Skip Borg install',
-    description: 'Use this when Borg is managed separately on the agent machine.',
-  },
-]
+const borgInstallOptions: BorgInstallMode[] = ['borg1', 'borg2', 'both', 'skip']
 
-const serviceUserOptions: Array<{
-  value: AgentServiceUserMode
-  label: string
-  description: string
-}> = [
-  {
-    value: 'current',
-    label: 'Installing user',
-    description: 'The agent can access the same files as the user running the installer.',
-  },
-  {
-    value: 'dedicated',
-    label: 'Dedicated borg-ui-agent user',
-    description: 'Use a separate low-privilege service account for stricter isolation.',
-  },
-  {
-    value: 'root',
-    label: 'Root',
-    description: 'Use only when the agent must back up root-owned paths.',
-  },
-]
+const serviceUserOptions: AgentServiceUserMode[] = ['current', 'dedicated', 'root']
 
 function expiryPayload(option: ExpiryOption): Omit<AgentEnrollmentTokenCreate, 'name'> {
   switch (option) {
@@ -190,6 +134,12 @@ export default function AddAgentDialog({
   initialBorgInstallMode?: BorgInstallMode
   initialServiceUserMode?: AgentServiceUserMode
 }) {
+  const { t } = useTranslation()
+  const wizardSteps: WizardStep[] = [
+    { key: 'location', label: t('managedAgents.add.steps.target'), icon: <Globe size={16} /> },
+    { key: 'config', label: t('managedAgents.add.steps.details'), icon: <Settings size={16} /> },
+    { key: 'review', label: t('managedAgents.add.steps.install'), icon: <Terminal size={16} /> },
+  ]
   const [step, setStep] = useState<WizardStepIndex>(0)
   const [agentName, setAgentName] = useState(initialAgentName)
   const [expiry, setExpiry] = useState<ExpiryOption>('7d')
@@ -243,8 +193,9 @@ export default function AddAgentDialog({
   const serverUrlIsInvalid = !normalizedServerUrl.startsWith('http')
   const canContinue =
     step === 0 ? !serverUrlIsInvalid : step === 1 ? agentName.trim().length > 0 : true
-  const selectedServiceUserOption =
-    serviceUserOptions.find((option) => option.value === serviceUserMode) || serviceUserOptions[0]
+  const selectedServiceUserOption = serviceUserOptions.includes(serviceUserMode)
+    ? serviceUserMode
+    : serviceUserOptions[0]
   const isRootServiceUser = serviceUserMode === 'root'
 
   const handleGenerate = async () => {
@@ -262,7 +213,7 @@ export default function AddAgentDialog({
       const message =
         err && typeof err === 'object' && 'message' in err
           ? String((err as { message?: string }).message)
-          : 'Failed to create enrollment token'
+          : t('managedAgents.add.errors.createToken')
       setError(message)
     }
   }
@@ -271,7 +222,7 @@ export default function AddAgentDialog({
     <Stack spacing={2.5}>
       <Stack spacing={1.25}>
         <Typography variant="overline" color="text.secondary" sx={{ letterSpacing: 0.6 }}>
-          Platform
+          {t('managedAgents.add.platform')}
         </Typography>
         <Box
           sx={{
@@ -292,19 +243,19 @@ export default function AddAgentDialog({
             <Stack spacing={1}>
               <Stack direction="row" spacing={1} alignItems="center">
                 <Server size={18} />
-                <Typography fontWeight={700}>Linux</Typography>
+                <Typography fontWeight={700}>{t('managedAgents.add.platforms.linux')}</Typography>
               </Stack>
               <Chip
                 size="small"
                 color="primary"
-                label="Selected"
+                label={t('managedAgents.add.selected')}
                 sx={{ alignSelf: 'flex-start' }}
               />
             </Stack>
           </Paper>
           {[
-            { label: 'macOS', Icon: Laptop },
-            { label: 'Windows', Icon: Monitor },
+            { label: t('managedAgents.add.platforms.macos'), Icon: Laptop },
+            { label: t('managedAgents.add.platforms.windows'), Icon: Monitor },
           ].map(({ label, Icon }) => (
             <Paper
               key={label}
@@ -316,7 +267,11 @@ export default function AddAgentDialog({
                   <Icon size={18} />
                   <Typography fontWeight={700}>{label}</Typography>
                 </Stack>
-                <Chip size="small" label="Coming later" sx={{ alignSelf: 'flex-start' }} />
+                <Chip
+                  size="small"
+                  label={t('managedAgents.add.comingLater')}
+                  sx={{ alignSelf: 'flex-start' }}
+                />
               </Stack>
             </Paper>
           ))}
@@ -324,21 +279,18 @@ export default function AddAgentDialog({
       </Stack>
       <Stack spacing={1.25}>
         <Typography variant="overline" color="text.secondary" sx={{ letterSpacing: 0.6 }}>
-          Server URL
+          {t('managedAgents.add.serverUrl')}
         </Typography>
         <TextField
-          label="Server URL"
+          label={t('managedAgents.add.serverUrl')}
           value={serverUrl}
           onChange={(event) => setServerUrl(event.target.value)}
           error={serverUrlIsInvalid}
           helperText={
             isLocalAgentServerUrl(normalizedServerUrl) && !serverUrlIsInvalid ? (
-              <InlineWarning>
-                localhost only works when the agent runs on the same machine as Borg UI. Remote
-                machines need a reachable host name, IP, or HTTPS URL.
-              </InlineWarning>
+              <InlineWarning>{t('managedAgents.add.localhostWarning')}</InlineWarning>
             ) : (
-              'This URL must be reachable from the agent machine.'
+              t('managedAgents.add.serverUrlHelper')
             )
           }
           FormHelperTextProps={{
@@ -359,52 +311,52 @@ export default function AddAgentDialog({
   const renderDetailsStep = () => (
     <Stack spacing={2}>
       <TextField
-        label="Agent name"
+        label={t('managedAgents.add.agentName')}
         value={agentName}
         onChange={(event) => setAgentName(event.target.value)}
         fullWidth
         autoFocus
       />
       <TextField
-        label="Default path"
+        label={t('managedAgents.add.defaultPath')}
         value={defaultPath}
         onChange={(event) => setDefaultPath(event.target.value)}
         placeholder="/home/karanhudia"
-        helperText="Starting directory for browsing this agent's files."
+        helperText={t('managedAgents.add.defaultPathHelper')}
         fullWidth
       />
       <FormControl fullWidth>
-        <InputLabel id="agent-token-expiry-label">Token expiry</InputLabel>
+        <InputLabel id="agent-token-expiry-label">{t('managedAgents.add.tokenExpiry')}</InputLabel>
         <Select
           labelId="agent-token-expiry-label"
-          label="Token expiry"
+          label={t('managedAgents.add.tokenExpiry')}
           value={expiry}
           onChange={(event) => setExpiry(event.target.value as ExpiryOption)}
         >
           {expiryOptions.map((option) => (
-            <MenuItem key={option.value} value={option.value}>
-              {option.label}
+            <MenuItem key={option} value={option}>
+              {t(`managedAgents.add.expiry.${option}`)}
             </MenuItem>
           ))}
         </Select>
       </FormControl>
       <FormControl fullWidth>
-        <InputLabel id="agent-service-user-label">Service user</InputLabel>
+        <InputLabel id="agent-service-user-label">{t('managedAgents.add.serviceUser')}</InputLabel>
         <Select
           labelId="agent-service-user-label"
-          label="Service user"
+          label={t('managedAgents.add.serviceUser')}
           value={serviceUserMode}
-          renderValue={(value) =>
-            serviceUserOptions.find((option) => option.value === value)?.label || 'Installing user'
-          }
+          renderValue={(value) => t(`managedAgents.add.serviceUsers.${value}.label`)}
           onChange={(event) => setServiceUserMode(event.target.value as AgentServiceUserMode)}
         >
           {serviceUserOptions.map((option) => (
-            <MenuItem key={option.value} value={option.value}>
+            <MenuItem key={option} value={option}>
               <Stack spacing={0.25}>
-                <Typography fontWeight={700}>{option.label}</Typography>
+                <Typography fontWeight={700}>
+                  {t(`managedAgents.add.serviceUsers.${option}.label`)}
+                </Typography>
                 <Typography variant="body2" color="text.secondary">
-                  {option.description}
+                  {t(`managedAgents.add.serviceUsers.${option}.description`)}
                 </Typography>
               </Stack>
             </MenuItem>
@@ -415,17 +367,14 @@ export default function AddAgentDialog({
           sx={{ mx: 0, color: isRootServiceUser ? 'warning.main' : undefined }}
         >
           {isRootServiceUser ? (
-            <InlineWarning>
-              Root mode lets this agent run root-level Borg operations. Use it only for root-owned
-              paths.
-            </InlineWarning>
+            <InlineWarning>{t('managedAgents.add.rootWarning')}</InlineWarning>
           ) : (
-            selectedServiceUserOption.description
+            t(`managedAgents.add.serviceUsers.${selectedServiceUserOption}.description`)
           )}
         </FormHelperText>
       </FormControl>
       <FormControl component="fieldset">
-        <FormLabel component="legend">Borg installation</FormLabel>
+        <FormLabel component="legend">{t('managedAgents.add.borgInstallation')}</FormLabel>
         <RadioGroup
           value={borgInstallMode}
           onChange={(event) => setBorgInstallMode(event.target.value as BorgInstallMode)}
@@ -437,17 +386,19 @@ export default function AddAgentDialog({
           }}
         >
           {borgInstallOptions.map((option) => {
-            const selected = borgInstallMode === option.value
+            const selected = borgInstallMode === option
             return (
               <FormControlLabel
-                key={option.value}
-                value={option.value}
+                key={option}
+                value={option}
                 control={<Radio />}
                 label={
                   <Stack spacing={0.35} sx={{ minWidth: 0 }}>
-                    <Typography fontWeight={700}>{option.label}</Typography>
+                    <Typography fontWeight={700}>
+                      {t(`managedAgents.add.borgOptions.${option}.label`)}
+                    </Typography>
                     <Typography variant="body2" color="text.secondary">
-                      {option.description}
+                      {t(`managedAgents.add.borgOptions.${option}.description`)}
                     </Typography>
                   </Stack>
                 }
@@ -495,7 +446,7 @@ export default function AddAgentDialog({
       title={
         <Stack direction="row" spacing={1} alignItems="center">
           <Terminal size={19} />
-          <span>Add Agent</span>
+          <span>{t('managedAgents.add.title')}</span>
         </Stack>
       }
       steps={wizardSteps}
@@ -506,17 +457,19 @@ export default function AddAgentDialog({
       }}
       footer={
         <DialogActions sx={{ px: { xs: 1, sm: 3 }, pb: { xs: 1, sm: 2 } }}>
-          <Button onClick={onClose}>{step === 2 ? 'Close' : 'Cancel'}</Button>
+          <Button onClick={onClose}>
+            {step === 2 ? t('common.buttons.close') : t('common.buttons.cancel')}
+          </Button>
           <Box sx={{ flex: 1 }} />
           <Button
             disabled={step === 0 || creatingToken}
             onClick={() => setStep((step - 1) as WizardStepIndex)}
           >
-            Back
+            {t('common.buttons.back')}
           </Button>
           {step === 0 ? (
             <Button variant="contained" onClick={() => setStep(1)} disabled={!canContinue}>
-              Next
+              {t('common.buttons.next')}
             </Button>
           ) : step === 1 ? (
             <Button
@@ -524,7 +477,7 @@ export default function AddAgentDialog({
               onClick={handleGenerate}
               disabled={!canContinue || creatingToken}
             >
-              Generate install command
+              {t('managedAgents.add.generateInstallCommand')}
             </Button>
           ) : null}
         </DialogActions>

--- a/frontend/src/pages/managed-agents/AgentInstallCommand.tsx
+++ b/frontend/src/pages/managed-agents/AgentInstallCommand.tsx
@@ -1,6 +1,7 @@
 import { Box, Button, Stack, Tooltip, Typography } from '@mui/material'
 import { alpha, keyframes } from '@mui/material/styles'
 import { CheckCircle, Copy, Loader2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import type { AgentMachineResponse } from '../../services/api'
 import {
   buildAgentInstallCommand,
@@ -30,6 +31,7 @@ export default function AgentInstallCommand({
   connectedAgent?: AgentMachineResponse | null
   onCopy: (value: string) => void
 }) {
+  const { t } = useTranslation()
   const command = buildAgentInstallCommand(
     serverUrl,
     token,
@@ -41,7 +43,7 @@ export default function AgentInstallCommand({
   return (
     <Stack spacing={1.5}>
       <Typography variant="subtitle2" fontWeight={700}>
-        Install command
+        {t('managedAgents.installCommand.title')}
       </Typography>
       <Box sx={{ position: 'relative', minWidth: 0 }}>
         <Box
@@ -64,9 +66,9 @@ export default function AgentInstallCommand({
         >
           {command}
         </Box>
-        <Tooltip title="Copy install command">
+        <Tooltip title={t('managedAgents.installCommand.copy')}>
           <Button
-            aria-label="Copy install command"
+            aria-label={t('managedAgents.installCommand.copy')}
             variant="outlined"
             size="small"
             onClick={() => onCopy(command)}
@@ -97,8 +99,7 @@ export default function AgentInstallCommand({
         </Tooltip>
       </Box>
       <Typography variant="body2" color="text.secondary">
-        Run the command on the Linux machine. The installer registers the agent and enables the
-        systemd service by default.
+        {t('managedAgents.installCommand.description')}
       </Typography>
       <Box
         sx={{
@@ -138,13 +139,15 @@ export default function AgentInstallCommand({
         <Stack spacing={0.25} sx={{ minWidth: 0 }}>
           <Typography variant="body2" fontWeight={600}>
             {connectedAgent
-              ? `${connectedAgent.name || connectedAgent.hostname || 'Agent'} connected`
-              : 'Waiting for agent to connect…'}
+              ? t('managedAgents.installCommand.connected', {
+                  name: connectedAgent.name || connectedAgent.hostname || t('managedAgents.agent'),
+                })
+              : t('managedAgents.installCommand.waiting')}
           </Typography>
           <Typography variant="caption" color="text.secondary">
             {connectedAgent
-              ? 'You can close this dialog; the agent will keep running.'
-              : 'This page will update automatically once the install completes.'}
+              ? t('managedAgents.installCommand.connectedDescription')
+              : t('managedAgents.installCommand.waitingDescription')}
           </Typography>
         </Stack>
       </Box>


### PR DESCRIPTION
## Description

Completes the #775 audit of user-facing English literals in production frontend components. The PR now translates the audited strings across managed agents, account and authentication, backup plans, schedules, archives, cloud storage, notifications, shared controls, and wizard surfaces. All new copy has English, German, Spanish, and Italian entries.

Technical values and identifiers remain intentionally unchanged: Borg versions, protocol names, commands, machine-readable defaults, and Storybook fixture copy.

## Related Issue

Fixes #775

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [x] ♻️ Refactoring

## Testing

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Validated with:

- `npm run check:locales`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npx vitest run src/components/__tests__/ArchivesList.test.tsx src/pages/__tests__/Scripts.test.tsx --reporter=verbose`

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable. This change localizes existing UI without altering layout or interaction.

## Additional Context

The included implementation plan records the audit scope and verification approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized user-facing text across account, backup, scheduling, repository, cloud storage, diagnostics, managed-agent, wizard, and API-token interfaces.
  * Expanded English, German, Spanish, and Italian translations, including actions, statuses, errors, dialogs, accessibility labels, and dynamic messages.
  * Improved localized fallbacks for unknown values, empty states, repository labels, and status displays.

* **Bug Fixes**
  * Corrected untranslated and inconsistently labeled interface text while preserving existing workflows.

* **Documentation**
  * Added frontend internationalization planning and validation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 17 changed, 0 added, 0 removed, 441 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-811/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/31707380810
<details>
<summary>Changed files</summary>
- `backup-plans-sourceselectiondialog--database-scan-remote-target.png` (6.78%)
- `components-richselect--default--mobile.png` (0.01%)
- `components-wizard-rclone-remote-dialog--borg-ui-o-auth-credentials-partially-saved--mobile.png` (0.00%)
- `components-wizard-rclone-remote-dialog--borg-ui-o-auth-setup-missing--mobile.png` (0.00%)
- `components-wizard-rclone-remote-dialog--guided-google-drive-remote--mobile.png` (0.03%)
- `pages-cloudstorage--add-guided-remote-setup-missing.png` (0.10%)
- `pages-cloudstorage--add-guided-remote.png` (0.10%)
- `pages-cloudstorage--browse-dialog.png` (0.13%)
- `pages-cloudstorage--delete-confirmation--mobile.png` (0.23%)
- `pages-cloudstorage--delete-confirmation.png` (0.25%)
- `pages-cloudstorage--editing-remote.png` (0.10%)
- `pages-cloudstorage--locked-community--mobile.png` (0.37%)
- `pages-cloudstorage--locked-community.png` (0.27%)
- `pages-cloudstorage--overview--mobile.png` (0.41%)
- `pages-cloudstorage--overview.png` (0.33%)
- `pages-managedagents--agent-reinstall-dialog-open--mobile.png` (73.77%)
- `pages-managedagents--delete-confirmation--mobile.png` (67.91%)
</details>
<details>
<summary>New screenshots</summary>
- None
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->