### PR TITLE
chore(runtime-base): adopt Borg 2.0.0b22, with the command changes it forces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG BASE_IMAGE=docker.io/ainullcode/borg-ui-runtime-base:runtime-borg1-1.4.5-borg2-2.0.0b21-r1
+ARG BASE_IMAGE=docker.io/ainullcode/borg-ui-runtime-base:runtime-borg1-1.4.5-borg2-2.0.0b22-r1
 # The Python the builder stages use — kept in step with runtime-base.env by a
 # guard test; the site-packages COPY paths derive from it.
 ARG PYTHON_VERSION=3.12

--- a/Dockerfile.runtime-base
+++ b/Dockerfile.runtime-base
@@ -18,8 +18,8 @@ ARG PYTHON_VERSION=3.12
 FROM python:${PYTHON_VERSION}-slim AS builder
 
 ARG BORG1_VERSION=1.4.5
-ARG BORG2_VERSION=2.0.0b21
-ARG BORGSTORE_VERSION=0.4.1
+ARG BORG2_VERSION=2.0.0b22
+ARG BORGSTORE_VERSION=0.5.5
 
 # Build-time only. OS packages track the base image's Debian release rather than
 # pinned versions (DL3008): upstream does not pin them either and a pin would
@@ -93,7 +93,7 @@ FROM python:${PYTHON_VERSION}-slim AS runtime-base
 
 ARG PYTHON_VERSION
 ARG BORG1_VERSION=1.4.5
-ARG BORG2_VERSION=2.0.0b21
+ARG BORG2_VERSION=2.0.0b22
 ENV BORG1_VERSION=${BORG1_VERSION}
 ENV BORG2_VERSION=${BORG2_VERSION}
 

