### PR TITLE
fix(remote): classify borg warning exit codes as warnings, and record the resolved archive name

### DIFF
--- a/agent/borg_ui_agent/repository_ops.py
+++ b/agent/borg_ui_agent/repository_ops.py
@@ -1043,12 +1043,6 @@ def _execute_streaming_repository_operation(
     )
 
 
-def _is_borg_warning_rc(return_code: Optional[int]) -> bool:
-    # Borg uses exit code 1 (and 100-127 in newer builds) for warnings that
-    # still produced output. Mirrors restore_check_service._is_borg_warning_exit_code.
-    return return_code == 1 or (return_code is not None and 100 <= return_code <= 127)
-
-
 def _resolve_restore_target(operation: dict[str, Any]) -> tuple[str, bool]:
     """Return (target_dir, is_temp) for a repository.restore job.
 
@@ -1151,7 +1145,7 @@ def _execute_restore_operation(
                     )
 
         return_code = process.wait()
-        warning = _is_borg_warning_rc(return_code)
+        warning = is_warning_return_code(return_code)
 
         # A hard borg failure has no meaningful verification verdict.
         if return_code != 0 and not warning:

--- a/app/api/agents.py
+++ b/app/api/agents.py
@@ -25,6 +25,7 @@ from app.core.agent_auth import (
     resolve_agent_from_token,
 )
 from app.core.agent_constants import DEFAULT_AGENT_POLL_INTERVAL_SECONDS
+from app.core.borg_errors import is_borg_warning_exit_code
 from app.core.security import get_password_hash, verify_password
 from app.database.database import get_db
 from app.database.models import (
@@ -60,18 +61,6 @@ FINAL_AGENT_JOB_STATUSES = {
     "failed",
     "canceled",
 }
-
-
-def _is_borg_warning_return_code(return_code: Any) -> bool:
-    """Borg's warning exit codes: legacy rc 1, modern range 100-127.
-
-    Same classification the server-side services apply to their own borg
-    processes - the agent path finally speaks it too instead of collapsing
-    every non-zero exit into "failed".
-    """
-    return isinstance(return_code, int) and (
-        return_code == 1 or 100 <= return_code <= 127
-    )
 
 
 STALE_AGENT_JOB_REQUEUE_AFTER = timedelta(minutes=15)
@@ -619,7 +608,19 @@ def _complete_agent_job(
     if job.status in FINAL_AGENT_JOB_STATUSES:
         return
     return_code = result.get("return_code") if isinstance(result, dict) else None
-    warning = _is_borg_warning_return_code(return_code)
+    if return_code is not None and (
+        not isinstance(return_code, int) or isinstance(return_code, bool)
+    ):
+        # A completion report is only trusted with a well-formed exit code.
+        # Anything else fails closed instead of being recorded as success.
+        _fail_agent_job(
+            job,
+            db,
+            error_message=f"agent reported a malformed return code: {return_code!r}",
+            completed_at=completed_at,
+        )
+        return
+    warning = is_borg_warning_exit_code(return_code)
     if isinstance(return_code, int) and return_code != 0 and not warning:
         # A completion report carrying an explicit borg *error* code is a
         # failure, no matter which transport delivered it - the server is

--- a/app/core/borg_errors.py
+++ b/app/core/borg_errors.py
@@ -245,6 +245,20 @@ def get_exit_code_message(exit_code: int) -> str:
         return f"Unknown error (exit code {exit_code})"
 
 
+def is_borg_warning_exit_code(exit_code) -> bool:
+    """Borg's warning exit codes: legacy rc 1, modern range 100-127.
+
+    Warnings mean the operation ran to completion but something was worth
+    telling the operator (a file changed mid-read, a path was missing).
+    They are not failures; jobs record them as completed_with_warnings.
+    """
+    return (
+        isinstance(exit_code, int)
+        and not isinstance(exit_code, bool)
+        and (exit_code == 1 or 100 <= exit_code <= 127)
+    )
+
+
 def is_lock_error(exit_code: int = None, msgid: str = None) -> bool:
     """
     Check if an error is a lock-related error

--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -13,7 +13,11 @@ from app.database.models import BackupJob, Repository, RepositoryScript, SystemS
 from app.database.database import SessionLocal
 from app.config import settings
 from app.core.borg_router import BorgRouter
