### PR TITLE
docs(ssh): say where SSHFS pull mode needs FUSE access, and what it looks like when it is missing

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -358,7 +358,8 @@ This grants powerful host access to the Borg UI container. You can avoid mountin
 
 Archive mounting uses `borg mount` and requires FUSE access.
 
-Remote source backups and SSH restore destinations use SSHFS and also require FUSE access.
+Remote source backups in SSHFS pull mode and SSH restore destinations also use
+FUSE (through SSHFS); Remote Direct Backups do not.
 
 ```yaml
 cap_add:
@@ -371,7 +372,17 @@ environment:
   - BORG_FUSE_IMPL=pyfuse3
 ```
 
-Add this only if you need archive mounts, SSHFS remote source backups, or SSH restore destinations. See [Mounting Archives](mounting).
+Add this only if you need archive mounts, SSHFS remote source backups, or SSH
+restore destinations. These three settings are the narrow replacement for
+`privileged: true`: the repository's own `docker-compose.yml` runs the
+container privileged for the same reason, which grants this access and a great
+deal more. Use one or the other, not both. The host also needs FUSE itself: `/dev/fuse` must exist
+there (`ls -l /dev/fuse`; if it is missing, `modprobe fuse`). Without it, and
+without the lines above, SSHFS pull-mode backups fail with
+`fuse: device not found` before they read a single file. `SYS_ADMIN` plus `apparmor:unconfined` widens the
+container's privileges noticeably - Remote Direct Backups need neither. See
+[Mounting Archives](mounting) and
+[Remote Machines](ssh-keys#remote-source-backups).
 
 ## Docker Run
 

--- a/docs/ssh-keys.md
+++ b/docs/ssh-keys.md
@@ -137,6 +137,29 @@ for Borg UI's Borg-over-SSH repository setup. See
 [Provider Guides](provider-guides) for BorgBase, Hetzner Storage Box, Synology,
 Unraid, and other hosted or NAS examples.
 
+## Remote Source Backups
+
+A backup plan can use a Remote Machine as its *source*. Borg UI runs that
+backup in one of two ways:
+
+- **SSHFS pull mode** (when Remote Direct Backup does not apply): the container mounts the remote
+  filesystem with SSHFS and runs `borg create` itself. This needs FUSE access
+  from the Docker host - `/dev/fuse`, the `SYS_ADMIN` capability and an
+  AppArmor exception - which the Compose examples in
+  [Installation](installation) do not grant. See
+  [Optional FUSE Access](installation#optional-fuse-access) for the exact
+  lines; `privileged: true`, as the repository's own `docker-compose.yml`
+  uses, is the broader way to get the same access - use one or the other,
+  not both. Without either the job fails before it reads a single file (see
+  [Troubleshooting](#sshfs-mount-fails-with-fuse-device-not-found)).
+- **Remote Direct Backup**: `borg create` runs on the remote machine itself,
+  see below. It needs no FUSE access and no extra container privileges.
+
+`SYS_ADMIN` plus `apparmor:unconfined` is a real widening of the container's
+privileges, and `privileged: true` more so. If you would rather not grant
+either, put source and repository on the same SSH connection and use Remote
+Direct Backup mode instead.
+
 ## Remote Direct Backups
 
 When a backup plan uses an SSH source and an SSH repository on the same SSH
@@ -226,3 +249,20 @@ The remote user needs read access to source paths and write access to repository
 ### Host key changed
 
 Verify the host change first. Then update known-hosts through the UI or by reconnecting as appropriate.
+
+### SSHFS mount fails with `fuse: device not found`
+
+A remote-source backup in SSHFS pull mode fails immediately with
+`backend.errors.service.failedPrepareSourcePaths`, and the container log shows
+`SSHFS mount failed: fuse: device not found, try 'modprobe fuse' first` or
+`fusermount3: mount failed: Operation not permitted`.
+
+The container has no FUSE access. Add `/dev/fuse`, `SYS_ADMIN` and the AppArmor
+exception from [Optional FUSE Access](installation#optional-fuse-access) to the
+Borg UI service (or run it with `privileged: true`, which includes all three),
+make sure `/dev/fuse` exists on the host (`ls -l /dev/fuse`; if it is missing,
+`modprobe fuse`), and recreate the container.
+On Ubuntu the AppArmor line is the one that matters: the `docker-default`
+profile denies `fusermount3` even when the device and capability are present.
+If you would rather not widen the container's privileges, use
+[Remote Direct Backup](#remote-direct-backups) mode, which needs none of this.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,6 +19,12 @@ the SSH repository connection are the same. Different SSH source/repository
 pairs still run on the Borg UI server and may see warnings when active files
 change during backup.
 
+Pull mode mounts the remote filesystem inside the container and therefore
+needs FUSE access (`/dev/fuse`, `SYS_ADMIN`, AppArmor exception). A job that
+fails at once with `failedPrepareSourcePaths` and `fuse: device not found` is
+missing that - see
+[Remote Machines](ssh-keys#sshfs-mount-fails-with-fuse-device-not-found).
+
 ### Slow first backup after a pull or restart
 
 `docker compose pull` and container recreates do not remove Docker volumes or


### PR DESCRIPTION
## Problem

Backing up a remote SSH source in pull mode mounts the remote filesystem with SSHFS inside the container. That needs `/dev/fuse`, `SYS_ADMIN` and an AppArmor exception - `docs/installation.md` does document those lines under *Optional FUSE Access* - but `docs/ssh-keys.md`, the page users land on for SSH sources, never mentioned pull mode, FUSE, or what the failure looks like, and nothing linked the two. Following the SSH-source docs as written leads straight to a job that dies before reading a single file with `failedPrepareSourcePaths` and `SSHFS mount failed: fuse: device not found` (#839).

## What this PR does

Documentation only, no code.

- **`docs/ssh-keys.md`**
  - new *Remote Source Backups* section, right before *Remote Direct Backups*: names the two modes, states that pull mode needs FUSE access with a link to the exact Compose lines in installation.md, and spells out the privilege trade-off (`SYS_ADMIN` + `apparmor:unconfined`) with Remote Direct Backup as the alternative that needs none of it.
  - new troubleshooting entry *SSHFS mount fails with `fuse: device not found`*: symptom (`failedPrepareSourcePaths`, the two log messages), cause, fix (the three lines + `/dev/fuse` present on the host + recreate), the Ubuntu/AppArmor angle from #760, and the no-privileges alternative.
- **`docs/installation.md`** *Optional FUSE Access*: the host-side requirement (`/dev/fuse` must exist; `modprobe fuse` only if it does not, so kernels with FUSE built in are not sent chasing a module), the failure symptom so search finds it, the trade-off, and a link back to the SSH page. The pre-existing sentence that said remote source backups require FUSE is now qualified to SSHFS pull mode - Remote Direct Backups do not.
- **`docs/troubleshooting.md`**: one pointer from the hub page's existing SSHFS note to the new entry.

Kept the Compose snippet in one place (installation.md) and linked to it rather than copying it a third time.

## Testing

- `npm run build` in `docs/` (VitePress, dead links are build errors) passes; the new anchors render (`#remote-source-backups`, `#sshfs-mount-fails-with-fuse-device-not-found`) and every cross-link resolves to an existing id.

Fixes #839
Related: #760
