### PR TITLE
fix(scheduler): keep executor_type in the router repo snapshot

### DIFF
--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -136,7 +136,15 @@ V2_ONLY_ENCRYPTION_MODES = {
 
 
 def _router_repo_snapshot(repository: Repository) -> SimpleNamespace:
-    return SimpleNamespace(id=repository.id, borg_version=repository.borg_version)
+    # BorgRouter routes on executor_type (with the legacy execution_target
+    # fallback). Keep those in the snapshot so the router's agent gate stays
+    # functional even though these endpoints branch on the executor earlier.
+    return SimpleNamespace(
+        id=repository.id,
+        borg_version=repository.borg_version,
+        executor_type=repository.executor_type,
+        execution_target=repository.execution_target,
+    )
 
 
 def _dispatch_router_check(router_repo: SimpleNamespace, job: CheckJob):

--- a/app/services/check_scheduler.py
+++ b/app/services/check_scheduler.py
@@ -23,7 +23,15 @@ STALE_PENDING_SCHEDULED_CHECK_AFTER = timedelta(minutes=15)
 
 
 def _router_repo_snapshot(repository: Repository) -> SimpleNamespace:
-    return SimpleNamespace(id=repository.id, borg_version=repository.borg_version)
+    # BorgRouter routes on executor_type (with the legacy execution_target
+    # fallback). Dropping those here would silently disable its agent gate
+    # and run checks for agent-executed repositories on the server.
+    return SimpleNamespace(
+        id=repository.id,
+        borg_version=repository.borg_version,
+        executor_type=repository.executor_type,
+        execution_target=repository.execution_target,
+    )
 
 
 def _dispatch_router_check(router_repo: SimpleNamespace, job: CheckJob):

--- a/tests/unit/test_schedulers.py
+++ b/tests/unit/test_schedulers.py
@@ -103,6 +103,46 @@ async def test_check_scheduler_creates_job_and_updates_next_run(db_session):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_check_scheduler_snapshot_preserves_agent_routing(db_session):
+    # BorgRouter decides agent-vs-server on executor_type. The scheduler hands
+    # the router a detached snapshot instead of the ORM instance; if that
+    # snapshot drops executor_type, checks for agent-executed repositories
+    # silently run on the server.
+    from app.services.repository_executor import is_agent_executor
+
+    repo = Repository(
+        name="Agent Repo",
+        path="rest://borg@host/repo",
+        encryption="none",
+        compression="lz4",
+        repository_type="local",
+        executor_type="agent",
+        borg_version=2,
+        check_cron_expression="0 2 * * *",
+    )
+    db_session.add(repo)
+    db_session.commit()
+    db_session.refresh(repo)
+
+    with patch(
+        "app.services.check_scheduler.start_background_maintenance_job"
+    ) as mock_start:
+        mock_start.side_effect = lambda db, repo, job_model, **kwargs: CheckJob(
+            id=43,
+            repository_id=repo.id,
+            status="pending",
+            scheduled_check=True,
+        )
+        await run_due_scheduled_checks(db_session)
+
+    mock_start.assert_called_once()
+    snapshot = mock_start.call_args.kwargs["dispatcher"].args[0]
+    assert snapshot.executor_type == "agent"
+    assert is_agent_executor(snapshot) is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_availability_automation_success_advances_next_check(db_session):
     repo = Repository(
         name="Availability source",


### PR DESCRIPTION
## Problem

`BorgRouter` is the single choke point for the agent-vs-server decision: `_is_agent()` calls `is_agent_executor(repo)`, which reads `executor_type` (with the legacy `execution_target` fallback).

The check scheduler hands the router a detached `SimpleNamespace` snapshot instead of the ORM instance — deliberately, so the dispatched background task does not depend on the scheduler's session. But the snapshot carried only `id` and `borg_version`, so `is_agent_executor` always fell back to "server": **scheduled checks for agent-executed repositories run borg on the server** instead of delegating to the managed agent.

Consequences:

- It works at all only when the server happens to reach the repository backend; where it cannot, every scheduled check fails while a manual check on the same repository succeeds via the agent — with no visible reason for the difference.
- It bypasses the agent path's job bookkeeping (e.g. the `started_at` backfill when the agent reports completion).

## Fix

- `app/services/check_scheduler.py`: include `executor_type` and `execution_target` in `_router_repo_snapshot` so the router routes scheduled checks exactly like manual ones.
- `app/api/repositories.py`: same fields for the identical snapshot there. Those endpoints branch on the executor before dispatching to the router, so this is defensive — but the snapshot should never be the thing that silently disables the router's gate.

## Tests

New `test_check_scheduler_snapshot_preserves_agent_routing`: seeds an `executor_type="agent"` repository, runs the scheduler, and asserts the dispatcher's snapshot still satisfies `is_agent_executor` — i.e. the router's agent gate sees the agent executor.

`pytest` (scheduler suite plus the repositories/router suites) and `ruff check` / `ruff format --check` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)