-from app.core.borg_errors import format_error_message, is_lock_error
+from app.core.borg_errors import (
+    format_error_message,
+    is_borg_warning_exit_code,
+    is_lock_error,
+)
 from app.services.notification_service import notification_service
 from app.services.script_executor import execute_script
 from app.services.script_library_executor import ScriptLibraryExecutor
@@ -2729,7 +2733,7 @@ class BackupService:
                             "Failed to send backup notification", error=str(e)
                         )
 
-            elif actual_returncode == 1 or (100 <= actual_returncode <= 127):
+            elif is_borg_warning_exit_code(actual_returncode):
                 # Warning (legacy exit code 1 or modern exit codes 100-127)
                 job.status = "completed_with_warnings"
                 job.progress = 100

--- a/app/services/check_service.py
+++ b/app/services/check_service.py
@@ -9,6 +9,7 @@ from app.database.models import CheckJob, Repository
 from app.database.database import SessionLocal
 from app.config import settings
 from app.core.borg import borg
+from app.core.borg_errors import is_borg_warning_exit_code
 from app.services.notification_service import NotificationService
 from app.utils.db_retries import commit_with_retry
 from app.utils.borg_env import build_repository_borg_env, cleanup_temp_key_file
@@ -379,7 +380,7 @@ class CheckService:
                 # Update repository's last_check timestamp
                 repository.last_check = datetime.utcnow()
                 logger.info("Check completed successfully", job_id=job_id)
-            elif process.returncode == 1 or (100 <= process.returncode <= 127):
+            elif is_borg_warning_exit_code(process.returncode):
                 # Warning (legacy exit code 1 or modern exit codes 100-127)
                 job.status = "completed_with_warnings"
                 job.progress = 100

--- a/app/services/delete_archive_service.py
+++ b/app/services/delete_archive_service.py
@@ -7,6 +7,7 @@ from app.database.models import DeleteArchiveJob, Repository
 from app.database.database import SessionLocal
 from app.config import settings
 from app.core.borg import borg
+from app.core.borg_errors import is_borg_warning_exit_code
 from app.utils.db_retries import commit_with_retry
 from app.utils.borg_env import build_repository_borg_env, cleanup_temp_key_file
 
@@ -220,7 +221,7 @@ class DeleteArchiveService:
                 job.progress = 100
                 job.progress_message = f"Archive {archive_name} deleted successfully"
                 logger.info("Delete job completed", job_id=job_id)
-            elif process.returncode == 1 or (100 <= process.returncode <= 127):
+            elif is_borg_warning_exit_code(process.returncode):
                 # Warning (legacy exit code 1 or modern exit codes 100-127)
                 job.status = "completed_with_warnings"
                 job.progress = 100

--- a/app/services/maintenance_state.py
+++ b/app/services/maintenance_state.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+from app.core.borg_errors import is_borg_warning_exit_code
+
 
 def apply_compact_completion(job, repository, returncode: int, *, now=None) -> None:
     """Apply the shared terminal compact state to a job and repository."""
@@ -13,7 +15,7 @@ def apply_compact_completion(job, repository, returncode: int, *, now=None) -> N
         repository.last_compact = completed_at
         return
 
