### PR TITLE
fix(ci): recognise Borg release assets by their name shape

### DIFF
--- a/.github/workflows/borg-binary-update.yml
+++ b/.github/workflows/borg-binary-update.yml
@@ -85,3 +85,14 @@ jobs:
 
             Re-running the job updates this same PR rather than opening another.
           labels: dependencies
+
+      # A release this job cannot read is otherwise indistinguishable from no
+      # release at all: the run says "up to date" and stays green while the pin
+      # falls behind. borgbackup renaming its Linux assets (glibc235 -> glibc239
+      # in 2.0.0b22) hid a Borg 2 release that way. Red here is the only signal
+      # there is; a release caught mid-upload clears itself on the next run.
+      - name: Flag releases that could not be adopted
+        if: steps.refresh.outputs.unadoptable != ''
+        run: |
+          echo "::error title=Borg release not adopted::${{ steps.refresh.outputs.unadoptable }}"
+          exit 1

--- a/scripts/refresh_borg_binary_manifest.py
+++ b/scripts/refresh_borg_binary_manifest.py
@@ -43,14 +43,22 @@ API = "https://api.github.com/repos/borgbackup/borg/releases/tags/{version}"
 RELEASES_API = "https://api.github.com/repos/borgbackup/borg/releases?per_page=100"
 RELEASE_URL = "https://github.com/borgbackup/borg/releases/download/{version}/{asset}"
 
-# Published asset name -> (uname -m arch, oldest glibc it was built against).
-# Assets outside this list are ignored: macOS and FreeBSD builds, and the source
-# tarballs, are not something the Debian-family installer can use.
-KNOWN_VARIANTS = {
-    "borg-linux-glibc231-x86_64": ("x86_64", "2.31"),
-    "borg-linux-glibc235-x86_64-gh": ("x86_64", "2.35"),
-    "borg-linux-glibc235-arm64-gh": ("aarch64", "2.35"),
-}
+# The published Linux binaries a Debian-family installer can use, recognised by
+# the shape of the asset name rather than by a list of the names seen so far.
+# borgbackup renames these whenever it moves its build runner — 2.0.0b21 shipped
+# borg-linux-glibc235-*, 2.0.0b22 borg-linux-glibc239-* — and to a fixed
+# allow-list such a release reads as "publishes nothing installable", which is
+# indistinguishable from "no new release" and stalls the pin in silence.
+#
+# The anchors are what exclude everything else: the macOS and FreeBSD builds,
+# the .tgz and .asc companions, and the source tarballs never match. The glibc
+# version is carried in the name as its digits without the dot (glibc239 =
+# glibc 2.39), so it is read back the same way.
+LINUX_ASSET = re.compile(r"^borg-linux-glibc(\d)(\d+)-(x86_64|arm64)(?:-gh)?$")
+
+# borgbackup names the ARM asset after the Debian architecture; the installer
+# matches on `uname -m`.
+ARCH_NAMES = {"x86_64": "x86_64", "arm64": "aarch64"}
 
 
 def _get_json(url: str):
@@ -88,17 +96,17 @@ def _linux_binaries(release: dict) -> list[dict]:
     """The manifest entries an installer can use from a release's assets."""
     entries = []
     for asset in release.get("assets", []):
-        variant = KNOWN_VARIANTS.get(asset["name"])
-        if variant is None:
+        match = LINUX_ASSET.match(asset["name"])
+        if match is None:
             continue
+        glibc_major, glibc_minor, arch = match.groups()
         digest = asset.get("digest", "")
         if not digest.startswith("sha256:"):
             raise SystemExit(f"No sha256 digest published for {asset['name']}")
-        arch, min_glibc = variant
         entries.append(
             {
-                "arch": arch,
-                "min_glibc": min_glibc,
+                "arch": ARCH_NAMES[arch],
+                "min_glibc": f"{glibc_major}.{glibc_minor}",
                 "asset": asset["name"],
                 "sha256": digest.removeprefix("sha256:"),
             }
@@ -136,10 +144,19 @@ def _covers_both_arches(release: dict) -> bool:
     }
 
 
