### PR TITLE
chore(deps): bump webauthn to 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,5 +28,5 @@ structlog==26.1.0
 tzdata==2026.3
 uvicorn[standard]==0.52.1
 paho-mqtt==2.1.0
-webauthn==2.7.1
+webauthn==3.0.0
 websocket-client==1.9.0


### PR DESCRIPTION
Supersedes #823 (as announced there) — webauthn 2.7.1 → 3.0.0.

The app's entire webauthn surface is the 14 symbols lazily imported in `app/core/passkeys.py` (`require_webauthn`): the five top-level functions, `base64url_to_bytes`, the two credential-JSON parsers, the two exception types, and the four structs. All 14 resolve unchanged under 3.0.0 (verified by import probe), so no code changes are needed.

Verified: the auth test suite (104 tests, exercising the passkey registration/authentication endpoints) passes.