-    if returncode == 1 or (100 <= returncode <= 127):
+    if is_borg_warning_exit_code(returncode):
         job.status = "completed_with_warnings"
         job.progress = 100
         job.progress_message = (

--- a/app/services/prune_service.py
+++ b/app/services/prune_service.py
@@ -7,6 +7,7 @@ from app.database.models import PruneJob, Repository
 from app.database.database import SessionLocal
 from app.config import settings
 from app.core.borg import borg
+from app.core.borg_errors import is_borg_warning_exit_code
 from app.utils.db_retries import commit_with_retry
 from app.utils.borg_env import build_repository_borg_env, cleanup_temp_key_file
 
@@ -268,7 +269,7 @@ class PruneService:
                 logger.info(
                     "Prune completed successfully", job_id=job_id, dry_run=dry_run
                 )
-            elif process.returncode == 1 or (100 <= process.returncode <= 127):
+            elif is_borg_warning_exit_code(process.returncode):
                 # Warning (legacy exit code 1 or modern exit codes 100-127)
                 job.status = "completed_with_warnings"
                 job.error_message = (

--- a/app/services/remote_backup_service.py
+++ b/app/services/remote_backup_service.py
@@ -20,10 +20,35 @@ from sqlalchemy.orm import Session
 from app.database.models import BackupJob, Repository, SSHConnection, SSHKey
 from app.database.database import SessionLocal
 from app.config import settings
+from app.core.borg_errors import is_borg_warning_exit_code
 from app.services.notification_service import notification_service
 from app.utils.ssh_utils import ssh_key_auth_args, write_ssh_key_to_tempfile
 
 logger = structlog.get_logger()
+
+
+def _parse_created_archive_name(stdout) -> str | None:
+    """Extract the resolved archive name from ``borg create --json`` stdout.
+
+    borg expands placeholders such as ``{hostname}-{now}`` when it creates the
+    archive and reports the resolved name as ``archive.name`` in the JSON
+    result document. Returns None when the output is absent or unparseable so
+    the caller can fall back to the requested (template) name.
+    """
+    if not stdout or not stdout.strip():
+        return None
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    archive = data.get("archive")
+    if isinstance(archive, dict):
+        name = archive.get("name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+    return None
 
 
 class RemoteBackupService:
@@ -134,13 +159,46 @@ class RemoteBackupService:
                 db=db,
             )
 
+            # borg expanded the {hostname}-{now} placeholders on the remote
+            # host and reports the resolved name in its --json result document.
+            resolved_name = _parse_created_archive_name(result.get("stdout"))
+
+            # A warning exit code only counts as a warning when borg proves it
+            # wrote an archive (the result document above). An exit in the
+            # warning range without it is the remote shell speaking - 127 for
+            # a missing borg binary, 126 for a non-executable one - and means
+            # the backup never ran.
+            warning = (
+                is_borg_warning_exit_code(result.get("returncode"))
+                and resolved_name is not None
+            )
+            if warning:
+                result = {**result, "success": True, "warning": True, "error": None}
+
             # Update final job status
             job = db.query(BackupJob).filter(BackupJob.id == job_id).first()
             if result["success"]:
-                job.status = "completed"
+                if resolved_name:
+                    archive_name = resolved_name
+                job.archive_name = archive_name
                 job.progress = 100
                 job.progress_percent = 100.0
-                logger.info("Remote backup completed successfully", job_id=job_id)
+                if warning:
+                    job.status = "completed_with_warnings"
+                    job.error_message = json.dumps(
+                        {
+                            "key": "backend.errors.service.backupCompletedWithWarning",
+                            "params": {"exitCode": result["returncode"]},
+                        }
+                    )
+                    logger.warning(
+                        "Remote backup completed with warnings",
+                        job_id=job_id,
+                        exit_code=result["returncode"],
+                    )
+                else:
+                    job.status = "completed"
+                    logger.info("Remote backup completed successfully", job_id=job_id)
             else:
                 job.status = "failed"
                 job.error_message = result.get("error", "Remote backup failed")
@@ -188,16 +246,28 @@ class RemoteBackupService:
         archive_name: str,
     ) -> None:
         try:
+            stats = {
+                "original_size": job.original_size,
+                "compressed_size": job.compressed_size,
+                "deduplicated_size": job.deduplicated_size,
+            }
             if job.status == "completed":
                 await notification_service.send_backup_success(
                     db,
                     repository.name,
                     archive_name,
-                    stats={
-                        "original_size": job.original_size,
-                        "compressed_size": job.compressed_size,
-                        "deduplicated_size": job.deduplicated_size,
-                    },
+                    stats=stats,
+                    completion_time=job.completed_at,
+                    started_at=job.started_at,
+                    nfiles=job.nfiles,
+                )
+            elif job.status == "completed_with_warnings":
+                await notification_service.send_backup_warning(
+                    db,
+                    repository.name,
+                    archive_name,
+                    job.error_message,
+                    stats=stats,
                     completion_time=job.completed_at,
                     started_at=job.started_at,
                     nfiles=job.nfiles,
@@ -457,7 +527,9 @@ class RemoteBackupService:
                 # Clean up
                 del self.running_processes[job_id]
 
-                # Return result
+                # Return transport facts only; whether a non-zero exit is a
+                # borg warning or a failure is decided by the caller, which
+                # knows what command ran and what output to expect.
                 success = returncode == 0
                 return {
                     "success": success,

--- a/app/services/restore_check_service.py
+++ b/app/services/restore_check_service.py
@@ -12,6 +12,7 @@ import structlog
 from fastapi import HTTPException
 
 from app.config import settings
+from app.core.borg_errors import is_borg_warning_exit_code
 from app.core.borg_router import BorgRouter
 from app.database.database import SessionLocal
 from app.database.models import Repository, RestoreCheckJob
@@ -93,10 +94,6 @@ def _http_detail_text(exc: HTTPException) -> str:
     if isinstance(detail, dict):
         return detail.get("message") or detail.get("key") or str(detail)
     return str(detail)
-
-
-def _is_borg_warning_exit_code(returncode: int | None) -> bool:
-    return returncode == 1 or (returncode is not None and 100 <= returncode <= 127)
 
 
 class RestoreCheckService:
@@ -354,7 +351,7 @@ class RestoreCheckService:
                     )
 
                 returncode = await run_extract(attempt_paths)
-                warning_exit = _is_borg_warning_exit_code(returncode)
+                warning_exit = is_borg_warning_exit_code(returncode)
 
                 if not use_canary:
                     break
@@ -384,7 +381,7 @@ class RestoreCheckService:
                     continue
                 break
 
-            warning_exit = _is_borg_warning_exit_code(returncode)
+            warning_exit = is_borg_warning_exit_code(returncode)
             if canary_prerequisite_error:
                 job.status = "needs_backup"
                 job.progress = 100

--- a/app/services/restore_service.py
+++ b/app/services/restore_service.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 
 from app.database.models import RestoreJob, Repository, SSHConnection
 from app.database.database import SessionLocal
+from app.core.borg_errors import is_borg_warning_exit_code
 from app.core.borg_router import BorgRouter
 from app.services.notification_service import notification_service
 from app.utils.borg_env import (
@@ -883,7 +884,7 @@ class RestoreService:
                         logger.warning(
                             "Failed to send restore success notification", error=str(e)
                         )
-                elif process.returncode == 1 or (100 <= process.returncode <= 127):
+                elif is_borg_warning_exit_code(process.returncode):
                     # Exit code 1 or 100-127 can be warnings OR errors
                     # If no files were restored, treat as failure (likely permission/path error)
                     stderr_output = "\n".join(stderr_lines)
@@ -1490,11 +1491,7 @@ class RestoreService:
             await process.wait()
 
             # Check exit code (same logic as local restore)
-            if (
-                process.returncode == 0
-                or process.returncode == 1
-                or (100 <= process.returncode <= 127)
-            ):
+            if process.returncode == 0 or is_borg_warning_exit_code(process.returncode):
                 if process.returncode == 1:
                     warning_msgs = [
                         line

--- a/app/services/v2/check_service.py
+++ b/app/services/v2/check_service.py
@@ -15,6 +15,7 @@ import structlog
 from app.database.models import CheckJob, Repository
 from app.database.database import SessionLocal
 from app.core.borg2 import _get_borg2_binary
+from app.core.borg_errors import is_borg_warning_exit_code
 from app.config import settings
 from app.utils.db_retries import commit_with_retry
 from app.utils.borg_env import build_repository_borg_env, cleanup_temp_key_file
@@ -300,7 +301,7 @@ class CheckV2Service:
                 job.completed_at = datetime.utcnow()
                 repo.last_check = datetime.utcnow()
                 logger.info("Borg2 check completed", job_id=job_id)
-            elif process.returncode == 1 or (100 <= process.returncode <= 127):
+            elif is_borg_warning_exit_code(process.returncode):
                 job.status = "completed_with_warnings"
                 job.progress = 100
                 job.progress_message = (

--- a/tests/unit/test_api_agents.py
+++ b/tests/unit/test_api_agents.py
@@ -852,6 +852,40 @@ class TestAgentJobTransport:
         assert job.status == "failed"
         assert "exited with code 2" in (job.error_message or "")
 
+    @pytest.mark.parametrize("malformed", ["2", 2.0, True, [1]])
+    def test_malformed_return_code_in_completion_report_fails_closed(
+        self, test_client: TestClient, test_db, admin_headers, malformed
+    ):
+        """A completion report is only trusted with an int return code;
+        anything else fails the job (and its linked backup job) instead of
+        slipping past the classification as a success."""
+        registered = _register_agent(
+            test_client,
+            _create_enrollment_token(test_client, admin_headers)["token"],
+        )
+        agent = _get_agent(test_db, registered["agent_id"])
+        job = _create_agent_job(test_db, agent, status="running")
+        backup_job = BackupJob(repository="/repo", status="running")
+        test_db.add(backup_job)
+        test_db.commit()
+        job.backup_job_id = backup_job.id
+        test_db.commit()
+        headers = _agent_headers(registered["agent_token"])
+
+        complete = test_client.post(
+            f"/api/agents/jobs/{job.id}/complete",
+            json={"result": {"return_code": malformed}},
+            headers=headers,
+        )
+        assert complete.status_code == 200
+        assert complete.json()["status"] == "failed"
+
+        test_db.refresh(job)
+        test_db.refresh(backup_job)
+        assert job.status == "failed"
+        assert "malformed return code" in (job.error_message or "")
+        assert backup_job.status == "failed"
+
     def test_repeated_complete_report_is_idempotent(
         self, test_client: TestClient, test_db, admin_headers
     ):

--- a/tests/unit/test_borg_errors.py
+++ b/tests/unit/test_borg_errors.py
@@ -11,6 +11,7 @@ from app.core.borg_errors import (
     format_error_message,
     get_error_details,
     get_exit_code_message,
+    is_borg_warning_exit_code,
     is_lock_error,
 )
 
@@ -164,3 +165,20 @@ def test_format_error_message_uses_unknown_error_when_no_inputs():
     payload = json.loads(format_error_message())
 
     assert payload == {"key": "backend.errors.borg.unknownError"}
+
+
+@pytest.mark.unit
+def test_is_borg_warning_exit_code():
+    """Warnings are legacy rc 1 and the modern 100-127 range, nothing else"""
+    assert is_borg_warning_exit_code(1) is True
+    assert is_borg_warning_exit_code(100) is True
+    assert is_borg_warning_exit_code(127) is True
+    assert is_borg_warning_exit_code(0) is False
+    assert is_borg_warning_exit_code(2) is False
+    assert is_borg_warning_exit_code(99) is False
+    assert is_borg_warning_exit_code(128) is False
+    assert is_borg_warning_exit_code(-1) is False
+    assert is_borg_warning_exit_code(None) is False
+    assert is_borg_warning_exit_code("1") is False
+    assert is_borg_warning_exit_code(True) is False
+    assert is_borg_warning_exit_code(False) is False

--- a/tests/unit/test_remote_backup_service.py
+++ b/tests/unit/test_remote_backup_service.py
@@ -2,8 +2,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import json
+
 from app.database.models import BackupJob, Repository, SSHConnection, SSHKey
-from app.services.remote_backup_service import RemoteBackupService
+from app.services.remote_backup_service import (
+    RemoteBackupService,
+    _parse_created_archive_name,
+)
 
 
 def _remote_entities(test_db):
@@ -102,15 +107,23 @@ async def test_execute_remote_backup_updates_same_job_row_and_uses_source_borg_w
             },
             db,
         )
-        return {"success": True, "returncode": 0, "stdout": "{}", "stderr": ""}
+        return {
+            "success": True,
+            "returncode": 0,
+            "stdout": json.dumps(
+                {"archive": {"name": "docker-host.example-2026-08-20T11:18:00"}}
+            ),
+            "stderr": "",
+        }
 
     monkeypatch.setattr(
         "app.services.remote_backup_service.SessionLocal", lambda: test_db
     )
     monkeypatch.setattr(service, "_execute_ssh_command", fake_execute_ssh_command)
+    send_success = AsyncMock()
     monkeypatch.setattr(
         "app.services.remote_backup_service.notification_service.send_backup_success",
-        AsyncMock(),
+        send_success,
     )
 
     result = await service.execute_remote_backup(
@@ -125,6 +138,8 @@ async def test_execute_remote_backup_updates_same_job_row_and_uses_source_borg_w
     job = test_db.query(BackupJob).filter(BackupJob.id == job_id).one()
     assert result["success"] is True
     assert job.status == "completed"
+    assert job.archive_name == "docker-host.example-2026-08-20T11:18:00"
+    assert send_success.await_args.args[2] == "docker-host.example-2026-08-20T11:18:00"
     assert job.started_at is not None
     assert job.completed_at is not None
     assert job.remote_hostname == connection_host
@@ -217,7 +232,12 @@ async def test_execute_remote_backup_keeps_completed_status_when_success_notific
     job_id = job.id
 
     async def fake_execute_ssh_command(*args, **kwargs):
-        return {"success": True, "returncode": 0, "stdout": "{}", "stderr": ""}
+        return {
+            "success": True,
+            "returncode": 0,
+            "stdout": "{}",
+            "stderr": "",
+        }
 
     monkeypatch.setattr(
         "app.services.remote_backup_service.SessionLocal", lambda: test_db
@@ -367,3 +387,175 @@ async def test_update_progress_from_json_only_sets_percent_with_known_total(test
     assert job_without_total.progress_percent == 0.0
     assert job_with_total.progress == 50
     assert job_with_total.progress_percent == 50.0
+
+
+@pytest.mark.asyncio
+async def test_execute_remote_backup_records_warning_exit_as_completed_with_warnings(
+    test_db, monkeypatch
+):
+    connection, repository, job = _remote_entities(test_db)
+    service = RemoteBackupService()
+    connection_id = connection.id
+    repository_id = repository.id
+    job_id = job.id
+
+    async def fake_execute_ssh_command(*args, **kwargs):
+        return {
+            "success": False,
+            "returncode": 1,
+            "stdout": json.dumps({"archive": {"name": "host-2026-08-20T11:18:00"}}),
+            "stderr": "BackupFileNotFoundError: /etc/dangling-symlink",
+            "error": "Remote backup failed with exit code 1",
+        }
+
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.SessionLocal", lambda: test_db
+    )
+    monkeypatch.setattr(service, "_execute_ssh_command", fake_execute_ssh_command)
+    send_warning = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.notification_service.send_backup_warning",
+        send_warning,
+    )
+
+    result = await service.execute_remote_backup(
+        job_id=job_id,
+        source_ssh_connection_id=connection_id,
+        repository_id=repository_id,
+        source_paths=["/var/lib/docker/volumes/app"],
+    )
+
+    job = test_db.query(BackupJob).filter(BackupJob.id == job_id).one()
+    assert result["success"] is True
+    assert job.status == "completed_with_warnings"
+    assert job.progress == 100
+    assert job.progress_percent == 100.0
+    assert job.completed_at is not None
+    assert job.archive_name == "host-2026-08-20T11:18:00"
+    assert json.loads(job.error_message) == {
+        "key": "backend.errors.service.backupCompletedWithWarning",
+        "params": {"exitCode": 1},
+    }
+    send_warning.assert_awaited_once()
+    assert send_warning.await_args.args[2] == "host-2026-08-20T11:18:00"
+
+
+@pytest.mark.asyncio
+async def test_execute_ssh_command_reports_transport_facts_only(monkeypatch):
+    """_execute_ssh_command must not classify warnings - the exit code may be
+    the remote shell's (127 = borg missing), so the caller decides."""
+    service = RemoteBackupService()
+    connection = SSHConnection(
+        id=7,
+        host="truenas.example",
+        username="backup",
+        port=2222,
+        ssh_key_id=42,
+    )
+    ssh_key = MagicMock(spec=SSHKey)
+    job = MagicMock(spec=BackupJob)
+    db = MagicMock()
+
+    def query_side_effect(model):
+        query = MagicMock()
+        if model == SSHKey:
+            query.filter.return_value.first.return_value = ssh_key
+        elif model == BackupJob:
+            query.filter.return_value.first.return_value = job
+        return query
+
+    db.query.side_effect = query_side_effect
+
+    process = AsyncMock()
+    process.pid = 1234
+    process.stdout.readline = AsyncMock(return_value=b"")
+    process.stderr.readline = AsyncMock(return_value=b"")
+
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.write_ssh_key_to_tempfile",
+        lambda key: "/tmp/source.key",
+    )
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=process),
+    )
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.os.unlink", lambda path: None
+    )
+
+    for returncode in (0, 1, 104, 127, 2):
+        process.wait = AsyncMock(return_value=returncode)
+        result = await service._execute_ssh_command(
+            ssh_connection=connection,
+            command="borg create /repo::archive /data",
+            job_id=99,
+            db=db,
+        )
+        assert result["success"] is (returncode == 0), returncode
+        assert "warning" not in result
+        if returncode == 0:
+            assert result["error"] is None
+        else:
+            assert (
+                result["error"] == f"Remote backup failed with exit code {returncode}"
+            )
+
+
+@pytest.mark.asyncio
+async def test_execute_remote_backup_treats_shell_127_as_failure(test_db, monkeypatch):
+    """Exit 127 is the remote shell's 'command not found' - inside borg's
+    modern warning range, but no archive was written. Must stay a failure."""
+    connection, repository, job = _remote_entities(test_db)
+    service = RemoteBackupService()
+    connection_id = connection.id
+    repository_id = repository.id
+    job_id = job.id
+
+    async def fake_execute_ssh_command(*args, **kwargs):
+        return {
+            "success": False,
+            "returncode": 127,
+            "stdout": "",
+            "stderr": "bash: line 1: /usr/local/bin/borg-wrapper: command not found",
+            "error": "Remote backup failed with exit code 127",
+        }
+
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.SessionLocal", lambda: test_db
+    )
+    monkeypatch.setattr(service, "_execute_ssh_command", fake_execute_ssh_command)
+    send_failure = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.notification_service.send_backup_failure",
+        send_failure,
+    )
+
+    result = await service.execute_remote_backup(
+        job_id=job_id,
+        source_ssh_connection_id=connection_id,
+        repository_id=repository_id,
+        source_paths=["/var/lib/docker/volumes/app"],
+    )
+
+    job = test_db.query(BackupJob).filter(BackupJob.id == job_id).one()
+    assert result["success"] is False
+    assert job.status == "failed"
+    assert job.archive_name is None
+    assert job.error_message == "Remote backup failed with exit code 127"
+    send_failure.assert_awaited_once()
+
+
+def test_parse_created_archive_name():
+    stdout = json.dumps(
+        {
+            "archive": {"name": "host-2026-08-20T11:18:00", "id": "ceb0dfe2"},
+            "repository": {"location": "ssh://backup@host/repo"},
+        },
+        indent=4,
+    )
+    assert _parse_created_archive_name(stdout) == "host-2026-08-20T11:18:00"
+    assert _parse_created_archive_name("") is None
+    assert _parse_created_archive_name(None) is None
+    assert _parse_created_archive_name("not json") is None
+    assert _parse_created_archive_name(json.dumps({"archive": {}})) is None
+    assert _parse_created_archive_name(json.dumps(["archive"])) is None