-def latest_adoptable() -> dict[str, str]:
+def latest_adoptable() -> tuple[dict[str, str], list[str]]:
     """The newest release GitHub publishes for each line: a stable 1.x, and a
-    2.x that may still be a beta, since that is what this repo pins today."""
+    2.x that may still be a beta, since that is what this repo pins today.
+
+    Alongside it, the releases that were passed over for carrying no usable pair
+    of Linux binaries though they are newer than the pick. A release whose assets
+    are still uploading looks the same as one this script cannot read, so passing
+    it over cannot be an error here — but it must not be silent either, or an
+    upstream rename freezes a line for months behind a green weekly job. The
+    caller decides how loud to be.
+    """
     latest: dict[str, Version] = {}
+    passed_over: dict[str, Version] = {}
     for release in _get_json(RELEASES_API):
         if release.get("draft"):
             continue
@@ -156,10 +173,18 @@ def latest_adoptable() -> dict[str, str]:
             continue
         if _covers_both_arches(release):
             latest[major] = version
+        elif version > passed_over.get(major, Version("0")):
+            passed_over[major] = version
     if set(latest) != {"1", "2"}:
         missing = {"1", "2"} - set(latest)
         raise SystemExit(f"No adoptable Borg release found for line(s) {missing}")
-    return {major: str(version) for major, version in latest.items()}
+    unadoptable = [
+        f"Borg {version} is newer than the {latest[major]} this run picked, but "
+        f"publishes no borg-linux-glibc*-{{x86_64,arm64}} pair to install"
+        for major, version in sorted(passed_over.items())
+        if version > latest[major]
+    ]
+    return {major: str(version) for major, version in latest.items()}, unadoptable
 
 
 def _rewrite(path: Path, pattern: str, new_version: str) -> None:
@@ -230,7 +255,12 @@ def adopt_latest() -> int:
     """Bump the versions file, its Dockerfile mirror, and the manifest to the
     newest published releases."""
     current = versions_from_env()
-    latest = latest_adoptable()
+    latest, unadoptable = latest_adoptable()
+    for note in unadoptable:
+        print(f"NOT ADOPTABLE: {note}")
+    # Reported through the workflow rather than raised: the file writes below
+    # still have to happen, and the PR they feed still has to be opened.
+    passed_over = "; ".join(unadoptable)
     bumps = {
         major: latest[major]
         for major in ("1", "2")
@@ -238,7 +268,7 @@ def adopt_latest() -> int:
     }
     if not bumps:
         print(f"Up to date: Borg {current['1']}, {current['2']}")
-        _emit_output(changed="false")
+        _emit_output(changed="false", unadoptable=passed_over)
         return 0
 
     # Read the coverage the outgoing versions offer before the manifest is
@@ -279,7 +309,13 @@ def adopt_latest() -> int:
             "Affected machines fall back to `--borg-source distro`:\n"
             + "\n".join(f"> - {note}" for note in warnings)
         )
-    _emit_output(changed="true", title=title, summary=summary, warnings_md=warnings_md)
+    _emit_output(
+        changed="true",
+        title=title,
+        summary=summary,
+        warnings_md=warnings_md,
+        unadoptable=passed_over,
+    )
     return 0
 
 

--- a/tests/unit/test_borg_binary_manifest.py
+++ b/tests/unit/test_borg_binary_manifest.py
@@ -1,14 +1,76 @@
-"""The refresh script must notice when adopting a Borg release narrows which
-machines a server-source install can reach.
+"""The refresh script must see every Borg release, and must notice when adopting
+one narrows which machines a server-source install can reach.
 
-borgbackup does not announce dropped binaries in its changelog — 1.4.5 quietly
-stopped publishing the glibc 2.31 x86_64 build — so the version bump is measured
-against the manifest it replaces, and any regression is surfaced in the PR.
+borgbackup announces neither in its changelog. 1.4.5 quietly stopped publishing
+the glibc 2.31 x86_64 build, so a version bump is measured against the manifest
+it replaces and any regression is surfaced in the PR. 2.0.0b22 quietly renamed
+the Linux pair from glibc235 to glibc239, so which assets count as installable
+is derived from the name rather than listed.
 """
 
 from __future__ import annotations
 
