### PR TITLE
fix(agent): list Borg 2 archives without reading every archive's metadata

### DIFF
--- a/agent/borg_ui_agent/repository_ops.py
+++ b/agent/borg_ui_agent/repository_ops.py
@@ -200,7 +200,19 @@ class RepositoryOperationPayload:
 
         if self.job_kind == "repository.list_archives":
             if self.borg_version == 2:
-                return [*self._base_borg2("repo-list"), "--json"]
+                # A bare `repo-list --json` fills its default keys by reading
+                # every archive's metadata, which borgstore serves as
+                # whole-pack loads on remote repositories — listing N archives
+                # can transfer N packs. Restricting the keys to what the
+                # server reads (name, id, time) keeps the listing to the
+                # archives directory entries; the --json output shape is
+                # unchanged, borg just emits the requested keys.
+                return [
+                    *self._base_borg2("repo-list"),
+                    "--json",
+                    "--format",
+                    "{name}{id}{time}",
+                ]
             return [*self._base_borg1("list"), "--json", self.repository_path]
 
         if self.job_kind == "repository.list_archive_contents":

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -562,6 +562,50 @@ def test_repository_rinfo_payload_builds_borg2_command():
 
 
 @pytest.mark.unit
+def test_repository_list_archives_payload_builds_light_borg2_command():
+    """The Borg 2 listing must restrict the JSON keys to name/id/time — the
+    default key set makes repo-list read every archive's metadata, which
+    borgstore serves as whole-pack loads on remote repositories."""
+    payload = RepositoryOperationPayload.from_job_payload(
+        {
+            "schema_version": 1,
+            "job_kind": "repository.list_archives",
+            "repository": {"path": "/agent/repo2", "borg_version": 2},
+        }
+    )
+
+    assert payload.build_command() == [
+        "borg2",
+        "-r",
+        "/agent/repo2",
+        "repo-list",
+        "--json",
+        "--format",
+        "{name}{id}{time}",
+    ]
+
+
+@pytest.mark.unit
+def test_repository_list_archives_payload_keeps_plain_borg1_command():
+    """Borg 1's list --json reads the manifest only — no per-archive cost, so
+    it stays untouched."""
+    payload = RepositoryOperationPayload.from_job_payload(
+        {
+            "schema_version": 1,
+            "job_kind": "repository.list_archives",
+            "repository": {"path": "/agent/repo", "borg_version": 1},
+        }
+    )
+
+    assert payload.build_command() == [
+        "borg",
+        "list",
+        "--json",
+        "/agent/repo",
+    ]
+
+
+@pytest.mark.unit
 def test_repository_archive_info_payload_builds_borg2_command():
     payload = RepositoryOperationPayload.from_job_payload(
         {


### PR DESCRIPTION
## Problem

The agent runs `borg2 repo-list --json` for `repository.list_archives`. A bare `--json` fills its default key set by reading **every archive's metadata chunk**, and borgstore serves those reads as **whole-pack loads** on remote repositories (`load(packs/<id>, offset=0, size=None)` — full 200 responses, while other reads use ranged 206 requests). Listing N archives can therefore transfer up to N whole packs.

On a repository with large packs (~40 MB, high-churn hourly backups) behind a slow link, one listing of 27 archives transferred >1 GB and exceeded the agent's 300 s operation timeout — every hour, since the periodic stats refresh drives this job. Two knock-on effects made it worse:

- the killed borg cannot remove its **shared store lock**, which stays until borgstore's staleness window (30 min) passes — post-backup compacts that landed in that window failed with `LockTimeout` (rc 73);
- the timeout left one zombie borg per attempt behind.

Debug evidence (borg 2.0.0b22, `--debug`): per archive, two ~757 B ranged reads of the archives entry, then one full-pack GET of 34–44 MB taking 27–42 s.

## Fix

Request only the keys the server actually consumes — `--format "{name}{id}{time}"` alongside `--json`. Per `repo-list --help`, the format's *keys* select what the JSON contains; with name/id/time, borg reads only the archives directory entries. The `--json` output shape is unchanged (`{"archives": [{"name", "id", "time", ...}]}`), so every consumer (stats refresh, the archives endpoints, DB-side enrichment) keeps working — the dropped default keys (per-archive stats, hostname, comment) were never read from this path.

Verified against 2.0.0b22 on the affected repository: the same listing that timed out after 420 s returns in about a second.

Borg 1 is untouched: its `list --json` reads the manifest, there is no per-archive cost.

I'll also report the underlying read pattern (whole-pack loads for archive metadata) upstream to borgbackup — this change just stops asking for data the UI never uses.

## Tests

`test_repository_list_archives_payload_builds_light_borg2_command` pins the Borg 2 command; `test_repository_list_archives_payload_keeps_plain_borg1_command` pins that Borg 1 stays unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)