### PR TITLE
fix(remote): keep borg's output for remote backups, and stop logging the passphrase

### DIFF
--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -1124,7 +1124,19 @@ def _repository_init_failure_detail(result: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Pydantic models
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
+
+
+def _single_line_passphrase(value: Optional[str]) -> Optional[str]:
+    """A passphrase must be a single line.
+
+    The remote-backup path shlex-quotes it into a shell command, and every
+    redaction of echoed output there works line-by-line — a value spanning
+    lines would be read back as fragments that defeat the masking pattern.
+    """
+    if value and ("\n" in value or "\r" in value):
+        raise ValueError("passphrase must not contain line breaks")
+    return value
 
 
 class RepositoryCreate(BaseModel):
@@ -1181,6 +1193,11 @@ class RepositoryCreate(BaseModel):
     rclone_extra_flags: Optional[List[str]] = None
     rclone_cache_path: Optional[str] = None
 
+    @field_validator("passphrase")
+    @classmethod
+    def _passphrase_single_line(cls, value: Optional[str]) -> Optional[str]:
+        return _single_line_passphrase(value)
+
 
 class RepositoryImport(BaseModel):
     name: str
@@ -1234,6 +1251,11 @@ class RepositoryImport(BaseModel):
     rclone_sync_timezone: Optional[str] = None
     rclone_extra_flags: Optional[List[str]] = None
     rclone_cache_path: Optional[str] = None
+
+    @field_validator("passphrase")
+    @classmethod
+    def _passphrase_single_line(cls, value: Optional[str]) -> Optional[str]:
+        return _single_line_passphrase(value)
 
 
 class RepositoryUpdate(BaseModel):

--- a/app/services/remote_backup_service.py
+++ b/app/services/remote_backup_service.py
@@ -21,10 +21,37 @@ from app.database.models import BackupJob, Repository, SSHConnection, SSHKey
 from app.database.database import SessionLocal
 from app.config import settings
 from app.core.borg_errors import is_borg_warning_exit_code
+from app.services.log_policy import get_log_save_policy, job_has_logs_by_policy
 from app.services.notification_service import notification_service
 from app.utils.ssh_utils import ssh_key_auth_args, write_ssh_key_to_tempfile
 
 logger = structlog.get_logger()
+
+# BORG_PASSPHRASE=<value> as _build_remote_command emits it: shlex.quote yields
+# either a bare word or a single-quoted string with '"'"' for embedded quotes.
+_PASSPHRASE_ASSIGNMENT = re.compile(
+    r"""BORG_PASSPHRASE=(?:'(?:[^']|'"'"')*'|[^\s']+)"""
+)
+
+
+def _redact_command(text: str) -> str:
+    """Mask passphrase assignments wherever they appear in text bound for logs.
+
+    Applied to the built command, and defensively to borg's output and the
+    error message too - a shell that chokes on the command line echoes it.
+    """
+    return _PASSPHRASE_ASSIGNMENT.sub("BORG_PASSPHRASE=***", text)
+
+
+def _collapse_carriage_returns(line: str) -> str:
+    """Keep what a terminal would show of a \\r-overwritten line.
+
+    borg's --progress writes its updates to stderr terminated by \\r, so a
+    single readline() yields the whole progress history up to the next real
+    line. Only the final state is worth keeping.
+    """
+    segments = [segment for segment in line.split("\r") if segment.strip()]
+    return segments[-1].strip() if segments else ""
 
 
 def _parse_created_archive_name(stdout) -> str | None:
@@ -148,7 +175,7 @@ class RemoteBackupService:
             logger.info(
                 "Built borg command for remote execution",
                 job_id=job_id,
-                command_preview=borg_command[:200],
+                command=_redact_command(borg_command),
             )
 
             # Execute command on remote host
@@ -201,12 +228,15 @@ class RemoteBackupService:
                     logger.info("Remote backup completed successfully", job_id=job_id)
             else:
                 job.status = "failed"
-                job.error_message = result.get("error", "Remote backup failed")
+                job.error_message = _redact_command(
+                    result.get("error") or "Remote backup failed"
+                )
                 logger.error(
-                    "Remote backup failed", job_id=job_id, error=result.get("error")
+                    "Remote backup failed", job_id=job_id, error=job.error_message
                 )
 
             job.completed_at = datetime.utcnow()
+            self._store_job_logs(db, job, borg_command, result)
             db.commit()
 
             await self._send_completion_notification(
@@ -237,6 +267,49 @@ class RemoteBackupService:
             raise
         finally:
             db.close()
+
+    def _store_job_logs(
+        self, db: Session, job: BackupJob, command: str, result: dict
+    ) -> None:
+        """Keep the remote borg output the way the local path keeps its own.
+
+        The transcript is the redacted command, borg's stderr and its --json
+        result. Per the log save policy it goes to a per-job file (so the
+        Activity view can stream it) or, when the policy says not to keep a
+        file, into the job row like local backups do.
+        """
+        parts = [f"$ {command}"]
+        for stream in ("stderr", "stdout"):
+            text = (result.get(stream) or "").strip()
+            if text:
+                parts.append(text)
+        transcript = _redact_command("\n".join(parts))
+
+        try:
+            should_save = job_has_logs_by_policy(
+                job,
+                get_log_save_policy(db),
+                output_text=transcript,
+                status=job.status,
+                exit_code=result.get("returncode"),
+            )
+            if should_save:
+                log_file = (
+                    self.log_dir
+                    / f"backup_job_{job.id}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
+                )
+                log_file.write_text(transcript + "\n")
+                job.log_file_path = str(log_file)
+                job.logs = f"Logs saved to: {log_file.name}"
+            else:
+                job.logs = transcript
+        except Exception as e:
+            job.logs = transcript
+            logger.warning(
+                "Failed to save remote backup log file, kept transcript in DB",
+                job_id=job.id,
+                error=str(e),
+            )
 
     async def _send_completion_notification(
         self,
@@ -464,10 +537,7 @@ class RemoteBackupService:
                 ]
 
                 logger.info(
-                    "Executing SSH command",
-                    job_id=job_id,
-                    host=ssh_connection.host,
-                    command_preview=command[:200],
+                    "Executing SSH command", job_id=job_id, host=ssh_connection.host
                 )
 
                 # Execute command
@@ -512,7 +582,17 @@ class RemoteBackupService:
                         line = await process.stderr.readline()
                         if not line:
                             break
-                        line_str = line.decode("utf-8", errors="replace").strip()
+                        # Redact at capture: a remote shell can echo the
+                        # BORG_PASSPHRASE assignment back on stderr, and every
+                        # downstream path (debug log, transcript, result) reads
+                        # from stderr_lines.
+                        line_str = _redact_command(
+                            _collapse_carriage_returns(
+                                line.decode("utf-8", errors="replace")
+                            )
+                        )
+                        if not line_str:
+                            continue
                         stderr_lines.append(line_str)
                         logger.debug(
                             "Remote backup stderr", job_id=job_id, line=line_str
@@ -529,16 +609,25 @@ class RemoteBackupService:
 
                 # Return transport facts only; whether a non-zero exit is a
                 # borg warning or a failure is decided by the caller, which
-                # knows what command ran and what output to expect.
+                # knows what command ran and what output to expect. On failure,
+                # borg's last line on stderr names the cause; surface it next
+                # to the exit code. stderr_lines is already redacted at
+                # capture, and redaction must precede this truncation (a
+                # cut-off quoted assignment would no longer match the
+                # redaction pattern).
                 success = returncode == 0
+                error = None
+                if not success:
+                    error = f"Remote backup failed with exit code {returncode}"
+                    if stderr_lines:
+                        cause = stderr_lines[-1][:300]
+                        error = f"{error}: {cause}"
                 return {
                     "success": success,
                     "returncode": returncode,
                     "stdout": "\n".join(stdout_lines),
                     "stderr": "\n".join(stderr_lines),
-                    "error": None
-                    if success
-                    else f"Remote backup failed with exit code {returncode}",
+                    "error": error,
                 }
 
             finally:

--- a/app/services/remote_backup_service.py
+++ b/app/services/remote_backup_service.py
@@ -564,7 +564,15 @@ class RemoteBackupService:
                         line = await process.stdout.readline()
                         if not line:
                             break
-                        line_str = line.decode("utf-8", errors="replace").strip()
+                        # Redact at capture, like stderr below: a remote shell
+                        # error can echo the whole command line — with its
+                        # BORG_PASSPHRASE assignment — on either stream, and
+                        # stdout_lines is returned and stored. Redaction never
+                        # alters borg's own JSON, so progress parsing still
+                        # sees the line unchanged.
+                        line_str = _redact_command(
+                            line.decode("utf-8", errors="replace").strip()
+                        )
                         stdout_lines.append(line_str)
 
                         # Try to parse Borg JSON progress
@@ -763,16 +771,22 @@ class RemoteBackupService:
 
                     return {"installed": True, "version": version, "path": borg_path}
                 else:
+                    # No passphrase is involved in a --version probe, but the
+                    # stream is redacted anyway: every stderr that leaves this
+                    # service is, so no future caller has to re-check.
+                    stderr_text = _redact_command(
+                        stderr.decode("utf-8", errors="replace")
+                    )
                     logger.warning(
                         "Borg not found on remote host",
                         connection_id=ssh_connection_id,
-                        stderr=stderr.decode("utf-8", errors="replace"),
+                        stderr=stderr_text,
                     )
                     return {
                         "installed": False,
                         "version": None,
                         "path": None,
-                        "error": stderr.decode("utf-8", errors="replace"),
+                        "error": stderr_text,
                     }
 
             finally:

--- a/app/services/remote_backup_service.py
+++ b/app/services/remote_backup_service.py
@@ -29,8 +29,14 @@ logger = structlog.get_logger()
 
 # BORG_PASSPHRASE=<value> as _build_remote_command emits it: shlex.quote yields
 # either a bare word or a single-quoted string with '"'"' for embedded quotes.
+# The unquoted branch refuses our own mask, which makes redaction IDEMPOTENT:
+# output is redacted at capture and again at transcript assembly, and without
+# the lookahead the second pass would re-match `***` and eat what follows it
+# (e.g. the colon in "BORG_PASSPHRASE=***: command not found"). A real value
+# can never look like the mask here - shlex.quote single-quotes anything
+# containing `*`, so it lands in the quoted branch.
 _PASSPHRASE_ASSIGNMENT = re.compile(
-    r"""BORG_PASSPHRASE=(?:'(?:[^']|'"'"')*'|[^\s']+)"""
+    r"""BORG_PASSPHRASE=(?:'(?:[^']|'"'"')*'|(?!\*\*\*)[^\s']+)"""
 )
 
 
@@ -39,6 +45,7 @@ def _redact_command(text: str) -> str:
 
     Applied to the built command, and defensively to borg's output and the
     error message too - a shell that chokes on the command line echoes it.
+    Idempotent, so capture-time and assembly-time redaction can overlap.
     """
     return _PASSPHRASE_ASSIGNMENT.sub("BORG_PASSPHRASE=***", text)
 

--- a/tests/unit/test_api_repositories.py
+++ b/tests/unit/test_api_repositories.py
@@ -473,6 +473,45 @@ class TestRepositoriesCreate:
             "key": "backend.errors.repo.invalidUploadLimit"
         }
 
+    def test_create_repository_rejects_multiline_passphrase(
+        self, test_client: TestClient, admin_headers
+    ):
+        """The remote path shlex-quotes the passphrase into a shell command and
+        redacts echoed output line-by-line; a passphrase spanning lines would
+        come back as fragments the masking pattern cannot match."""
+        response = test_client.post(
+            "/api/repositories/",
+            json={
+                "name": "Multiline Passphrase Repo",
+                "path": "/tmp/multiline-pass-repo",
+                "encryption": "repokey",
+                "compression": "lz4",
+                "repository_type": "local",
+                "passphrase": "first line\nsecond line",
+            },
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 422
+        assert "line breaks" in response.text
+
+    def test_import_repository_rejects_multiline_passphrase(
+        self, test_client: TestClient, admin_headers
+    ):
+        response = test_client.post(
+            "/api/repositories/import",
+            json={
+                "name": "Multiline Passphrase Import",
+                "path": "/tmp/multiline-pass-import",
+                "encryption": "repokey",
+                "passphrase": "first line\nsecond line",
+            },
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 422
+        assert "line breaks" in response.text
+
     def test_create_ssh_repository(
         self, test_client: TestClient, admin_headers, test_db
     ):

--- a/tests/unit/test_remote_backup_service.py
+++ b/tests/unit/test_remote_backup_service.py
@@ -824,3 +824,73 @@ async def test_successful_remote_backup_keeps_transcript_in_job_row_per_policy(
     assert list(log_dir.iterdir()) == []
     assert job.logs.startswith("$ BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK=yes ")
     assert stats in job.logs
+
+
+@pytest.mark.asyncio
+async def test_execute_ssh_command_never_returns_or_logs_the_passphrase(monkeypatch):
+    """A remote shell error can echo the whole command line — including the
+    BORG_PASSPHRASE assignment — on either stream. Both streams are redacted
+    at capture, so neither the returned output nor anything handed to the
+    logger ever carries the secret."""
+    secret = "hunter2-super-secret"
+    echoed = f"sh: 1: BORG_PASSPHRASE={shlex.quote(secret)} borg: not found"
+
+    service = RemoteBackupService()
+    connection = SSHConnection(
+        id=7, host="truenas.example", username="backup", port=2222, ssh_key_id=42
+    )
+    ssh_key = MagicMock(spec=SSHKey)
+    job = MagicMock(spec=BackupJob)
+    db = MagicMock()
+
+    def query_side_effect(model):
+        query = MagicMock()
+        if model == SSHKey:
+            query.filter.return_value.first.return_value = ssh_key
+        elif model == BackupJob:
+            query.filter.return_value.first.return_value = job
+        return query
+
+    db.query.side_effect = query_side_effect
+
+    process = AsyncMock()
+    process.pid = 1234
+    process.stdout.readline = AsyncMock(side_effect=[echoed.encode(), b""])
+    process.stderr.readline = AsyncMock(side_effect=[echoed.encode(), b""])
+    process.wait = AsyncMock(return_value=127)
+
+    log_records: list[tuple] = []
+
+    class RecordingLogger:
+        def __getattr__(self, level):
+            def record(*args, **kwargs):
+                log_records.append((level, args, kwargs))
+
+            return record
+
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.write_ssh_key_to_tempfile",
+        lambda key: "/tmp/source.key",
+    )
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=process),
+    )
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.os.unlink", lambda path: None
+    )
+    monkeypatch.setattr("app.services.remote_backup_service.logger", RecordingLogger())
+
+    result = await service._execute_ssh_command(
+        ssh_connection=connection,
+        command=f"BORG_PASSPHRASE={shlex.quote(secret)} borg create /repo::a /data",
+        job_id=99,
+        db=db,
+    )
+
+    for field in ("stdout", "stderr", "error"):
+        assert secret not in (result[field] or ""), field
+    # The mask proves redaction ran (rather than the lines being dropped).
+    assert "BORG_PASSPHRASE=***" in result["stdout"]
+    assert "BORG_PASSPHRASE=***" in result["stderr"]
+    assert secret not in repr(log_records)

--- a/tests/unit/test_remote_backup_service.py
+++ b/tests/unit/test_remote_backup_service.py
@@ -582,6 +582,16 @@ def test_redact_command_masks_every_shape_shlex_quote_produces():
     assert _redact_command(untouched) == untouched
 
 
+def test_redact_command_is_idempotent():
+    """Output is redacted at capture and again at transcript assembly; the
+    second pass must leave already-masked text untouched (it used to eat the
+    character after the mask, e.g. the colon of a shell error)."""
+    once = _redact_command("bash: BORG_PASSPHRASE='s3cret pass': command not found")
+
+    assert once == "bash: BORG_PASSPHRASE=***: command not found"
+    assert _redact_command(once) == once
+
+
 def test_collapse_carriage_returns_keeps_the_final_state():
     assert (
         _collapse_carriage_returns("Initializing\r 12% done\r 80%\rWARNING: changed\n")
@@ -737,17 +747,20 @@ async def test_failed_remote_backup_stores_redacted_transcript_in_log_file(
 
     async def fake_execute_ssh_command(ssh_connection, command, job_id, db):
         assert "BORG_PASSPHRASE='s3cret pass'" in command
+        # The executor redacts both streams at capture, so its result never
+        # carries the raw value - the stub models that contract, and the
+        # transcript's second redaction pass must leave the mask untouched.
         return {
             "success": False,
             "returncode": 2,
             "stdout": "",
             "stderr": (
-                "bash: BORG_PASSPHRASE='s3cret pass': command not found\n"
+                "bash: BORG_PASSPHRASE=***: command not found\n"
                 "Cannot acquire a passphrase: BORG_PASSPHRASE is not set."
             ),
             "error": (
                 "Remote backup failed with exit code 2: "
-                "bash: BORG_PASSPHRASE='s3cret pass': command not found"
+                "bash: BORG_PASSPHRASE=***: command not found"
             ),
         }
 

--- a/tests/unit/test_remote_backup_service.py
+++ b/tests/unit/test_remote_backup_service.py
@@ -3,11 +3,14 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import json
+import shlex
 
 from app.database.models import BackupJob, Repository, SSHConnection, SSHKey
 from app.services.remote_backup_service import (
     RemoteBackupService,
+    _collapse_carriage_returns,
     _parse_created_archive_name,
+    _redact_command,
 )
 
 
@@ -559,3 +562,265 @@ def test_parse_created_archive_name():
     assert _parse_created_archive_name("not json") is None
     assert _parse_created_archive_name(json.dumps({"archive": {}})) is None
     assert _parse_created_archive_name(json.dumps(["archive"])) is None
+
+
+def test_redact_command_masks_every_shape_shlex_quote_produces():
+    for passphrase in ["simple", "s3cret pass", "it's", "a'b'c", 'x"y', "ends with '"]:
+        command = (
+            f"BORG_RELOCATED_REPO_ACCESS_IS_OK=yes "
+            f"BORG_PASSPHRASE={shlex.quote(passphrase)} "
+            f"BORG_REMOTE_PATH=/usr/bin/borg /usr/bin/borg create repo::a /data"
+        )
+        assert _redact_command(command) == (
+            "BORG_RELOCATED_REPO_ACCESS_IS_OK=yes BORG_PASSPHRASE=*** "
+            "BORG_REMOTE_PATH=/usr/bin/borg /usr/bin/borg create repo::a /data"
+        ), passphrase
+
+    untouched = (
+        "BORG_RELOCATED_REPO_ACCESS_IS_OK=yes /usr/bin/borg create repo::a /data"
+    )
+    assert _redact_command(untouched) == untouched
+
+
+def test_collapse_carriage_returns_keeps_the_final_state():
+    assert (
+        _collapse_carriage_returns("Initializing\r 12% done\r 80%\rWARNING: changed\n")
+        == "WARNING: changed"
+    )
+    assert _collapse_carriage_returns("plain line\n") == "plain line"
+    assert _collapse_carriage_returns("\r\r\n") == ""
+
+
+@pytest.mark.asyncio
+async def test_execute_ssh_command_collapses_progress_and_names_the_failure_cause(
+    monkeypatch,
+):
+    service = RemoteBackupService()
+    connection = SSHConnection(
+        id=7, host="truenas.example", username="backup", port=2222, ssh_key_id=42
+    )
+    ssh_key = MagicMock(spec=SSHKey)
+    job = MagicMock(spec=BackupJob)
+    db = MagicMock()
+
+    def query_side_effect(model):
+        query = MagicMock()
+        if model == SSHKey:
+            query.filter.return_value.first.return_value = ssh_key
+        elif model == BackupJob:
+            query.filter.return_value.first.return_value = job
+        return query
+
+    db.query.side_effect = query_side_effect
+
+    process = AsyncMock()
+    process.pid = 1234
+    process.stdout.readline = AsyncMock(return_value=b"")
+    process.stderr.readline = AsyncMock(
+        side_effect=[
+            b"Initializing cache\r 12% done\r 80% done\rWARNING: file changed\n",
+            b"Cannot acquire a passphrase: BORG_PASSPHRASE is not set.\n",
+            b"",
+        ]
+    )
+    process.wait = AsyncMock(return_value=2)
+
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.write_ssh_key_to_tempfile",
+        lambda key: "/tmp/source.key",
+    )
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=process),
+    )
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.os.unlink", lambda path: None
+    )
+
+    result = await service._execute_ssh_command(
+        ssh_connection=connection,
+        command="borg create /repo::archive /data",
+        job_id=99,
+        db=db,
+    )
+
+    assert result["success"] is False
+    assert result["stderr"] == (
+        "WARNING: file changed\nCannot acquire a passphrase: BORG_PASSPHRASE is not set."
+    )
+    assert result["error"] == (
+        "Remote backup failed with exit code 2: "
+        "Cannot acquire a passphrase: BORG_PASSPHRASE is not set."
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_ssh_command_redacts_the_failure_cause_before_truncating(
+    monkeypatch,
+):
+    """A shell echoing a long quoted BORG_PASSPHRASE= assignment must not leak
+    part of it through the 300-character cut - redaction runs first."""
+    service = RemoteBackupService()
+    connection = SSHConnection(
+        id=7, host="truenas.example", username="backup", port=2222, ssh_key_id=42
+    )
+    ssh_key = MagicMock(spec=SSHKey)
+    job = MagicMock(spec=BackupJob)
+    db = MagicMock()
+
+    def query_side_effect(model):
+        query = MagicMock()
+        if model == SSHKey:
+            query.filter.return_value.first.return_value = ssh_key
+        elif model == BackupJob:
+            query.filter.return_value.first.return_value = job
+        return query
+
+    db.query.side_effect = query_side_effect
+    passphrase = "p" * 400
+    echoed = (
+        f"bash: BORG_PASSPHRASE={shlex.quote(passphrase + ' x')}: command not found\n"
+    )
+
+    process = AsyncMock()
+    process.pid = 1234
+    process.stdout.readline = AsyncMock(return_value=b"")
+    process.stderr.readline = AsyncMock(side_effect=[echoed.encode(), b""])
+    process.wait = AsyncMock(return_value=127)
+
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.write_ssh_key_to_tempfile",
+        lambda key: "/tmp/source.key",
+    )
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=process),
+    )
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.os.unlink", lambda path: None
+    )
+
+    result = await service._execute_ssh_command(
+        ssh_connection=connection,
+        command="borg create /repo::archive /data",
+        job_id=99,
+        db=db,
+    )
+
+    assert result["error"] == (
+        "Remote backup failed with exit code 127: "
+        "bash: BORG_PASSPHRASE=***: command not found"
+    )
+    assert "ppp" not in result["error"]
+    # Redaction happens at capture, so the retained stderr (the transcript
+    # source) never holds the raw passphrase either.
+    assert result["stderr"] == "bash: BORG_PASSPHRASE=***: command not found"
+    assert "ppp" not in result["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_failed_remote_backup_stores_redacted_transcript_in_log_file(
+    test_db, monkeypatch, tmp_path
+):
+    """Default policy (failed_and_warnings): a failed job gets a per-job log
+    file with the command (passphrase masked), borg's stderr and stdout -
+    what the local path has always produced."""
+    connection, repository, job = _remote_entities(test_db)
+    repository.encryption = "repokey"
+    repository.passphrase = "s3cret pass"
+    test_db.commit()
+    service = RemoteBackupService()
+    service.log_dir = tmp_path
+    connection_id = connection.id
+    repository_id = repository.id
+    job_id = job.id
+
+    async def fake_execute_ssh_command(ssh_connection, command, job_id, db):
+        assert "BORG_PASSPHRASE='s3cret pass'" in command
+        return {
+            "success": False,
+            "returncode": 2,
+            "stdout": "",
+            "stderr": (
+                "bash: BORG_PASSPHRASE='s3cret pass': command not found\n"
+                "Cannot acquire a passphrase: BORG_PASSPHRASE is not set."
+            ),
+            "error": (
+                "Remote backup failed with exit code 2: "
+                "bash: BORG_PASSPHRASE='s3cret pass': command not found"
+            ),
+        }
+
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.SessionLocal", lambda: test_db
+    )
+    monkeypatch.setattr(service, "_execute_ssh_command", fake_execute_ssh_command)
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.notification_service.send_backup_failure",
+        AsyncMock(),
+    )
+
+    await service.execute_remote_backup(
+        job_id=job_id,
+        source_ssh_connection_id=connection_id,
+        repository_id=repository_id,
+        source_paths=["/var/lib/docker/volumes/app"],
+    )
+
+    job = test_db.query(BackupJob).filter(BackupJob.id == job_id).one()
+    assert job.status == "failed"
+    assert job.log_file_path and job.log_file_path.startswith(str(tmp_path))
+    assert job.logs.startswith("Logs saved to: backup_job_")
+    content = open(job.log_file_path).read()
+    assert content.startswith("$ BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK=yes ")
+    assert "BORG_PASSPHRASE=***" in content
+    # neither the command line nor a shell echoing it may leak the value
+    assert "s3cret pass" not in content
+    assert "s3cret pass" not in job.error_message
+    assert job.error_message.endswith("bash: BORG_PASSPHRASE=***: command not found")
+    assert "/usr/local/bin/borg-wrapper create" in content
+    assert "/var/lib/docker/volumes/app" in content
+    assert "Cannot acquire a passphrase: BORG_PASSPHRASE is not set." in content
+
+
+@pytest.mark.asyncio
+async def test_successful_remote_backup_keeps_transcript_in_job_row_per_policy(
+    test_db, monkeypatch, tmp_path
+):
+    """Default policy keeps no file for a clean success; the transcript still
+    lands in the job row so the Activity view has something to show."""
+    connection, repository, job = _remote_entities(test_db)
+    service = RemoteBackupService()
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    service.log_dir = log_dir
+    connection_id = connection.id
+    repository_id = repository.id
+    job_id = job.id
+    stats = json.dumps({"archive": {"name": "host-2026-08-20T11:18:00"}})
+
+    async def fake_execute_ssh_command(*args, **kwargs):
+        return {"success": True, "returncode": 0, "stdout": stats, "stderr": ""}
+
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.SessionLocal", lambda: test_db
+    )
+    monkeypatch.setattr(service, "_execute_ssh_command", fake_execute_ssh_command)
+    monkeypatch.setattr(
+        "app.services.remote_backup_service.notification_service.send_backup_success",
+        AsyncMock(),
+    )
+
+    await service.execute_remote_backup(
+        job_id=job_id,
+        source_ssh_connection_id=connection_id,
+        repository_id=repository_id,
+        source_paths=["/var/lib/docker/volumes/app"],
+    )
+
+    job = test_db.query(BackupJob).filter(BackupJob.id == job_id).one()
+    assert job.status == "completed"
+    assert job.log_file_path is None
+    assert list(log_dir.iterdir()) == []
+    assert job.logs.startswith("$ BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK=yes ")
+    assert stats in job.logs


### PR DESCRIPTION
## Problem

For `execution_mode = remote_ssh`, a failed job leaves nothing to diagnose with (#838):

- `backup_jobs.logs` is empty and `log_file_path` is NULL - borg's stdout/stderr are read for progress and then discarded
- `error_message` is only `Remote backup failed with exit code N`
- the container log's `command_preview` is cut at 200 characters, which lands just before the repository and source paths - and prints `BORG_PASSPHRASE=…` in clear text at INFO

Local backups write a full `backup_job_<id>_<ts>.log` with borg's output, which is what makes them debuggable; the remote path never did.

## What this PR does

- **Keep the transcript, the way the local path does.** After the job ends, the redacted command, borg's stderr and its `--json` result are stored per the existing log save policy: into a per-job `backup_job_<id>_<ts>.log` in the same log directory (so the Activity view streams it and retention cleans it like any other job log), or - when the policy says not to keep a file - into the job row's `logs` column, exactly as local backups do. Uses the shared `job_has_logs_by_policy` helper, no new knob.
- **Name the cause in `error_message`.** borg's last line on stderr is the one that says what went wrong; it now sits next to the exit code: `Remote backup failed with exit code 2: Cannot acquire a passphrase: BORG_PASSPHRASE is not set.` (bounded to 300 chars).
- **Readable transcripts.** borg's `--progress` writes `\r`-terminated updates to stderr, so one `readline()` yields the whole progress history up to the next real line; each such run is collapsed to its final state, the way a terminal would show it. Warnings and errors are on their own lines and all survive.
- **Log the command once, in full, masked.** `BORG_PASSPHRASE=<value>` is replaced with `BORG_PASSPHRASE=***` (covers every shape `shlex.quote` produces, including embedded single quotes); the truncated clear-text preview at execution time is gone. The same masking runs over the whole stored transcript and the error message, so a remote shell that chokes on the command line and echoes it back cannot leak the value either.

Unchanged: the command itself, progress parsing, notifications, status handling.

## Testing

- New unit tests: redaction across the quoting shapes (plain, spaces, embedded `'`, `"`, trailing `'`) and a no-passphrase command left untouched; `\r` collapsing; `_execute_ssh_command` turning a `\r`-progress run plus two stderr lines into a two-line stderr and an `error` that names the cause; a failed job under the default policy writing a log file whose first line is the masked command (passphrase absent from the file and from `error_message` even when the remote shell echoes the command line, repository/source paths present) and whose body is borg's stderr; a clean success under the default policy keeping no file but the transcript in the job row.
- `ruff check` / `ruff format --check` clean.

Fixes #838
