### PR TITLE
feat(agents): offer Borg verify/update in the reinstall dialog

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -341,7 +341,28 @@
         "title": "Agent neu installieren",
         "copyCommand": "Neuinstallationsbefehl kopieren",
         "description": "Führen Sie dies auf dem registrierten Rechner aus, um das Borg-UI-Agent-Paket zu aktualisieren und den systemd-Dienst neu zu starten. Kein Registrierungstoken oder Registrierungsschritt erforderlich.",
-        "configPreserved": "Das Skript behält die vorhandene Agent-Konfiguration bei unter"
+        "configPreserved": "Das Skript behält die vorhandene Agent-Konfiguration unter",
+        "serviceUserPreserved": "Der Dienst läuft außerdem weiter unter dem in seiner systemd-Unit hinterlegten Benutzer. Führen Sie den Befehl von einem beliebigen sudo-fähigen Konto aus.",
+        "borgInstallation": "Borg-Installation",
+        "borgSelectionHint": "Vorausgewählt anhand der letzten Meldung des Agents. Eine Borg-Auswahl aktualisiert diese Binaries zusätzlich auf die Versionen dieses Servers.",
+        "borgOptions": {
+          "borg1": {
+            "label": "Borg 1.x",
+            "description": "Prüft oder aktualisiert Borg 1 als 'borg' auf die Version dieses Servers."
+          },
+          "borg2": {
+            "label": "Nur Borg 2.x Beta",
+            "description": "Prüft oder aktualisiert Borg 2 als 'borg2' auf die Version dieses Servers."
+          },
+          "both": {
+            "label": "Borg 1.x und Borg 2.x Beta",
+            "description": "Prüft oder aktualisiert Borg 1 als 'borg' und Borg 2 als 'borg2' auf die Versionen dieses Servers."
+          },
+          "skip": {
+            "label": "Borg-Installation überspringen",
+            "description": "Standard. Aktualisiert nur das Agent-Paket; Borg-Binaries bleiben unangetastet."
+          }
+        }
       },
       "logs": {
         "agent": "Agent-Protokolle",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -344,7 +344,7 @@
         "configPreserved": "Das Skript behält die vorhandene Agent-Konfiguration unter",
         "serviceUserPreserved": "Der Dienst läuft außerdem weiter unter dem in seiner systemd-Unit hinterlegten Benutzer. Führen Sie den Befehl von einem beliebigen sudo-fähigen Konto aus.",
         "borgInstallation": "Borg-Installation",
-        "borgSelectionHint": "Vorausgewählt anhand der letzten Meldung des Agents. Eine Borg-Auswahl aktualisiert diese Binaries zusätzlich auf die Versionen dieses Servers.",
+        "borgSelectionHint": "Eine Borg-Auswahl aktualisiert diese Binaries auf dem Agenten auf die Versionen dieses Servers. Lassen Sie die Auswahl auf Überspringen, sofern kein Borg-Upgrade beabsichtigt ist.",
         "borgOptions": {
           "borg1": {
             "label": "Borg 1.x",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -344,7 +344,7 @@
         "configPreserved": "The script preserves the existing agent config at",
         "serviceUserPreserved": "The service also keeps running as the user recorded in its systemd unit — run the command from any account that can sudo.",
         "borgInstallation": "Borg installation",
-        "borgSelectionHint": "Preselected from what the agent last reported. Selecting Borg versions also updates those binaries to the versions this server provides.",
+        "borgSelectionHint": "Selecting Borg versions upgrades those binaries on the agent to the versions this server provides. Leave this on Skip unless a Borg upgrade is intended.",
         "borgOptions": {
           "borg1": {
             "label": "Borg 1.x",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -341,7 +341,28 @@
         "title": "Reinstall agent",
         "copyCommand": "Copy reinstall command",
         "description": "Run this on the enrolled machine to update the Borg UI agent package and restart the systemd service. No enrollment token or registration step is required.",
-        "configPreserved": "The script preserves the existing agent config at"
+        "configPreserved": "The script preserves the existing agent config at",
+        "serviceUserPreserved": "The service also keeps running as the user recorded in its systemd unit — run the command from any account that can sudo.",
+        "borgInstallation": "Borg installation",
+        "borgSelectionHint": "Preselected from what the agent last reported. Selecting Borg versions also updates those binaries to the versions this server provides.",
+        "borgOptions": {
+          "borg1": {
+            "label": "Borg 1.x",
+            "description": "Verifies or updates Borg 1 as 'borg' to this server's version."
+          },
+          "borg2": {
+            "label": "Borg 2.x beta only",
+            "description": "Verifies or updates Borg 2 as 'borg2' to this server's version."
+          },
+          "both": {
+            "label": "Borg 1.x and Borg 2.x beta",
+            "description": "Verifies or updates Borg 1 as 'borg' and Borg 2 as 'borg2' to this server's versions."
+          },
+          "skip": {
+            "label": "Skip Borg install",
+            "description": "Default. Only updates the agent package; Borg binaries are left untouched."
+          }
+        }
       },
       "logs": {
         "agent": "Agent Logs",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -344,7 +344,7 @@
         "configPreserved": "El script conserva la configuración existente del agente en",
         "serviceUserPreserved": "El servicio también sigue ejecutándose con el usuario registrado en su unidad de systemd; ejecute el comando desde cualquier cuenta con sudo.",
         "borgInstallation": "Instalación de Borg",
-        "borgSelectionHint": "Preseleccionado según lo último que informó el agente. Seleccionar versiones de Borg también actualiza esos binarios a las versiones que ofrece este servidor.",
+        "borgSelectionHint": "Seleccionar versiones de Borg actualiza esos binarios en el agente a las versiones que ofrece este servidor. Deje la opción en Omitir salvo que desee un upgrade de Borg.",
         "borgOptions": {
           "borg1": {
             "label": "Borg 1.x",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -341,7 +341,28 @@
         "title": "Reinstalar agente",
         "copyCommand": "Copiar comando de reinstalación",
         "description": "Ejecute esto en la máquina registrada para actualizar el paquete del agente Borg UI y reiniciar el servicio systemd. No se requiere token ni paso de registro.",
-        "configPreserved": "El script conserva la configuración existente del agente en"
+        "configPreserved": "El script conserva la configuración existente del agente en",
+        "serviceUserPreserved": "El servicio también sigue ejecutándose con el usuario registrado en su unidad de systemd; ejecute el comando desde cualquier cuenta con sudo.",
+        "borgInstallation": "Instalación de Borg",
+        "borgSelectionHint": "Preseleccionado según lo último que informó el agente. Seleccionar versiones de Borg también actualiza esos binarios a las versiones que ofrece este servidor.",
+        "borgOptions": {
+          "borg1": {
+            "label": "Borg 1.x",
+            "description": "Verifica o actualiza Borg 1 como 'borg' a la versión de este servidor."
+          },
+          "borg2": {
+            "label": "Solo Borg 2.x beta",
+            "description": "Verifica o actualiza Borg 2 como 'borg2' a la versión de este servidor."
+          },
+          "both": {
+            "label": "Borg 1.x y Borg 2.x beta",
+            "description": "Verifica o actualiza Borg 1 como 'borg' y Borg 2 como 'borg2' a las versiones de este servidor."
+          },
+          "skip": {
+            "label": "Omitir instalación de Borg",
+            "description": "Predeterminado. Solo actualiza el paquete del agente; los binarios de Borg no se tocan."
+          }
+        }
       },
       "logs": {
         "agent": "Registros del agente",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -344,7 +344,7 @@
         "configPreserved": "Lo script conserva la configurazione dell'agente esistente in",
         "serviceUserPreserved": "Il servizio continua inoltre a essere eseguito con l'utente registrato nella sua unità systemd: esegui il comando da qualsiasi account con sudo.",
         "borgInstallation": "Installazione di Borg",
-        "borgSelectionHint": "Preselezionato in base all'ultimo report dell'agente. Selezionando le versioni di Borg vengono aggiornati anche quei binari alle versioni offerte da questo server.",
+        "borgSelectionHint": "Selezionando le versioni di Borg quei binari sull'agente vengono aggiornati alle versioni offerte da questo server. Lascia la selezione su Salta se non intendi eseguire un upgrade di Borg.",
         "borgOptions": {
           "borg1": {
             "label": "Borg 1.x",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -341,7 +341,28 @@
         "title": "Reinstalla agente",
         "copyCommand": "Copia comando di reinstallazione",
         "description": "Esegui questo comando sulla macchina registrata per aggiornare il pacchetto dell'agente Borg UI e riavviare il servizio systemd. Non sono richiesti token o passaggi di registrazione.",
-        "configPreserved": "Lo script conserva la configurazione dell'agente esistente in"
+        "configPreserved": "Lo script conserva la configurazione dell'agente esistente in",
+        "serviceUserPreserved": "Il servizio continua inoltre a essere eseguito con l'utente registrato nella sua unità systemd: esegui il comando da qualsiasi account con sudo.",
+        "borgInstallation": "Installazione di Borg",
+        "borgSelectionHint": "Preselezionato in base all'ultimo report dell'agente. Selezionando le versioni di Borg vengono aggiornati anche quei binari alle versioni offerte da questo server.",
+        "borgOptions": {
+          "borg1": {
+            "label": "Borg 1.x",
+            "description": "Verifica o aggiorna Borg 1 come 'borg' alla versione di questo server."
+          },
+          "borg2": {
+            "label": "Solo Borg 2.x beta",
+            "description": "Verifica o aggiorna Borg 2 come 'borg2' alla versione di questo server."
+          },
+          "both": {
+            "label": "Borg 1.x e Borg 2.x beta",
+            "description": "Verifica o aggiorna Borg 1 come 'borg' e Borg 2 come 'borg2' alle versioni di questo server."
+          },
+          "skip": {
+            "label": "Salta installazione Borg",
+            "description": "Predefinito. Aggiorna solo il pacchetto dell'agente; i binari di Borg restano intatti."
+          }
+        }
       },
       "logs": {
         "agent": "Registri agente",

--- a/frontend/src/pages/ManagedAgents.stories.tsx
+++ b/frontend/src/pages/ManagedAgents.stories.tsx
@@ -578,39 +578,6 @@ export const AgentReinstallDialogOpen: Story = {
   ),
 }
 
-// An agent whose Borg binaries the installer manages: the Borg selection is
-// preselected from the reported install_source, and the command carries
-// --borg-version accordingly.
-export const AgentReinstallDialogInstallerManagedBorg: Story = {
-  render: () => (
-    <Box sx={{ p: 3, bgcolor: 'background.default', minHeight: '100vh' }}>
-      <AgentReinstallDialog
-        open
-        agent={{
-          ...agents[0],
-          borg_versions: [
-            {
-              major: 1,
-              version: '1.4.5',
-              path: '/opt/borg-ui-agent/borg1/current/borg',
-              install_source: 'borg-ui-installer',
-            },
-            {
-              major: 2,
-              version: '2.0.0b23',
-              path: '/opt/borg-ui-agent/borg2/current/borg',
-              install_source: 'borg-ui-installer',
-            },
-          ],
-        }}
-        serverUrl="https://borg-ui.example.com"
-        onCancel={() => {}}
-        onCopy={() => {}}
-      />
-    </Box>
-  ),
-}
-
 export const AgentDiagnosticsSuccess: Story = {
   render: () => (
     <Box sx={{ p: 3, bgcolor: 'background.default', minHeight: '100vh' }}>

--- a/frontend/src/pages/ManagedAgents.stories.tsx
+++ b/frontend/src/pages/ManagedAgents.stories.tsx
@@ -578,6 +578,39 @@ export const AgentReinstallDialogOpen: Story = {
   ),
 }
 
+// An agent whose Borg binaries the installer manages: the Borg selection is
+// preselected from the reported install_source, and the command carries
+// --borg-version accordingly.
+export const AgentReinstallDialogInstallerManagedBorg: Story = {
+  render: () => (
+    <Box sx={{ p: 3, bgcolor: 'background.default', minHeight: '100vh' }}>
+      <AgentReinstallDialog
+        open
+        agent={{
+          ...agents[0],
+          borg_versions: [
+            {
+              major: 1,
+              version: '1.4.5',
+              path: '/opt/borg-ui-agent/borg1/current/borg',
+              install_source: 'borg-ui-installer',
+            },
+            {
+              major: 2,
+              version: '2.0.0b23',
+              path: '/opt/borg-ui-agent/borg2/current/borg',
+              install_source: 'borg-ui-installer',
+            },
+          ],
+        }}
+        serverUrl="https://borg-ui.example.com"
+        onCancel={() => {}}
+        onCopy={() => {}}
+      />
+    </Box>
+  ),
+}
+
 export const AgentDiagnosticsSuccess: Story = {
   render: () => (
     <Box sx={{ p: 3, bgcolor: 'background.default', minHeight: '100vh' }}>

--- a/frontend/src/pages/ManagedAgents.tsx
+++ b/frontend/src/pages/ManagedAgents.tsx
@@ -69,7 +69,6 @@ import { resolveAgentServerUrl } from './managed-agents/agentServerUrl'
 import {
   buildAgentInstallCommand,
   buildAgentReinstallCommand,
-  deriveBorgInstallMode,
   type BorgInstallMode,
 } from './managed-agents/agentInstallCommandText'
 import {
@@ -1480,13 +1479,13 @@ export function AgentReinstallDialog({
   onCopy: (value: string) => void
 }) {
   const { t } = useTranslation()
-  // Preselected from what the agent last reported: majors whose binaries the
-  // installer manages get verified/updated, everything else defaults to the
-  // reinstall behavior of leaving Borg untouched. The radio group lets the
-  // user override either way.
+  // Always defaults to Skip — a routine reinstall must never preselect a Borg
+  // upgrade (a Borg change moves users between versions, and Borg 2 betas
+  // still change repository formats). Changing Borg is an explicit choice,
+  // reset whenever the dialog targets a different agent.
   const [borgInstallMode, setBorgInstallMode] = useState<BorgInstallMode>('skip')
   useEffect(() => {
-    setBorgInstallMode(deriveBorgInstallMode(agent?.borg_versions))
+    setBorgInstallMode('skip')
   }, [agent])
   const command = buildAgentReinstallCommand(serverUrl, borgInstallMode)
 

--- a/frontend/src/pages/ManagedAgents.tsx
+++ b/frontend/src/pages/ManagedAgents.tsx
@@ -64,10 +64,13 @@ import LogViewerDialog, { type LogViewerFetchLogs } from '../components/shared/L
 import ResponsiveDialog from '../components/shared/ResponsiveDialog'
 import DiagnosticsTcpTargetFields from '../components/shared/DiagnosticsTcpTargetFields'
 import AddAgentDialog from './managed-agents/AddAgentDialog'
+import BorgInstallModeRadioGroup from './managed-agents/BorgInstallModeRadioGroup'
 import { resolveAgentServerUrl } from './managed-agents/agentServerUrl'
 import {
   buildAgentInstallCommand,
   buildAgentReinstallCommand,
+  deriveBorgInstallMode,
+  type BorgInstallMode,
 } from './managed-agents/agentInstallCommandText'
 import {
   agentJobLogsToViewerResult,
@@ -1477,7 +1480,15 @@ export function AgentReinstallDialog({
   onCopy: (value: string) => void
 }) {
   const { t } = useTranslation()
-  const command = buildAgentReinstallCommand(serverUrl)
+  // Preselected from what the agent last reported: majors whose binaries the
+  // installer manages get verified/updated, everything else defaults to the
+  // reinstall behavior of leaving Borg untouched. The radio group lets the
+  // user override either way.
+  const [borgInstallMode, setBorgInstallMode] = useState<BorgInstallMode>('skip')
+  useEffect(() => {
+    setBorgInstallMode(deriveBorgInstallMode(agent?.borg_versions))
+  }, [agent])
+  const command = buildAgentReinstallCommand(serverUrl, borgInstallMode)
 
   return (
     <ResponsiveDialog
@@ -1511,6 +1522,22 @@ export function AgentReinstallDialog({
               {t('managedAgents.page.reinstallDialog.description')}
             </Typography>
           </Box>
+          <Box>
+            <BorgInstallModeRadioGroup
+              value={borgInstallMode}
+              onChange={setBorgInstallMode}
+              i18nPrefix="managedAgents.page.reinstallDialog"
+            />
+            <Typography
+              variant="body2"
+              sx={{
+                color: 'text.secondary',
+                mt: 1,
+              }}
+            >
+              {t('managedAgents.page.reinstallDialog.borgSelectionHint')}
+            </Typography>
+          </Box>
           <CopyableCodeBlock
             value={command}
             copyLabel={t('managedAgents.page.reinstallDialog.copyCommand')}
@@ -1518,7 +1545,8 @@ export function AgentReinstallDialog({
           />
           <Alert severity="info" sx={{ borderRadius: 1.5 }}>
             {t('managedAgents.page.reinstallDialog.configPreserved')}{' '}
-            <Box component="code">/etc/borg-ui-agent/config.toml</Box>.
+            <Box component="code">/etc/borg-ui-agent/config.toml</Box>.{' '}
+            {t('managedAgents.page.reinstallDialog.serviceUserPreserved')}
           </Alert>
         </Stack>
       </DialogContent>

--- a/frontend/src/pages/__tests__/ManagedAgents.test.tsx
+++ b/frontend/src/pages/__tests__/ManagedAgents.test.tsx
@@ -21,10 +21,7 @@ import {
   managedAgentsAPI,
 } from '../../services/api'
 import type { AxiosResponse } from 'axios'
-import {
-  buildAgentReinstallCommand,
-  deriveBorgInstallMode,
-} from '../managed-agents/agentInstallCommandText'
+import { buildAgentReinstallCommand } from '../managed-agents/agentInstallCommandText'
 
 const { mockPlanCan, mockTrackSystem } = vi.hoisted(() => ({
   mockPlanCan: vi.fn((_feature: string) => true),
@@ -746,45 +743,7 @@ describe('ManagedAgents', () => {
     )
   })
 
-  it('derives the Borg selection from the reported install sources', () => {
-    const installer1 = {
-      major: 1,
-      version: '1.4.5',
-      path: '/opt/borg-ui-agent/borg1/current/borg',
-      install_source: 'borg-ui-installer',
-    }
-    const installer2 = {
-      major: 2,
-      version: '2.0.0b23',
-      path: '/opt/borg-ui-agent/borg2/current/borg',
-      install_source: 'borg-ui-installer',
-    }
-
-    expect(deriveBorgInstallMode([installer1, installer2])).toBe('both')
-    expect(deriveBorgInstallMode([installer1])).toBe('borg1')
-    expect(deriveBorgInstallMode([installer2])).toBe('borg2')
-    // Binaries the installer does not manage must not be touched by default:
-    // distro packages, custom paths, or agents that have not reported yet.
-    expect(
-      deriveBorgInstallMode([
-        { major: 1, version: '1.2.8', path: '/usr/bin/borg', install_source: 'system-package' },
-      ])
-    ).toBe('skip')
-    expect(
-      deriveBorgInstallMode([
-        {
-          major: 2,
-          version: '2.0.0b23',
-          path: '/usr/local/bin/borg2',
-          install_source: 'custom-path',
-        },
-      ])
-    ).toBe('skip')
-    expect(deriveBorgInstallMode([])).toBe('skip')
-    expect(deriveBorgInstallMode(undefined)).toBe('skip')
-  })
-
-  it('preselects the reported Borg majors in the reinstall dialog and follows overrides', async () => {
+  it('defaults the reinstall dialog to Skip and makes a Borg change an explicit choice', async () => {
     const user = userEvent.setup()
     const onCopy = vi.fn()
     const agent = {
@@ -826,19 +785,19 @@ describe('ManagedAgents', () => {
     )
 
     const dialog = screen.getByRole('dialog', { name: /reinstall agent/i })
-    expect(
-      within(dialog).getByRole('radio', { name: /Borg 1\.x and Borg 2\.x beta/i })
-    ).toBeChecked()
+    // Even for an agent whose Borg binaries the installer manages, a routine
+    // reinstall must not preselect a Borg upgrade.
+    expect(within(dialog).getByRole('radio', { name: /Skip Borg install/i })).toBeChecked()
 
-    await user.click(within(dialog).getByLabelText('Copy reinstall command'))
-    expect(onCopy).toHaveBeenLastCalledWith(
-      'curl -fsSL https://borg-ui.example.com/agent/install.sh | sudo bash -s -- --reinstall --borg-version both'
-    )
-
-    await user.click(within(dialog).getByRole('radio', { name: /Skip Borg install/i }))
     await user.click(within(dialog).getByLabelText('Copy reinstall command'))
     expect(onCopy).toHaveBeenLastCalledWith(
       'curl -fsSL https://borg-ui.example.com/agent/install.sh | sudo bash -s -- --reinstall'
+    )
+
+    await user.click(within(dialog).getByRole('radio', { name: /Borg 1\.x and Borg 2\.x beta/i }))
+    await user.click(within(dialog).getByLabelText('Copy reinstall command'))
+    expect(onCopy).toHaveBeenLastCalledWith(
+      'curl -fsSL https://borg-ui.example.com/agent/install.sh | sudo bash -s -- --reinstall --borg-version both'
     )
   }, 60000)
 

--- a/frontend/src/pages/__tests__/ManagedAgents.test.tsx
+++ b/frontend/src/pages/__tests__/ManagedAgents.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient } from '@tanstack/react-query'
 import ManagedAgents, {
   AgentDiagnosticsDialog,
   AgentList,
+  AgentReinstallDialog,
   AgentSetupGuide,
   AgentSetupHelpContent,
   JobsTable,
@@ -20,7 +21,10 @@ import {
   managedAgentsAPI,
 } from '../../services/api'
 import type { AxiosResponse } from 'axios'
-import { buildAgentReinstallCommand } from '../managed-agents/agentInstallCommandText'
+import {
+  buildAgentReinstallCommand,
+  deriveBorgInstallMode,
+} from '../managed-agents/agentInstallCommandText'
 
 const { mockPlanCan, mockTrackSystem } = vi.hoisted(() => ({
   mockPlanCan: vi.fn((_feature: string) => true),
@@ -726,6 +730,118 @@ describe('ManagedAgents', () => {
     expect(command).not.toContain(' register ')
   })
 
+  it('adds --borg-version to the reinstall command for a Borg selection', () => {
+    const base =
+      'curl -fsSL https://borg-ui.example.com/agent/install.sh | sudo bash -s -- --reinstall'
+
+    expect(buildAgentReinstallCommand('https://borg-ui.example.com', 'skip')).toBe(base)
+    expect(buildAgentReinstallCommand('https://borg-ui.example.com', 'borg1')).toBe(
+      `${base} --borg-version 1`
+    )
+    expect(buildAgentReinstallCommand('https://borg-ui.example.com', 'borg2')).toBe(
+      `${base} --borg-version 2`
+    )
+    expect(buildAgentReinstallCommand('https://borg-ui.example.com', 'both')).toBe(
+      `${base} --borg-version both`
+    )
+  })
+
+  it('derives the Borg selection from the reported install sources', () => {
+    const installer1 = {
+      major: 1,
+      version: '1.4.5',
+      path: '/opt/borg-ui-agent/borg1/current/borg',
+      install_source: 'borg-ui-installer',
+    }
+    const installer2 = {
+      major: 2,
+      version: '2.0.0b23',
+      path: '/opt/borg-ui-agent/borg2/current/borg',
+      install_source: 'borg-ui-installer',
+    }
+
+    expect(deriveBorgInstallMode([installer1, installer2])).toBe('both')
+    expect(deriveBorgInstallMode([installer1])).toBe('borg1')
+    expect(deriveBorgInstallMode([installer2])).toBe('borg2')
+    // Binaries the installer does not manage must not be touched by default:
+    // distro packages, custom paths, or agents that have not reported yet.
+    expect(
+      deriveBorgInstallMode([
+        { major: 1, version: '1.2.8', path: '/usr/bin/borg', install_source: 'system-package' },
+      ])
+    ).toBe('skip')
+    expect(
+      deriveBorgInstallMode([
+        {
+          major: 2,
+          version: '2.0.0b23',
+          path: '/usr/local/bin/borg2',
+          install_source: 'custom-path',
+        },
+      ])
+    ).toBe('skip')
+    expect(deriveBorgInstallMode([])).toBe('skip')
+    expect(deriveBorgInstallMode(undefined)).toBe('skip')
+  })
+
+  it('preselects the reported Borg majors in the reinstall dialog and follows overrides', async () => {
+    const user = userEvent.setup()
+    const onCopy = vi.fn()
+    const agent = {
+      id: 8,
+      agent_id: 'agent-client-8',
+      name: 'client',
+      hostname: 'client-02',
+      status: 'online',
+      os: 'linux',
+      arch: 'x86_64',
+      agent_version: '0.4.0',
+      borg_versions: [
+        {
+          major: 1,
+          version: '1.4.5',
+          path: '/opt/borg-ui-agent/borg1/current/borg',
+          install_source: 'borg-ui-installer',
+        },
+        {
+          major: 2,
+          version: '2.0.0b23',
+          path: '/opt/borg-ui-agent/borg2/current/borg',
+          install_source: 'borg-ui-installer',
+        },
+      ],
+      last_seen_at: '2026-05-18T10:00:00.000Z',
+      created_at: '2026-05-18T09:00:00.000Z',
+      updated_at: '2026-05-18T10:00:00.000Z',
+    } as AgentMachineResponse
+
+    renderWithProviders(
+      <AgentReinstallDialog
+        open
+        agent={agent}
+        serverUrl="https://borg-ui.example.com"
+        onCancel={vi.fn()}
+        onCopy={onCopy}
+      />
+    )
+
+    const dialog = screen.getByRole('dialog', { name: /reinstall agent/i })
+    expect(
+      within(dialog).getByRole('radio', { name: /Borg 1\.x and Borg 2\.x beta/i })
+    ).toBeChecked()
+
+    await user.click(within(dialog).getByLabelText('Copy reinstall command'))
+    expect(onCopy).toHaveBeenLastCalledWith(
+      'curl -fsSL https://borg-ui.example.com/agent/install.sh | sudo bash -s -- --reinstall --borg-version both'
+    )
+
+    await user.click(within(dialog).getByRole('radio', { name: /Skip Borg install/i }))
+    await user.click(within(dialog).getByLabelText('Copy reinstall command'))
+    expect(onCopy).toHaveBeenLastCalledWith(
+      'curl -fsSL https://borg-ui.example.com/agent/install.sh | sudo bash -s -- --reinstall'
+    )
+  }, 60000)
+
   it('opens a tokenless reinstall script from an agent card', async () => {
     const user = userEvent.setup()
     const onCopy = vi.fn()
@@ -763,6 +879,9 @@ describe('ManagedAgents', () => {
     expect(within(dialog).getByText(/client-01/i)).toBeInTheDocument()
     expect(
       within(dialog).getByText(/No enrollment token or registration step is required/i)
+    ).toBeInTheDocument()
+    expect(
+      within(dialog).getByText(/run the command from any account that can sudo/i)
     ).toBeInTheDocument()
     expect(
       within(dialog).getByText((content) =>

--- a/frontend/src/pages/managed-agents/AddAgentDialog.tsx
+++ b/frontend/src/pages/managed-agents/AddAgentDialog.tsx
@@ -6,14 +6,10 @@ import {
   Chip,
   DialogActions,
   FormControl,
-  FormControlLabel,
   FormHelperText,
-  FormLabel,
   InputLabel,
   MenuItem,
   Paper,
-  Radio,
-  RadioGroup,
   Select,
   Stack,
   TextField,
@@ -29,6 +25,7 @@ import type {
 } from '../../services/api'
 import AgentInstallCommand from './AgentInstallCommand'
 import type { AgentServiceUserMode, BorgInstallMode } from './agentInstallCommandText'
+import BorgInstallModeRadioGroup from './BorgInstallModeRadioGroup'
 import { isLocalAgentServerUrl, normalizeAgentServerUrl } from './agentServerUrl'
 
 type WizardStepIndex = 0 | 1 | 2
@@ -67,8 +64,6 @@ function InlineWarning({ children }: { children: ReactNode }) {
 type ExpiryOption = '1h' | '24h' | '7d' | '30d' | 'never'
 
 const expiryOptions: ExpiryOption[] = ['1h', '24h', '7d', '30d', 'never']
-
-const borgInstallOptions: BorgInstallMode[] = ['borg1', 'borg2', 'both', 'skip']
 
 const serviceUserOptions: AgentServiceUserMode[] = ['current', 'dedicated', 'root']
 
@@ -420,65 +415,11 @@ export default function AddAgentDialog({
           )}
         </FormHelperText>
       </FormControl>
-      <FormControl component="fieldset">
-        <FormLabel component="legend">{t('managedAgents.add.borgInstallation')}</FormLabel>
-        <RadioGroup
-          value={borgInstallMode}
-          onChange={(event) => setBorgInstallMode(event.target.value as BorgInstallMode)}
-          sx={{
-            mt: 1,
-            display: 'grid',
-            gap: 1,
-            gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' },
-          }}
-        >
-          {borgInstallOptions.map((option) => {
-            const selected = borgInstallMode === option
-            return (
-              <FormControlLabel
-                key={option}
-                value={option}
-                control={<Radio />}
-                label={
-                  <Stack spacing={0.35} sx={{ minWidth: 0 }}>
-                    <Typography
-                      sx={{
-                        fontWeight: 700,
-                      }}
-                    >
-                      {t(`managedAgents.add.borgOptions.${option}.label`)}
-                    </Typography>
-                    <Typography
-                      variant="body2"
-                      sx={{
-                        color: 'text.secondary',
-                      }}
-                    >
-                      {t(`managedAgents.add.borgOptions.${option}.description`)}
-                    </Typography>
-                  </Stack>
-                }
-                sx={{
-                  m: 0,
-                  p: 1.25,
-                  alignItems: 'flex-start',
-                  border: '1px solid',
-                  borderColor: selected ? 'primary.main' : 'divider',
-                  borderRadius: 1,
-                  bgcolor: selected ? 'action.hover' : 'background.paper',
-                  cursor: 'pointer',
-                  transition: 'border-color 180ms ease, background-color 180ms ease',
-                  '&:hover': {
-                    borderColor: selected ? 'primary.main' : 'text.secondary',
-                    bgcolor: 'action.hover',
-                  },
-                  '& .MuiFormControlLabel-label': { width: '100%' },
-                }}
-              />
-            )
-          })}
-        </RadioGroup>
-      </FormControl>
+      <BorgInstallModeRadioGroup
+        value={borgInstallMode}
+        onChange={setBorgInstallMode}
+        i18nPrefix="managedAgents.add"
+      />
     </Stack>
   )
 

--- a/frontend/src/pages/managed-agents/BorgInstallModeRadioGroup.tsx
+++ b/frontend/src/pages/managed-agents/BorgInstallModeRadioGroup.tsx
@@ -1,0 +1,92 @@
+import {
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Radio,
+  RadioGroup,
+  Stack,
+  Typography,
+} from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import type { BorgInstallMode } from './agentInstallCommandText'
+
+const borgInstallOptions: BorgInstallMode[] = ['borg1', 'borg2', 'both', 'skip']
+
+// The Borg selection cards shared by the add-agent wizard and the reinstall
+// dialog. The two contexts describe the same choices differently (install vs
+// verify/update, and which option is the default), so the labels come from the
+// caller's i18n prefix: `${i18nPrefix}.borgInstallation` for the legend and
+// `${i18nPrefix}.borgOptions.<option>.{label,description}` for the cards.
+export default function BorgInstallModeRadioGroup({
+  value,
+  onChange,
+  i18nPrefix,
+}: {
+  value: BorgInstallMode
+  onChange: (mode: BorgInstallMode) => void
+  i18nPrefix: string
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <FormControl component="fieldset">
+      <FormLabel component="legend">{t(`${i18nPrefix}.borgInstallation`)}</FormLabel>
+      <RadioGroup
+        value={value}
+        onChange={(event) => onChange(event.target.value as BorgInstallMode)}
+        sx={{
+          mt: 1,
+          display: 'grid',
+          gap: 1,
+          gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' },
+        }}
+      >
+        {borgInstallOptions.map((option) => {
+          const selected = value === option
+          return (
+            <FormControlLabel
+              key={option}
+              value={option}
+              control={<Radio />}
+              label={
+                <Stack spacing={0.35} sx={{ minWidth: 0 }}>
+                  <Typography
+                    sx={{
+                      fontWeight: 700,
+                    }}
+                  >
+                    {t(`${i18nPrefix}.borgOptions.${option}.label`)}
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      color: 'text.secondary',
+                    }}
+                  >
+                    {t(`${i18nPrefix}.borgOptions.${option}.description`)}
+                  </Typography>
+                </Stack>
+              }
+              sx={{
+                m: 0,
+                p: 1.25,
+                alignItems: 'flex-start',
+                border: '1px solid',
+                borderColor: selected ? 'primary.main' : 'divider',
+                borderRadius: 1,
+                bgcolor: selected ? 'action.hover' : 'background.paper',
+                cursor: 'pointer',
+                transition: 'border-color 180ms ease, background-color 180ms ease',
+                '&:hover': {
+                  borderColor: selected ? 'primary.main' : 'text.secondary',
+                  bgcolor: 'action.hover',
+                },
+                '& .MuiFormControlLabel-label': { width: '100%' },
+              }}
+            />
+          )
+        })}
+      </RadioGroup>
+    </FormControl>
+  )
+}

--- a/frontend/src/pages/managed-agents/agentInstallCommandText.ts
+++ b/frontend/src/pages/managed-agents/agentInstallCommandText.ts
@@ -52,6 +52,41 @@ export function buildAgentInstallCommand(
     .join(' ')
 }
 
-export function buildAgentReinstallCommand(serverUrl: string) {
-  return [`curl -fsSL ${serverUrl}/agent/install.sh`, '| sudo bash -s --', '--reinstall'].join(' ')
+// Reconstruct the installer's Borg choice from what the agent last reported.
+// The install flags themselves are not persisted anywhere, but the agent
+// classifies each detected binary's install_source, and "borg-ui-installer"
+// means the binary lives where install.sh puts the Borgs it manages — so those
+// majors are the ones a reinstall should verify/update. Anything else
+// (system-package, custom-path, or no report yet) maps to the reinstall
+// default of not touching Borg.
+export function deriveBorgInstallMode(
+  borgVersions?: Array<Record<string, unknown>> | null
+): BorgInstallMode {
+  const installerManaged = new Set<number>()
+  for (const entry of borgVersions ?? []) {
+    if (entry && entry['install_source'] === 'borg-ui-installer') {
+      const major = Number(entry['major'])
+      if (major === 1 || major === 2) installerManaged.add(major)
+    }
+  }
+  if (installerManaged.has(1) && installerManaged.has(2)) return 'both'
+  if (installerManaged.has(1)) return 'borg1'
+  if (installerManaged.has(2)) return 'borg2'
+  return 'skip'
+}
+
+export function buildAgentReinstallCommand(
+  serverUrl: string,
+  borgInstallMode: BorgInstallMode = 'skip'
+) {
+  return [
+    `curl -fsSL ${serverUrl}/agent/install.sh`,
+    '| sudo bash -s --',
+    '--reinstall',
+    // Reinstall mode skips Borg by default, so "skip" needs no flag; a Borg
+    // selection passes --borg-version to also verify/update those binaries.
+    borgInstallMode === 'skip' ? null : borgInstallArgs(borgInstallMode),
+  ]
+    .filter(Boolean)
+    .join(' ')
 }

--- a/frontend/src/pages/managed-agents/agentInstallCommandText.ts
+++ b/frontend/src/pages/managed-agents/agentInstallCommandText.ts
@@ -52,29 +52,6 @@ export function buildAgentInstallCommand(
     .join(' ')
 }
 
-// Reconstruct the installer's Borg choice from what the agent last reported.
-// The install flags themselves are not persisted anywhere, but the agent
-// classifies each detected binary's install_source, and "borg-ui-installer"
-// means the binary lives where install.sh puts the Borgs it manages — so those
-// majors are the ones a reinstall should verify/update. Anything else
-// (system-package, custom-path, or no report yet) maps to the reinstall
-// default of not touching Borg.
-export function deriveBorgInstallMode(
-  borgVersions?: Array<Record<string, unknown>> | null
-): BorgInstallMode {
-  const installerManaged = new Set<number>()
-  for (const entry of borgVersions ?? []) {
-    if (entry && entry['install_source'] === 'borg-ui-installer') {
-      const major = Number(entry['major'])
-      if (major === 1 || major === 2) installerManaged.add(major)
-    }
-  }
-  if (installerManaged.has(1) && installerManaged.has(2)) return 'both'
-  if (installerManaged.has(1)) return 'borg1'
-  if (installerManaged.has(2)) return 'borg2'
-  return 'skip'
-}
-
 export function buildAgentReinstallCommand(
   serverUrl: string,
   borgInstallMode: BorgInstallMode = 'skip'


### PR DESCRIPTION
## What

The **Reinstall agent** dialog only emitted `--reinstall`, which updates the agent package but never touches Borg — although `install.sh` already supports `--reinstall --borg-version 1|2|both` to also verify or update the Borg binaries to the versions the server provides. Updating an installer-managed Borg therefore required knowing the flags by heart.

The dialog now shows the same Borg selection cards as the add-agent wizard, **preselected from what the agent last reported**, and the generated command carries `--borg-version` accordingly.

## How

- **`BorgInstallModeRadioGroup`** (new): the selection cards extracted from `AddAgentDialog`. The two contexts describe the same choices differently (install vs verify/update, and which option is the default — in reinstall mode that's *Skip*), so the labels come from the caller's i18n prefix.
- **`deriveBorgInstallMode(borg_versions)`**: the install flags themselves are not persisted anywhere, but the agent classifies each detected binary's `install_source`, and `borg-ui-installer` means the binary lives where install.sh puts the Borgs it manages. Majors reported with that source preselect `1`/`2`/`both`; system packages, custom paths, or agents without a report map to the reinstall default of leaving Borg untouched.
- **`buildAgentReinstallCommand(url, mode)`**: appends `--borg-version`; *Skip* stays flag-free (reinstall mode skips Borg by default). The selection can be overridden either way.
- **Info alert**: now also notes that the reinstall preserves the service user recorded in the systemd unit, so the command can be run from any sudo-capable account — the operator does not need to remember the original install user.

UI-only; no backend changes.

## Tests

- Builder matrix (`skip`/`borg1`/`borg2`/`both`) and derivation matrix (installer-managed majors, system-package, custom-path, empty, undefined).
- Dialog interaction test: preselects *both* from an installer-managed report, copy yields `--borg-version both`, switching to *Skip* drops the flag.
- Existing reinstall tests unchanged and green; full suite 2313/2313.
- Storybook: new `AgentReinstallDialogInstallerManagedBorg` story shows the preselected state.
- Locales: en/de/es/it in parity.

Reviewed by CodeRabbit on our fork (ioanalytica#34, all threads resolved) before submission.