### PR TITLE
fix(remote): pass the borg environment through sudo explicitly

### DIFF
--- a/app/services/remote_backup_service.py
+++ b/app/services/remote_backup_service.py
@@ -310,6 +310,10 @@ class RemoteBackupService:
           --compression lz4 \
           ssh://user@repo-host:/path::{hostname}-{now} \
           /data /etc
+
+        With use_sudo the borg invocation becomes
+        ``sudo -n --preserve-env=BORG_PASSPHRASE,... borg create ...`` so the
+        variables survive sudo's env_reset.
         """
         # Get DB session for connection lookup
         db = SessionLocal()
@@ -320,8 +324,8 @@ class RemoteBackupService:
         finally:
             db.close()
 
-        # Build borg command parts
-        cmd_parts = [
+        # Environment for borg, as shell assignments in front of the command
+        env_assignments = [
             "BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK=yes",
             "BORG_RELOCATED_REPO_ACCESS_IS_OK=yes",
         ]
@@ -334,15 +338,26 @@ class RemoteBackupService:
         ):
             # Use shlex.quote to safely escape the passphrase
             escaped_passphrase = shlex.quote(repository.passphrase)
-            cmd_parts.append(f"BORG_PASSPHRASE={escaped_passphrase}")
+            env_assignments.append(f"BORG_PASSPHRASE={escaped_passphrase}")
 
         # Add remote path if configured
         if repository.remote_path:
-            cmd_parts.append(f"BORG_REMOTE_PATH={shlex.quote(repository.remote_path)}")
+            env_assignments.append(
+                f"BORG_REMOTE_PATH={shlex.quote(repository.remote_path)}"
+            )
+
+        cmd_parts = list(env_assignments)
 
         # Borg binary path (optionally prefixed with sudo)
         if use_sudo:
-            cmd_parts.append("sudo")
+            # sudo's env_reset (the Debian-family default) strips the
+            # assignments above before borg starts; name them explicitly as
+            # preserved. -n fails fast instead of waiting for a password that
+            # can never arrive over a non-interactive ssh command.
+            preserved = ",".join(
+                assignment.split("=", 1)[0] for assignment in env_assignments
+            )
+            cmd_parts.extend(["sudo", "-n", f"--preserve-env={preserved}"])
         cmd_parts.append(shlex.quote(borg_binary_path))
 
         # Create command

--- a/docs/ssh-keys.md
+++ b/docs/ssh-keys.md
@@ -66,7 +66,7 @@ Common options:
 | SFTP deployment mode | Key deployment needs SFTP mode, for example Hetzner Storage Box |
 | SSH path prefix | SSH commands need a prefix that SFTP browsing does not, for example some NAS paths |
 | Logical mount point | You want a friendly name for the remote machine in path pickers |
-| Use sudo | SSHFS access needs the remote SFTP server to run through sudo |
+| Use sudo | The SSH user's own permissions are not enough: SSHFS runs the remote SFTP server through sudo, and Remote Direct Backups run `borg create` through sudo (see below) |
 
 SFTP deployment mode can break some older SSH servers or NAS devices. Disable it when key deployment fails on those systems.
 
@@ -172,6 +172,24 @@ Use the connection's Borg binary path when the source host needs a wrapper
 script, for example to pause Docker containers before Borg starts and resume
 them after Borg exits. The repository `remote_path` setting is different: it is
 passed to Borg as the repository-side remote Borg path.
+
+With *Use sudo* enabled, Borg UI runs
+`sudo -n --preserve-env=BORG_PASSPHRASE,... borg create ...` on the source
+host, so the passphrase and the other `BORG_*` variables survive sudo's
+`env_reset` (the default on Debian, Ubuntu and Raspberry Pi OS). The SSH user
+needs passwordless sudo that also allows preserving those variables. Prefer a
+rule scoped to the Borg binary with the `SETENV:` tag, for example
+`backup ALL=(root) NOPASSWD: SETENV: /usr/bin/borg` - the path in the rule must
+be the connection's configured Borg binary path, exactly as entered, wrapper
+scripts included, because that is what runs after `sudo`. The configured
+binary or wrapper and its parent directories must be owned by root and not
+writable by the SSH user - otherwise the rule executes user-controlled code
+as root. The unrestricted
+`NOPASSWD: ALL` that many images grant their default user works as well, but
+it lets the SSH user run any command as root - use it only where that is
+intentional, and prefer the scoped `SETENV` rule otherwise.
+Without either, sudo refuses the command or the environment and the backup
+fails before it touches the repository.
 
 ## Synology and NAS Path Prefixes
 

--- a/docs/ssh-keys.md
+++ b/docs/ssh-keys.md
@@ -181,10 +181,17 @@ needs passwordless sudo that also allows preserving those variables. Prefer a
 rule scoped to the Borg binary with the `SETENV:` tag, for example
 `backup ALL=(root) NOPASSWD: SETENV: /usr/bin/borg` - the path in the rule must
 be the connection's configured Borg binary path, exactly as entered, wrapper
-scripts included, because that is what runs after `sudo`. The configured
-binary or wrapper and its parent directories must be owned by root and not
-writable by the SSH user - otherwise the rule executes user-controlled code
-as root. The unrestricted
+scripts included, because that is what runs after `sudo`.
+
+::: warning The sudo target must not be writable by the SSH user
+The configured Borg binary or wrapper - and every parent directory on its
+path - must be owned by root and not writable by the SSH user. A file or
+directory the SSH user can modify turns the sudo rule into root code
+execution: the user replaces the target (or redirects a parent directory)
+and sudo runs it as root.
+:::
+
+The unrestricted
 `NOPASSWD: ALL` that many images grant their default user works as well, but
 it lets the SSH user run any command as root - use it only where that is
 intentional, and prefer the scoped `SETENV` rule otherwise.

--- a/tests/unit/test_remote_backup_service.py
+++ b/tests/unit/test_remote_backup_service.py
@@ -83,6 +83,92 @@ def test_repository_url_keeps_canonical_ssh_url_for_different_connection(test_db
 
 
 @pytest.mark.asyncio
+async def test_build_remote_command_passes_borg_env_through_sudo(test_db, monkeypatch):
+    """sudo's env_reset (the Debian-family default) drops the BORG_* shell
+    assignments in front of the command, so with use_sudo they must be named
+    explicitly as preserved - otherwise borg prompts for a passphrase that
+    can never arrive and exits 2 before touching the repository."""
+    connection, repository, _job = _remote_entities(test_db)
+    repository.encryption = "repokey"
+    repository.passphrase = "s3cret pass"
+    test_db.commit()
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.SessionLocal", lambda: test_db
+    )
+    service = RemoteBackupService()
+
+    with_sudo = await service._build_remote_command(
+        repository=repository,
+        archive_name="{hostname}-{now}",
+        source_paths=["/data"],
+        exclude_patterns=[],
+        borg_binary_path="/usr/bin/borg",
+        use_sudo=True,
+        source_ssh_connection=connection,
+    )
+    without_sudo = await service._build_remote_command(
+        repository=repository,
+        archive_name="{hostname}-{now}",
+        source_paths=["/data"],
+        exclude_patterns=[],
+        borg_binary_path="/usr/bin/borg",
+        use_sudo=False,
+        source_ssh_connection=connection,
+    )
+
+    env_prefix = (
+        "BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK=yes "
+        "BORG_RELOCATED_REPO_ACCESS_IS_OK=yes "
+        "BORG_PASSPHRASE='s3cret pass' "
+        "BORG_REMOTE_PATH=/usr/lib/borg/borg "
+    )
+    assert with_sudo.startswith(
+        env_prefix + "sudo -n --preserve-env="
+        "BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK,"
+        "BORG_RELOCATED_REPO_ACCESS_IS_OK,"
+        "BORG_PASSPHRASE,"
+        "BORG_REMOTE_PATH "
+        "/usr/bin/borg create "
+    )
+    assert without_sudo.startswith(env_prefix + "/usr/bin/borg create ")
+    assert "sudo" not in without_sudo
+
+
+@pytest.mark.asyncio
+async def test_build_remote_command_preserve_env_lists_only_variables_set(
+    test_db, monkeypatch
+):
+    """An unencrypted repository without remote_path sets neither
+    BORG_PASSPHRASE nor BORG_REMOTE_PATH, and the preserve list follows."""
+    connection, repository, _job = _remote_entities(test_db)
+    repository.remote_path = None
+    test_db.commit()
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.SessionLocal", lambda: test_db
+    )
+    service = RemoteBackupService()
+
+    command = await service._build_remote_command(
+        repository=repository,
+        archive_name="{hostname}-{now}",
+        source_paths=["/data"],
+        exclude_patterns=[],
+        borg_binary_path="/usr/bin/borg",
+        use_sudo=True,
+        source_ssh_connection=connection,
+    )
+
+    assert (
+        "sudo -n --preserve-env="
+        "BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK,"
+        "BORG_RELOCATED_REPO_ACCESS_IS_OK "
+        "/usr/bin/borg create "
+    ) in command
+    assert "BORG_PASSPHRASE" not in command
+    assert "BORG_REMOTE_PATH" not in command
+
+
+@pytest.mark.asyncio
 async def test_execute_remote_backup_updates_same_job_row_and_uses_source_borg_wrapper(
     test_db, monkeypatch
 ):


### PR DESCRIPTION
## Problem

With *Use sudo* enabled, `_build_remote_command()` produces

```
BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK=yes BORG_RELOCATED_REPO_ACCESS_IS_OK=yes \
BORG_PASSPHRASE=… sudo /usr/bin/borg create …
```

sudo ships with `env_reset` on by default on Debian, Ubuntu and Raspberry Pi OS, so none of those assignments reach the borg process. borg falls back to an interactive passphrase prompt, which cannot succeed over a non-interactive ssh command, and the job fails with exit 2 within a second - before touching the repository (#837).

## What this PR does

- Names the variables explicitly: `sudo -n --preserve-env=BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK,BORG_RELOCATED_REPO_ACCESS_IS_OK,BORG_PASSPHRASE,BORG_REMOTE_PATH borg create …` (the list follows whatever is actually set - an unencrypted repository without `remote_path` preserves only the two access flags).
- `--preserve-env=LIST` rather than `sudo env VAR=… borg`: it works under `NOPASSWD: ALL`, under a per-command rule with the `SETENV:` tag, and with the `env_keep` workaround users have already applied for this bug, so nobody regresses; it does not additionally require `/usr/bin/env` in sudoers (which a setup hardened to `NOPASSWD: /usr/bin/borg` will not have); and it keeps the passphrase out of the root process's argv.
- `-n` so sudo fails fast with a clear message instead of waiting for a password that can never arrive.
- Documents the sudoers requirement in `docs/ssh-keys.md` - the *Use sudo* row only mentioned SSHFS, and nothing said what sudo must allow for Remote Direct Backups.

Unchanged: the non-sudo command; which variables are set and how they are quoted.

## Testing

- New unit tests for `_build_remote_command`: with `use_sudo` the preserve list names exactly the variables set and precedes the borg binary; without `use_sudo` the command is untouched; an unencrypted repository without `remote_path` preserves only the two access flags.
- `ruff check` / `ruff format --check` clean.

Fixes #837
