### PR TITLE
style(frontend): restore prettier 3.9.6 formatting (unbreaks Code Quality on every PR)

### DIFF
--- a/frontend/src/components/RepositoryScriptsTab.tsx
+++ b/frontend/src/components/RepositoryScriptsTab.tsx
@@ -403,11 +403,7 @@ export default function RepositoryScriptsTab({
                   size="small"
                   color={
                     getRunOnColor(effectiveRunOn) as
-                      | 'success'
-                      | 'error'
-                      | 'warning'
-                      | 'info'
-                      | 'default'
+                      'success' | 'error' | 'warning' | 'info' | 'default'
                   }
                   sx={{ height: 20, fontSize: '0.7rem' }}
                 />

--- a/frontend/src/components/SystemSettingsTab.tsx
+++ b/frontend/src/components/SystemSettingsTab.tsx
@@ -132,8 +132,7 @@ const SystemSettingsTab: React.FC = () => {
   const cacheStats = cacheData
   const systemSettings = systemData?.settings
   const timeoutSources = systemSettings?.timeout_sources as
-    | Record<string, string | null>
-    | undefined
+    Record<string, string | null> | undefined
   const proxyAuthConfig = authConfigData
 
   useEffect(() => {

--- a/frontend/src/components/__tests__/ScheduleJobCard.test.tsx
+++ b/frontend/src/components/__tests__/ScheduleJobCard.test.tsx
@@ -140,8 +140,7 @@ describe('ScheduleJobCard', () => {
     )
 
     const props = entityCardMock.mock.lastCall?.[0] as
-      | { primaryAction?: { disabled?: boolean } }
-      | undefined
+      { primaryAction?: { disabled?: boolean } } | undefined
 
     expect(props?.primaryAction?.disabled).toBe(false)
   })
@@ -162,8 +161,7 @@ describe('ScheduleJobCard', () => {
     )
 
     const props = entityCardMock.mock.lastCall?.[0] as
-      | { primaryAction?: { disabled?: boolean } }
-      | undefined
+      { primaryAction?: { disabled?: boolean } } | undefined
 
     expect(props?.primaryAction?.disabled).toBe(true)
   })

--- a/frontend/src/components/shared/RichSelect.tsx
+++ b/frontend/src/components/shared/RichSelect.tsx
@@ -293,9 +293,7 @@ const menuItemSx = {
 }
 
 type RichSelectSxItem =
-  | boolean
-  | SystemStyleObject<Theme>
-  | ((theme: Theme) => SystemStyleObject<Theme>)
+  boolean | SystemStyleObject<Theme> | ((theme: Theme) => SystemStyleObject<Theme>)
 
 function toSxArray(sx?: SxProps<Theme>): RichSelectSxItem[] {
   if (!sx) return []

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -176,10 +176,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
               setAuthError(
                 translateBackendKey(
                   detail as
-                    | string
-                    | { key: string; params?: Record<string, unknown> }
-                    | null
-                    | undefined
+                    string | { key: string; params?: Record<string, unknown> } | null | undefined
                 ) || 'Insecure no-auth mode is enabled but Borg UI could not resolve a local user.'
               )
             }

--- a/frontend/src/pages/dashboard-v3/CapabilityLaunchpad.tsx
+++ b/frontend/src/pages/dashboard-v3/CapabilityLaunchpad.tsx
@@ -6,10 +6,7 @@ import { useT } from './tokens'
 import type { DashboardOverview } from './types'
 
 type LaunchpadRoute =
-  | '/backup-plans'
-  | '/cloud-storage'
-  | '/remote-clients'
-  | '/schedule/restore-checks'
+  '/backup-plans' | '/cloud-storage' | '/remote-clients' | '/schedule/restore-checks'
 type LaunchpadSource = 'backup_plans' | 'cloud_storage' | 'remote_clients' | 'restore_verification'
 
 type LaunchpadCard = {

--- a/frontend/src/pages/ssh-connections-single-key/hostValidation.ts
+++ b/frontend/src/pages/ssh-connections-single-key/hostValidation.ts
@@ -1,6 +1,5 @@
 export type HostValidationResult =
-  | { ok: true; host: string }
-  | { ok: false; errorKey: 'sshConnections.validation.hostBareOnly' }
+  { ok: true; host: string } | { ok: false; errorKey: 'sshConnections.validation.hostBareOnly' }
 
 const HOST_ERROR_KEY = 'sshConnections.validation.hostBareOnly' as const
 const DNS_LABEL_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/

--- a/frontend/src/utils/analyticsProperties.ts
+++ b/frontend/src/utils/analyticsProperties.ts
@@ -1,11 +1,5 @@
 export type JobStatus =
-  | 'pending'
-  | 'running'
-  | 'completed'
-  | 'completed_with_warnings'
-  | 'failed'
-  | 'cancelled'
-  | string
+  'pending' | 'running' | 'completed' | 'completed_with_warnings' | 'failed' | 'cancelled' | string
 
 export const TERMINAL_JOB_STATUSES = new Set<JobStatus>([
   'completed',

--- a/frontend/src/utils/translateBackendKey.ts
+++ b/frontend/src/utils/translateBackendKey.ts
@@ -1,10 +1,7 @@
 import i18n from '../i18n'
 
 export type BackendDetail =
-  | string
-  | { key: string; params?: Record<string, unknown> }
-  | null
-  | undefined
+  string | { key: string; params?: Record<string, unknown> } | null | undefined
 
 /**
  * Translates a backend-originating detail/message value into a user-facing string.


### PR DESCRIPTION
Unbreaks CI for every open PR.

The prettier-normalize sweep (`474bc66c`) appears to have been produced with an older prettier: it reverted the 3.9-style formatting that nine files received in #812 when the repo pin moved to prettier 3.9.6. As a result `npm run format:check` fails **on main itself**, so the **Frontend / Code Quality** check is red on every open PR — including the trivially-green dependabot minors #819/#820 — and dependabot auto-merge is stalled again.

Fix: re-ran the repo's pinned `prettier --write` over the nine files. Formatting only, no code changes (+10/−35 lines). Verified: `format:check` clean, typecheck 0, eslint clean.

Once this lands, #819/#820 should go green on their next run; #816 already carries the same normalization internally (it fixed the drift during its rebase) and will drop the duplicate hunks on its next update.