### PR TITLE
fix(agents): send notifications for agent-executed jobs

### DIFF
--- a/app/api/agents.py
+++ b/app/api/agents.py
@@ -49,6 +49,12 @@ from app.services.agent_job_dispatcher import (
     agent_job_kind as live_agent_job_kind,
     dispatch_agent_job_best_effort,
 )
+from app.services.agent_job_notifications import (
+    notify_backup_job_finished,
+    notify_backup_job_started,
+    notify_check_job_finished,
+    orm_identity_id,
+)
 from app.utils.datetime_utils import serialize_datetime
 
 logger = structlog.get_logger()
@@ -527,9 +533,12 @@ def _mark_agent_job_claimed(job: AgentJob, *, now: Optional[datetime] = None) ->
 
 def _mark_agent_job_started(
     job: AgentJob, db: Session, *, started_at: Optional[datetime] = None
-) -> None:
+) -> Optional[BackupJob]:
+    """Returns the linked backup job when this start report is its first one,
+    so the caller can send the backup-start notification exactly once (a
+    requeued job keeps its original started_at and does not notify again)."""
     if job.status in FINAL_AGENT_JOB_STATUSES:
-        return
+        return None
     now = _now_utc()
     if job.claimed_at is None:
         job.claimed_at = now
@@ -537,14 +546,31 @@ def _mark_agent_job_started(
         job.started_at = _normalize_agent_timestamp(started_at)
     if job.status != "cancel_requested":
         job.status = "running"
+    newly_started_backup_job = None
     backup_job = _get_linked_backup_job(job, db)
     if backup_job:
+        # Guarded write: the first start report claims started_at even against
+        # a concurrent report on the other transport, so exactly one report
+        # triggers the backup-start notification.
+        first_start = (
+            db.query(BackupJob)
+            .filter(
+                BackupJob.id == backup_job.id,
+                BackupJob.started_at.is_(None),
+            )
+            .update(
+                {BackupJob.started_at: job.started_at},
+                synchronize_session=False,
+            )
+        )
         backup_job.status = "running"
-        if backup_job.started_at is None:
-            backup_job.started_at = job.started_at
+        db.expire(backup_job, ["started_at"])
+        if first_start:
+            newly_started_backup_job = backup_job
     else:
         _sync_repository_operation_progress(job, db)
     job.updated_at = now
+    return newly_started_backup_job
 
 
 def _apply_agent_job_progress(
@@ -598,41 +624,70 @@ def _append_agent_job_log(
     return True
 
 
+def _claim_terminal_transition(
+    job: AgentJob, db: Session, values: dict[Any, Any]
+) -> bool:
+    """Atomically flip the job into a terminal state while it is still active.
+
+    A concurrent report on the other transport (or the reaper's worker thread)
+    may have finalized the job between this handler's load and its write; the
+    WHERE guard makes exactly one writer win, so linked records are finalized
+    and notifications dispatched exactly once, and a loser cannot overwrite
+    the winner's terminal state. On success the ORM object is refreshed so the
+    caller works with the values it just claimed.
+    """
+    claimed = (
+        db.query(AgentJob)
+        .filter(
+            AgentJob.id == job.id,
+            AgentJob.status.notin_(FINAL_AGENT_JOB_STATUSES),
+        )
+        .update(values, synchronize_session=False)
+    )
+    if not claimed:
+        # Reload so the caller (and its response) sees the winner's state
+        # instead of the stale in-memory row.
+        db.expire(job)
+        return False
+    db.refresh(job)
+    return True
+
+
 def _complete_agent_job(
     job: AgentJob,
     db: Session,
     *,
     result: dict[str, Any],
     completed_at: Optional[datetime] = None,
-) -> None:
+) -> bool:
+    """Returns True when this report moved the job into a terminal state, so
+    the caller notifies exactly once even if the report is redelivered."""
     if job.status in FINAL_AGENT_JOB_STATUSES:
-        return
+        return False
     return_code = result.get("return_code") if isinstance(result, dict) else None
     if return_code is not None and (
         not isinstance(return_code, int) or isinstance(return_code, bool)
     ):
         # A completion report is only trusted with a well-formed exit code.
         # Anything else fails closed instead of being recorded as success.
-        _fail_agent_job(
+        return _fail_agent_job(
             job,
             db,
             error_message=f"agent reported a malformed return code: {return_code!r}",
             completed_at=completed_at,
         )
-        return
     warning = is_borg_warning_exit_code(return_code)
     if isinstance(return_code, int) and return_code != 0 and not warning:
         # A completion report carrying an explicit borg *error* code is a
         # failure, no matter which transport delivered it - the server is
         # authoritative over the classification.
-        _fail_agent_job(
+        return _fail_agent_job(
             job,
             db,
             error_message=f"borg exited with code {return_code}",
             return_code=return_code,
             completed_at=completed_at,
         )
-        return
 
     completed = _normalize_agent_timestamp(completed_at)
     status_value = "completed_with_warnings" if warning else "completed"
@@ -646,11 +701,18 @@ def _complete_agent_job(
         if warning
         else None
     )
-    job.status = status_value
-    job.completed_at = completed
-    job.result = result
-    job.error_message = warning_message
-    job.updated_at = _now_utc()
+    if not _claim_terminal_transition(
+        job,
+        db,
+        {
+            AgentJob.status: status_value,
+            AgentJob.completed_at: completed,
+            AgentJob.result: result,
+            AgentJob.error_message: warning_message,
+            AgentJob.updated_at: _now_utc(),
+        },
+    ):
+        return False
     _finish_linked_backup_job(
         job,
         db,
@@ -672,6 +734,7 @@ def _complete_agent_job(
         completed_at=completed,
         error_message=warning_message,
     )
+    return True
 
 
 def _fail_agent_job(
@@ -681,15 +744,25 @@ def _fail_agent_job(
     error_message: str,
     return_code: Optional[int] = None,
     completed_at: Optional[datetime] = None,
-) -> None:
+) -> bool:
+    """Returns True when this report moved the job into a terminal state."""
     if job.status in FINAL_AGENT_JOB_STATUSES:
-        return
+        return False
     completed = _normalize_agent_timestamp(completed_at)
-    job.status = "failed"
-    job.completed_at = completed
-    job.error_message = error_message
-    job.result = {"return_code": return_code} if return_code is not None else {}
-    job.updated_at = _now_utc()
+    if not _claim_terminal_transition(
+        job,
+        db,
+        {
+            AgentJob.status: "failed",
+            AgentJob.completed_at: completed,
+            AgentJob.error_message: error_message,
+            AgentJob.result: {"return_code": return_code}
+            if return_code is not None
+            else {},
+            AgentJob.updated_at: _now_utc(),
+        },
+    ):
+        return False
     _finish_linked_backup_job(
         job,
         db,
@@ -704,6 +777,32 @@ def _fail_agent_job(
         completed_at=completed,
         error_message=error_message,
     )
+    return True
+
+
+async def _notify_agent_job_outcome(db: Session, job: AgentJob) -> None:
+    """Send user-facing notifications for a finished agent job's linked jobs.
+
+    Server-side runs notify from inside their execution services; an agent job
+    reaches its terminal state only here, so the transport handlers own the
+    dispatch. Called after the terminal state is committed - so even the
+    linked-job lookups (attribute reads on the expired job can hit the
+    database) must stay inside the boundary and never fail the transport.
+    """
+    try:
+        backup_job = _get_linked_backup_job(job, db)
+        if backup_job is not None:
+            await notify_backup_job_finished(db, backup_job)
+            return
+        operation_job = _get_repository_operation_job(job, db)
+        if isinstance(operation_job, CheckJob):
+            await notify_check_job_finished(db, operation_job)
+    except Exception as exc:
+        logger.warning(
+            "Failed to dispatch agent job notification",
+            agent_job_id=orm_identity_id(job),
+            error=str(exc),
+        )
 
 
 def _cancel_agent_job(
@@ -712,9 +811,16 @@ def _cancel_agent_job(
     if job.status in FINAL_AGENT_JOB_STATUSES:
         return
     completed = _normalize_agent_timestamp(completed_at)
-    job.status = "canceled"
-    job.completed_at = completed
-    job.updated_at = _now_utc()
+    if not _claim_terminal_transition(
+        job,
+        db,
+        {
+            AgentJob.status: "canceled",
+            AgentJob.completed_at: completed,
+            AgentJob.updated_at: _now_utc(),
+        },
+    ):
+        return
     _finish_linked_backup_job(
         job,
         db,
@@ -804,10 +910,12 @@ async def _handle_agent_session_message(
 
     if message_type == "job_started":
         if job:
-            _mark_agent_job_started(
+            started_backup_job = _mark_agent_job_started(
                 job, db, started_at=_parse_optional_datetime(message.get("started_at"))
             )
             db.commit()
+            if started_backup_job is not None:
+                await notify_backup_job_started(db, job, started_backup_job)
         return
 
     if message_type == "progress":
@@ -870,13 +978,15 @@ async def _handle_agent_session_message(
             job_id=int(job_id) if job_id else None,
         )
         if job:
-            _complete_agent_job(
+            transitioned = _complete_agent_job(
                 job,
                 db,
                 result=result_payload,
                 completed_at=_parse_optional_datetime(message.get("completed_at")),
             )
             db.commit()
+            if transitioned:
+                await _notify_agent_job_outcome(db, job)
         return
 
     if message_type == "command_error":
@@ -902,7 +1012,7 @@ async def _handle_agent_session_message(
             job_id=int(job_id) if job_id else None,
         )
         if job:
-            _fail_agent_job(
+            transitioned = _fail_agent_job(
                 job,
                 db,
                 error_message=error_message,
@@ -910,6 +1020,8 @@ async def _handle_agent_session_message(
                 completed_at=_parse_optional_datetime(message.get("completed_at")),
             )
             db.commit()
+            if transitioned:
+                await _notify_agent_job_outcome(db, job)
         return
 
     if message_type == "job_canceled":
@@ -1206,22 +1318,12 @@ async def start_job(
             detail={"key": "backend.errors.agents.jobNotStartable"},
         )
 
-    now = _now_utc()
-    if job.claimed_at is None:
-        job.claimed_at = now
-    if job.started_at is None:
-        job.started_at = _normalize_agent_timestamp(payload.started_at)
-    if job.status != "cancel_requested":
-        job.status = "running"
-    backup_job = _get_linked_backup_job(job, db)
-    if backup_job:
-        backup_job.status = "running"
-        if backup_job.started_at is None:
-            backup_job.started_at = job.started_at
-    else:
-        _sync_repository_operation_progress(job, db)
-    job.updated_at = now
+    # Same path the WebSocket transport takes - one place applies a start
+    # report and decides whether it triggers the backup-start notification.
+    started_backup_job = _mark_agent_job_started(job, db, started_at=payload.started_at)
     db.commit()
+    if started_backup_job is not None:
+        await notify_backup_job_started(db, job, started_backup_job)
 
     return AgentJobStatusResponse(id=job.id, status=job.status)
 
@@ -1300,10 +1402,12 @@ async def complete_job(
 
     # Same path the WebSocket transport takes - one place decides how a
     # completion (including borg warning exit codes) is classified.
-    _complete_agent_job(
+    transitioned = _complete_agent_job(
         job, db, result=payload.result, completed_at=payload.completed_at
     )
     db.commit()
+    if transitioned:
+        await _notify_agent_job_outcome(db, job)
 
     return AgentJobStatusResponse(id=job.id, status=job.status)
 
@@ -1363,31 +1467,18 @@ async def fail_job(
     if job.status in FINAL_AGENT_JOB_STATUSES:
         return AgentJobStatusResponse(id=job.id, status=job.status)
 
-    result = {}
-    if payload.return_code is not None:
-        result["return_code"] = payload.return_code
-
-    now = _now_utc()
-    job.status = "failed"
-    job.completed_at = _normalize_agent_timestamp(payload.completed_at)
-    job.error_message = payload.error_message
-    job.result = result
-    job.updated_at = now
-    _finish_linked_backup_job(
+    # Same path the WebSocket transport takes - one place records the failure
+    # and finishes the linked jobs.
+    transitioned = _fail_agent_job(
         job,
         db,
-        status_value="failed",
-        completed_at=job.completed_at,
         error_message=payload.error_message,
-    )
-    _finish_linked_repository_operation_job(
-        job,
-        db,
-        status_value="failed",
-        completed_at=job.completed_at,
-        error_message=payload.error_message,
+        return_code=payload.return_code,
+        completed_at=payload.completed_at,
     )
     db.commit()
+    if transitioned:
+        await _notify_agent_job_outcome(db, job)
 
     return AgentJobStatusResponse(id=job.id, status=job.status)
 
@@ -1403,24 +1494,9 @@ async def mark_job_canceled(
     if job.status in FINAL_AGENT_JOB_STATUSES:
         return AgentJobStatusResponse(id=job.id, status=job.status)
 
-    now = _now_utc()
-    job.status = "canceled"
-    job.completed_at = _normalize_agent_timestamp(payload.completed_at)
-    job.updated_at = now
-    _finish_linked_backup_job(
-        job,
-        db,
-        status_value="cancelled",
-        completed_at=job.completed_at,
-        error_message="Agent job canceled",
-    )
-    _finish_linked_repository_operation_job(
-        job,
-        db,
-        status_value="cancelled",
-        completed_at=job.completed_at,
-        error_message="Agent job canceled",
-    )
+    # Same path the WebSocket transport takes - the guarded transition keeps a
+    # late cancel report from overwriting an already-finalized job.
+    _cancel_agent_job(job, db, completed_at=payload.completed_at)
     db.commit()
 
     return AgentJobStatusResponse(id=job.id, status=job.status)

--- a/app/services/agent_job_notifications.py
+++ b/app/services/agent_job_notifications.py
@@ -1,0 +1,205 @@
+"""User-facing notifications for agent-executed jobs.
+
+Server-side execution paths send their notifications from inside the backup
+and check services. Agent-executed jobs never pass through those services -
+they reach their terminal state in the agent transport handlers (WebSocket +
+REST) and in the agent job reaper - so without an explicit dispatch there,
+configured notifications (backup start/success/warning/failure, check
+success/failure) silently never fire for agent repositories.
+
+This module renders the linked job rows into the same notification calls the
+server-side paths make. Callers invoke it after the terminal state has been
+committed; the entire dispatch - including every ORM attribute read, which can
+itself hit the database on a committed (expired) object - runs inside the
+exception boundary, so a failure is logged and never propagates into the
+agent protocol.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import structlog
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.orm import Session
+
+from app.database.models import (
+    AgentJob,
+    BackupJob,
+    BackupPlan,
+    CheckJob,
+    Repository,
+    ScheduledJob,
+)
+from app.services.notification_service import notification_service
+
+logger = structlog.get_logger()
+
+
+def orm_identity_id(obj: Any) -> Optional[int]:
+    """Primary key from the ORM identity map - no database access, so it is
+    safe to call on an expired object inside an exception handler."""
+    identity = sa_inspect(obj).identity
+    return identity[0] if identity else None
+
+
+def _as_utc(value: Optional[datetime]) -> Optional[datetime]:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def backup_job_label(db: Session, backup_job: BackupJob) -> Optional[str]:
+    """Plan or schedule name for notification titles, if any."""
+    if backup_job.backup_plan_id:
+        plan = (
+            db.query(BackupPlan)
+            .filter(BackupPlan.id == backup_job.backup_plan_id)
+            .first()
+        )
+        if plan and plan.name:
+            return plan.name
+    if backup_job.scheduled_job_id:
+        scheduled_job = (
+            db.query(ScheduledJob)
+            .filter(ScheduledJob.id == backup_job.scheduled_job_id)
+            .first()
+        )
+        if scheduled_job and scheduled_job.name:
+            return scheduled_job.name
+    return None
+
+
+async def notify_backup_job_started(
+    db: Session, agent_job: AgentJob, backup_job: BackupJob
+) -> None:
+    """Send the backup-start notification for an agent backup job."""
+    try:
+        payload = agent_job.payload or {}
+        backup_payload = payload.get("backup") if isinstance(payload, dict) else None
+        source_paths = None
+        if isinstance(backup_payload, dict):
+            raw_paths = backup_payload.get("source_paths")
+            if isinstance(raw_paths, list):
+                source_paths = [str(path) for path in raw_paths]
+
+        await notification_service.send_backup_start(
+            db,
+            backup_job.repository,
+            backup_job.archive_name or "",
+            source_paths,
+            None,
+            backup_job_label(db, backup_job),
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to send agent backup start notification",
+            backup_job_id=orm_identity_id(backup_job),
+            error=str(exc),
+        )
+
+
+async def notify_backup_job_finished(db: Session, backup_job: BackupJob) -> None:
+    """Send the success/warning/failure notification for a finished backup job.
+
+    Statuses without a server-side notification (e.g. cancelled) are skipped.
+    """
+    status_value = None
+    try:
+        status_value = backup_job.status
+        if status_value not in ("completed", "completed_with_warnings", "failed"):
+            return
+
+        job_name = backup_job_label(db, backup_job)
+        if status_value == "failed":
+            await notification_service.send_backup_failure(
+                db,
+                backup_job.repository,
+                backup_job.error_message or "Unknown error",
+                backup_job.id,
+                job_name,
+            )
+            return
+
+        stats = {
+            "original_size": backup_job.original_size,
+            "compressed_size": backup_job.compressed_size,
+            "deduplicated_size": backup_job.deduplicated_size,
+        }
+        if status_value == "completed_with_warnings":
+            await notification_service.send_backup_warning(
+                db,
+                backup_job.repository,
+                backup_job.archive_name or "",
+                backup_job.error_message or "",
+                stats,
+                _as_utc(backup_job.completed_at),
+                job_name,
+                started_at=_as_utc(backup_job.started_at),
+                nfiles=backup_job.nfiles,
+            )
+        else:
+            await notification_service.send_backup_success(
+                db,
+                backup_job.repository,
+                backup_job.archive_name or "",
+                stats,
+                _as_utc(backup_job.completed_at),
+                job_name,
+                started_at=_as_utc(backup_job.started_at),
+                nfiles=backup_job.nfiles,
+            )
+    except Exception as exc:
+        logger.warning(
+            "Failed to send agent backup notification",
+            backup_job_id=orm_identity_id(backup_job),
+            status=status_value,
+            error=str(exc),
+        )
+
+
+async def notify_check_job_finished(db: Session, check_job: CheckJob) -> None:
+    """Send the check success/failure notification for a finished check job.
+
+    A check that completed with warnings still verified the repository and is
+    reported as completed, matching how the server-side path classifies it.
+    """
+    status_value = None
+    try:
+        status_value = check_job.status
+        if status_value not in ("completed", "completed_with_warnings", "failed"):
+            return
+
+        repository = (
+            db.query(Repository)
+            .filter(Repository.id == check_job.repository_id)
+            .first()
+        )
+        duration_seconds = None
+        started_at = _as_utc(check_job.started_at)
+        completed_at = _as_utc(check_job.completed_at)
+        if started_at and completed_at:
+            duration_seconds = int((completed_at - started_at).total_seconds())
+
+        notified_status = "failed" if status_value == "failed" else "completed"
+        await notification_service.send_check_completion(
+            db=db,
+            repository_name=repository.name if repository else "Unknown",
+            repository_path=repository.path if repository else "Unknown",
+            status=notified_status,
+            duration_seconds=duration_seconds,
+            error_message=check_job.error_message
+            if notified_status == "failed"
+            else None,
+            check_type="scheduled" if check_job.scheduled_check else "manual",
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to send agent check notification",
+            check_job_id=orm_identity_id(check_job),
+            status=status_value,
+            error=str(exc),
+        )

--- a/app/services/agent_job_reaper.py
+++ b/app/services/agent_job_reaper.py
@@ -69,10 +69,14 @@ def reap_stale_agent_jobs(
     *,
     now: Optional[datetime] = None,
     reap_after: timedelta = AGENT_JOB_REAP_AFTER,
+    failed_backup_job_ids: Optional[list[int]] = None,
 ) -> int:
     """Fail in-flight agent jobs with no activity for `reap_after`.
 
-    Returns the number of jobs reaped.
+    Returns the number of jobs reaped. Backup jobs this pass flipped to failed
+    are appended to `failed_backup_job_ids` (when given) so the caller can send
+    failure notifications from an async context - the reaper is the only place
+    an offline agent's job turns terminal, so no other path notifies for it.
     """
     now = now or datetime.now(timezone.utc)
     cutoff = now - reap_after
@@ -117,17 +121,23 @@ def reap_stale_agent_jobs(
         reaped += 1
 
         if job.backup_job_id:
-            db.query(BackupJob).filter(
-                BackupJob.id == job.backup_job_id,
-                BackupJob.status.notin_(TERMINAL_BACKUP_STATUSES),
-            ).update(
-                {
-                    BackupJob.status: "failed",
-                    BackupJob.completed_at: now,
-                    BackupJob.error_message: message,
-                },
-                synchronize_session=False,
+            backup_job_failed = (
+                db.query(BackupJob)
+                .filter(
+                    BackupJob.id == job.backup_job_id,
+                    BackupJob.status.notin_(TERMINAL_BACKUP_STATUSES),
+                )
+                .update(
+                    {
+                        BackupJob.status: "failed",
+                        BackupJob.completed_at: now,
+                        BackupJob.error_message: message,
+                    },
+                    synchronize_session=False,
+                )
             )
+            if backup_job_failed and failed_backup_job_ids is not None:
+                failed_backup_job_ids.append(job.backup_job_id)
 
     if reaped:
         db.commit()
@@ -138,7 +148,7 @@ def reap_stale_agent_jobs(
     return reaped
 
 
-def _reap_once() -> int:
+def _reap_once(failed_backup_job_ids: Optional[list[int]] = None) -> int:
     """One reap pass with its own session (runs in a worker thread)."""
     from app.utils.process_utils import (
         reconcile_orphaned_maintenance_jobs,
@@ -147,7 +157,7 @@ def _reap_once() -> int:
 
     db = SessionLocal()
     try:
-        reaped = reap_stale_agent_jobs(db)
+        reaped = reap_stale_agent_jobs(db, failed_backup_job_ids=failed_backup_job_ids)
         # Reconcile backup rows stuck in a running maintenance state whose
         # maintenance op died without writing a terminal status (startup-only
         # cleanup previously left these "running" until the next restart).
@@ -157,6 +167,22 @@ def _reap_once() -> int:
         # they block the repository via admission control forever.
         reaped += reconcile_orphaned_maintenance_jobs(db)
         return reaped
+    finally:
+        db.close()
+
+
+async def _notify_reaped_backup_jobs(backup_job_ids: list[int]) -> None:
+    """Send failure notifications for backup jobs the reaper just failed."""
+    from app.services.agent_job_notifications import notify_backup_job_finished
+
+    db = SessionLocal()
+    try:
+        for backup_job_id in backup_job_ids:
+            backup_job = (
+                db.query(BackupJob).filter(BackupJob.id == backup_job_id).first()
+            )
+            if backup_job is not None:
+                await notify_backup_job_finished(db, backup_job)
     finally:
         db.close()
 
@@ -176,7 +202,10 @@ async def start_agent_job_reaper(
             # Offload the synchronous DB work to a thread so a slow query never
             # blocks the event loop. The session is created and used inside the
             # thread (SQLite connections are thread-affine).
-            await asyncio.to_thread(_reap_once)
+            failed_backup_job_ids: list[int] = []
+            await asyncio.to_thread(_reap_once, failed_backup_job_ids)
+            if failed_backup_job_ids:
+                await _notify_reaped_backup_jobs(failed_backup_job_ids)
         except asyncio.CancelledError:
             logger.info("Agent job reaper stopped")
             raise

--- a/tests/unit/test_api_agents.py
+++ b/tests/unit/test_api_agents.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -12,7 +13,10 @@ from app.database.models import (
     AgentJobLog,
     AgentMachine,
     BackupJob,
+    BackupPlan,
+    CheckJob,
     LicensingState,
+    Repository,
 )
 
 
@@ -1307,3 +1311,451 @@ class TestAgentJobReaper:
 
         test_db.refresh(backup_job)
         assert backup_job.status == "completed"
+
+
+NOTIFIER_PATCH_TARGET = "app.services.agent_job_notifications.notification_service"
+
+
+@pytest.mark.unit
+class TestAgentJobNotifications:
+    """Agent-executed jobs must fire the same user-facing notifications the
+    server-side execution paths send from inside their services."""
+
+    def _register(self, test_client, test_db, admin_headers):
+        registered = _register_agent(
+            test_client,
+            _create_enrollment_token(test_client, admin_headers)["token"],
+        )
+        agent = _get_agent(test_db, registered["agent_id"])
+        return agent, _agent_headers(registered["agent_token"])
+
+    def _linked_backup_job(self, test_db, agent, *, agent_status="running"):
+        backup_job = BackupJob(repository="/repo", status="running")
+        test_db.add(backup_job)
+        test_db.commit()
+        test_db.refresh(backup_job)
+        job = _create_agent_job(test_db, agent, status=agent_status)
+        job.backup_job_id = backup_job.id
+        test_db.commit()
+        return job, backup_job
+
+    def test_completed_backup_job_sends_success_notification(
+        self, test_client, test_db, admin_headers
+    ):
+        agent, headers = self._register(test_client, test_db, admin_headers)
+        job, backup_job = self._linked_backup_job(test_db, agent)
+
+        with patch(NOTIFIER_PATCH_TARGET, new_callable=AsyncMock) as notifier:
+            response = test_client.post(
+                f"/api/agents/jobs/{job.id}/complete",
+                json={"result": {"archive_name": "agent-archive", "return_code": 0}},
+                headers=headers,
+            )
+
+        assert response.status_code == 200
+        notifier.send_backup_success.assert_awaited_once()
+        args = notifier.send_backup_success.await_args.args
+        assert args[1] == "/repo"
+        assert args[2] == "agent-archive"
+        notifier.send_backup_warning.assert_not_awaited()
+        notifier.send_backup_failure.assert_not_awaited()
+
+    def test_warning_completion_sends_warning_notification(
+        self, test_client, test_db, admin_headers
+    ):
+        agent, headers = self._register(test_client, test_db, admin_headers)
+        job, backup_job = self._linked_backup_job(test_db, agent)
+
+        with patch(NOTIFIER_PATCH_TARGET, new_callable=AsyncMock) as notifier:
+            response = test_client.post(
+                f"/api/agents/jobs/{job.id}/complete",
+                json={"result": {"archive_name": "agent-archive", "return_code": 1}},
+                headers=headers,
+            )
+
+        assert response.status_code == 200
+        notifier.send_backup_warning.assert_awaited_once()
+        notifier.send_backup_success.assert_not_awaited()
+
+    def test_error_return_code_sends_failure_notification(
+        self, test_client, test_db, admin_headers
+    ):
+        agent, headers = self._register(test_client, test_db, admin_headers)
+        job, backup_job = self._linked_backup_job(test_db, agent)
+
+        with patch(NOTIFIER_PATCH_TARGET, new_callable=AsyncMock) as notifier:
+            response = test_client.post(
+                f"/api/agents/jobs/{job.id}/complete",
+                json={"result": {"return_code": 2}},
+                headers=headers,
+            )
+
+        assert response.status_code == 200
+        notifier.send_backup_failure.assert_awaited_once()
+        args = notifier.send_backup_failure.await_args.args
+        assert args[1] == "/repo"
+        assert "borg exited with code 2" in args[2]
+        assert args[3] == backup_job.id
+        notifier.send_backup_success.assert_not_awaited()
+
+    def test_failed_job_sends_failure_notification(
+        self, test_client, test_db, admin_headers
+    ):
+        agent, headers = self._register(test_client, test_db, admin_headers)
+        job, backup_job = self._linked_backup_job(test_db, agent)
+
+        with patch(NOTIFIER_PATCH_TARGET, new_callable=AsyncMock) as notifier:
+            response = test_client.post(
+                f"/api/agents/jobs/{job.id}/fail",
+                json={"error_message": "disk full", "return_code": 2},
+                headers=headers,
+            )
+
+        assert response.status_code == 200
+        notifier.send_backup_failure.assert_awaited_once()
+        args = notifier.send_backup_failure.await_args.args
+        assert args[2] == "disk full"
+
+    def test_repeated_completion_does_not_duplicate_notification(
+        self, test_client, test_db, admin_headers
+    ):
+        agent, headers = self._register(test_client, test_db, admin_headers)
+        job, backup_job = self._linked_backup_job(test_db, agent)
+
+        with patch(NOTIFIER_PATCH_TARGET, new_callable=AsyncMock) as notifier:
+            for _ in range(2):
+                response = test_client.post(
+                    f"/api/agents/jobs/{job.id}/complete",
+                    json={
+                        "result": {"archive_name": "agent-archive", "return_code": 0}
+                    },
+                    headers=headers,
+                )
+                assert response.status_code == 200
+
+        notifier.send_backup_success.assert_awaited_once()
+
+    def test_first_start_report_sends_backup_start_notification(
+        self, test_client, test_db, admin_headers
+    ):
+        agent, headers = self._register(test_client, test_db, admin_headers)
+        job, backup_job = self._linked_backup_job(
+            test_db, agent, agent_status="claimed"
+        )
+
+        with patch(NOTIFIER_PATCH_TARGET, new_callable=AsyncMock) as notifier:
+            for _ in range(2):
+                response = test_client.post(
+                    f"/api/agents/jobs/{job.id}/start",
+                    json={},
+                    headers=headers,
+                )
+                assert response.status_code == 200
+
+        notifier.send_backup_start.assert_awaited_once()
+        args = notifier.send_backup_start.await_args.args
+        assert args[1] == "/repo"
+
+    def _agent_check_job(self, test_db, agent, *, name="agent-check-repo"):
+        repository = Repository(name=name, path=f"/{name}")
+        test_db.add(repository)
+        test_db.commit()
+        test_db.refresh(repository)
+        check_job = CheckJob(repository_id=repository.id, status="running")
+        test_db.add(check_job)
+        test_db.commit()
+        test_db.refresh(check_job)
+        now = datetime.now(timezone.utc)
+        job = AgentJob(
+            agent_machine_id=agent.id,
+            job_type="repository",
+            status="running",
+            payload={
+                "schema_version": 1,
+                "job_kind": "repository.check",
+                "repository": {"id": repository.id},
+                "operation": {"maintenance_job": {"kind": "check", "id": check_job.id}},
+            },
+            created_at=now,
+            updated_at=now,
+        )
+        test_db.add(job)
+        test_db.commit()
+        test_db.refresh(job)
+        return job, check_job, repository
+
+    def test_agent_check_completion_sends_check_notification(
+        self, test_client, test_db, admin_headers
+    ):
+        agent, headers = self._register(test_client, test_db, admin_headers)
+        job, check_job, repository = self._agent_check_job(test_db, agent)
+
+        with patch(NOTIFIER_PATCH_TARGET, new_callable=AsyncMock) as notifier:
+            response = test_client.post(
+                f"/api/agents/jobs/{job.id}/complete",
+                json={"result": {"return_code": 0}},
+                headers=headers,
+            )
+
+        assert response.status_code == 200
+        notifier.send_check_completion.assert_awaited_once()
+        kwargs = notifier.send_check_completion.await_args.kwargs
+        assert kwargs["status"] == "completed"
+        assert kwargs["repository_name"] == repository.name
+        assert kwargs["check_type"] == "manual"
+
+    def test_agent_check_failure_sends_check_notification(
+        self, test_client, test_db, admin_headers
+    ):
+        agent, headers = self._register(test_client, test_db, admin_headers)
+        job, check_job, repository = self._agent_check_job(
+            test_db, agent, name="agent-check-repo-2"
+        )
+
+        with patch(NOTIFIER_PATCH_TARGET, new_callable=AsyncMock) as notifier:
+            response = test_client.post(
+                f"/api/agents/jobs/{job.id}/fail",
+                json={"error_message": "check failed", "return_code": 2},
+                headers=headers,
+            )
+
+        assert response.status_code == 200
+        notifier.send_check_completion.assert_awaited_once()
+        kwargs = notifier.send_check_completion.await_args.kwargs
+        assert kwargs["status"] == "failed"
+        assert kwargs["error_message"] == "check failed"
+
+    async def test_notify_backup_job_finished_prefers_plan_name(self, test_db):
+        from app.services.agent_job_notifications import notify_backup_job_finished
+
+        plan = BackupPlan(name="nightly", source_directories="[]")
+        test_db.add(plan)
+        test_db.commit()
+        test_db.refresh(plan)
+        backup_job = BackupJob(
+            repository="/repo",
+            status="failed",
+            backup_plan_id=plan.id,
+            error_message="agent session lost",
+        )
+        test_db.add(backup_job)
+        test_db.commit()
+        test_db.refresh(backup_job)
+
+        with patch(NOTIFIER_PATCH_TARGET, new_callable=AsyncMock) as notifier:
+            await notify_backup_job_finished(test_db, backup_job)
+
+        notifier.send_backup_failure.assert_awaited_once()
+        args = notifier.send_backup_failure.await_args.args
+        assert args[2] == "agent session lost"
+        assert args[4] == "nightly"
+
+    async def test_notify_backup_job_finished_skips_cancelled(self, test_db):
+        from app.services.agent_job_notifications import notify_backup_job_finished
+
+        backup_job = BackupJob(repository="/repo", status="cancelled")
+        test_db.add(backup_job)
+        test_db.commit()
+
+        with patch(NOTIFIER_PATCH_TARGET, new_callable=AsyncMock) as notifier:
+            await notify_backup_job_finished(test_db, backup_job)
+
+        notifier.send_backup_failure.assert_not_awaited()
+        notifier.send_backup_success.assert_not_awaited()
+
+    def test_reaper_collects_failed_backup_jobs_for_notification(
+        self, test_client, test_db, admin_headers
+    ):
+        from app.services.agent_job_reaper import reap_stale_agent_jobs
+
+        agent, _headers = self._register(test_client, test_db, admin_headers)
+        backup_job = BackupJob(repository="/repo", status="running")
+        test_db.add(backup_job)
+        test_db.commit()
+        test_db.refresh(backup_job)
+        job = _create_agent_job(test_db, agent, status="running")
+        stale_at = datetime.now(timezone.utc) - timedelta(minutes=30)
+        job.backup_job_id = backup_job.id
+        job.started_at = stale_at
+        job.updated_at = stale_at
+        test_db.commit()
+
+        failed_backup_job_ids: list[int] = []
+        reaped = reap_stale_agent_jobs(
+            test_db, failed_backup_job_ids=failed_backup_job_ids
+        )
+
+        assert reaped == 1
+        assert failed_backup_job_ids == [backup_job.id]
+
+    def test_reaper_does_not_collect_terminal_backup_jobs(
+        self, test_client, test_db, admin_headers
+    ):
+        from app.services.agent_job_reaper import reap_stale_agent_jobs
+
+        agent, _headers = self._register(test_client, test_db, admin_headers)
+        backup_job = BackupJob(repository="/repo", status="completed")
+        test_db.add(backup_job)
+        test_db.commit()
+        test_db.refresh(backup_job)
+        job = _create_agent_job(test_db, agent, status="running")
+        stale_at = datetime.now(timezone.utc) - timedelta(minutes=30)
+        job.backup_job_id = backup_job.id
+        job.started_at = stale_at
+        job.updated_at = stale_at
+        test_db.commit()
+
+        failed_backup_job_ids: list[int] = []
+        reap_stale_agent_jobs(test_db, failed_backup_job_ids=failed_backup_job_ids)
+
+        assert failed_backup_job_ids == []
+
+    def test_stale_completion_report_cannot_double_finalize(
+        self, test_client, test_db, admin_headers
+    ):
+        from sqlalchemy.orm import Session as SASession
+
+        from app.api.agents import _complete_agent_job
+
+        agent, _headers = self._register(test_client, test_db, admin_headers)
+        job, backup_job = self._linked_backup_job(test_db, agent)
+
+        # A second session models the other transport holding a stale view of
+        # the still-running job (its read transaction already closed, as after
+        # a completed request cycle).
+        stale_db = SASession(bind=test_db.get_bind(), expire_on_commit=False)
+        try:
+            stale_job = stale_db.query(AgentJob).filter(AgentJob.id == job.id).first()
+            assert stale_job.status == "running"
+            stale_db.commit()
+
+            # The reaper (or the other transport) finalizes the job first.
+            test_db.query(AgentJob).filter(AgentJob.id == job.id).update(
+                {AgentJob.status: "failed", AgentJob.error_message: "reaped"},
+                synchronize_session=False,
+            )
+            test_db.query(BackupJob).filter(BackupJob.id == backup_job.id).update(
+                {BackupJob.status: "failed", BackupJob.error_message: "reaped"},
+                synchronize_session=False,
+            )
+            test_db.commit()
+
+            transitioned = _complete_agent_job(
+                stale_job, stale_db, result={"archive_name": "late", "return_code": 0}
+            )
+            stale_db.commit()
+            assert transitioned is False
+        finally:
+            stale_db.close()
+
+        test_db.expire_all()
+        assert (
+            test_db.query(AgentJob).filter(AgentJob.id == job.id).first().status
+            == "failed"
+        )
+        linked = test_db.query(BackupJob).filter(BackupJob.id == backup_job.id).first()
+        assert linked.status == "failed"
+        assert linked.error_message == "reaped"
+
+    def test_stale_start_report_does_not_claim_start_notification(
+        self, test_client, test_db, admin_headers
+    ):
+        from sqlalchemy.orm import Session as SASession
+
+        from app.api.agents import _mark_agent_job_started
+
+        agent, _headers = self._register(test_client, test_db, admin_headers)
+        job, backup_job = self._linked_backup_job(
+            test_db, agent, agent_status="claimed"
+        )
+
+        stale_db = SASession(bind=test_db.get_bind(), expire_on_commit=False)
+        try:
+            stale_job = stale_db.query(AgentJob).filter(AgentJob.id == job.id).first()
+            stale_db.commit()
+
+            first = _mark_agent_job_started(job, test_db)
+            test_db.commit()
+            assert first is not None
+
+            second = _mark_agent_job_started(stale_job, stale_db)
+            stale_db.commit()
+            assert second is None
+        finally:
+            stale_db.close()
+
+    async def test_expired_object_reads_stay_inside_notification_boundary(
+        self, test_db
+    ):
+        from app.services.agent_job_notifications import notify_backup_job_finished
+
+        backup_job = BackupJob(repository="/repo", status="failed", error_message="x")
+        test_db.add(backup_job)
+        test_db.commit()
+        test_db.refresh(backup_job)
+        # Detached + expired: every attribute read raises, modeling a refresh
+        # failure on the committed (expired) row after the job turned final.
+        test_db.expire(backup_job)
+        test_db.expunge(backup_job)
+
+        with patch(NOTIFIER_PATCH_TARGET, new_callable=AsyncMock) as notifier:
+            await notify_backup_job_finished(test_db, backup_job)
+
+        notifier.send_backup_failure.assert_not_awaited()
+
+    async def test_notifier_failure_does_not_propagate(self, test_db):
+        from app.services.agent_job_notifications import notify_backup_job_finished
+
+        backup_job = BackupJob(repository="/repo", status="failed", error_message="x")
+        test_db.add(backup_job)
+        test_db.commit()
+        test_db.refresh(backup_job)
+
+        with patch(NOTIFIER_PATCH_TARGET, new_callable=AsyncMock) as notifier:
+            notifier.send_backup_failure.side_effect = RuntimeError("boom")
+            await notify_backup_job_finished(test_db, backup_job)
+
+        notifier.send_backup_failure.assert_awaited_once()
+
+    def test_stale_cancel_report_cannot_overwrite_terminal_state(
+        self, test_client, test_db, admin_headers
+    ):
+        from sqlalchemy.orm import Session as SASession
+
+        from app.api.agents import _cancel_agent_job
+
+        agent, _headers = self._register(test_client, test_db, admin_headers)
+        job, backup_job = self._linked_backup_job(test_db, agent)
+
+        stale_db = SASession(bind=test_db.get_bind(), expire_on_commit=False)
+        try:
+            stale_job = stale_db.query(AgentJob).filter(AgentJob.id == job.id).first()
+            stale_db.commit()
+
+            test_db.query(AgentJob).filter(AgentJob.id == job.id).update(
+                {AgentJob.status: "failed", AgentJob.error_message: "reaped"},
+                synchronize_session=False,
+            )
+            test_db.query(BackupJob).filter(BackupJob.id == backup_job.id).update(
+                {BackupJob.status: "failed", BackupJob.error_message: "reaped"},
+                synchronize_session=False,
+            )
+            test_db.commit()
+
+            _cancel_agent_job(stale_job, stale_db)
+            stale_db.commit()
+        finally:
+            stale_db.close()
+
+        test_db.expire_all()
+        assert (
+            test_db.query(AgentJob).filter(AgentJob.id == job.id).first().status
+            == "failed"
+        )
+        assert (
+            test_db.query(BackupJob)
+            .filter(BackupJob.id == backup_job.id)
+            .first()
+            .status
+            == "failed"
+        )


### PR DESCRIPTION
## Problem

The notification settings expose per-event toggles (backup start/success/warning/failure, check success/failure), but none of them ever fire for repositories executed by a managed agent. The server-side execution paths send their notifications from inside `backup_service` / `check_service`; agent-executed jobs never pass through those services — they reach their terminal state in the agent transport handlers (`app/api/agents.py`, WebSocket + REST) and in the agent job reaper, none of which called the notification service. A failing agent backup or check was therefore silent, even with failure notifications enabled.

## Changes

- New `app/services/agent_job_notifications.py`: renders the linked `BackupJob` / `CheckJob` rows into the same `notification_service` calls the server-side paths make. The job name for notification titles resolves via `backup_plan_id` (plan name) or `scheduled_job_id` (schedule name); naive DB datetimes are coerced to UTC before duration math. Notification failures are logged and never propagate into the agent protocol.
- Both transports dispatch after the terminal state is committed (WebSocket `command_result` / `command_error`, REST `/complete`, `/fail`). Terminal transitions are claimed atomically: a shared guarded conditional UPDATE (`_claim_terminal_transition`, WHERE status not final — the same pattern the job reaper already uses) makes exactly one writer win, so a redelivered report (e.g. WebSocket plus a REST retry) or a concurrent reaper pass can neither double-notify nor overwrite an already-final state. This includes completion reports the server classifies as failures (borg error exit codes, malformed return codes), and the first backup-start notification is claimed the same way (guarded UPDATE on `started_at IS NULL`).
- The backup-start notification fires on the job's first start report (WebSocket + REST); a requeued job keeps its original `started_at` and does not notify again.
- The whole notification dispatch — including every ORM attribute read, which can itself hit the database on a committed (expired) object — runs inside an exception boundary: a failure is logged and never propagates into the agent protocol. The exception handlers log primary keys via an identity-map helper (`orm_identity_id`) so the logging itself cannot re-raise on an expired object.
- The REST `/start`, `/fail` and `/cancel` endpoints now reuse the shared transition helpers instead of duplicating the logic inline, so a late cancel report cannot overwrite a job the reaper or the other transport already finalized.
- Agent-executed repository checks (`repository.check` with a linked `CheckJob`) send `send_check_completion` on success and failure, with `check_type` derived from `scheduled_check`.
- The agent job reaper reports the backup jobs it fails (agent session lost) through the same path: `reap_stale_agent_jobs` collects the flipped backup-job ids via an optional out-parameter (signature otherwise unchanged) and the background loop sends the failure notifications with its own session.

Deliberate parity choices with the server-side paths: cancelled jobs do not notify; a check that completed with warnings is reported as completed (the repository was verified); prune/compact remain notification-less (no toggles exist for them).

## Tests

17 new tests in `tests/unit/test_api_agents.py`: success/warning/failure notifications over both transports, exactly-once delivery on repeated completion reports, start-notification dedup, check success/failure, plan-name resolution, cancelled-status skip, reaper collection (positive case + terminal-status guard), stale-transport races for completion, start and cancel (a second session models the other transport losing the guarded claim), and the exception boundary (a detached/expired row and a raising notification service must not propagate). The full file passes, the adjacent agent/notification/backup/repository suites stay green, and `ruff check` / `ruff format` are clean.
