### PR TITLE
docs(docker): explain supplementary group access

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,10 @@ Most configuration is available in the UI under Settings. Use environment variab
 | `LOCAL_MOUNT_POINTS` | `/local` | Comma-separated container paths shown as local mounts in the file browser |
 | `BASE_PATH` | empty | Sub-path deployment, for example `/borg-ui` |
 
+`PUID` and `PGID` set the Borg UI process's primary identity. If a source is
+readable through an additional host group, add that group's numeric GID with
+Docker Compose `group_add`; see [Permission denied](troubleshooting#permission-denied).
+
 ## Volumes
 
 Required:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -86,6 +86,37 @@ from inside the container can modify user data on the host and can fail for
 read-only mounts. Fix access with host permissions, runtime UID/GID mapping, or
 the rootless Podman `PUID=0` / `PGID=0` mode above.
 
+### Group-readable source paths in Docker
+
+`PUID` and `PGID` set the Borg UI container process's primary user and group;
+they do not grant it access to every supplementary group on the host. This can
+matter when a mounted source directory is readable by a group other than the
+configured `PGID` (for example, a directory owned by `otheruser:photos` with
+mode `2770`).
+
+Add the host group's **numeric GID** to the Borg UI service with `group_add`:
+
+```yaml
+services:
+  app:
+    environment:
+      - PUID=1008
+      - PGID=1008
+    group_add:
+      - "3001" # Host group with read access to the mounted source
+```
+
+Recreate the container after changing Compose. To confirm the running Borg UI
+process has the expected supplementary group, run:
+
+```bash
+docker exec borg-web-ui sh -c "cat /proc/1/status | grep -E 'Uid|Gid|Groups'"
+```
+
+Use the GID of the group that owns or can read the source directory, not a Borg
+UI web-login user. Prefer granting access only to the mounted data Borg UI
+needs rather than running the container as root.
+
 ### Path not found
 
 Check the Docker volume mapping and use the container path, not the host path.


### PR DESCRIPTION
## Description

Documents how to grant Borg UI access to group-readable Docker bind mounts with
Compose `group_add`, including how to identify the correct GID and verify the
running process's supplementary groups.

## Related Issue

None.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass

Validated with `git diff --check`. The repository-wide frontend formatting
command remains red on the nine known baseline files addressed by #828; this PR
does not modify frontend files.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable; documentation-only change.

## Additional Context

This guidance addresses Docker deployments where `PUID` and `PGID` match a host
user but a mounted source is readable through a separate host group.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU Affero General Public License v3.0 (AGPL-3.0), the same license as this project.