--- a/agent/borg_ui_agent/repository_ops.py
+++ b/agent/borg_ui_agent/repository_ops.py
@@ -47,7 +47,9 @@ REPOSITORY_JOB_KINDS = {
 # name it stores, so the agent translates it the same way the server does for
 # its own repositories (app/core/borg2.py: BORG2_ENCRYPTION_FLAGS). The two are
 # separate packages and share no imports, so the table is stated twice; a mode
-# missing here falls through to borg, which rejects it by name.
+# missing here is rejected up front with the mode name, mirroring the server —
+# passing it to repo-create would fail with an argument-parsing error that
+# does not name the actual problem.
 BORG2_ENCRYPTION_FLAGS = {
     "repokey-aes-ocb": ["--encryption", "aes256-ocb", "--key-location", "repokey"],
     "repokey-chacha20-poly1305": [
@@ -168,11 +170,15 @@ class RepositoryOperationPayload:
                 raise ValueError("repository.init requires operation.encryption")
             encryption = encryption.strip()
             if self.borg_version == 2:
+                encryption_flags = BORG2_ENCRYPTION_FLAGS.get(encryption)
+                if encryption_flags is None:
+                    raise ValueError(
+                        f"unsupported Borg 2 encryption mode {encryption!r}; "
+                        "expected one of " + ", ".join(BORG2_ENCRYPTION_FLAGS)
+                    )
                 return [
                     *self._base_borg2("repo-create"),
-                    *BORG2_ENCRYPTION_FLAGS.get(
-                        encryption, ["--encryption", encryption]
-                    ),
+                    *encryption_flags,
                 ]
             return [
                 *self._base_borg1("init"),

--- a/agent/borg_ui_agent/repository_ops.py
+++ b/agent/borg_ui_agent/repository_ops.py
@@ -42,6 +42,31 @@ REPOSITORY_JOB_KINDS = {
     "repository.rclone_sync",
 }
 
+# Borg 2.0.0b22 split repo-create's single --encryption value into the cipher,
+# where the key is stored, and the id hash. The server sends the combined mode
+# name it stores, so the agent translates it the same way the server does for
+# its own repositories (app/core/borg2.py: BORG2_ENCRYPTION_FLAGS). The two are
+# separate packages and share no imports, so the table is stated twice; a mode
+# missing here falls through to borg, which rejects it by name.
+BORG2_ENCRYPTION_FLAGS = {
+    "repokey-aes-ocb": ["--encryption", "aes256-ocb", "--key-location", "repokey"],
+    "repokey-chacha20-poly1305": [
+        "--encryption",
+        "chacha20-poly1305",
+        "--key-location",
+        "repokey",
+    ],
+    "keyfile-aes-ocb": ["--encryption", "aes256-ocb", "--key-location", "keyfile"],
+    "keyfile-chacha20-poly1305": [
+        "--encryption",
+        "chacha20-poly1305",
+        "--key-location",
+        "keyfile",
+    ],
+    "authenticated": ["--encryption", "authenticated"],
+    "none": ["--encryption", "none"],
+}
+
 # Kill a streaming extract only when no bytes have flowed for this long — a
 # wedged borg, not a slow one. Idle (not an absolute cap) so a legitimately
 # large/slow download is never truncated mid-transfer.
@@ -145,8 +170,9 @@ class RepositoryOperationPayload:
             if self.borg_version == 2:
                 return [
                     *self._base_borg2("repo-create"),
-                    "--encryption",
-                    encryption,
+                    *BORG2_ENCRYPTION_FLAGS.get(
+                        encryption, ["--encryption", encryption]
+                    ),
                 ]
             return [
                 *self._base_borg1("init"),
@@ -360,7 +386,13 @@ class RepositoryOperationPayload:
                     cmd.extend([flag, str(int(value))])
             keep_within = operation.get("keep_within")
             if keep_within is not None and str(keep_within).strip():
-                cmd.append(f"--keep-within={str(keep_within).strip()}")
+                # Borg 2.0.0b22 removed --keep-within (and --keep-last) in
+                # favour of --keep, which takes either form: a count or an
+                # interval like "1d". Borg 1 keeps the old spelling.
+                if self.borg_version == 2:
+                    cmd.extend(["--keep", str(keep_within).strip()])
+                else:
+                    cmd.append(f"--keep-within={str(keep_within).strip()}")
             if dry_run:
                 cmd.append("--dry-run")
             if self.borg_version == 1:

--- a/app/api/archives.py
+++ b/app/api/archives.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 from app.api.archive_download import extract_file_download, resolve_extracted_file_path
 from app.core.borg import borg
 from app.core.borg_router import BorgRouter
+from app.core.borg2 import normalize_repo_info_encryption
 from app.core.security import (
     check_repo_access,
     get_current_download_user,
@@ -305,7 +306,9 @@ async def get_archive_info(
                 "comment": archive_info.get("comment", ""),
                 # Repository info
                 "repository": archive_data.get("repository", {}),
-                "encryption": archive_data.get("encryption", {}),
+                "encryption": normalize_repo_info_encryption(archive_data).get(
+                    "encryption", {}
+                ),
                 "cache": archive_data.get("cache", {}),
             }
 

--- a/app/api/borg_binaries.json
+++ b/app/api/borg_binaries.json
@@ -1,11 +1,17 @@
 {
   "current": {
     "1": "1.4.5",
-    "2": "2.0.0b21"
+    "2": "2.0.0b22"
   },
   "release_url": "https://github.com/borgbackup/borg/releases/download/{version}/{asset}",
   "binaries": {
     "1.4.5": [
+      {
+        "arch": "x86_64",
+        "min_glibc": "2.31",
+        "asset": "borg-linux-glibc231-x86_64",
+        "sha256": "c8457f70660064d0f45b38283ab4cc65b342970012013201d3aec713a75898fb"
+      },
       {
         "arch": "aarch64",
         "min_glibc": "2.35",
@@ -19,18 +25,18 @@
         "sha256": "1410e28609be3080d0e3ab27a78f5c586a29fd0c75c2aa6415fcde1293bcd923"
       }
     ],
-    "2.0.0b21": [
+    "2.0.0b22": [
       {
         "arch": "aarch64",
-        "min_glibc": "2.35",
-        "asset": "borg-linux-glibc235-arm64-gh",
-        "sha256": "d008c57e97d977a409e5570a93e805be022ce6a69aef42db4d53dd68f4326a8f"
+        "min_glibc": "2.39",
+        "asset": "borg-linux-glibc239-arm64-gh",
+        "sha256": "41531b3e0ca312a01bf6886db65dcb8b1e477569c38b13ad2158364895d362fd"
       },
       {
         "arch": "x86_64",
-        "min_glibc": "2.35",
-        "asset": "borg-linux-glibc235-x86_64-gh",
-        "sha256": "1cde53b9d248c1a600df6f938eea3207f27141be0e8d7a80542fa8f901f221c5"
+        "min_glibc": "2.39",
+        "asset": "borg-linux-glibc239-x86_64-gh",
+        "sha256": "960a8853e16dd3c12c1e94561c61b5dfed8acc1c41d8241e7e6348c8a34223bf"
       }
     ]
   }

--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -48,6 +48,7 @@ from app.core.security import get_current_user, check_repo_access, decrypt_secre
 from app.core.borg import BorgInterface
 from app.core.borg_router import BorgRouter
 from app.core.borg_errors import is_lock_error
+from app.core.borg2 import normalize_repo_info_encryption
 from app.core.features import (
     FEATURES,
     get_current_plan,
@@ -872,6 +873,13 @@ async def _update_agent_repository_stats(repository: Repository, db: Session) ->
                 db, rinfo_job.id, timeout_seconds=timeouts["info_timeout"]
             )
             rinfo = json.loads((rinfo_result or {}).get("stdout") or "{}")
+            # Deliberately NOT normalize_repo_info_encryption() here. That fills
+            # `mode` with the bare cipher for Borg 2.0.0b22, which is right for
+            # display but wrong for this column: the stored value is the combined
+            # name the repository was created with (repokey-aes-ocb), and b22's
+            # repo-info does not report the key location, so writing its cipher
+            # back would drop that half for good. No mode, no write — the stored
+            # name stands.
             encryption_mode = (rinfo.get("encryption") or {}).get("mode")
             # Borg 1 `info --json` exposes repo-level dedup size in cache.stats;
             # Borg 2 `repo-info --json` does not (remote size is unknowable).
@@ -6089,7 +6097,7 @@ async def get_repository_info(
                 agent_job.id,
                 timeout_seconds=get_operation_timeouts(db)["info_timeout"],
             )
-            info_data = _parse_agent_json_result(result)
+            info_data = normalize_repo_info_encryption(_parse_agent_json_result(result))
 
             # The dialog's stats panel (the Borg 2 view in particular) is driven
             # by `archives`. Borg 2 `info --json` already carries the archive list
@@ -6147,7 +6155,7 @@ async def get_repository_info(
         )
         # Parse JSON output
         try:
-            info_data = json.loads(stdout.decode())
+            info_data = normalize_repo_info_encryption(json.loads(stdout.decode()))
 
             # Extract relevant information
             repository_info = info_data.get("repository", {})

--- a/app/api/v2/archives.py
+++ b/app/api/v2/archives.py
@@ -23,7 +23,7 @@ from app.core.security import (
     get_current_download_user,
 )
 from app.core.features import require_feature
-from app.core.borg2 import borg2
+from app.core.borg2 import borg2, normalize_repo_info_encryption
 from app.services.agent_job_dispatcher import dispatch_agent_job_best_effort
 from app.services.archive_browse_service import (
     build_browse_items,
@@ -340,7 +340,9 @@ async def get_archive_info(
             "limits": archive_info.get("limits", {}),
             "comment": archive_info.get("comment", ""),
             "repository": archive_data.get("repository", {}),
-            "encryption": archive_data.get("encryption", {}),
+            "encryption": normalize_repo_info_encryption(archive_data).get(
+                "encryption", {}
+            ),
             "cache": archive_data.get("cache", {}),
         }
 

--- a/app/api/v2/repositories.py
+++ b/app/api/v2/repositories.py
@@ -18,7 +18,11 @@ from app.database.database import get_db
 from app.database.models import User, Repository, SSHConnection, SystemSettings
 from app.core.security import check_repo_access, get_current_user
 from app.core.features import require_feature
-from app.core.borg2 import borg2, BORG2_ENCRYPTION_MODES
+from app.core.borg2 import (
+    borg2,
+    BORG2_ENCRYPTION_MODES,
+    normalize_repo_info_encryption,
+)
 from app.core.borg_errors import is_lock_error
 from app.services.repository_info_sync import sync_archive_stats_from_info
 from app.services.agent_job_dispatcher import dispatch_agent_job_best_effort
@@ -568,7 +572,10 @@ async def get_repository_info(
             if rinfo_data.get("encryption") and not info_data.get("encryption"):
                 info_data["encryption"] = rinfo_data["encryption"]
             sync_archive_stats_from_info(repo, info_data, db)
-            return {"info": info_data, "borg_version": 2}
+            return {
+                "info": normalize_repo_info_encryption(info_data),
+                "borg_version": 2,
+            }
 
         bypass_lock = _resolve_bypass_lock(repo, db, "bypass_lock_on_info")
         with repository_borg_env(repo, db) as env:
@@ -634,7 +641,11 @@ async def get_repository_info(
         # fetched, or the dialog shows a count the card contradicts.
         sync_archive_stats_from_info(repo, info_data, db)
 
-        return {"info": info_data, "borg_version": 2}
+        # Normalised on the way out, not at either parse site: both `info --json`
+        # and `repo-info --json` carry the block, and the merge above only fires
+        # when info_data has none of its own — so normalising a source would miss
+        # the case where borg2 info already supplied one.
+        return {"info": normalize_repo_info_encryption(info_data), "borg_version": 2}
 
     return await run_serialized_repository_command(repo_id, _operation)
 

--- a/app/api/v2/repositories.py
+++ b/app/api/v2/repositories.py
@@ -764,4 +764,4 @@ async def get_repository_stats(
     except json.JSONDecodeError:
         stats_data = {}
 
-    return {"stats": stats_data, "borg_version": 2}
+    return {"stats": normalize_repo_info_encryption(stats_data), "borg_version": 2}

--- a/app/core/borg2.py
+++ b/app/core/borg2.py
@@ -27,7 +27,8 @@ Key command differences from Borg 1:
   Borg 2 command that carried it failed at argument parsing, which read as an
   unreachable repository rather than as a flag this Borg does not know.
 
-  Encryption modes (borg 2 only):
+  Encryption modes (borg 2 only), translated to repo-create's
+  --encryption/--key-location split by BORG2_ENCRYPTION_FLAGS:
     repokey-aes-ocb            (default — recommended)
     repokey-chacha20-poly1305
     keyfile-aes-ocb
@@ -49,14 +50,75 @@ from app.utils.ssh_utils import public_key_only_ssh_args
 
 logger = structlog.get_logger()
 
-BORG2_ENCRYPTION_MODES = [
-    "repokey-aes-ocb",
-    "repokey-chacha20-poly1305",
-    "keyfile-aes-ocb",
-    "keyfile-chacha20-poly1305",
-    "authenticated",
-    "none",
-]
+# The encryption modes Borg 2 repositories are offered in, keyed by the combined
+# name the API, the UI and the repository row all speak, mapped to the flags
+# repo-create wants.
+#
+# Borg 2.0.0b22 split repo-create's single --encryption value into three
+# orthogonal options: the cipher (--encryption), where the key is stored
+# (--key-location) and the id hash (--id-hash, sha256 by default). Translating
+# here keeps that split where it belongs — one command builder — instead of
+# pushing a schema and vocabulary change through every caller and stored row.
+#
+# --key-location is omitted where borg's default is what the combined name has
+# always meant: `none` has no key at all, and `authenticated` keeps its key in
+# the repository. blake2 modes are not offered — b22 replaced BLAKE2b with
+# BLAKE3 for new repositories.
+BORG2_ENCRYPTION_FLAGS: Dict[str, List[str]] = {
+    "repokey-aes-ocb": ["--encryption", "aes256-ocb", "--key-location", "repokey"],
+    "repokey-chacha20-poly1305": [
+        "--encryption",
+        "chacha20-poly1305",
+        "--key-location",
+        "repokey",
+    ],
+    "keyfile-aes-ocb": ["--encryption", "aes256-ocb", "--key-location", "keyfile"],
+    "keyfile-chacha20-poly1305": [
+        "--encryption",
+        "chacha20-poly1305",
+        "--key-location",
+        "keyfile",
+    ],
+    "authenticated": ["--encryption", "authenticated"],
+    "none": ["--encryption", "none"],
+}
+
+BORG2_ENCRYPTION_MODES = list(BORG2_ENCRYPTION_FLAGS)
+
+
+def borg2_encryption_flags(mode: str) -> List[str]:
+    """The repo-create flags for a combined encryption mode name."""
+    try:
+        return list(BORG2_ENCRYPTION_FLAGS[mode])
+    except KeyError:
+        raise ValueError(
+            f"unsupported Borg 2 encryption mode {mode!r}; expected one of "
+            + ", ".join(BORG2_ENCRYPTION_MODES)
+        ) from None
+
+
+def normalize_repo_info_encryption(info: Dict) -> Dict:
+    """Give repo-info's encryption block a `mode` again, in place.
+
+    Borg 2.0.0b22 replaced repo-info's single ``{"mode": "repokey-aes-ocb"}``
+    with ``{"encryption": "aes256-ocb", "id_hash": "sha256"}`` (#9168), the same
+    split it made on the repo-create side. Everything downstream — the stored
+    repository row, the API response, the info dialog — reads ``mode``, and got
+    nothing, so the UI showed "N/A" for a repository that is in fact encrypted.
+
+    The cipher is what `mode` is filled from. The key location is deliberately
+    NOT reconstructed: b22 does not report it here, so `repokey-` or `keyfile-`
+    would be a guess, and a guess about where the key lives is worse than a
+    field that names only what borg actually said. `id_hash` is left in place
+    for callers that want it.
+    """
+    encryption = info.get("encryption")
+    if isinstance(encryption, dict) and not encryption.get("mode"):
+        cipher = encryption.get("encryption")
+        if cipher:
+            encryption["mode"] = cipher
+    return info
+
 
 DEFAULT_BORG2_BINARY = "borg2"
 
@@ -287,8 +349,7 @@ class Borg2Interface:
             "-r",
             repository,
             "repo-create",
-            "--encryption",
-            encryption,
+            *borg2_encryption_flags(encryption),
         ]
         if remote_path:
             cmd.extend(["--remote-path", remote_path])
@@ -551,7 +612,9 @@ class Borg2Interface:
         if keep_yearly > 0:
             cmd.extend(["--keep-yearly", str(keep_yearly)])
         if keep_within and keep_within.strip():
-            cmd.append(f"--keep-within={keep_within.strip()}")
+            # Borg 2.0.0b22 removed --keep-within (and --keep-last) in favour of
+            # --keep, which takes either form: a count or an interval like "1d".
+            cmd.extend(["--keep", keep_within.strip()])
         cmd.append("--list")
         if dry_run:
             cmd.append("--dry-run")

--- a/app/services/v2/compact_service.py
+++ b/app/services/v2/compact_service.py
@@ -2,9 +2,12 @@
 
 Mirrors compact_service.py but uses the borg2 binary.
 
-Borg 2 compact has two phases (verified against live borg2 2.0.0b21):
+Borg 2 compact has two phases (verified against live borg2 2.0.0b22):
   operation=1  compact.analyze_archives  "Computing used chunks X%"   → 0-50%
-  operation=2  compact.report_and_delete "Deleting unused objects X%"  → 50-100%
+  operation=2  compact.compact_packs     "Compacting packs X%"        → 50-100%
+
+The second phase was compact.report_and_delete until 2.0.0b22 renamed it; the
+progress split keys on `operation`, not on the msgid, so it did not move.
 
 Both phases emit progress_percent on stderr with --progress --log-json.
 """

--- a/app/services/v2/compact_service.py
+++ b/app/services/v2/compact_service.py
@@ -283,7 +283,7 @@ class CompactV2Service:
                                         pct = (current / total) * 100
                                         # Two phases:
                                         # operation=1 (compact.analyze_archives) → 0-50%
-                                        # operation=2 (compact.report_and_delete) → 50-100%
+                                        # operation=2 (compact.compact_packs) → 50-100%
                                         if operation == 1:
                                             job.progress = int(pct / 2)
                                         else:

--- a/app/services/v2/prune_service.py
+++ b/app/services/v2/prune_service.py
@@ -153,7 +153,9 @@ class PruneV2Service:
             if keep_yearly > 0:
                 cmd.extend(["--keep-yearly", str(keep_yearly)])
             if keep_within and keep_within.strip():
-                cmd.append(f"--keep-within={keep_within.strip()}")
+                # Borg 2.0.0b22 removed --keep-within (and --keep-last) in favour
+                # of --keep, which takes either form: a count or an interval.
+                cmd.extend(["--keep", keep_within.strip()])
             if dry_run:
                 cmd.append("--dry-run")
 

--- a/app/services/v2/repository_service.py
+++ b/app/services/v2/repository_service.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, Optional
 
-from app.core.borg2 import borg2
+from app.core.borg2 import borg2, borg2_encryption_flags
 from app.database.database import SessionLocal  # noqa: F401
 from app.utils.fs import calculate_path_size_bytes
 from app.utils.borg_env import ssh_key_borg_env
@@ -36,8 +36,7 @@ class RepositoryV2Service:
                         "-r",
                         path,
                         "repo-create",
-                        "--encryption",
-                        encryption,
+                        *borg2_encryption_flags(encryption),
                     ]
                     + (["--remote-path", remote_path] if remote_path else []),
                     timeout=init_timeout,

--- a/docker/runtime-base.env
+++ b/docker/runtime-base.env
@@ -5,8 +5,14 @@
 # one place by runtime-base-tag.sh —
 #   runtime-borg1-${BORG1_VERSION}-borg2-${BORG2_VERSION}-r${RUNTIME_BASE_REVISION}
 BORG1_VERSION=1.4.5
-BORG2_VERSION=2.0.0b21
-BORGSTORE_VERSION=0.4.1
+# Borg 2 has no stable release; this pin has always named a beta (b21 before
+# b22), so upstream's "not for production repositories" applies to Borg 2
+# support as a whole, not to this bump.
+#
+# b22 is the packs release: it needs NEW repositories and cannot read repos
+# written by earlier betas.
+BORG2_VERSION=2.0.0b22
+BORGSTORE_VERSION=0.5.5
 PYTHON_VERSION=3.12
 # rclone is fetched as the official static binary (downloads.rclone.org), not the
 # distro package — the Debian build lags years behind and breaks OneDrive

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -414,10 +414,18 @@ Do not delete `borg_data` or `borg_cache` unless you intentionally want to remov
 > release changed the repository format (packs) and cannot read a repository
 > written by any earlier Borg 2 beta — opening one fails with
 > `repository version 3 is not supported by this borg version`. There is no
-> in-place conversion: delete the old Borg 2 repositories before upgrading and
-> let Borg UI create them again. Borg 1 repositories are unaffected. Borg 2 is
-> a beta line with no stable release yet, and upstream reserves exactly this
-> kind of break between betas.
+> in-place conversion. Before upgrading:
+>
+> 1. Keep the image you are upgrading from available — it is the only thing
+>    that can still read the old repositories.
+> 2. Move the old Borg 2 repositories aside (rename the directory, or point
+>    the repository at a fresh path) rather than deleting them, and let
+>    Borg UI create new ones.
+> 3. Delete the old repositories only once the new ones hold backups you have
+>    verified.
+>
+> Borg 1 repositories are unaffected. Borg 2 is a beta line with no stable
+> release yet, and upstream reserves exactly this kind of break between betas.
 
 If the first backup after an image pull or container recreate is slower than later backups, see [Slow first backup after a pull or restart](troubleshooting#slow-first-backup-after-a-pull-or-restart).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -410,6 +410,15 @@ docker compose up -d
 
 Do not delete `borg_data` or `borg_cache` unless you intentionally want to remove application state or Borg cache data.
 
+> **Borg 2 repositories do not survive the upgrade to Borg 2.0.0b22.** That
+> release changed the repository format (packs) and cannot read a repository
+> written by any earlier Borg 2 beta — opening one fails with
+> `repository version 3 is not supported by this borg version`. There is no
+> in-place conversion: delete the old Borg 2 repositories before upgrading and
+> let Borg UI create them again. Borg 1 repositories are unaffected. Borg 2 is
+> a beta line with no stable release yet, and upstream reserves exactly this
+> kind of break between betas.
+
 If the first backup after an image pull or container recreate is slower than later backups, see [Slow first backup after a pull or restart](troubleshooting#slow-first-backup-after-a-pull-or-restart).
 
 ## Next

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -412,10 +412,10 @@ This does not include Redis. Use Compose for normal deployments.
 > 1. Keep the image you are upgrading from available — it is the only thing
 >    that can still read the old repositories.
 > 2. Move the old Borg 2 repositories aside (rename the directory, or point
->    the repository at a fresh path) rather than deleting them, and let
->    Borg UI create new ones.
-> 3. Delete the old repositories only once the new ones hold backups you have
->    verified.
+>    the repository at a fresh path) rather than deleting them.
+> 3. After the new image is running, let Borg UI create new repositories —
+>    the old image cannot create 2.0.0b22 repositories — and delete the old
+>    ones only once the new ones hold backups you have verified.
 >
 > Borg 1 repositories are unaffected. Borg 2 is a beta line with no stable
 > release yet, and upstream reserves exactly this kind of break between betas.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -403,13 +403,6 @@ This does not include Redis. Use Compose for normal deployments.
 
 ## Upgrade
 
-```bash
-docker compose pull
-docker compose up -d
-```
-
-Do not delete `borg_data` or `borg_cache` unless you intentionally want to remove application state or Borg cache data.
-
 > **Borg 2 repositories do not survive the upgrade to Borg 2.0.0b22.** That
 > release changed the repository format (packs) and cannot read a repository
 > written by any earlier Borg 2 beta — opening one fails with
@@ -426,6 +419,15 @@ Do not delete `borg_data` or `borg_cache` unless you intentionally want to remov
 >
 > Borg 1 repositories are unaffected. Borg 2 is a beta line with no stable
 > release yet, and upstream reserves exactly this kind of break between betas.
+
+Then pull and start the new image:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Do not delete `borg_data` or `borg_cache` unless you intentionally want to remove application state or Borg cache data.
 
 If the first backup after an image pull or container recreate is slower than later backups, see [Slow first backup after a pull or restart](troubleshooting#slow-first-backup-after-a-pull-or-restart).
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -141,6 +141,19 @@ compact, mount, or external Borg process is using the repository.
 
 Break the lock only when you are certain the previous Borg process is gone.
 
+### Borg 2 repository unreadable after an upgrade
+
+Borg operations on an existing Borg 2 repository fail with
+`repository version 3 is not supported by this borg version`, or a repository
+that worked before an image pull is suddenly not accessible.
+
+Borg 2.0.0b22 changed the repository format (packs) and cannot read a repository
+written by an earlier Borg 2 beta. Nothing is wrong with the storage, the
+passphrase or the key — the format is simply one this Borg cannot open, and
+there is no in-place conversion. Delete the affected Borg 2 repositories and
+create them again, or go back to the image you upgraded from. Borg 1
+repositories are not affected.
+
 ### Slow archive browsing
 
 The first browse of a large archive can be slow because Borg has to list archive

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -144,15 +144,21 @@ Break the lock only when you are certain the previous Borg process is gone.
 ### Borg 2 repository unreadable after an upgrade
 
 Borg operations on an existing Borg 2 repository fail with
-`repository version 3 is not supported by this borg version`, or a repository
-that worked before an image pull is suddenly not accessible.
+`repository version 3 is not supported by this borg version`.
 
-Borg 2.0.0b22 changed the repository format (packs) and cannot read a repository
-written by an earlier Borg 2 beta. Nothing is wrong with the storage, the
-passphrase or the key — the format is simply one this Borg cannot open, and
-there is no in-place conversion. Delete the affected Borg 2 repositories and
-create them again, or go back to the image you upgraded from. Borg 1
+This exact error means a Borg 2.0.0b22 (or later) client is reading a
+repository written by an earlier Borg 2 beta: that release changed the
+repository format (packs) and cannot open the old one. With this error — and
+only with this error — the storage, the passphrase and the key are fine; the
+format alone is the problem, and there is no in-place conversion. To keep
+using the repository, go back to the image you upgraded from. To move on,
+move the repository aside and let a fresh one be created — and delete the old
+one only once the new one holds backups you have verified. Borg 1
 repositories are not affected.
+
+A repository that became inaccessible after an image pull but reports a
+different error is an ordinary access problem — check the job log for the
+actual message and start from storage, network and credentials.
 
 ### Slow archive browsing
 

--- a/frontend/src/components/__tests__/CommandPreview.test.tsx
+++ b/frontend/src/components/__tests__/CommandPreview.test.tsx
@@ -71,8 +71,12 @@ describe('CommandPreview', () => {
         />
       )
 
+      // The combined mode name stays the component's input; Borg 2.0.0b22 split
+      // the emitted flags into cipher + key location (see borgUtils).
       expect(
-        screen.getByText(/borg2 -r \/backups\/repo repo-create --encryption repokey-aes-ocb/)
+        screen.getByText(
+          /borg2 -r \/backups\/repo repo-create --encryption aes256-ocb --key-location repokey/
+        )
       ).toBeInTheDocument()
       expect(screen.getByText(/borg2 create/)).toBeInTheDocument()
     })

--- a/frontend/src/utils/borgUtils.test.ts
+++ b/frontend/src/utils/borgUtils.test.ts
@@ -281,6 +281,8 @@ describe('generateBorgInitCommand', () => {
       encryption: 'repokey-aes-ocb',
     })
 
-    expect(cmd).toBe('borg2 -r /backups/repo repo-create --encryption repokey-aes-ocb')
+    expect(cmd).toBe(
+      'borg2 -r /backups/repo repo-create --encryption aes256-ocb --key-location repokey'
+    )
   })
 })

--- a/frontend/src/utils/borgUtils.ts
+++ b/frontend/src/utils/borgUtils.ts
@@ -22,6 +22,26 @@ export interface BorgInitCommandOptions {
 
 const getBorgBinary = (borgVersion: 1 | 2 = 1): string => (borgVersion === 2 ? 'borg2' : 'borg')
 
+/**
+ * Borg 2.0.0b22 split repo-create's single --encryption value into the cipher
+ * and where the key is stored (--key-location). The combined names stay the
+ * vocabulary of the UI and of the stored repository, so a command shown to the
+ * user is translated here — the same table the server and the agent keep
+ * (app/core/borg2.py, agent/borg_ui_agent/repository_ops.py). Three runtimes,
+ * no shared module, so it is stated three times.
+ *
+ * A mode this table does not know is passed through: borg names the valid ones
+ * in its own error, which beats this file inventing a flag.
+ */
+const BORG2_ENCRYPTION_FLAGS: Record<string, string> = {
+  'repokey-aes-ocb': '--encryption aes256-ocb --key-location repokey',
+  'repokey-chacha20-poly1305': '--encryption chacha20-poly1305 --key-location repokey',
+  'keyfile-aes-ocb': '--encryption aes256-ocb --key-location keyfile',
+  'keyfile-chacha20-poly1305': '--encryption chacha20-poly1305 --key-location keyfile',
+  authenticated: '--encryption authenticated',
+  none: '--encryption none',
+}
+
 export const generateBorgInitCommand = (options: BorgInitCommandOptions): string => {
   const {
     repositoryPath,
@@ -31,7 +51,8 @@ export const generateBorgInitCommand = (options: BorgInitCommandOptions): string
   } = options
 
   if (borgVersion === 2) {
-    return `${getBorgBinary(2)} -r ${repositoryPath} repo-create ${remotePathFlag}--encryption ${encryption}`
+    const encryptionFlags = BORG2_ENCRYPTION_FLAGS[encryption] ?? `--encryption ${encryption}`
+    return `${getBorgBinary(2)} -r ${repositoryPath} repo-create ${remotePathFlag}${encryptionFlags}`
   }
 
   return `${getBorgBinary(1)} init --encryption ${encryption} ${remotePathFlag}${repositoryPath}`

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -690,6 +690,26 @@ def test_repository_init_payload_builds_borg2_command():
 
 
 @pytest.mark.unit
+def test_repository_init_payload_rejects_unknown_borg2_encryption_mode():
+    """A mode the table does not know (a legacy blake2 name, a typo) must fail
+    with the mode's name, mirroring the server — handed to repo-create it dies
+    at argument parsing, which does not name the actual problem."""
+    payload = RepositoryOperationPayload.from_job_payload(
+        {
+            "schema_version": 1,
+            "job_kind": "repository.init",
+            "repository": {"path": "/agent/repo2", "borg_version": 2},
+            "operation": {"encryption": "repokey-blake2"},
+        }
+    )
+
+    with pytest.raises(
+        ValueError, match="unsupported Borg 2 encryption mode 'repokey-blake2'"
+    ):
+        payload.build_command()
+
+
+@pytest.mark.unit
 def test_borg1_prune_keeps_the_old_keep_within_spelling():
     """--keep-within was removed in Borg 2.0.0b22 only; Borg 1 never gained
     --keep, so the two majors part ways on this flag."""

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -675,14 +675,36 @@ def test_repository_init_payload_builds_borg2_command():
 
     command = payload.build_command()
 
+    # Borg 2.0.0b22 takes the cipher and the key location separately; the server
+    # still sends the combined mode name it stores.
     assert command == [
         "borg2",
         "-r",
         "/agent/repo2",
         "repo-create",
         "--encryption",
-        "repokey-aes-ocb",
+        "aes256-ocb",
+        "--key-location",
+        "repokey",
     ]
+
+
+@pytest.mark.unit
+def test_borg1_prune_keeps_the_old_keep_within_spelling():
+    """--keep-within was removed in Borg 2.0.0b22 only; Borg 1 never gained
+    --keep, so the two majors part ways on this flag."""
+    payload = RepositoryOperationPayload.from_job_payload(
+        {
+            "job_kind": "repository.prune",
+            "repository": {"path": "/agent/repo", "borg_version": 1},
+            "operation": {"keep_daily": 7, "keep_within": "1d"},
+        }
+    )
+
+    command = payload.build_command()
+
+    assert "--keep-within=1d" in command
+    assert "--keep" not in command
 
 
 @pytest.mark.unit
@@ -1754,7 +1776,8 @@ def test_repository_operation_payload_builds_agent_local_commands():
         "7",
         "--keep-3monthly",
         "3",
-        "--keep-within=1d",
+        "--keep",
+        "1d",
         "--dry-run",
     ]
     # Borg 1 prune keeps --stats; quarterly is --keep-3monthly on borg1 too

--- a/tests/unit/test_api_repositories.py
+++ b/tests/unit/test_api_repositories.py
@@ -1194,6 +1194,67 @@ class TestRepositoriesCreate:
         )
         run_local.assert_not_called()
 
+    def test_agent_repository_info_normalizes_borg2_b22_encryption(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """The route the info dialog actually calls for an agent repository.
+
+        BorgApiClient sends every agent repo to the v1 path regardless of Borg
+        major (`v = execution_target === 'agent' ? '' : ...`), so a fix that only
+        landed on /api/v2/repositories left the dialog showing "N/A". The payload
+        is verbatim from `borg2 info --json` on 2.0.0b22.
+        """
+        agent = _agent_machine_with_capabilities("repository.info")
+        repo = Repository(
+            name="Agent b22 Repo",
+            path="/agent/b22/repo",
+            encryption="repokey-aes-ocb",
+            compression="lz4",
+            executor_type="agent",
+            execution_target="agent",
+            agent_machine_id=1,
+            repository_type="local",
+            borg_version=2,
+        )
+        test_db.add_all([agent, repo])
+        test_db.commit()
+        repo.agent_machine_id = agent.id
+        test_db.commit()
+        test_db.refresh(repo)
+
+        with (
+            patch(
+                "app.api.repositories.wait_for_agent_repository_operation_job",
+                new=AsyncMock(
+                    return_value={
+                        "data": {
+                            "repository": {"id": "abc"},
+                            "cache": {},
+                            "encryption": {
+                                "encryption": "aes256-ocb",
+                                "id_hash": "sha256",
+                            },
+                            "archives": [],
+                        }
+                    }
+                ),
+            ),
+            patch(
+                "app.api.repositories._run_repository_command",
+                new=AsyncMock(return_value=(0, b"{}", b"")),
+            ),
+        ):
+            response = test_client.get(
+                f"/api/repositories/{repo.id}/info", headers=admin_headers
+            )
+
+        assert response.status_code == 200
+        assert response.json()["info"]["encryption"] == {
+            "encryption": "aes256-ocb",
+            "id_hash": "sha256",
+            "mode": "aes256-ocb",
+        }
+
     def test_agent_repository_info_syncs_archive_stats_to_the_row(
         self, test_client: TestClient, admin_headers, test_db
     ):

--- a/tests/unit/test_api_v2_repositories.py
+++ b/tests/unit/test_api_v2_repositories.py
@@ -1307,6 +1307,46 @@ class TestV2RepositoryRoutes:
         assert response.json()["borg_version"] == 2
         mock_rinfo.assert_awaited_once()
 
+    def test_get_repository_stats_normalizes_borg2_b22_encryption(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """/stats returns the same rinfo payload as /info, so b22's mode-less
+        encryption block needs the same normalization — a client reading
+        `stats.encryption.mode` would otherwise get nothing while /info has
+        it. The payload is verbatim from 2.0.0b22.
+        """
+        _enable_borg_v2(test_db)
+        repo = _create_v2_repo(test_db, path="/tmp/v2-b22-stats-repo")
+
+        with patch(
+            "app.api.v2.repositories.borg2.rinfo",
+            new=AsyncMock(
+                return_value={
+                    "success": True,
+                    "stdout": json.dumps(
+                        {
+                            "repository": {"id": 9},
+                            "encryption": {
+                                "encryption": "aes256-ocb",
+                                "id_hash": "sha256",
+                            },
+                        }
+                    ),
+                    "stderr": "",
+                }
+            ),
+        ):
+            response = test_client.get(
+                f"/api/v2/repositories/{repo.id}/stats", headers=admin_headers
+            )
+
+        assert response.status_code == 200
+        assert response.json()["stats"]["encryption"] == {
+            "encryption": "aes256-ocb",
+            "id_hash": "sha256",
+            "mode": "aes256-ocb",
+        }
+
     def test_get_repository_stats_returns_500_on_borg_failure(
         self, test_client: TestClient, admin_headers, test_db
     ):

--- a/tests/unit/test_api_v2_repositories.py
+++ b/tests/unit/test_api_v2_repositories.py
@@ -972,6 +972,56 @@ class TestV2RepositoryRoutes:
         assert repo.archive_count == 2
         assert repo.last_backup == datetime(2026, 8, 19, 19, 3, 18)
 
+    def test_get_repository_info_normalizes_borg2_b22_encryption(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """Borg 2.0.0b22 reports the cipher and the id hash instead of a single
+        `mode`, and `info --json` carries the block too — so the rinfo merge
+        below never fires and the dialog showed "N/A" for an encrypted
+        repository. Both payloads are verbatim from 2.0.0b22.
+        """
+        _enable_borg_v2(test_db)
+        repo = _create_v2_repo(test_db, path="/tmp/v2-b22-repo")
+        b22_encryption = {"encryption": "aes256-ocb", "id_hash": "sha256"}
+
+        with patch(
+            "app.api.v2.repositories.borg2.info_repo",
+            new=AsyncMock(
+                return_value={
+                    "success": True,
+                    "stdout": json.dumps(
+                        {"archives": [], "encryption": dict(b22_encryption)}
+                    ),
+                    "stderr": "",
+                }
+            ),
+        ):
+            with patch(
+                "app.api.v2.repositories.borg2.rinfo",
+                new=AsyncMock(
+                    return_value={
+                        "success": True,
+                        "stdout": json.dumps(
+                            {
+                                "repository": {"id": 9},
+                                "encryption": dict(b22_encryption),
+                            }
+                        ),
+                        "stderr": "",
+                    }
+                ),
+            ):
+                response = test_client.get(
+                    f"/api/v2/repositories/{repo.id}/info", headers=admin_headers
+                )
+
+        assert response.status_code == 200
+        assert response.json()["info"]["encryption"] == {
+            "encryption": "aes256-ocb",
+            "id_hash": "sha256",
+            "mode": "aes256-ocb",
+        }
+
     def test_get_repository_info_returns_500_on_info_failure(
         self, test_client: TestClient, admin_headers, test_db
     ):

--- a/tests/unit/test_borg2.py
+++ b/tests/unit/test_borg2.py
@@ -4,7 +4,12 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from app.config import settings
-from app.core.borg2 import borg2
+from app.core.borg2 import (
+    BORG2_ENCRYPTION_MODES,
+    borg2,
+    borg2_encryption_flags,
+    normalize_repo_info_encryption,
+)
 
 
 @pytest.mark.unit
@@ -130,8 +135,119 @@ async def test_rcreate_injects_managed_rclone_config_into_process_env(
         "repo-create",
         "--encryption",
         "none",
-    )
+    )  # 'none' has no key, so repo-create gets no --key-location
     assert captured["env"]["RCLONE_CONFIG"] == str(rclone_root / "rclone.conf")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        (
+            "repokey-aes-ocb",
+            ["--encryption", "aes256-ocb", "--key-location", "repokey"],
+        ),
+        (
+            "keyfile-chacha20-poly1305",
+            ["--encryption", "chacha20-poly1305", "--key-location", "keyfile"],
+        ),
+        ("authenticated", ["--encryption", "authenticated"]),
+        ("none", ["--encryption", "none"]),
+    ],
+)
+def test_encryption_mode_is_translated_to_the_repo_create_split(mode, expected):
+    """Borg 2.0.0b22 takes the cipher and the key location as separate options;
+    the combined name stays the vocabulary of the API, the UI and the stored
+    repository row."""
+    assert borg2_encryption_flags(mode) == expected
+
+
+@pytest.mark.unit
+def test_every_offered_encryption_mode_can_be_translated():
+    """The list the API validates against and the table repo-create is built
+    from are the same table, so a mode can never be offered without flags."""
+    for mode in BORG2_ENCRYPTION_MODES:
+        assert borg2_encryption_flags(mode)[0] == "--encryption"
+
+
+@pytest.mark.unit
+def test_an_unknown_encryption_mode_is_rejected_by_name():
+    """Rather than handing borg a value it will reject with an argparse error
+    that names no caller."""
+    with pytest.raises(ValueError, match="repokey-blake2-aes-ocb"):
+        borg2_encryption_flags("repokey-blake2-aes-ocb")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_prune_keep_within_is_sent_as_keep(monkeypatch):
+    """Borg 2.0.0b22 removed --keep-within; --keep takes the same interval. The
+    field keeps its name everywhere else — only the flag moved."""
+    captured: dict[str, object] = {}
+
+    class Process:
+        returncode = 0
+
+        async def communicate(self):
+            return b"", b""
+
+    async def create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        return Process()
+
+    monkeypatch.setattr(
+        "app.core.borg2.asyncio.create_subprocess_exec",
+        create_subprocess_exec,
+    )
+
+    await borg2.prune_archives(repository="/repo", keep_within="1d")
+
+    cmd = list(captured["cmd"])
+    assert "--keep" in cmd
+    assert cmd[cmd.index("--keep") + 1] == "1d"
+    assert not [arg for arg in cmd if arg.startswith("--keep-within")]
+
+
+@pytest.mark.unit
+def test_repo_info_encryption_from_b22_gets_a_mode():
+    """Verbatim from `borg2 repo-info --json` on 2.0.0b22: the single `mode`
+    became `encryption` + `id_hash`, which left every reader of `mode` — the
+    stored row, the API, the info dialog — showing nothing for an encrypted
+    repository."""
+    info = {
+        "encryption": {"encryption": "aes256-ocb", "id_hash": "sha256"},
+        "repository": {"id": "979d5a3d", "location": "/tmp/r"},
+    }
+
+    assert normalize_repo_info_encryption(info)["encryption"] == {
+        "encryption": "aes256-ocb",
+        "id_hash": "sha256",
+        "mode": "aes256-ocb",
+    }
+
+
+@pytest.mark.unit
+def test_repo_info_encryption_from_b21_is_left_alone():
+    """Verbatim from 2.0.0b21, and the Borg 1 shape too: a `mode` that is
+    already there is never rewritten."""
+    info = {"encryption": {"mode": "repokey-aes-ocb"}}
+
+    assert normalize_repo_info_encryption(info)["encryption"] == {
+        "mode": "repokey-aes-ocb"
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "info",
+    [{}, {"encryption": None}, {"encryption": {}}, {"encryption": "unexpected"}],
+)
+def test_repo_info_without_a_usable_encryption_block_is_untouched(info):
+    """An unencrypted repository, a failed call, or a shape nobody anticipated —
+    none of them should have a mode invented for them."""
+    before = dict(info)
+
+    assert normalize_repo_info_encryption(info) == before
 
 
 def _bypass_lock_commands() -> list[str]:

--- a/tests/unit/test_dockerfile_borg2_fuse.py
+++ b/tests/unit/test_dockerfile_borg2_fuse.py
@@ -18,15 +18,23 @@ def test_borg2_venv_installs_all_backend_dependencies():
     # borgstore version is parameterized as a build ARG, consistent with the
     # borg1/borg2 pins, so CI can override it without editing the install line.
     assert '"borgstore[rclone,sftp,rest,s3]==${BORGSTORE_VERSION}"' in content
-    assert "ARG BORGSTORE_VERSION=0.4.1" in content
+    assert re.search(r"^ARG BORGSTORE_VERSION=\S+", content, re.M)
 
 
-def test_runtime_base_env_pins_borgstore_version():
-    runtime_env = (
-        Path(__file__).resolve().parents[2] / "docker" / "runtime-base.env"
-    ).read_text()
+def test_runtime_base_env_agrees_with_the_dockerfile_borgstore_version():
+    """borgstore is single-sourced in runtime-base.env, like rclone, and the ARG
+    default must state the same version or a local build (no build-arg) resolves
+    a different one than CI. The version itself is not asserted: Borg 2 constrains
+    it (2.0.0b22 requires ~=0.5.5), so the pin moves with the Borg 2 pin."""
+    repo_root = Path(__file__).resolve().parents[2]
+    dockerfile = (repo_root / "Dockerfile.runtime-base").read_text()
+    env = _runtime_base_env(repo_root)
 
-    assert "BORGSTORE_VERSION=0.4.1" in runtime_env
+    arg = re.search(r"^ARG BORGSTORE_VERSION=(\S+)", dockerfile, re.M).group(1)
+    assert env["BORGSTORE_VERSION"] == arg, (
+        f"runtime-base.env pins borgstore {env['BORGSTORE_VERSION']}, "
+        f"Dockerfile.runtime-base builds {arg}"
+    )
 
 
 def test_runtime_base_installs_rclone_from_official_static_binary():

--- a/tests/unit/test_v2_prune_service.py
+++ b/tests/unit/test_v2_prune_service.py
@@ -157,7 +157,9 @@ async def test_borg2_prune_command_omits_stats_flag():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_borg2_prune_command_includes_keep_within():
+async def test_borg2_prune_command_sends_keep_within_as_keep():
+    """Borg 2.0.0b22 removed --keep-within; --keep takes the same interval. The
+    field is still called keep_within everywhere above the command builder."""
     with patch(
         "app.core.borg2.borg2._run",
         new=AsyncMock(return_value={"success": True, "stdout": "", "stderr": ""}),
@@ -169,5 +171,6 @@ async def test_borg2_prune_command_includes_keep_within():
             dry_run=True,
         )
 
-    cmd = mock_run.await_args.args[0]
-    assert "--keep-within=1d" in cmd
+    cmd = list(mock_run.await_args.args[0])
+    assert cmd[cmd.index("--keep") + 1] == "1d"
+    assert not [arg for arg in cmd if str(arg).startswith("--keep-within")]


### PR DESCRIPTION
> [!CAUTION]
> **Borg 2.0.0b22 changes the repository format and cannot read existing Borg 2 repositories.**
> This is the packs release. A repository written by any earlier Borg 2 beta fails to open with
> `repository version 3 is not supported by this borg version`, and there is no in-place conversion —
> `borg transfer` only converts Borg 1 repositories. **Every Borg 2 repository has to be deleted and
> created again after this upgrade lands.** Borg 1 repositories are unaffected.
>
> Verified, not inferred: a repository created with 2.0.0b21 and opened with 2.0.0b22 gives exactly
> that error. Upstream's release note says packs "needs new repositories, no support for repos
> from previous betas", and adds "rather expect alpha quality / stability".
>
> This PR documents the break where an operator meets it — `docs/installation.md` (Upgrade),
> `docs/troubleshooting.md` (with the error string, so a search lands there) and next to the pin in
> `docker/runtime-base.env`. It should also reach the release notes and the announcements feed when
> a release is cut; a PR description stops being visible the moment it merges.

**Contains #840's commit** — the watcher fix that noticed this release is the base this sits on. Once that PR merges, this one rebases to a two-commit diff. Reviewing just the adoption: commits 2 and 3.

Borg 2.0.0b22 was released 2026-07-22 and went unnoticed for a month; #840 fixes the watcher that missed it. This adopts it. **The pin and the command changes are one PR on purpose: b22 breaks three shapes this repo speaks, so adopting it without them ships a Borg 2 that cannot create a repository.**

## The pin

- `BORG2_VERSION` 2.0.0b21 → 2.0.0b22, `BORGSTORE_VERSION` 0.4.1 → 0.5.5 (b22 declares `borgstore[rest]~=0.5.5`; the old pin no longer resolves), Dockerfile ARG mirrors, manifest regenerated, `BASE_IMAGE` pointed at the new runtime-base tag.
- The borgstore pin is now read from `runtime-base.env` by the guard test instead of asserted as a literal, the way the rclone pin already is. Borg 2 is what decides that version — restating it in a test only means editing two places for one fact.
- Regenerating the manifest also widens Borg 1.4.5 from two binaries to three: borgbackup has since re-added the glibc 2.31 x86_64 asset it dropped at release, so the coverage regression noted when 1.4.5 was adopted is healed. Borg 2 moves the other way — b22's binaries carry a **glibc 2.39 floor**, up from 2.35, which costs a server-source install on Debian 12 and Ubuntu 22.04. The images are unaffected: they compile Borg from the sdist.

## What b22 forces

**`repo-create --encryption` was split** into three orthogonal options: the cipher (`--encryption`), where the key is stored (`--key-location`) and the id hash (`--id-hash`). `repokey-aes-ocb` is no longer a value b22 accepts:

```
error: argument -e/--encryption: invalid choice: 'repokey-aes-ocb'
       (choose from none, authenticated, aes256-ocb, chacha20-poly1305)
```

The combined names stay the vocabulary of the API, the UI, the locales and the stored repository row — they are translated into flags where a command is built, so nothing above has to change. `BORG2_ENCRYPTION_MODES` is now derived from that same table, so a mode can no longer be offered without flags to build it from. blake2 stays a Borg 1 mode: b22 replaced BLAKE2b with BLAKE3 for new repositories.

That translation is needed in three runtimes with no shared module, so the table is stated three times and says so: the server (`app/core/borg2.py`), the agent's own payload builder, and the frontend, which prints a `repo-create` the user is invited to copy into a shell.

**`repo-info --json` made the same split on the way back.** `{"mode": "repokey-aes-ocb"}` became `{"encryption": "aes256-ocb", "id_hash": "sha256"}`, so every reader of `mode` got nothing and the repository info dialog showed **"N/A" for a repository that is encrypted**. The block is normalised at every point it leaves for a client — both repository info routes and both archive info routes (the client sends every agent repository to the v1 path whatever its Borg major, so normalising only the v2 routes fixes nothing for agent repositories). The key location is deliberately not reconstructed — b22 does not report it there, so `repokey-` or `keyfile-` would be a guess, and a guess about where a key lives is worse than a field naming only what borg said. For the same reason the normalisation is kept off the agent stats refresh, which writes `repository.encryption`: the stored value is the combined name the repository was created with, and it feeds the agent's `repository.init` payload; writing b22's bare cipher back would drop the key-location half for good — silently, since b22 accepts a bare cipher.

**`prune --keep-within` was removed** (along with `--keep-last`) in favour of `--keep`, which takes either form — a count or an interval like `1d`. Only the emitted flag moves; the field is `keep_within` from the schedule row down to the job payload, and Borg 1 keeps the old spelling, so the agent — which builds for both majors — branches there.

`app/services/v2/compact_service.py` documented its progress mapping as "verified against live borg2 2.0.0b21", which this PR invalidates. Re-checked: packs renamed the second phase `compact.report_and_delete` → `compact.compact_packs`, but the split keys on `operation` (still 1 and 2), so the mapping holds — the docstring now says that instead of carrying a stale verification claim.

## Verified against the real binary

An image was built at this pin and every command shape the builders produce was run against borg 2.0.0b22 — all six encryption modes, prune with `keep_within`, the agent's repo-init:

```
repo-create --encryption aes256-ocb --key-location repokey          ok
repo-create --encryption chacha20-poly1305 --key-location repokey   ok
repo-create --encryption aes256-ocb --key-location keyfile          ok
repo-create --encryption chacha20-poly1305 --key-location keyfile   ok
repo-create --encryption authenticated                              ok
repo-create --encryption none                                       ok
prune --list --progress --show-rc --log-json \
      --keep-daily 7 --keep-3monthly 3 --keep 1d --dry-run          ok
```

`info`, `repo-list`, `list --json-lines --depth`, `create --stats`, `extract --umask`, `delete`, `check`, `compact`, `break-lock` and `repo-delete --force` were checked the same way and are unchanged in b22. Both beta shapes of the repo-info JSON are in the tests verbatim. Beyond the smoke tests, this pin has been running a real multi-node deployment (managed agents, scheduled backups, prune/compact, the info dialog) since adoption day.

Full unit suite: 2705 passed.

## The human half — what adopting this asks of you

- [ ] Rebuild and push the runtime base for the new tag (`runtime-borg1-1.4.5-borg2-2.0.0b22-r1`) and the `BASE_IMAGE` guard goes green — this PR already points the Dockerfile at that tag, so **the base-image check is red by design until then**, exactly as the adoption workflow's own checklist describes.
- [ ] Carry the repository-format warning into the release notes and `docs/announcements.json` — the wording is ready in `docs/installation.md`'s Upgrade section.

## What this PR does not do

- **Packs are not finished upstream.** `check --repair` and `repo-compress` are not implemented for them yet.
- Two pre-existing issues found while verifying, left for their own PRs: `--bypass-lock` is emitted on Borg 2 commands although Borg 2 has never had that flag (absent from b21 and b22 alike), and the repository card's archive count goes stale against the info dialog. Both follow separately once this merges.

