### PR TITLE
fix(repos): sync archive stats from the info dialog's listing

### DIFF
--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -89,6 +89,7 @@ from app.services.job_admission import (
     ensure_repository_admission,
 )
 from app.services.log_policy import get_log_save_policy, job_has_logs_by_policy
+from app.services.repository_info_sync import sync_archive_stats_from_info
 from app.services.repository_command_lock import run_serialized_repository_command
 from app.services.rclone_repository_service import (
     SYNC_DIRECTION_AGENT_TO_REMOTE,
@@ -6079,6 +6080,10 @@ async def get_repository_info(
                 agent_job_id=agent_job.id,
                 archive_count=len(archives),
             )
+            # The card renders the stored columns; sync them from the list just
+            # fetched (Borg 2 only — the helper guards), or the dialog shows a
+            # count the card contradicts.
+            sync_archive_stats_from_info(repository, info_data, db)
             return {
                 "success": True,
                 "info": {
@@ -6122,6 +6127,10 @@ async def get_repository_info(
             encryption_info = info_data.get("encryption", {})
 
             logger.info("Repository info retrieved successfully", repo_id=repo_id)
+
+            # Same sync as the agent branch above: the card renders the stored
+            # columns (Borg 2 only — the helper guards).
+            sync_archive_stats_from_info(repository, info_data, db)
 
             return {
                 "success": True,

--- a/app/api/v2/repositories.py
+++ b/app/api/v2/repositories.py
@@ -20,6 +20,7 @@ from app.core.security import get_current_user
 from app.core.features import require_feature
 from app.core.borg2 import borg2, BORG2_ENCRYPTION_MODES
 from app.core.borg_errors import is_lock_error
+from app.services.repository_info_sync import sync_archive_stats_from_info
 from app.services.agent_job_dispatcher import dispatch_agent_job_best_effort
 from app.services.repository_command_lock import run_serialized_repository_command
 from app.services.repository_executor import (
@@ -565,6 +566,7 @@ async def get_repository_info(
                 info_data["repository"] = rinfo_data["repository"]
             if rinfo_data.get("encryption") and not info_data.get("encryption"):
                 info_data["encryption"] = rinfo_data["encryption"]
+            sync_archive_stats_from_info(repo, info_data, db)
             return {"info": info_data, "borg_version": 2}
 
         bypass_lock = _resolve_bypass_lock(repo, db, "bypass_lock_on_info")
@@ -640,6 +642,10 @@ async def get_repository_info(
                     }
             except Exception:
                 pass
+
+        # The card renders the stored columns; sync them from the list just
+        # fetched, or the dialog shows a count the card contradicts.
+        sync_archive_stats_from_info(repo, info_data, db)
 
         return {"info": info_data, "borg_version": 2}
 

--- a/app/services/repository_info_sync.py
+++ b/app/services/repository_info_sync.py
@@ -1,0 +1,88 @@
+"""Write archive stats back to the repository row from a fresh `info` listing.
+
+The repository card renders the stored archive_count/last_backup columns; they
+are written by the stats refresh and, in part, by backup completion. The info
+dialog fetches the authoritative archive list moments later and used to throw
+it away — so a backup finishing between a stats refresh and the info click left
+the dialog showing two archives while the card still said one.
+
+Borg 2 only: Borg 1's repository-level `info --json` carries no archive list,
+so the parsed shape yields [] even for a populated repository, and writing that
+back would wipe a real count to 0 — the same trap the stats refresh guards
+against with its list_ok check.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import structlog
+
+from app.database.models import Repository
+
+logger = structlog.get_logger()
+
+
+def _newest_archive_time(archives: list) -> Optional[datetime]:
+    """The newest archive timestamp as a naive UTC value, matching the column."""
+    newest = None
+    for archive in archives:
+        if not isinstance(archive, dict):
+            continue
+        value = archive.get("time") or archive.get("start")
+        if not isinstance(value, str) or not value.strip():
+            continue
+        try:
+            dt = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if dt.tzinfo is not None:
+            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+        if newest is None or dt > newest:
+            newest = dt
+    return newest
+
+
+def sync_archive_stats_from_info(
+    repository: Repository, info_data: Dict[str, Any], db
+) -> None:
+    """Best-effort by design: the info response has already been served either
+    way, so a failed write is logged, never raised."""
+    if repository.borg_version != 2:
+        return
+    archives = info_data.get("archives")
+    if not isinstance(archives, list):
+        return
+    # Captured before the commit/rollback below: a rollback expires ORM
+    # attributes, so reading repository.name afterwards could itself hit the
+    # database and raise — inside the handler that promises never to.
+    repository_name = repository.name
+    try:
+        repository.archive_count = len(archives)
+        newest = _newest_archive_time(archives)
+        if archives:
+            # Archives whose times we cannot parse must not wipe a known
+            # last_backup — absence of evidence only counts when the list
+            # itself is empty.
+            if newest:
+                repository.last_backup = newest
+        else:
+            repository.last_backup = None
+        db.commit()
+    except Exception as e:
+        try:
+            db.rollback()
+        except Exception as rollback_error:
+            # Still best-effort: a session too broken to roll back must not
+            # take the already-served info response down with it.
+            logger.warning(
+                "rollback after failed archive stats sync failed",
+                repository=repository_name,
+                error=str(rollback_error),
+            )
+        logger.warning(
+            "archive stats sync from info failed",
+            repository=repository_name,
+            error=str(e),
+        )

--- a/frontend/src/pages/Repositories.tsx
+++ b/frontend/src/pages/Repositories.tsx
@@ -233,6 +233,15 @@ export default function Repositories() {
     retry: false,
   })
 
+  // Fresh info carries the authoritative archive list, and the backend syncs
+  // archive_count/last_backup from it — refetch the list so the card catches
+  // up with the dialog instead of rendering the stale stored count.
+  React.useEffect(() => {
+    if (repositoryInfo) {
+      queryClient.invalidateQueries({ queryKey: ['repositories'] })
+    }
+  }, [repositoryInfo, queryClient])
+
   // Handle repository info error
   React.useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/unit/test_api_repositories.py
+++ b/tests/unit/test_api_repositories.py
@@ -1155,6 +1155,71 @@ class TestRepositoriesCreate:
         )
         run_local.assert_not_called()
 
+    def test_agent_repository_info_syncs_archive_stats_to_the_row(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """The live case: stats refresh wrote 1, a backup finished, the info
+        click showed 2 in the dialog while the card kept rendering the stale
+        stored count. The info route now writes the list it fetched back."""
+        agent = _agent_machine_with_capabilities("repository.info")
+        repo = Repository(
+            name="Agent Sync Repo",
+            path="/agent/sync/repo",
+            encryption="repokey-aes-ocb",
+            compression="lz4",
+            executor_type="agent",
+            execution_target="agent",
+            agent_machine_id=1,
+            repository_type="local",
+            borg_version=2,
+            archive_count=1,
+        )
+        test_db.add_all([agent, repo])
+        test_db.commit()
+        repo.agent_machine_id = agent.id
+        test_db.commit()
+        test_db.refresh(repo)
+
+        with (
+            patch(
+                "app.api.repositories.wait_for_agent_repository_operation_job",
+                new=AsyncMock(
+                    return_value={
+                        "data": {
+                            "repository": {"id": "abc"},
+                            "cache": {},
+                            "encryption": {
+                                "encryption": "aes256-ocb",
+                                "id_hash": "sha256",
+                            },
+                            "archives": [
+                                {
+                                    "name": "k8s-borg",
+                                    "start": "2026-08-19T20:03:15.388152+02:00",
+                                },
+                                {
+                                    "name": "k8s-borg",
+                                    "start": "2026-08-19T21:03:18.624537+02:00",
+                                },
+                            ],
+                        }
+                    }
+                ),
+            ),
+            patch(
+                "app.api.repositories._run_repository_command",
+                new=AsyncMock(return_value=(0, b"{}", b"")),
+            ),
+        ):
+            response = test_client.get(
+                f"/api/repositories/{repo.id}/info", headers=admin_headers
+            )
+
+        assert response.status_code == 200
+        test_db.refresh(repo)
+        assert repo.archive_count == 2
+        assert repo.last_backup == datetime(2026, 8, 19, 19, 3, 18, 624537)
+
     async def test_agent_stats_refresh_keeps_count_when_list_job_fails(self, test_db):
         # A completed list job can still carry a non-zero borg exit with no
         # stdout (-> []). That must not wipe the stored archive_count to 0.
@@ -2726,6 +2791,51 @@ class TestRepositoriesStatistics:
         assert cmd[0] == "borg2"
         assert "-r" in cmd
         assert "info" in cmd
+
+    def test_get_repository_info_syncs_archive_stats_on_server_path(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """The server-managed branch must sync the stored columns exactly like
+        the agent branch above it."""
+        repo = Repository(
+            name="V2 Server Sync Repo",
+            path="/tmp/v2-server-sync-repo",
+            encryption="none",
+            compression="lz4",
+            repository_type="local",
+            borg_version=2,
+            archive_count=1,
+        )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+
+        info_json = json.dumps(
+            {
+                "repository": {"id": "abc"},
+                "archives": [
+                    {"name": "s", "start": "2026-08-19T20:03:15+02:00"},
+                    {"name": "s", "start": "2026-08-19T21:03:18+02:00"},
+                ],
+            }
+        ).encode()
+
+        with (
+            patch("app.core.borg2.borg2.borg_cmd", "borg2"),
+            patch(
+                "app.api.repositories._run_repository_command",
+                new=AsyncMock(return_value=(0, info_json, b"")),
+            ),
+        ):
+            response = test_client.get(
+                f"/api/repositories/{repo.id}/info",
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        test_db.refresh(repo)
+        assert repo.archive_count == 2
+        assert repo.last_backup == datetime(2026, 8, 19, 19, 3, 18)
 
     def test_get_repository_stats_not_found(
         self, test_client: TestClient, admin_headers

--- a/tests/unit/test_api_v2_repositories.py
+++ b/tests/unit/test_api_v2_repositories.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import contextlib
 import json
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -917,6 +918,59 @@ class TestV2RepositoryRoutes:
         mock_info.assert_awaited_once()
         mock_rinfo.assert_awaited_once()
         mock_size.assert_awaited_once_with([repo.path], timeout=30)
+
+    def test_get_repository_info_syncs_archive_stats_to_the_row(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """The dialog's list must reach the stored columns the card renders."""
+        _enable_borg_v2(test_db)
+        repo = _create_v2_repo(test_db, path="/tmp/v2-sync-repo")
+        repo.archive_count = 1
+        test_db.commit()
+
+        with (
+            patch(
+                "app.api.v2.repositories.borg2.info_repo",
+                new=AsyncMock(
+                    return_value={
+                        "success": True,
+                        "stdout": json.dumps(
+                            {
+                                "archives": [
+                                    {
+                                        "name": "s",
+                                        "start": "2026-08-19T20:03:15+02:00",
+                                    },
+                                    {
+                                        "name": "s",
+                                        "start": "2026-08-19T21:03:18+02:00",
+                                    },
+                                ]
+                            }
+                        ),
+                        "stderr": "",
+                    }
+                ),
+            ),
+            patch(
+                "app.api.v2.repositories.borg2.rinfo",
+                new=AsyncMock(
+                    return_value={
+                        "success": True,
+                        "stdout": json.dumps({}),
+                        "stderr": "",
+                    }
+                ),
+            ),
+        ):
+            response = test_client.get(
+                f"/api/v2/repositories/{repo.id}/info", headers=admin_headers
+            )
+
+        assert response.status_code == 200
+        test_db.refresh(repo)
+        assert repo.archive_count == 2
+        assert repo.last_backup == datetime(2026, 8, 19, 19, 3, 18)
 
     def test_get_repository_info_returns_500_on_info_failure(
         self, test_client: TestClient, admin_headers, test_db

--- a/tests/unit/test_repository_info_sync.py
+++ b/tests/unit/test_repository_info_sync.py
@@ -1,0 +1,181 @@
+"""The info dialog's archive list must reach the repository row.
+
+The real sequence this guards (observed live): stats refresh writes
+archive_count=1, a backup finishes two minutes later, the info click then shows
+two archives in the dialog while the card still says one — because the info
+routes fetched the authoritative list and threw it away.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from app.services.repository_info_sync import sync_archive_stats_from_info
+
+
+class FakeDb:
+    def __init__(self):
+        self.commits = 0
+        self.rollbacks = 0
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+
+class FakeRepo:
+    def __init__(self, borg_version, archive_count=1, last_backup=None):
+        self.name = "repo"
+        self.borg_version = borg_version
+        self.archive_count = archive_count
+        self.last_backup = last_backup
+
+
+@pytest.mark.unit
+def test_borg2_count_and_newest_time_are_written():
+    """The timestamps are verbatim from the live case — offset-carrying ISO
+    strings; the column stores naive UTC."""
+    repo = FakeRepo(borg_version=2, archive_count=1)
+    db = FakeDb()
+    info = {
+        "archives": [
+            {"name": "k8s-borg", "start": "2026-08-19T20:03:15.388152+02:00"},
+            {"name": "k8s-borg", "start": "2026-08-19T21:03:18.624537+02:00"},
+        ]
+    }
+
+    sync_archive_stats_from_info(repo, info, db)
+
+    assert repo.archive_count == 2
+    assert repo.last_backup == datetime(2026, 8, 19, 19, 3, 18, 624537)
+    assert db.commits == 1
+
+
+@pytest.mark.unit
+def test_borg1_is_never_touched():
+    """Borg 1's repository-level info carries no archive list; the parsed shape
+    yields [] even for a populated repository. Writing that back would wipe a
+    real count to 0."""
+    repo = FakeRepo(borg_version=1, archive_count=5)
+    db = FakeDb()
+
+    sync_archive_stats_from_info(repo, {"archives": []}, db)
+
+    assert repo.archive_count == 5
+    assert db.commits == 0
+
+
+@pytest.mark.unit
+def test_an_empty_borg2_repository_writes_zero_and_clears_last_backup():
+    """Zero archives with a stale newest-backup time would contradict itself
+    on the card — an empty listing clears both columns."""
+    repo = FakeRepo(borg_version=2, archive_count=3, last_backup=datetime(2026, 8, 1))
+    db = FakeDb()
+
+    sync_archive_stats_from_info(repo, {"archives": []}, db)
+
+    assert repo.archive_count == 0
+    assert repo.last_backup is None
+    assert db.commits == 1
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("info", [{}, {"archives": None}, {"archives": "raw"}])
+def test_a_response_without_a_list_is_ignored(info):
+    repo = FakeRepo(borg_version=2, archive_count=4)
+    db = FakeDb()
+
+    sync_archive_stats_from_info(repo, info, db)
+
+    assert repo.archive_count == 4
+    assert db.commits == 0
+
+
+@pytest.mark.unit
+def test_unparsable_times_still_update_the_count_and_keep_last_backup():
+    """Archives exist, only their times are unreadable — that is no evidence
+    the known last_backup is wrong, so it stays."""
+    repo = FakeRepo(borg_version=2, archive_count=0, last_backup=datetime(2026, 8, 1))
+    db = FakeDb()
+    info = {"archives": [{"name": "a", "time": "not-a-date"}, {"name": "b"}]}
+
+    sync_archive_stats_from_info(repo, info, db)
+
+    assert repo.archive_count == 2
+    assert repo.last_backup == datetime(2026, 8, 1)
+
+
+@pytest.mark.unit
+def test_a_failing_commit_is_swallowed_and_rolled_back():
+    """The info response has already been served — a stats write must never
+    turn it into a 500."""
+
+    class FailingDb(FakeDb):
+        def commit(self):
+            raise RuntimeError("database is locked")
+
+    repo = FakeRepo(borg_version=2)
+    db = FailingDb()
+
+    sync_archive_stats_from_info(repo, {"archives": []}, db)
+
+    assert db.rollbacks == 1
+
+
+@pytest.mark.unit
+def test_a_failing_rollback_is_swallowed_too():
+    """A session broken enough that even rollback() raises must still not
+    escape the helper — the never-raise contract has no exceptions."""
+
+    class BrokenDb(FakeDb):
+        def commit(self):
+            raise RuntimeError("database is locked")
+
+        def rollback(self):
+            super().rollback()
+            raise RuntimeError("connection is closed")
+
+    repo = FakeRepo(borg_version=2)
+    db = BrokenDb()
+
+    sync_archive_stats_from_info(repo, {"archives": []}, db)
+
+    assert db.rollbacks == 1
+
+
+@pytest.mark.unit
+def test_the_warning_logs_do_not_read_orm_attributes_after_rollback():
+    """A rollback expires ORM attributes, so on a broken session even
+    repository.name can hit the database and raise when read afterwards — the
+    warning logs must use the name captured up front."""
+
+    class ExpiringRepo(FakeRepo):
+        expired = False
+
+        def __getattribute__(self, item):
+            if item == "name" and object.__getattribute__(self, "expired"):
+                raise RuntimeError("attribute refresh on a broken session")
+            return object.__getattribute__(self, item)
+
+    class FailingDb(FakeDb):
+        def __init__(self, repo):
+            super().__init__()
+            self._repo = repo
+
+        def commit(self):
+            raise RuntimeError("database is locked")
+
+        def rollback(self):
+            super().rollback()
+            self._repo.expired = True
+
+    repo = ExpiringRepo(borg_version=2)
+    db = FailingDb(repo)
+
+    sync_archive_stats_from_info(repo, {"archives": []}, db)
+
+    assert db.rollbacks == 1


### PR DESCRIPTION
## Problem

For Borg 2 repositories, the info dialog fetches a fresh archive listing, but the repository card keeps rendering the stored `archive_count` / `last_backup` columns. After a backup finishes, the dialog shows the new count while the card contradicts it with the stale stored value until the next stats refresh.

## Fix

New `app/services/repository_info_sync.py`: `sync_archive_stats_from_info` writes the archive count and newest archive time from the listing the info route just fetched back to the repository row. Best-effort by design — the info response has been served either way, so a failed write is logged, never raised; the helper self-guards on `borg_version == 2` and on the archives shape, so Borg 1 info output is untouched.

Called from all three info paths: the v1 route's agent branch and server-managed branch, and the v2 route (agent and server paths).

## Tests

Unit tests for the helper (count, newest-archive timestamp normalization to naive UTC, guard behaviour), plus route-level regression tests for each path asserting the stored columns update (`test_agent_repository_info_syncs_archive_stats_to_the_row`, `test_get_repository_info_syncs_archive_stats_on_server_path`, `test_get_repository_info_syncs_archive_stats_to_the_row`).

Independent of #841 and #852.

🤖 Generated with [Claude Code](https://claude.com/claude-code)