### PR TITLE
fix(dashboard): surface prune, scheduled check, and restore runs in the activity timeline

### DIFF
--- a/app/api/dashboard.py
+++ b/app/api/dashboard.py
@@ -19,6 +19,7 @@ from app.database.models import (
     ScheduledJobRepository,
     CheckJob,
     CompactJob,
+    PruneJob,
     RestoreCheckJob,
     SSHConnection,
     SystemSettings,
@@ -1044,6 +1045,9 @@ async def get_dashboard_overview(
             .filter(CompactJob.started_at >= fourteen_days_ago)
             .all()
         )
+        recent_prunes = (
+            db.query(PruneJob).filter(PruneJob.started_at >= fourteen_days_ago).all()
+        )
         recent_restore_checks = (
             db.query(RestoreCheckJob)
             .filter(RestoreCheckJob.started_at >= fourteen_days_ago)
@@ -1161,6 +1165,40 @@ async def get_dashboard_overview(
                     "repository": repo_name,
                     "timestamp": serialize_datetime(job.started_at),
                     "message": f"Compact {job.status}",
+                    "error": job.error_message if job.status == "failed" else None,
+                }
+            )
+
+        for job in recent_prunes:
+            # Try multiple ways to get repo name
+            repo_name = None
+            if job.repository_path in repo_name_map:
+                repo_name = repo_name_map[job.repository_path]
+            elif (
+                job.repository_path and job.repository_path.rstrip("/") in repo_name_map
+            ):
+                repo_name = repo_name_map[job.repository_path.rstrip("/")]
+            elif (
+                hasattr(job, "repository_id")
+                and job.repository_id
+                and job.repository_id in repo_id_map
+            ):
+                repo_name = repo_id_map[job.repository_id]
+            else:
+                repo_name = (
+                    job.repository_path.rstrip("/").split("/")[-1]
+                    if job.repository_path
+                    else "Unknown"
+                )
+
+            activity_feed.append(
+                {
+                    "id": job.id,
+                    "type": "prune",
+                    "status": job.status,
+                    "repository": repo_name,
+                    "timestamp": serialize_datetime(job.started_at),
+                    "message": f"Prune {job.status}",
                     "error": job.error_message if job.status == "failed" else None,
                 }
             )

--- a/app/services/v2/check_service.py
+++ b/app/services/v2/check_service.py
@@ -76,8 +76,8 @@ class CheckV2Service:
                 )
                 return
 
-            # Job is pre-set to running by the endpoint; refresh to ensure we have latest state.
-            # If the job was somehow already completed/cancelled (race), bail out.
+            # Refresh to ensure we have the latest state. If the job was
+            # somehow already completed/cancelled (race), bail out.
             db.refresh(job)
             if job.status not in ("running", "pending"):
                 logger.warning(
@@ -86,6 +86,44 @@ class CheckV2Service:
                     status=job.status,
                 )
                 return
+
+            # The manual endpoint pre-sets the job to running, but scheduler
+            # jobs arrive as pending. Record the actual execution start either
+            # way so started_at is never left NULL (job history and the
+            # dashboard activity feed both filter on it). The status predicate
+            # keeps a concurrent cancellation from being overwritten.
+            started_at = datetime.utcnow()
+            claimed = 0
+
+            def persist_start_state():
+                nonlocal claimed
+                claimed = (
+                    db.query(CheckJob)
+                    .filter(
+                        CheckJob.id == job_id,
+                        CheckJob.status.in_(("pending", "running")),
+                    )
+                    .update(
+                        {"status": "running", "started_at": started_at},
+                        synchronize_session=False,
+                    )
+                )
+
+            await commit_with_retry(
+                db,
+                prepare=persist_start_state,
+                logger=logger,
+                action="borg2_check_start",
+                job_id=job_id,
+                repository_id=repository_id,
+            )
+            if not claimed:
+                logger.warning(
+                    "Check job reached a terminal state before start, skipping",
+                    job_id=job_id,
+                )
+                return
+            db.refresh(job)
 
             env, temp_key_file = build_repository_borg_env(
                 repo,

--- a/app/services/v2/compact_service.py
+++ b/app/services/v2/compact_service.py
@@ -110,8 +110,8 @@ class CompactV2Service:
                 )
                 return
 