-from scripts.refresh_borg_binary_manifest import _coverage, _coverage_regressions
+import scripts.refresh_borg_binary_manifest as refresh
+from scripts.refresh_borg_binary_manifest import (
+    _covers_both_arches,
+    _coverage,
+    _coverage_regressions,
+    _linux_binaries,
+)
+
+BOTH_ARCHES = ("borg-linux-glibc239-x86_64-gh", "borg-linux-glibc239-arm64-gh")
+
+
+def _release(*names: str, tag: str = "0.0.0") -> dict:
+    """A release payload carrying the named assets, digests filled in."""
+    return {
+        "tag_name": tag,
+        "assets": [{"name": name, "digest": "sha256:" + "0" * 64} for name in names],
+    }
+
+
+def test_linux_assets_are_read_from_their_name():
+    """The glibc floor is the digits in the asset name, whichever they are — the
+    list of names seen so far does not get a say."""
+    entries = _linux_binaries(
+        _release(
+            "borg-linux-glibc239-x86_64-gh",
+            "borg-linux-glibc239-arm64-gh",
+            "borg-linux-glibc231-x86_64",
+        )
+    )
+
+    assert [(entry["arch"], entry["min_glibc"]) for entry in entries] == [
+        ("x86_64", "2.39"),
+        ("aarch64", "2.39"),
+        ("x86_64", "2.31"),
+    ]
+
+
+def test_assets_the_installer_cannot_use_are_ignored():
+    """Other platforms, the archive and signature companions, and the sources."""
+    assert (
+        _linux_binaries(
+            _release(
+                "borg-macos-15-arm64-gh",
+                "borg-freebsd-15-x86_64-gh",
+                "borg-linux-glibc239-x86_64-gh.tgz",
+                "borg-linux-glibc231-x86_64.asc",
+                "borgbackup-2.0.0b22.tar.gz",
+                "00_README.txt",
+            )
+        )
+        == []
+    )
+
+
+def test_a_renamed_linux_pair_still_counts_as_adoptable():
+    """The 2.0.0b22 regression: recognised by a fixed list of names, this release
+    read as one that publishes nothing installable, and was passed over without
+    a word — which is how a Borg 2 release went unnoticed for a month."""
+    assert _covers_both_arches(
+        _release("borg-linux-glibc239-x86_64-gh", "borg-linux-glibc239-arm64-gh")
+    )
 
 
 def test_coverage_takes_the_lowest_glibc_per_arch():
@@ -50,3 +112,67 @@ def test_no_regression_when_coverage_holds_or_widens():
         {"arch": "aarch64", "min_glibc": "2.35"},
     ]
     assert _coverage_regressions(old, new) == []
+
+
+def test_a_newer_release_without_both_arches_is_named_not_just_skipped():
+    """Passing one over is right — it may still be uploading — but saying
+    nothing is how the b22 rename went unnoticed for a month."""
+    releases = [
+        _release("borg-linux-glibc239-x86_64-gh", tag="2.0.0b23"),  # no arm64 yet
+        _release(*BOTH_ARCHES, tag="2.0.0b22"),
+        _release(*BOTH_ARCHES, tag="1.4.5"),
+    ]
+
+    latest, unadoptable = _with_releases(releases, refresh.latest_adoptable)
+
+    assert latest == {"1": "1.4.5", "2": "2.0.0b22"}
+    assert len(unadoptable) == 1
+    assert "2.0.0b23" in unadoptable[0]
+    assert "2.0.0b22" in unadoptable[0]
+
+
+def test_nothing_is_reported_when_the_newest_release_is_the_one_picked():
+    releases = [_release(*BOTH_ARCHES, tag=tag) for tag in ("2.0.0b22", "1.4.5")]
+
+    latest, unadoptable = _with_releases(releases, refresh.latest_adoptable)
+
+    assert latest == {"1": "1.4.5", "2": "2.0.0b22"}
+    assert unadoptable == []
+
+
+def test_a_passed_over_release_reaches_the_workflow_with_nothing_to_bump(
+    monkeypatch, tmp_path
+):
+    """The shape of the miss: the pin is already at the newest adoptable
+    release, so no PR is opened and the job output is the only place the
+    skipped one can surface — the workflow fails the run on it."""
+    releases = [
+        _release("borg-linux-glibc239-x86_64-gh", tag="2.0.0b23"),
+        _release(*BOTH_ARCHES, tag="2.0.0b22"),
+        _release(*BOTH_ARCHES, tag="1.4.5"),
+    ]
+    output = tmp_path / "github_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    monkeypatch.setattr(
+        refresh, "versions_from_env", lambda: {"1": "1.4.5", "2": "2.0.0b22"}
+    )
+
+    assert _with_releases(releases, refresh.adopt_latest) == 0
+
+    written = output.read_text(encoding="utf-8")
+    assert "changed=false" in written
+    assert "unadoptable=Borg 2.0.0b23 " in written
+
+
+def _with_releases(releases, call):
+    """Run `call` with the release API answering `releases`.
+
+    Not a fixture: two of these tests want the value returned, one wants the
+    side effect, and both need the same one-line stand-in for the network.
+    """
+    original = refresh._get_json
+    refresh._get_json = lambda url: releases
+    try:
+        return call()
+    finally:
+        refresh._get_json = original


