### PR TITLE
fix(borg2): stop sending --bypass-lock to a Borg that never had it

### DIFF
--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -5997,7 +5997,10 @@ async def list_repository_archives(
         cmd = router.build_repo_list_command(repository.path)
         if repository.remote_path:
             cmd.extend(["--remote-path", repository.remote_path])
-        if use_bypass_lock:
+        # BorgRouter returns a Borg 2 command for a Borg 2 repository, and Borg 2
+        # has no --bypass-lock (see app/core/borg2.py), so the flag goes on only
+        # where it exists.
+        if use_bypass_lock and not router.is_v2:
             cmd.append("--bypass-lock")
 
         stdout = await _run_repository_command_with_retries(
@@ -6097,7 +6100,10 @@ async def get_repository_info(
         cmd = router.build_repo_info_command(repository.path)
         if repository.remote_path:
             cmd.extend(["--remote-path", repository.remote_path])
-        if use_bypass_lock:
+        # BorgRouter returns a Borg 2 command for a Borg 2 repository, and Borg 2
+        # has no --bypass-lock (see app/core/borg2.py), so the flag goes on only
+        # where it exists.
+        if use_bypass_lock and not router.is_v2:
             cmd.append("--bypass-lock")
 
         stdout = await _run_repository_command_with_retries(

--- a/app/api/v2/repositories.py
+++ b/app/api/v2/repositories.py
@@ -577,25 +577,11 @@ async def get_repository_info(
                 timeout=info_timeout,
                 env=env,
             )
-        if (
-            not result["success"]
-            and not bypass_lock
-            and _is_borg2_lock_like_failure(result)
-        ):
-            logger.warning(
-                "Retrying borg2 info_repo with bypass lock after lock-like failure",
-                repo_id=repo.id,
-                path=repo.path,
-            )
-            with repository_borg_env(repo, db) as env:
-                result = await borg2.info_repo(
-                    repository=repo.path,
-                    passphrase=repo.passphrase,
-                    remote_path=repo.remote_path,
-                    bypass_lock=True,
-                    timeout=info_timeout,
-                    env=env,
-                )
+        # No lock-error retry here. It used to re-run the command with
+        # bypass_lock=True, which only ever meant "--bypass-lock" — a flag Borg 2
+        # does not have. With that gone the retry would issue the identical
+        # command and double the wait on every lock error, so the lock error is
+        # reported as one.
         if not result["success"]:
             raise HTTPException(
                 status_code=500,

--- a/app/core/borg2.py
+++ b/app/core/borg2.py
@@ -21,6 +21,12 @@ Key command differences from Borg 1:
     borg2 check    REPO
     borg2 mount    REPO::ARCHIVE  MOUNTPOINT
 
+  --bypass-lock is Borg 1 only. Borg 2 has never had it — it is absent from
+  2.0.0b21 and 2.0.0b22 alike — so the bypass_lock arguments below are accepted
+  (callers and the repository settings speak for both majors) and ignored. A
+  Borg 2 command that carried it failed at argument parsing, which read as an
+  unreachable repository rather than as a flag this Borg does not know.
+
   Encryption modes (borg 2 only):
     repokey-aes-ocb            (default — recommended)
     repokey-chacha20-poly1305
@@ -329,8 +335,6 @@ class Borg2Interface:
         cmd = [self.borg_cmd, "-r", repository, "info", "--json"]
         if remote_path:
             cmd.extend(["--remote-path", remote_path])
-        if bypass_lock:
-            cmd.append("--bypass-lock")
         exec_env = env.copy() if env else {}
         if passphrase:
             exec_env["BORG_PASSPHRASE"] = passphrase
@@ -386,8 +390,6 @@ class Borg2Interface:
         cmd = [self.borg_cmd, "-r", repository, "info", "--json", archive]
         if remote_path:
             cmd.extend(["--remote-path", remote_path])
-        if bypass_lock:
-            cmd.append("--bypass-lock")
         exec_env = env.copy() if env else {}
         if passphrase:
             exec_env["BORG_PASSPHRASE"] = passphrase
@@ -411,8 +413,6 @@ class Borg2Interface:
             cmd.extend(["--depth", str(browse_depth)])
         if remote_path:
             cmd.extend(["--remote-path", remote_path])
-        if bypass_lock:
-            cmd.append("--bypass-lock")
         cmd.append(archive)
         if path:
             cmd.append(path.strip("/"))
@@ -485,8 +485,6 @@ class Borg2Interface:
             cmd.extend(["--remote-path", remote_path])
         if dry_run:
             cmd.append("--dry-run")
-        if bypass_lock:
-            cmd.append("--bypass-lock")
         cmd.append(archive)
         if paths:
             cmd.extend(paths)

--- a/app/services/v2/restore_service.py
+++ b/app/services/v2/restore_service.py
@@ -17,7 +17,7 @@ class RestoreV2Service:
         archive_name: str,
         paths: Optional[List[str]] = None,
         remote_path: Optional[str] = None,
-        bypass_lock: bool = False,
+        bypass_lock: bool = False,  # noqa: ARG002 - Borg 1 only, see app/core/borg2.py
         strip_components: Optional[int] = None,
     ) -> List[str]:
         cmd = [
@@ -31,8 +31,6 @@ class RestoreV2Service:
         ]
         if remote_path:
             cmd.extend(["--remote-path", remote_path])
-        if bypass_lock:
-            cmd.append("--bypass-lock")
         if strip_components:
             cmd.extend(["--strip-components", str(strip_components)])
         cmd.append(archive_name)

--- a/tests/unit/test_api_v2_repositories.py
+++ b/tests/unit/test_api_v2_repositories.py
@@ -962,9 +962,12 @@ class TestV2RepositoryRoutes:
         assert detail["key"] == "backend.errors.repo.remoteBorg2Incompatible"
         assert "params" not in detail
 
-    def test_get_repository_info_retries_with_bypass_lock_on_lock_like_failure(
+    def test_get_repository_info_reports_a_lock_error_without_retrying(
         self, test_client: TestClient, admin_headers, test_db
     ):
+        """The retry used to re-run the command with bypass_lock=True, which only
+        ever meant --bypass-lock — a flag Borg 2 does not have. Repeating the
+        identical command would just double the wait on every lock error."""
         _enable_borg_v2(test_db)
         repo = _create_v2_repo(test_db, path="/tmp/v2-lock-retry")
 
@@ -972,22 +975,12 @@ class TestV2RepositoryRoutes:
             patch(
                 "app.api.v2.repositories.borg2.info_repo",
                 new=AsyncMock(
-                    side_effect=[
-                        {
-                            "success": False,
-                            "stdout": "",
-                            "stderr": "ObjectNotFound: locks/ddba06e6e875813a",
-                            "return_code": 2,
-                        },
-                        {
-                            "success": True,
-                            "stdout": json.dumps(
-                                {"archives": [], "repository": {"id": 9}}
-                            ),
-                            "stderr": "",
-                            "return_code": 0,
-                        },
-                    ]
+                    return_value={
+                        "success": False,
+                        "stdout": "",
+                        "stderr": "ObjectNotFound: locks/ddba06e6e875813a",
+                        "return_code": 2,
+                    }
                 ),
             ) as mock_info,
             patch(
@@ -1005,10 +998,8 @@ class TestV2RepositoryRoutes:
                 f"/api/v2/repositories/{repo.id}/info", headers=admin_headers
             )
 
-        assert response.status_code == 200
-        assert mock_info.await_count == 2
-        assert mock_info.await_args_list[0].kwargs["bypass_lock"] is False
-        assert mock_info.await_args_list[1].kwargs["bypass_lock"] is True
+        assert response.status_code == 500
+        assert mock_info.await_count == 1
 
     def test_get_repository_info_returns_404_for_missing_repo(
         self, test_client: TestClient, admin_headers, test_db

--- a/tests/unit/test_borg2.py
+++ b/tests/unit/test_borg2.py
@@ -1,3 +1,4 @@
+import inspect
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -133,23 +134,39 @@ async def test_rcreate_injects_managed_rclone_config_into_process_env(
     assert captured["env"]["RCLONE_CONFIG"] == str(rclone_root / "rclone.conf")
 
 
+def _bypass_lock_commands() -> list[str]:
+    """Every borg2 command builder that takes a bypass_lock argument.
+
+    Read off the interface rather than listed, so a new command that accepts
+    bypass_lock is covered the day it is added, and a renamed one fails loudly
+    instead of quietly dropping out of the parametrisation.
+    """
+    names = [
+        name
+        for name, member in inspect.getmembers(borg2, inspect.iscoroutinefunction)
+        if not name.startswith("_")
+        and "bypass_lock" in inspect.signature(member).parameters
+    ]
+    assert names, "no borg2 command takes bypass_lock — has the interface moved?"
+    return names
+
+
+# Stand-ins for the arguments a command needs besides bypass_lock. Nothing is
+# executed: create_subprocess_exec is replaced, so only the argv is built.
+_ARGUMENTS = {
+    "repository": "/repo",
+    "archive": "series",
+    "paths": ["etc/hosts"],
+    "destination": "/restore",
+    "path": "etc/hosts",
+    "mount_point": "/mnt/repo",
+}
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("call", "kwargs"),
-    [
-        ("rinfo", {}),
-        ("info_repo", {}),
-        ("list_repo", {}),
-        ("info_archive", {"archive": "series"}),
-        ("list_archive_contents", {"archive": "series"}),
-        (
-            "extract_archive",
-            {"archive": "series", "paths": ["etc/hosts"], "destination": "/restore"},
-        ),
-    ],
-)
-async def test_no_borg2_command_carries_bypass_lock(monkeypatch, call, kwargs):
+@pytest.mark.parametrize("command", _bypass_lock_commands())
+async def test_no_borg2_command_carries_bypass_lock(monkeypatch, command):
     """--bypass-lock is a Borg 1 flag. Borg 2 has never had it — it is absent
     from the 2.0.0b21 and 2.0.0b22 sources alike — so a Borg 2 command carrying
     it dies at argument parsing, which reads as an unreachable repository rather
@@ -171,10 +188,12 @@ async def test_no_borg2_command_carries_bypass_lock(monkeypatch, call, kwargs):
     monkeypatch.setattr(
         "app.core.borg2.asyncio.create_subprocess_exec", create_subprocess_exec
     )
-    method = getattr(borg2, call, None)
-    if method is None:
-        pytest.skip(f"borg2 has no {call}()")
+    method = getattr(borg2, command)
+    kwargs = {"bypass_lock": True}
+    for name, parameter in inspect.signature(method).parameters.items():
+        if parameter.default is inspect.Parameter.empty and name in _ARGUMENTS:
+            kwargs[name] = _ARGUMENTS[name]
 
-    await method(repository="/repo", bypass_lock=True, **kwargs)
+    await method(**kwargs)
 
     assert "--bypass-lock" not in list(captured["cmd"])

--- a/tests/unit/test_borg2.py
+++ b/tests/unit/test_borg2.py
@@ -131,3 +131,50 @@ async def test_rcreate_injects_managed_rclone_config_into_process_env(
         "none",
     )
     assert captured["env"]["RCLONE_CONFIG"] == str(rclone_root / "rclone.conf")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("call", "kwargs"),
+    [
+        ("rinfo", {}),
+        ("info_repo", {}),
+        ("list_repo", {}),
+        ("info_archive", {"archive": "series"}),
+        ("list_archive_contents", {"archive": "series"}),
+        (
+            "extract_archive",
+            {"archive": "series", "paths": ["etc/hosts"], "destination": "/restore"},
+        ),
+    ],
+)
+async def test_no_borg2_command_carries_bypass_lock(monkeypatch, call, kwargs):
+    """--bypass-lock is a Borg 1 flag. Borg 2 has never had it — it is absent
+    from the 2.0.0b21 and 2.0.0b22 sources alike — so a Borg 2 command carrying
+    it dies at argument parsing, which reads as an unreachable repository rather
+    than as a flag this Borg does not know. The argument stays (callers and the
+    repository settings speak for both majors) and is ignored.
+    """
+    captured: dict[str, object] = {}
+
+    class Process:
+        returncode = 0
+
+        async def communicate(self):
+            return b"{}", b""
+
+    async def create_subprocess_exec(*cmd, **_):
+        captured["cmd"] = cmd
+        return Process()
+
+    monkeypatch.setattr(
+        "app.core.borg2.asyncio.create_subprocess_exec", create_subprocess_exec
+    )
+    method = getattr(borg2, call, None)
+    if method is None:
+        pytest.skip(f"borg2 has no {call}()")
+
+    await method(repository="/repo", bypass_lock=True, **kwargs)
+
+    assert "--bypass-lock" not in list(captured["cmd"])

--- a/tests/unit/test_v2_restore_service.py
+++ b/tests/unit/test_v2_restore_service.py
@@ -8,6 +8,9 @@ from app.services.v2.restore_service import RestoreV2Service
 
 @pytest.mark.unit
 def test_build_extract_command_uses_borg2_archive_identifier():
+    """bypass_lock is accepted and ignored: --bypass-lock is a Borg 1 flag that
+    Borg 2 has never had, and emitting it failed the command at argument
+    parsing."""
     with patch("app.services.v2.restore_service.borg2.borg_cmd", "borg2"):
         cmd = RestoreV2Service().build_extract_command(
             repository_path="/repos/v2",
@@ -28,7 +31,6 @@ def test_build_extract_command_uses_borg2_archive_identifier():
         "0022",
         "--remote-path",
         "/usr/local/bin/borg2",
-        "--bypass-lock",
         "--strip-components",
         "1",
         "manual-1",


### PR DESCRIPTION
## Problem

`--bypass-lock` is a Borg 1 flag. Borg 2 has never had it — it is absent from the 2.0.0b21 and 2.0.0b22 sources alike — so a Borg 2 command carrying it dies at argument parsing. That failure reads as an unreachable repository rather than as a flag this Borg does not know, which makes the repository-level "bypass lock" setting (and the system-wide `bypass_lock_on_*` settings) actively break every affected operation on Borg 2 repositories instead of doing nothing.

## Fix

- `app/core/borg2.py`: every command builder accepts the `bypass_lock` argument (callers and the repository settings speak for both majors) and ignores it, documented at the top of the module.
- `app/api/repositories.py`: the two places that append a raw `--bypass-lock` to an assembled command (repository info, archive list) now guard on `not router.is_v2`.
- `app/api/v2/repositories.py`, `app/services/v2/restore_service.py`: dropped the flag from the Borg 2 call sites.

## Tests

`test_no_borg2_command_carries_bypass_lock` discovers every borg2 command builder that takes a `bypass_lock` argument off the interface via `inspect` — a builder added tomorrow is covered the day it appears, and a renamed one fails loudly instead of dropping out of the parametrisation — and asserts none of them emits the flag.

Independent of #841 (the flag never existed in b21 either, so this bites today's Borg 2 support); it touches the same `app/core/borg2.py` docstring region, so whichever of the two lands second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)