-            # Job is pre-set to running by the endpoint; refresh to ensure we have latest state.
-            # If the job was somehow already completed/cancelled (race), bail out.
+            # Refresh to ensure we have the latest state. If the job was
+            # somehow already completed/cancelled (race), bail out.
             db.refresh(job)
             if job.status not in ("running", "pending"):
                 logger.warning(
@@ -120,6 +120,44 @@ class CompactV2Service:
                     status=job.status,
                 )
                 return
+
+            # The manual endpoint pre-sets the job to running, but scheduler
+            # jobs arrive as pending. Record the actual execution start either
+            # way so started_at is never left NULL (job history and the
+            # dashboard activity feed both filter on it). The status predicate
+            # keeps a concurrent cancellation from being overwritten.
+            started_at = datetime.utcnow()
+            claimed = 0
+
+            def persist_start_state():
+                nonlocal claimed
+                claimed = (
+                    db.query(CompactJob)
+                    .filter(
+                        CompactJob.id == job_id,
+                        CompactJob.status.in_(("pending", "running")),
+                    )
+                    .update(
+                        {"status": "running", "started_at": started_at},
+                        synchronize_session=False,
+                    )
+                )
+
+            await commit_with_retry(
+                db,
+                prepare=persist_start_state,
+                logger=logger,
+                action="borg2_compact_start",
+                job_id=job_id,
+                repository_id=repository_id,
+            )
+            if not claimed:
+                logger.warning(
+                    "Compact job reached a terminal state before start, skipping",
+                    job_id=job_id,
+                )
+                return
+            db.refresh(job)
 
             env, temp_key_file = build_repository_borg_env(
                 repository,

--- a/frontend/src/pages/dashboard-v3/ActivityTimeline.test.tsx
+++ b/frontend/src/pages/dashboard-v3/ActivityTimeline.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ActivityTimeline } from './ActivityTimeline'
+import { JOB_COLOR } from './tokens'
 import type { DashboardOverview } from './types'
 
 type Activity = DashboardOverview['activity_feed'][number]
@@ -51,5 +52,45 @@ describe('ActivityTimeline', () => {
         (title) => title.textContent?.split(' · ')[1]
       )
     ).toEqual(['oldest', 'middle', 'newest'])
+  })
+
+  it('maps restore_check events onto the restore lane', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-16T12:00:00Z'))
+
+    const activities: Activity[] = [
+      {
+        id: 1,
+        type: 'backup',
+        status: 'completed',
+        repository: 'repo',
+        timestamp: '2026-07-16T07:00:00Z',
+        message: 'Backup completed',
+        error: null,
+      },
+      {
+        id: 2,
+        type: 'restore_check',
+        status: 'completed',
+        repository: 'repo',
+        timestamp: '2026-07-16T08:00:00Z',
+        message: 'Restore check completed',
+        error: null,
+      },
+    ]
+
+    const { container } = render(<ActivityTimeline activities={activities} />)
+
+    const titles = Array.from(container.querySelectorAll('circle title'))
+    const restoreDot = titles.find((title) => title.textContent?.startsWith('restore_check'))
+    const backupDot = titles.find((title) => title.textContent?.startsWith('backup'))
+    expect(restoreDot).toBeDefined()
+    expect(backupDot).toBeDefined()
+
+    // The restore lane is 3 lanes below the backup lane, in the restore color.
+    const cyOf = (title: Element) => Number(title.closest('circle')?.getAttribute('cy'))
+    const laneHeight = 14
+    expect(cyOf(restoreDot!)).toBe(cyOf(backupDot!) + 3 * laneHeight)
+    expect(restoreDot!.closest('circle')?.getAttribute('fill')).toBe(JOB_COLOR.restore)
   })
 })