### PR DESCRIPTION
## The miss

The scheduled `borg-binary-update` job matched published release assets against a fixed list of names:

```python
KNOWN_VARIANTS = {
    "borg-linux-glibc231-x86_64": ("x86_64", "2.31"),
    "borg-linux-glibc235-x86_64-gh": ("x86_64", "2.35"),
    "borg-linux-glibc235-arm64-gh": ("aarch64", "2.35"),
}
```

borgbackup renames those whenever it moves its build runner. **2.0.0b22 (released 2026-07-22) ships `borg-linux-glibc239-*-gh`.** Against the list that release published nothing installable, `_covers_both_arches()` was `False`, and `latest_adoptable()` fell back to 2.0.0b21 — `changed=false`, "Up to date", exit 0, **green weekly job**, for a month.

Borg 1 was never affected, because 1.4.5 keeps the `glibc231`/`glibc235` names. From the outside the watcher therefore looked like it only served the 1.x line.

## The change

- Assets are recognised by the **shape** of the name (`borg-linux-glibc<digits>-<arch>[-gh]`), with the glibc floor read from the digits it carries. A rename now lands as a version bump instead of as silence. The anchors still exclude everything an installer cannot use: the macOS and FreeBSD builds, the `.tgz`/`.asc` companions, and the source tarballs.
- A release can still be passed over for a good reason — one caught mid-upload carries no assets yet — so that stays non-fatal. But it is no longer unsaid: `latest_adoptable()` returns what it could not adopt, the script emits it as an `unadoptable` output, and a new workflow step fails the run on it. A half-published release clears itself on the next run; a rename does not, and now says so.

## Verified

Against the live release API, with the manifest this repo pins today:

```
pinned : {'1': '1.4.5', '2': '2.0.0b21'}
latest : {'1': '1.4.5', '2': '2.0.0b22'}
passed over: []
   aarch64 2.39 borg-linux-glibc239-arm64-gh
   x86_64 2.39 borg-linux-glibc239-x86_64-gh
```

New tests cover the renamed pair, the assets that must stay ignored, that a renamed pair counts as adoptable, and the `unadoptable` output contract end to end (a newer release with an incomplete Linux pair is named in `GITHUB_OUTPUT`, where the failing workflow step picks it up).

## Notes for whoever adopts b22

Not part of this PR, but found while confirming the fix:

- b22's binaries carry a **glibc 2.39 floor** (b21: 2.35), so a server-source install loses Debian 12 / Ubuntu 22.04. The existing `_coverage_regressions()` reporting picks this up and shouts it in the adoption PR.
- borgbackup has since **re-added** a `borg-linux-glibc231-x86_64` asset to the 1.4.5 release, so the regression noted when 1.4.5 was adopted is healed — regenerating the manifest widens 1.4.5 from 2 binaries back to 3.

A companion PR adopting 2.0.0b22 itself (with the command-syntax changes it forces) follows separately, building on this one.
