### PR TITLE
fix(backup-plans): omit unavailable schedule fields

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -419,8 +419,8 @@ export interface BackupPlanData {
   schedule_mode?: 'cron' | 'availability'
   cron_expression?: string | null
   timezone: string
-  availability_check_interval_minutes?: number | null
-  min_success_interval_minutes?: number | null
+  availability_check_interval_minutes?: number
+  min_success_interval_minutes?: number
   pre_backup_script_id?: number | null
   post_backup_script_id?: number | null
   pre_backup_script_parameters?: Record<string, string> | null

--- a/frontend/src/utils/backupPlanPayload.test.ts
+++ b/frontend/src/utils/backupPlanPayload.test.ts
@@ -113,3 +113,36 @@ describe('backupPlanPayload prune keep-within', () => {
     expect(state.pruneKeepWithin).toBe('1d')
   })
 })
+
+describe('backupPlanPayload availability scheduling', () => {
+  it('omits availability-only integers for cron schedules', () => {
+    const payload = buildBackupPlanPayload({
+      ...createInitialState(),
+      name: 'Nightly backup',
+      sourceDirectories: ['/data'],
+      repositoryIds: [10],
+      scheduleEnabled: false,
+      scheduleMode: 'cron',
+    })
+
+    expect(payload).not.toHaveProperty('availability_check_interval_minutes')
+    expect(payload).not.toHaveProperty('min_success_interval_minutes')
+  })
+
+  it('sends integer availability settings for availability schedules', () => {
+    const payload = buildBackupPlanPayload({
+      ...createInitialState(),
+      name: 'Availability backup',
+      sourceDirectories: ['/data'],
+      repositoryIds: [10],
+      scheduleMode: 'availability',
+      availabilityCheckIntervalMinutes: 15,
+      minimumSuccessIntervalHours: 4,
+    })
+
+    expect(payload).toMatchObject({
+      availability_check_interval_minutes: 15,
+      min_success_interval_minutes: 240,
+    })
+  })
+})

--- a/frontend/src/utils/backupPlanPayload.ts
+++ b/frontend/src/utils/backupPlanPayload.ts
@@ -365,6 +365,7 @@ export function buildBackupPlanPayload(
   state: BackupPlanPayloadState,
   clearLegacySourceRepositoryIds: number[] = []
 ): BackupPlanData {
+  const scheduleMode = state.scheduleMode || 'cron'
   const sourceLocations = normalizeSourceLocations(state)
   const sourceDirectories = sourceLocations.length
     ? sourceLocations.flatMap((location) => location.paths)
@@ -400,18 +401,15 @@ export function buildBackupPlanPayload(
       state.repositoryRunMode === 'parallel' ? state.maxParallelRepositories : 1,
     failure_behavior: state.failureBehavior,
     schedule_enabled: state.scheduleEnabled,
-    schedule_mode: state.scheduleMode || 'cron',
-    cron_expression:
-      state.scheduleEnabled && (state.scheduleMode || 'cron') === 'cron'
-        ? state.cronExpression
-        : null,
+    schedule_mode: scheduleMode,
+    cron_expression: state.scheduleEnabled && scheduleMode === 'cron' ? state.cronExpression : null,
     timezone: state.timezone,
-    availability_check_interval_minutes:
-      state.scheduleMode === 'availability' ? (state.availabilityCheckIntervalMinutes ?? 30) : null,
-    min_success_interval_minutes:
-      state.scheduleMode === 'availability'
-        ? Math.round((state.minimumSuccessIntervalHours ?? 20) * 60)
-        : null,
+    ...(scheduleMode === 'availability'
+      ? {
+          availability_check_interval_minutes: state.availabilityCheckIntervalMinutes ?? 30,
+          min_success_interval_minutes: Math.round((state.minimumSuccessIntervalHours ?? 20) * 60),
+        }
+      : {}),
     pre_backup_script_id: firstPreHook?.script_id ?? state.preBackupScriptId,
     post_backup_script_id: firstPostHook?.script_id ?? state.postBackupScriptId,
     pre_backup_script_parameters:


### PR DESCRIPTION
## Description

Prevents normal cron backup-plan creation from sending `null` for the
integer-only availability schedule fields. The frontend now omits those fields
unless availability-triggered scheduling is selected.

## Related Issue

None — regression found during local verification.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass

Ran:

- `cd frontend && npm test -- --run src/utils/backupPlanPayload.test.ts`
- `cd frontend && npm run check:locales`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable — the change only affects the request payload.

## Additional Context

The production build passes. Vite reports the existing Node.js version and
bundle-size warnings in the local environment.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU Affero General Public License v3.0 (AGPL-3.0), the same license as this project.


<!-- visual-regression:start -->
## Visual regression report
No visual changes detected: 0 changed, 0 added, 0 removed, 474 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-856/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/32938203001
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- None
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->