### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,11 @@ For teams that need commercial support, larger rollouts, or an enterprise conver
 
 <div align="center">
 
-<a href="https://star-history.com/#karanhudia/borg-ui&Date">
+<a href="https://star-history.dera.page/#karanhudia/borg-ui&type=Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=karanhudia/borg-ui&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=karanhudia/borg-ui&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=karanhudia/borg-ui&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=karanhudia/borg-ui&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=karanhudia/borg-ui&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=karanhudia/borg-ui&type=Date" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken and does not render properly. This change updates the chart link and image sources so the chart works again and displays correctly for both light and dark themes.