--- a/frontend/src/pages/dashboard-v3/ActivityTimeline.tsx
+++ b/frontend/src/pages/dashboard-v3/ActivityTimeline.tsx
@@ -31,7 +31,10 @@ export function ActivityTimeline({
     'restore',
     'prune',
   ]
-  const laneIndex = (type: string) => LANES.indexOf(type)
+  // The API reports restore verification runs as "restore_check"; they
+  // belong on the restore lane.
+  const laneKey = (type: string) => (type === 'restore_check' ? 'restore' : type)
+  const laneIndex = (type: string) => LANES.indexOf(laneKey(type))
 
   const VB_W = 680
   const ML = 44
@@ -93,7 +96,7 @@ export function ActivityTimeline({
       const date = new Date(activity.timestamp)
       const offset = n === 1 ? 0 : (i / (n - 1) - 0.5) * spreadW
       const jobColor =
-        activity.status === 'failed' ? T.red : (JOB_COLOR[activity.type] ?? T.textMuted)
+        activity.status === 'failed' ? T.red : (JOB_COLOR[laneKey(activity.type)] ?? T.textMuted)
       dots.push({
         x: cx + offset,
         y: cy,

--- a/tests/unit/test_api_dashboard.py
+++ b/tests/unit/test_api_dashboard.py
@@ -23,6 +23,7 @@ from app.database.models import (
     BackupPlanRepository,
     CheckJob,
     CompactJob,
+    PruneJob,
     Repository,
     RestoreCheckJob,
     ScheduledJob,
@@ -817,6 +818,13 @@ class TestDashboardScheduleAndOverview:
                     started_at=now - timedelta(days=4),
                     completed_at=now - timedelta(days=4, minutes=20),
                 ),
+                PruneJob(
+                    repository_id=full_repo.id,
+                    repository_path=full_repo.path,
+                    status="completed",
+                    started_at=now - timedelta(days=5),
+                    completed_at=now - timedelta(days=5, minutes=5),
+                ),
                 RestoreCheckJob(
                     repository_id=full_repo.id,
                     repository_path=full_repo.path,
@@ -895,10 +903,13 @@ class TestDashboardScheduleAndOverview:
             "restore": "unknown",
         }
         assert len(data["repository_health"]) == 2
-        assert [item["type"] for item in data["activity_feed"]][:3] == [
+        assert [item["type"] for item in data["activity_feed"]] == [
             "restore_check",
             "backup",
             "backup",
+            "check",
+            "compact",
+            "prune",
         ]
         assert data["activity_feed"][0]["repository"] == "Full Repo"
         assert [item["name"] for item in data["upcoming_tasks"]] == [

--- a/tests/unit/test_v2_services.py
+++ b/tests/unit/test_v2_services.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy.orm import sessionmaker
@@ -174,7 +174,107 @@ class TestCheckV2Service:
         assert refreshed_job.has_logs is True
         assert refreshed_job.log_file_path is not None
         assert Path(refreshed_job.log_file_path).exists()
+        assert refreshed_job.started_at is not None
         assert refreshed_repo.last_check is not None
+        verification.close()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_execute_check_sets_started_at_on_pending_scheduler_job(
+        self, db_session, testing_session_local, borg_v2_repo_for_services, tmp_path
+    ):
+        # The check scheduler creates jobs as pending without started_at; the
+        # service must record the execution start itself or the job stays
+        # invisible to every started_at-based view (dashboard activity feed).
+        job = CheckJob(repository_id=borg_v2_repo_for_services.id, status="pending")
+        db_session.add(job)
+        db_session.commit()
+        db_session.refresh(job)
+
+        process = FakeProcess(returncode=0, stderr_lines=[])
+
+        service = CheckV2Service()
+        service.log_dir = tmp_path
+
+        with (
+            patch("app.services.v2.check_service.SessionLocal", testing_session_local),
+            patch(
+                "app.services.v2.check_service.resolve_repo_ssh_key_file",
+                return_value=None,
+            ),
+            patch(
+                "app.services.v2.check_service._get_borg2_binary", return_value="borg2"
+            ),
+            patch(
+                "app.services.v2.check_service._get_process_start_time",
+                return_value=123,
+            ),
+            patch(
+                "app.services.v2.check_service.asyncio.create_subprocess_exec",
+                return_value=process,
+            ),
+        ):
+            await service.execute_check(job.id, borg_v2_repo_for_services.id)
+
+        verification = testing_session_local()
+        refreshed_job = (
+            verification.query(CheckJob).filter(CheckJob.id == job.id).first()
+        )
+        assert refreshed_job.status == "completed"
+        assert refreshed_job.started_at is not None
+        verification.close()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_execute_check_does_not_resurrect_a_concurrently_cancelled_job(
+        self, db_session, testing_session_local, borg_v2_repo_for_services, tmp_path
+    ):
+        # A cancellation can land between the service's status guard and its
+        # start claim; the claim's status predicate must lose that race and
+        # never start borg on the cancelled job.
+        job = CheckJob(repository_id=borg_v2_repo_for_services.id, status="pending")
+        db_session.add(job)
+        db_session.commit()
+        db_session.refresh(job)
+
+        from app.services.v2 import check_service as check_service_module
+
+        real_commit_with_retry = check_service_module.commit_with_retry
+
+        async def cancel_then_commit(db, **kwargs):
+            if kwargs.get("action") == "borg2_check_start":
+                other = testing_session_local()
+                other.query(CheckJob).filter(CheckJob.id == job.id).update(
+                    {"status": "cancelled"}
+                )
+                other.commit()
+                other.close()
+            return await real_commit_with_retry(db, **kwargs)
+
+        spawn = MagicMock()
+        service = CheckV2Service()
+        service.log_dir = tmp_path
+
+        with (
+            patch("app.services.v2.check_service.SessionLocal", testing_session_local),
+            patch(
+                "app.services.v2.check_service.commit_with_retry",
+                new=cancel_then_commit,
+            ),
+            patch(
+                "app.services.v2.check_service.asyncio.create_subprocess_exec",
+                new=spawn,
+            ),
+        ):
+            await service.execute_check(job.id, borg_v2_repo_for_services.id)
+
+        spawn.assert_not_called()
+        verification = testing_session_local()
+        refreshed_job = (
+            verification.query(CheckJob).filter(CheckJob.id == job.id).first()
+        )
+        assert refreshed_job.status == "cancelled"
+        assert refreshed_job.started_at is None
         verification.close()
 
     @pytest.mark.unit
@@ -421,7 +521,108 @@ class TestCompactV2Service:
         assert refreshed.status == "completed"
         assert refreshed.progress == 100
         assert refreshed.has_logs is True
+        assert refreshed.started_at is not None
         assert refreshed_repo.last_compact is not None
+        verification.close()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_execute_compact_sets_started_at_on_pending_scheduler_job(
+        self, db_session, testing_session_local, borg_v2_repo_for_services, tmp_path
+    ):
+        # Same contract as the check service: jobs dispatched as pending must
+        # get started_at from the service itself.
+        job = CompactJob(repository_id=borg_v2_repo_for_services.id, status="pending")
+        db_session.add(job)
+        db_session.commit()
+        db_session.refresh(job)
+
+        service = CompactV2Service()
+        service.log_dir = tmp_path
+
+        with (
+            patch(
+                "app.services.v2.compact_service.SessionLocal", testing_session_local
+            ),
+            patch(
+                "app.services.v2.compact_service.resolve_repo_ssh_key_file",
+                return_value=None,
+            ),
+            patch(
+                "app.services.v2.compact_service._get_borg2_binary",
+                return_value="borg2",
+            ),
+            patch(
+                "app.services.v2.compact_service._get_process_start_time",
+                return_value=123,
+            ),
+            patch(
+                "app.services.v2.compact_service.asyncio.create_subprocess_exec",
+                return_value=FakeProcess(returncode=0, stderr_lines=[]),
+            ),
+        ):
+            await service.execute_compact(job.id, borg_v2_repo_for_services.id)
+
+        verification = testing_session_local()
+        refreshed = (
+            verification.query(CompactJob).filter(CompactJob.id == job.id).first()
+        )
+        assert refreshed.status == "completed"
+        assert refreshed.started_at is not None
+        verification.close()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_execute_compact_does_not_resurrect_a_concurrently_cancelled_job(
+        self, db_session, testing_session_local, borg_v2_repo_for_services, tmp_path
+    ):
+        # Same race as the check service: a cancellation landing between the
+        # status guard and the start claim must win.
+        job = CompactJob(repository_id=borg_v2_repo_for_services.id, status="pending")
+        db_session.add(job)
+        db_session.commit()
+        db_session.refresh(job)
+
+        from app.services.v2 import compact_service as compact_service_module
+
+        real_commit_with_retry = compact_service_module.commit_with_retry
+
+        async def cancel_then_commit(db, **kwargs):
+            if kwargs.get("action") == "borg2_compact_start":
+                other = testing_session_local()
+                other.query(CompactJob).filter(CompactJob.id == job.id).update(
+                    {"status": "cancelled"}
+                )
+                other.commit()
+                other.close()
+            return await real_commit_with_retry(db, **kwargs)
+
+        spawn = MagicMock()
+        service = CompactV2Service()
+        service.log_dir = tmp_path
+
+        with (
+            patch(
+                "app.services.v2.compact_service.SessionLocal", testing_session_local
+            ),
+            patch(
+                "app.services.v2.compact_service.commit_with_retry",
+                new=cancel_then_commit,
+            ),
+            patch(
+                "app.services.v2.compact_service.asyncio.create_subprocess_exec",
+                new=spawn,
+            ),
+        ):
+            await service.execute_compact(job.id, borg_v2_repo_for_services.id)
+
+        spawn.assert_not_called()
+        verification = testing_session_local()
+        refreshed = (
+            verification.query(CompactJob).filter(CompactJob.id == job.id).first()
+        )
+        assert refreshed.status == "cancelled"
+        assert refreshed.started_at is None
         verification.close()
 
     @pytest.mark.unit


### PR DESCRIPTION
## Problem

The dashboard's 14-day activity timeline renders five lanes (backup, check, compact, restore, prune), but three of them can never show anything:

1. **Prune lane always empty** — `GET /api/dashboard/overview` builds the activity feed from `BackupJob`, `CheckJob`, `CompactJob`, and `RestoreCheckJob` only; `PruneJob` is never queried, so completed prunes are simply not fetched.
2. **Scheduled checks and compacts invisible** — the Borg 2 check and compact services never set `started_at`. The manual endpoints pre-create their job as `running` with `started_at` set, but scheduler-dispatched jobs arrive as `pending`, so they complete with `started_at = NULL` and fall out of every `started_at`-based view — including the activity feed's 14-day window (`started_at >= now-14d`).
3. **Restore lane dead** — the API emits `type: "restore_check"`, but the timeline matches lane names exactly (`LANES.indexOf(a.type)`), so restore verification events are silently dropped.

Observed on a real install: nightly scheduled checks (61 failures in 14 days among them) and ~160 prunes/day were invisible while the dashboard reported "All systems nominal".

## Fix

- `app/api/dashboard.py`: query recent `PruneJob` rows and emit `type: "prune"` feed entries, following the existing per-type pattern.
- `app/services/v2/check_service.py`, `app/services/v2/compact_service.py`: mark the job `running` and record `started_at` at execution start, mirroring the v1 check and v2 prune services. The start transition is a conditional claim (`status IN ('pending', 'running')`, proceed only when a row matched), so a concurrent cancellation is never overwritten back to `running`.
- `frontend/.../ActivityTimeline.tsx`: map `restore_check` events onto the `restore` lane (position and color).

Complements #850: that fix routes scheduled checks to the executor that should run them; this one makes their runs (and prunes/restore checks) visible on the dashboard.

## Tests

- Overview test seeds a `PruneJob` and asserts the full feed type sequence.
- V2 service tests pin the scheduler path (a `pending` job ends `completed` **with** `started_at` set) and the cancellation race (a job cancelled between the status guard and the start claim stays `cancelled`, borg is never spawned) for check and compact.
- Frontend test: a `restore_check` event renders on the restore lane in the restore color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)