### PR DESCRIPTION
## Problem

Borg exits 1 (and 100-127 in modern builds) to say "completed with warnings" - the archive was written and is valid. The server has always classified its own borg processes that way, and #774 taught the agent path the same. The remote SSH path was the last holdout: any non-zero exit became `failed`, so a remote backup that hit a dangling symlink was reported as a failure while a complete, correct archive sat in the repository (#836).

The same code path also never recorded which archive it created: `backup_jobs.archive_name` stayed NULL and the success notification reported the literal `{hostname}-{now}` template instead of the name borg resolved - the same gap the agent path had before #729.

## What this PR does

- **One classifier.** The warning classification moves into `app/core/borg_errors.is_borg_warning_exit_code()` - the module that already owns borg exit-code knowledge - and every server-side site that had its own copy of `rc == 1 or 100 <= rc <= 127` now imports it (`agents.py`, `backup_service`, `check_service`, `v2/check_service`, `prune_service`, `delete_archive_service`, `restore_service`, `restore_check_service`, `maintenance_state`). The agent is a separately-deployed package that cannot import `app/`, so it keeps its single copy in `agent/borg_ui_agent/borg.py`; `repository_ops.py`'s private duplicate now uses that one. No copy of the expression remains anywhere else.
- **Resolved archive name.** The resolved name is parsed from `borg create --json` stdout (`archive.name`), stored on `job.archive_name`, and used in notifications - falling back to the requested template when the output is absent or unparseable.
- **Remote warning semantics, with proof.** `_execute_ssh_command` keeps reporting transport facts only (success = rc 0). `execute_remote_backup` classifies a warning only when the exit code is in borg's warning range **and** the `--json` result document above is present - i.e. borg itself says it wrote an archive. This matters because ssh hands back the *remote shell's* exit status: 127 (borg binary missing) and 126 (not executable) fall inside the modern warning range but mean the backup never ran, and they stay failures. The job then ends as `completed_with_warnings` with the same `backend.errors.service.backupCompletedWithWarning` message the local path stores (the key already exists in all four locales), and the warning notification is sent instead of the success one. rc 2-99 still fails, unchanged.

## Testing

- New unit tests: remote warning exit ends as `completed_with_warnings` with the i18n message and warning notification; shell exit 127 without a result document stays `failed`; `_execute_ssh_command` reports transport facts only for rc 0/1/104/127/2; archive-name parsing incl. fallback cases; classifier edge cases (incl. bool rejection) in `test_borg_errors.py`.
- Full backend suite green.
- `ruff check` and `ruff format --check` clean.

Fixes #836
