### PR TITLE
fix(repositories): stop treating borg's local archive times as UTC

### DIFF
--- a/agent/borg_ui_agent/borg.py
+++ b/agent/borg_ui_agent/borg.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import platform
 import re
 import shutil
@@ -7,6 +8,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Optional
+from zoneinfo import ZoneInfo
 
 
 @dataclass(frozen=True)
@@ -25,11 +27,44 @@ class BorgBinary:
         }
 
 
+def detect_timezone() -> Optional[str]:
+    """The machine's IANA zone name, best effort.
+
+    Borg writes archive timestamps in this machine's local time with no
+    offset; reporting the zone lets the server interpret them correctly.
+    Only a name zoneinfo can resolve is reported - DST needs the zone, a
+    bare offset would misplace archives from the other half of the year.
+    """
+    candidates = [os.environ.get("TZ")]
+    try:
+        candidates.append(Path("/etc/timezone").read_text(encoding="utf-8").strip())
+    except OSError:
+        pass
+    try:
+        # /etc/localtime -> .../zoneinfo/<Area/City> on most distributions.
+        target = Path("/etc/localtime").resolve()
+        parts = target.parts
+        if "zoneinfo" in parts:
+            candidates.append("/".join(parts[parts.index("zoneinfo") + 1 :]))
+    except OSError:
+        pass
+    for name in candidates:
+        if not name:
+            continue
+        try:
+            ZoneInfo(name)
+        except Exception:
+            continue
+        return name
+    return None
+
+
 def detect_platform() -> dict:
     return {
         "hostname": platform.node(),
         "os": platform.system().lower() or "unknown",
         "arch": platform.machine() or "unknown",
+        "timezone": detect_timezone(),
     }
 
 

--- a/agent/borg_ui_agent/cli.py
+++ b/agent/borg_ui_agent/cli.py
@@ -81,6 +81,7 @@ def _register(args: argparse.Namespace) -> int:
         agent_version=__version__,
         borg_versions=borg_versions,
         capabilities=get_capabilities(),
+        timezone=machine.get("timezone"),
     )
     config_path = save_config(
         AgentConfig(

--- a/agent/borg_ui_agent/client.py
+++ b/agent/borg_ui_agent/client.py
@@ -68,6 +68,7 @@ class AgentClient:
         borg_versions: list[dict[str, Any]],
         capabilities: list[str],
         labels: Optional[dict[str, Any]] = None,
+        timezone: Optional[str] = None,
     ) -> dict[str, Any]:
         return self._request(
             "POST",
@@ -80,6 +81,7 @@ class AgentClient:
                 "os": os_name,
                 "arch": arch,
                 "agent_version": agent_version,
+                "timezone": timezone,
                 "borg_versions": borg_versions,
                 "capabilities": capabilities,
                 "labels": labels or {},
@@ -96,6 +98,7 @@ class AgentClient:
         capabilities: list[str],
         running_job_ids: Optional[list[int]] = None,
         last_error: Optional[str] = None,
+        timezone: Optional[str] = None,
     ) -> dict[str, Any]:
         return self._request(
             "POST",
@@ -104,6 +107,7 @@ class AgentClient:
                 "agent_id": agent_id,
                 "hostname": hostname,
                 "agent_version": agent_version,
+                "timezone": timezone,
                 "borg_versions": borg_versions,
                 "capabilities": capabilities,
                 "running_job_ids": running_job_ids or [],

--- a/agent/borg_ui_agent/runtime.py
+++ b/agent/borg_ui_agent/runtime.py
@@ -107,6 +107,7 @@ class AgentRuntime:
             borg_versions=borg_versions,
             capabilities=get_capabilities(),
             running_job_ids=running_job_ids or [],
+            timezone=machine.get("timezone"),
         )
 
     def run_once(self) -> RunOnceResult:

--- a/agent/borg_ui_agent/session.py
+++ b/agent/borg_ui_agent/session.py
@@ -468,6 +468,7 @@ class AgentSessionRuntime:
                 "agent_id": self.config.agent_id,
                 "hostname": machine["hostname"],
                 "agent_version": __version__,
+                "timezone": machine.get("timezone"),
                 "borg_versions": borg_versions,
                 "capabilities": get_capabilities(),
                 "running_job_ids": [],

--- a/app/api/agents.py
+++ b/app/api/agents.py
@@ -3,6 +3,7 @@ import json
 import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
+from zoneinfo import ZoneInfo
 
 from fastapi import (
     APIRouter,
@@ -88,6 +89,22 @@ def _as_utc(dt: datetime) -> datetime:
     return dt.astimezone(timezone.utc)
 
 
+def _validated_timezone(value: Optional[str]) -> Optional[str]:
+    """The value if it names a real IANA zone, else None.
+
+    The zone interprets borg's local-time archive timestamps from this agent,
+    so an unknown name must not be stored - the parser would silently fall
+    back anyway, and a validated column keeps that fallback rare.
+    """
+    if not value:
+        return None
+    try:
+        ZoneInfo(value)
+    except Exception:
+        return None
+    return value
+
+
 def _invalid_enrollment_token() -> HTTPException:
     return HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
@@ -102,6 +119,7 @@ class AgentRegisterRequest(BaseModel):
     os: Optional[str] = None
     arch: Optional[str] = None
     agent_version: Optional[str] = None
+    timezone: Optional[str] = None
     borg_versions: list[dict[str, Any]] = Field(default_factory=list)
     capabilities: list[str] = Field(default_factory=list)
     labels: dict[str, Any] = Field(default_factory=dict)
@@ -121,6 +139,7 @@ class AgentHeartbeatRequest(BaseModel):
     agent_id: str
     hostname: Optional[str] = None
     agent_version: Optional[str] = None
+    timezone: Optional[str] = None
     borg_versions: list[dict[str, Any]] = Field(default_factory=list)
     capabilities: list[str] = Field(default_factory=list)
     running_job_ids: list[int] = Field(default_factory=list)
@@ -141,6 +160,7 @@ class AgentSessionHello(BaseModel):
     agent_id: str
     hostname: Optional[str] = None
     agent_version: Optional[str] = None
+    timezone: Optional[str] = None
     borg_versions: list[dict[str, Any]] = Field(default_factory=list)
     capabilities: list[str] = Field(default_factory=list)
     running_job_ids: list[int] = Field(default_factory=list)
@@ -1084,6 +1104,7 @@ async def register_agent(
         os=payload.os,
         arch=payload.arch,
         agent_version=payload.agent_version,
+        timezone=_validated_timezone(payload.timezone),
         default_path=enrollment_token.default_path,
         borg_versions=payload.borg_versions,
         capabilities=payload.capabilities,
@@ -1131,6 +1152,9 @@ async def heartbeat(
     now = _now_utc()
     current_agent.hostname = payload.hostname or current_agent.hostname
     current_agent.agent_version = payload.agent_version or current_agent.agent_version
+    current_agent.timezone = (
+        _validated_timezone(payload.timezone) or current_agent.timezone
+    )
     current_agent.borg_versions = payload.borg_versions
     current_agent.capabilities = payload.capabilities
     current_agent.last_error = payload.last_error
@@ -1196,6 +1220,9 @@ async def session(websocket: WebSocket, db: Session = Depends(get_db)):
         now = _now_utc()
         current_agent.hostname = hello.hostname or current_agent.hostname
         current_agent.agent_version = hello.agent_version or current_agent.agent_version
+        current_agent.timezone = (
+            _validated_timezone(hello.timezone) or current_agent.timezone
+        )
         current_agent.borg_versions = hello.borg_versions
         current_agent.capabilities = hello.capabilities
         current_agent.status = "online"

--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -64,6 +64,7 @@ from app.services.repository_wipe_service import (
     repository_wipe_service,
 )
 from app.services.repository_executor import (
+    agent_timezone_for_repository,
     is_agent_executor,
     legacy_execution_target,
     normalize_executor_type,
@@ -101,7 +102,7 @@ from app.services.rclone_repository_service import (
     normalize_rclone_relative_path,
     rclone_repository_service,
 )
-from app.utils.datetime_utils import serialize_datetime
+from app.utils.datetime_utils import parse_borg_archive_time, serialize_datetime
 from app.utils.schedule_time import (
     DEFAULT_SCHEDULE_TIMEZONE,
     InvalidScheduleTimezone,
@@ -486,27 +487,18 @@ def _repository_stats_borg_env(env: Dict[str, str]) -> Dict[str, str]:
     return stats_env
 
 
-def _parse_borg_archive_time(value: Any) -> Optional[datetime]:
-    """Parse a Borg archive timestamp as a naive UTC database value."""
-    if value is None:
-        return None
+def _parse_borg_archive_time(
+    value: Any, *, timezone_name: Optional[str] = None
+) -> Optional[datetime]:
+    """Parse a Borg archive timestamp as a naive UTC database value.
 
-    if isinstance(value, (int, float)):
-        return datetime.fromtimestamp(value, tz=timezone.utc).replace(tzinfo=None)
-
-    if not isinstance(value, str):
-        return None
-
-    normalized = value.strip()
-    if not normalized:
-        return None
-
-    dt = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    else:
-        dt = dt.astimezone(timezone.utc)
-    return dt.replace(tzinfo=None)
+    Naive values are wall clock in the zone borg rendered the listing in -
+    pass the agent's reported zone for agent listings and "UTC" for listings
+    forced to TZ=UTC; the server's local zone is the fallback. Assuming UTC
+    unconditionally shifted last_backup by the UTC offset on every non-UTC
+    deployment.
+    """
+    return parse_borg_archive_time(value, timezone_name=timezone_name)
 
 
 def _load_repository_with_access(
@@ -843,13 +835,18 @@ async def _update_agent_repository_stats(repository: Repository, db: Session) ->
         )
         archive_count = len(archives)
 
+        agent_zone = agent_timezone_for_repository(db, repository)
         archive_times = []
         for archive in archives:
-            archive_time = archive.get("time") or archive.get("start")
-            if not archive_time:
+            archive_time = archive.get("time")
+            if archive_time is None:
+                archive_time = archive.get("start")
+            if archive_time is None:
                 continue
             try:
-                parsed_time = _parse_borg_archive_time(archive_time)
+                parsed_time = _parse_borg_archive_time(
+                    archive_time, timezone_name=agent_zone
+                )
             except ValueError:
                 continue
             if parsed_time:
@@ -958,12 +955,18 @@ async def update_repository_stats(repository: Repository, db: Session) -> bool:
 
                 archive_times = []
                 for archive in archives:
-                    archive_time = archive.get("time") or archive.get("start")
-                    if not archive_time:
+                    archive_time = archive.get("time")
+                    if archive_time is None:
+                        archive_time = archive.get("start")
+                    if archive_time is None:
                         continue
 
                     try:
-                        parsed_time = _parse_borg_archive_time(archive_time)
+                        # This listing ran under stats_env (TZ=UTC), so borg
+                        # rendered these timestamps in UTC - not server-local.
+                        parsed_time = _parse_borg_archive_time(
+                            archive_time, timezone_name="UTC"
+                        )
                     except ValueError as te:
                         logger.warning(
                             "Failed to parse archive timestamp",

--- a/app/database/alembic/versions/b9d2c5e7f1a4_add_agent_machine_timezone.py
+++ b/app/database/alembic/versions/b9d2c5e7f1a4_add_agent_machine_timezone.py
@@ -1,0 +1,25 @@
+"""add agent machine timezone
+
+Revision ID: b9d2c5e7f1a4
+Revises: c7e4f8a1d2b3
+Create Date: 2026-09-02
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "b9d2c5e7f1a4"
+down_revision = "c7e4f8a1d2b3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("agent_machines") as batch_op:
+        batch_op.add_column(sa.Column("timezone", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("agent_machines") as batch_op:
+        batch_op.drop_column("timezone")

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -90,6 +90,9 @@ class AgentMachine(Base):
     os = Column(String, nullable=True)
     arch = Column(String, nullable=True)
     agent_version = Column(String, nullable=True)
+    # IANA zone the agent reported (e.g. "Europe/Berlin"); interprets the
+    # local-time archive timestamps borg emits on that machine.
+    timezone = Column(String, nullable=True)
     default_path = Column(String, nullable=True)
     borg_versions = Column(JSON, nullable=True)
     capabilities = Column(JSON, nullable=True)

--- a/app/services/repository_executor.py
+++ b/app/services/repository_executor.py
@@ -65,6 +65,24 @@ def is_agent_executor(repository: Repository) -> bool:
     return repository_executor_type(repository) == EXECUTOR_AGENT
 
 
+def agent_timezone_for_repository(db: Session, repository: Repository) -> Optional[str]:
+    """The IANA zone the repository's agent reported, if any.
+
+    Borg renders archive times in the local zone of the process that produced
+    the listing; for an agent-executed repository that is the agent, so its
+    reported (current) zone is the one to interpret those times with. None for
+    non-agent repositories and for agents that never reported a zone.
+    """
+    if not is_agent_executor(repository) or not repository.agent_machine_id:
+        return None
+    agent = (
+        db.query(AgentMachine)
+        .filter(AgentMachine.id == repository.agent_machine_id)
+        .first()
+    )
+    return agent.timezone if agent else None
+
+
 def legacy_execution_target(
     *, executor_type: str, repository_location: Optional[str] = None
 ) -> str:

--- a/app/services/repository_info_sync.py
+++ b/app/services/repository_info_sync.py
@@ -14,31 +14,38 @@ against with its list_ok check.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Dict, Optional
 
 import structlog
 
 from app.database.models import Repository
+from app.utils.datetime_utils import parse_borg_archive_time
 
 logger = structlog.get_logger()
 
 
-def _newest_archive_time(archives: list) -> Optional[datetime]:
-    """The newest archive timestamp as a naive UTC value, matching the column."""
+def _newest_archive_time(
+    archives: list, *, timezone_name: Optional[str] = None
+) -> Optional[datetime]:
+    """The newest archive timestamp as a naive UTC value, matching the column.
+
+    Naive Borg times are the creating machine's local wall clock; see
+    parse_borg_archive_time for how ``timezone_name`` resolves them.
+    """
     newest = None
     for archive in archives:
         if not isinstance(archive, dict):
             continue
-        value = archive.get("time") or archive.get("start")
-        if not isinstance(value, str) or not value.strip():
+        # The shared parser handles every shape borg may emit (ISO strings
+        # with or without offset, Unix epochs) and returns None for junk.
+        # Select on None, not truthiness - the epoch 0 is a valid time.
+        value = archive.get("time")
+        if value is None:
+            value = archive.get("start")
+        dt = parse_borg_archive_time(value, timezone_name=timezone_name)
+        if dt is None:
             continue
-        try:
-            dt = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
-        except ValueError:
-            continue
-        if dt.tzinfo is not None:
-            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
         if newest is None or dt > newest:
             newest = dt
     return newest
@@ -59,8 +66,14 @@ def sync_archive_stats_from_info(
     # database and raise — inside the handler that promises never to.
     repository_name = repository.name
     try:
+        # Local import: repository_executor pulls in the admission machinery,
+        # which must not become an import-time dependency of this module.
+        from app.services.repository_executor import agent_timezone_for_repository
+
         repository.archive_count = len(archives)
-        newest = _newest_archive_time(archives)
+        newest = _newest_archive_time(
+            archives, timezone_name=agent_timezone_for_repository(db, repository)
+        )
         if archives:
             # Archives whose times we cannot parse must not wipe a known
             # last_backup — absence of evidence only counts when the list

--- a/app/utils/datetime_utils.py
+++ b/app/utils/datetime_utils.py
@@ -6,7 +6,68 @@ This module provides utilities to ensure consistent serialization to frontend.
 """
 
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Optional
+from zoneinfo import ZoneInfo
+
+
+def parse_borg_archive_time(
+    value: Any, *, timezone_name: Optional[str] = None
+) -> Optional[datetime]:
+    """Parse a Borg archive timestamp into a naive UTC database value.
+
+    Borg stores archive timestamps as absolute values and renders them, with
+    no UTC offset, in the local zone of the process that produced the listing
+    - historical archives included. ``timezone_name`` names that process's
+    IANA zone (the zone an agent reported, or "UTC" for a listing forced to
+    TZ=UTC); without one, naive values are interpreted in this server's local
+    zone. Using the zone (not a fixed offset) keeps archives created on
+    either side of a DST switch correct. Numeric values are Unix epochs and
+    carry no ambiguity.
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(value, tz=timezone.utc).replace(tzinfo=None)
+        except (OverflowError, OSError, ValueError):
+            # Out-of-range epochs (junk input) must not escape into the
+            # transport handlers; absence is handled by every caller.
+            return None
+
+    if not isinstance(value, str):
+        return None
+
+    normalized = value.strip()
+    if not normalized:
+        return None
+
+    try:
+        dt = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+    if dt.tzinfo is None:
+        zone = None
+        if timezone_name:
+            try:
+                zone = ZoneInfo(timezone_name)
+            except Exception:
+                zone = None
+        if zone is not None:
+            # fold=0 pins wall times repeated by a DST fall-back to their
+            # EARLIER instant. Borg gives no disambiguator, so any choice is
+            # off by at most the DST shift for that one hour a year - the
+            # earlier reading only ever understates recency, which is the
+            # safe direction for last_backup and stale monitoring. Excluding
+            # ambiguous values instead could fall back to an arbitrarily
+            # older archive.
+            dt = dt.replace(tzinfo=zone, fold=0)
+        else:
+            # astimezone() on a naive datetime attaches the system zone
+            # (same fold=0 semantics as above).
+            dt = dt.astimezone()
+    return dt.astimezone(timezone.utc).replace(tzinfo=None)
 
 
 def serialize_datetime(dt: Optional[datetime]) -> Optional[str]:

--- a/tests/integration/test_borg_timestamp_rendering_integration.py
+++ b/tests/integration/test_borg_timestamp_rendering_integration.py
@@ -1,0 +1,125 @@
+"""The timezone contracts of borg's rendered archive timestamps, measured
+against real binaries.
+
+borg 1 renders archive times in the local zone of the listing process with no
+UTC offset - the reason parse_borg_archive_time needs to know the render zone.
+borg 2 (measured on 2.0.0b22 and 2.0.0b23) renders them WITH an explicit UTC
+offset, both in the bare ``repo-list --json`` and in the key-restricted
+``--json --format`` fast path the agent uses - those values are
+self-describing and take the parser's offset branch regardless of any zone
+hint. These tests pin both contracts so a borg release changing either
+rendering fails loudly instead of silently shifting ``last_backup``.
+"""
+
+import json
+import shutil
+import subprocess
+from datetime import datetime
+
+import pytest
+
+from app.utils.datetime_utils import parse_borg_archive_time
+from tests.utils.borg import create_archive, init_borg_repo, make_borg_test_env
+
+# Deliberately a zone without DST: the offset to UTC is +9 all year, so the
+# wrong-assumption assertion below is deterministic on any test date.
+CREATE_ZONE = "Asia/Tokyo"
+CREATE_OFFSET_HOURS = 9
+
+
+def _listing_time(binary: str, repo_path, env: dict, zone: str, *args) -> str:
+    borg2 = binary and shutil.which(binary) and binary.endswith("borg2")
+    if borg2:
+        cmd = [binary, "--repo", str(repo_path), "repo-list", "--json", *args]
+    else:
+        cmd = [binary, "list", "--json", *args, str(repo_path)]
+    result = subprocess.run(
+        cmd,
+        env={**env, "TZ": zone},
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+    archives = json.loads(result.stdout)["archives"]
+    assert archives, "expected one archive in the listing"
+    return archives[0]["time"]
+
+
+@pytest.mark.integration
+@pytest.mark.requires_borg
+def test_borg1_listing_times_are_naive_local_and_need_the_render_zone(tmp_path):
+    borg1 = shutil.which("borg")
+    if not borg1:
+        pytest.skip("borg binary not found")
+
+    env = make_borg_test_env(str(tmp_path))
+    env["TZ"] = CREATE_ZONE
+    repo_path = tmp_path / "repo"
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "f.txt").write_text("data\n", encoding="utf-8")
+    init_borg_repo(borg1, repo_path, env=env, encryption="none")
+    create_archive(borg1, repo_path, "tz-test", [source], env=env)
+
+    utc_str = _listing_time(borg1, repo_path, env, "UTC")
+    tokyo_str = _listing_time(borg1, repo_path, env, CREATE_ZONE)
+
+    # borg 1 renders in the listing process's zone, without an offset.
+    assert datetime.fromisoformat(utc_str).tzinfo is None
+    assert datetime.fromisoformat(tokyo_str).tzinfo is None
+    assert utc_str != tokyo_str
+
+    # With the render zone supplied, both listings resolve to the same
+    # UTC instant.
+    parsed_utc = parse_borg_archive_time(utc_str, timezone_name="UTC")
+    parsed_tokyo = parse_borg_archive_time(tokyo_str, timezone_name=CREATE_ZONE)
+    assert parsed_utc == parsed_tokyo
+
+    # Assuming UTC for a non-UTC rendering - the pre-fix behavior - shifts
+    # the value by the render zone's offset.
+    wrongly_assumed_utc = parse_borg_archive_time(tokyo_str, timezone_name="UTC")
+    shift = wrongly_assumed_utc - parsed_utc
+    assert shift.total_seconds() == CREATE_OFFSET_HOURS * 3600
+
+
+@pytest.mark.integration
+@pytest.mark.requires_borg
+def test_borg2_listing_times_carry_their_utc_offset(tmp_path):
+    borg2 = shutil.which("borg2")
+    if not borg2:
+        pytest.skip("borg2 binary not found")
+
+    env = make_borg_test_env(str(tmp_path))
+    env["TZ"] = CREATE_ZONE
+    repo_path = tmp_path / "repo2"
+    source = tmp_path / "src2"
+    source.mkdir()
+    (source / "f.txt").write_text("data\n", encoding="utf-8")
+    try:
+        init_borg_repo(borg2, repo_path, env=env, encryption="none")
+    except AssertionError:
+        # 2.0.0b23 renamed the unencrypted modes with no alias for the plain
+        # b22 names; the rendering contract under test is the same either way.
+        init_borg_repo(borg2, repo_path, env=env, encryption="none-sha256")
+    create_archive(borg2, repo_path, "tz-test", [source], env=env)
+
+    utc_str = _listing_time(borg2, repo_path, env, "UTC")
+    tokyo_str = _listing_time(borg2, repo_path, env, CREATE_ZONE)
+    # The key-restricted fast path the agent uses for remote-friendly
+    # listings must keep the same self-describing rendering.
+    fast_path_str = _listing_time(
+        borg2, repo_path, env, CREATE_ZONE, "--format", "{name}{id}{time}"
+    )
+
+    for value in (utc_str, tokyo_str, fast_path_str):
+        assert datetime.fromisoformat(value).tzinfo is not None
+
+    # Self-describing: all renderings resolve to one UTC instant without any
+    # zone hint.
+    parsed = {
+        parse_borg_archive_time(utc_str),
+        parse_borg_archive_time(tokyo_str),
+        parse_borg_archive_time(fast_path_str),
+    }
+    assert len(parsed) == 1

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -762,6 +762,7 @@ def test_session_runtime_connects_with_websocket_url_and_sends_hello(monkeypatch
         "agent_id": "agt_123",
         "hostname": "host.local",
         "agent_version": "0.1.3",
+        "timezone": None,
         "borg_versions": [],
         "capabilities": get_capabilities(),
         "running_job_ids": [],
@@ -2586,3 +2587,23 @@ def test_cli_unregister_revokes_agent_and_removes_config(
         ("unregister", "agt_cli"),
     ]
     assert "Unregistered agt_cli" in capsys.readouterr().out
+
+
+class TestTimezoneDetection:
+    def test_valid_tz_env_wins(self, monkeypatch):
+        from agent.borg_ui_agent.borg import detect_platform, detect_timezone
+
+        monkeypatch.setenv("TZ", "Europe/Berlin")
+
+        assert detect_timezone() == "Europe/Berlin"
+        assert detect_platform()["timezone"] == "Europe/Berlin"
+
+    def test_invalid_tz_env_is_never_reported(self, monkeypatch):
+        from agent.borg_ui_agent.borg import detect_timezone
+
+        # An unresolvable name must not reach the server - it could not
+        # interpret archive times with it. The fallback may still find the
+        # machine's real zone (or nothing); both are acceptable here.
+        monkeypatch.setenv("TZ", "Not/AZone")
+
+        assert detect_timezone() != "Not/AZone"

--- a/tests/unit/test_api_agents.py
+++ b/tests/unit/test_api_agents.py
@@ -1759,3 +1759,82 @@ class TestAgentJobNotifications:
             .status
             == "failed"
         )
+
+
+@pytest.mark.unit
+class TestAgentTimezone:
+    """The agent's reported IANA zone interprets borg's local-time archive
+    timestamps; only resolvable names may be stored."""
+
+    def _register_with_timezone(self, test_client, admin_headers, tz):
+        enrollment = _create_enrollment_token(test_client, admin_headers)
+        response = test_client.post(
+            "/api/agents/register",
+            json={
+                "enrollment_token": enrollment["token"],
+                "name": "tz-agent",
+                "hostname": "tz.local",
+                "os": "linux",
+                "arch": "amd64",
+                "agent_version": "0.1.1",
+                "timezone": tz,
+                "borg_versions": [],
+                "capabilities": ["backup.create"],
+            },
+        )
+        assert response.status_code == 200
+        return response.json()
+
+    def test_register_persists_valid_timezone(
+        self, test_client: TestClient, test_db, admin_headers
+    ):
+        registered = self._register_with_timezone(
+            test_client, admin_headers, "Europe/Berlin"
+        )
+
+        agent = _get_agent(test_db, registered["agent_id"])
+        assert agent.timezone == "Europe/Berlin"
+
+    def test_register_drops_invalid_timezone(
+        self, test_client: TestClient, test_db, admin_headers
+    ):
+        registered = self._register_with_timezone(
+            test_client, admin_headers, "Not/AZone"
+        )
+
+        agent = _get_agent(test_db, registered["agent_id"])
+        assert agent.timezone is None
+
+    def test_heartbeat_updates_timezone_but_keeps_it_on_omission(
+        self, test_client: TestClient, test_db, admin_headers
+    ):
+        registered = self._register_with_timezone(
+            test_client, admin_headers, "Europe/Berlin"
+        )
+        headers = _agent_headers(registered["agent_token"])
+
+        heartbeat = {
+            "agent_id": registered["agent_id"],
+            "hostname": "tz.local",
+            "agent_version": "0.1.1",
+            "borg_versions": [],
+            "capabilities": ["backup.create"],
+            "running_job_ids": [],
+        }
+
+        # A heartbeat without a zone (old agent) must not erase the stored one.
+        response = test_client.post(
+            "/api/agents/heartbeat", json=heartbeat, headers=headers
+        )
+        assert response.status_code == 200
+        agent = _get_agent(test_db, registered["agent_id"])
+        assert agent.timezone == "Europe/Berlin"
+
+        response = test_client.post(
+            "/api/agents/heartbeat",
+            json={**heartbeat, "timezone": "America/New_York"},
+            headers=headers,
+        )
+        assert response.status_code == 200
+        test_db.refresh(agent)
+        assert agent.timezone == "America/New_York"

--- a/tests/unit/test_api_repositories.py
+++ b/tests/unit/test_api_repositories.py
@@ -1371,6 +1371,63 @@ class TestRepositoriesCreate:
         test_db.refresh(repo)
         assert repo.archive_count == 5  # preserved, not overwritten with 0
 
+    @pytest.mark.asyncio
+    async def test_agent_stats_refresh_interprets_archive_times_in_agent_zone(
+        self, test_db
+    ):
+        # Borg reports archive times in the agent's local wall clock; the
+        # refresh must convert them with the agent's reported zone instead of
+        # assuming UTC (which pushed last_backup into the future).
+        from app.api.repositories import _update_agent_repository_stats
+
+        agent = _agent_machine_with_capabilities(
+            "repository.list_archives", "repository.rinfo"
+        )
+        agent.timezone = "Europe/Berlin"
+        repo = Repository(
+            name="Agent Zone Repo",
+            path="/agent/zone/repo",
+            encryption="repokey-blake2",
+            executor_type="agent",
+            execution_target="agent",
+            repository_type="local",
+        )
+        test_db.add_all([agent, repo])
+        test_db.commit()
+        repo.agent_machine_id = agent.id
+        test_db.commit()
+        test_db.refresh(repo)
+
+        list_stdout = json.dumps(
+            {"archives": [{"name": "a1", "time": "2026-09-02T12:45:14"}]}
+        )
+        rinfo_stdout = json.dumps({"encryption": {"mode": "repokey-blake2"}})
+        with (
+            patch(
+                "app.services.repository_executor.queue_agent_repository_operation_job",
+                side_effect=lambda db, r, **kw: SimpleNamespace(id=1),
+            ),
+            patch(
+                "app.services.agent_job_dispatcher.dispatch_agent_job_best_effort",
+                new=AsyncMock(),
+            ),
+            patch(
+                "app.services.repository_executor.wait_for_agent_repository_operation_job",
+                new=AsyncMock(
+                    side_effect=[
+                        {"return_code": 0, "stdout": list_stdout},
+                        {"return_code": 0, "stdout": rinfo_stdout},
+                    ]
+                ),
+            ),
+        ):
+            ok = await _update_agent_repository_stats(repo, test_db)
+
+        assert ok is True
+        test_db.refresh(repo)
+        # 12:45 CEST (UTC+2 on this date) stored as naive UTC.
+        assert repo.last_backup == datetime(2026, 9, 2, 10, 45, 14)
+
     def test_agent_repository_list_archives_queues_agent_job(
         self, test_client: TestClient, admin_headers, test_db
     ):

--- a/tests/unit/test_api_repositories_routes.py
+++ b/tests/unit/test_api_repositories_routes.py
@@ -341,10 +341,91 @@ class TestRepositoryHelperContracts:
             "ssh_path_prefix": "/volume1",
         }
 
-    def test_parse_borg_archive_time_treats_naive_values_as_utc(self):
-        parsed = repositories_api._parse_borg_archive_time("2026-04-27T03:00:06.000000")
+    def test_parse_borg_archive_time_uses_the_given_zone_for_naive_values(self):
+        # Borg emits naive local wall clock; the caller supplies the creating
+        # machine's zone. EDT on this date is UTC-4.
+        parsed = repositories_api._parse_borg_archive_time(
+            "2026-04-27T03:00:06.000000", timezone_name="America/New_York"
+        )
 
-        assert parsed == datetime(2026, 4, 27, 3, 0, 6)
+        assert parsed == datetime(2026, 4, 27, 7, 0, 6)
+
+    @pytest.mark.skipif(
+        not hasattr(__import__("time"), "tzset"), reason="requires POSIX tzset"
+    )
+    def test_parse_borg_archive_time_utc_zone_is_host_independent(self):
+        # The server stats listing runs borg under TZ=UTC (stats_env), so its
+        # naive timestamps must parse as UTC no matter the server's own zone.
+        import os
+        import time
+
+        old_tz = os.environ.get("TZ")
+        os.environ["TZ"] = "Europe/Berlin"
+        time.tzset()
+        try:
+            parsed = repositories_api._parse_borg_archive_time(
+                "2026-07-01T03:00:00", timezone_name="UTC"
+            )
+        finally:
+            if old_tz is None:
+                os.environ.pop("TZ", None)
+            else:
+                os.environ["TZ"] = old_tz
+            time.tzset()
+
+        assert parsed == datetime(2026, 7, 1, 3, 0, 0)
+
+    def test_parse_borg_archive_time_pins_ambiguous_dst_wall_times_to_earlier(self):
+        # Berlin's 2026 fall-back repeats 02:00-02:59 wall times on Oct 25.
+        # Borg gives no disambiguator; the parser pins the EARLIER instant
+        # (CEST, UTC+2) so recency is only ever understated, never overstated.
+        parsed = repositories_api._parse_borg_archive_time(
+            "2026-10-25T02:30:00", timezone_name="Europe/Berlin"
+        )
+
+        assert parsed == datetime(2026, 10, 25, 0, 30, 0)
+
+    def test_parse_borg_archive_time_zone_handles_dst_per_archive_date(self):
+        # The same zone resolves to different offsets on either side of the
+        # DST switch - a fixed offset would misplace half the archives.
+        summer = repositories_api._parse_borg_archive_time(
+            "2026-07-01T03:00:00", timezone_name="Europe/Berlin"
+        )
+        winter = repositories_api._parse_borg_archive_time(
+            "2026-01-15T03:00:00", timezone_name="Europe/Berlin"
+        )
+
+        assert summer == datetime(2026, 7, 1, 1, 0, 0)  # CEST, UTC+2
+        assert winter == datetime(2026, 1, 15, 2, 0, 0)  # CET, UTC+1
+
+    @pytest.mark.skipif(
+        not hasattr(__import__("time"), "tzset"), reason="requires POSIX tzset"
+    )
+    def test_parse_borg_archive_time_falls_back_to_server_local_zone(self):
+        import os
+        import time
+
+        old_tz = os.environ.get("TZ")
+        os.environ["TZ"] = "Europe/Berlin"
+        time.tzset()
+        try:
+            no_zone = repositories_api._parse_borg_archive_time("2026-07-01T03:00:00")
+            bad_zone = repositories_api._parse_borg_archive_time(
+                "2026-07-01T03:00:00", timezone_name="Not/AZone"
+            )
+        finally:
+            if old_tz is None:
+                os.environ.pop("TZ", None)
+            else:
+                os.environ["TZ"] = old_tz
+            time.tzset()
+
+        assert no_zone == datetime(2026, 7, 1, 1, 0, 0)
+        assert bad_zone == datetime(2026, 7, 1, 1, 0, 0)
+
+    def test_parse_borg_archive_time_rejects_out_of_range_epochs(self):
+        assert repositories_api._parse_borg_archive_time(1e18) is None
+        assert repositories_api._parse_borg_archive_time(-1e18) is None
 
     def test_parse_borg_archive_time_converts_offset_values_to_utc(self):
         parsed = repositories_api._parse_borg_archive_time("2026-04-27T03:00:06-04:00")

--- a/tests/unit/test_repository_info_sync.py
+++ b/tests/unit/test_repository_info_sync.py
@@ -12,7 +12,10 @@ from datetime import datetime
 
 import pytest
 
-from app.services.repository_info_sync import sync_archive_stats_from_info
+from app.services.repository_info_sync import (
+    _newest_archive_time,
+    sync_archive_stats_from_info,
+)
 
 
 class FakeDb:
@@ -179,3 +182,31 @@ def test_the_warning_logs_do_not_read_orm_attributes_after_rollback():
     sync_archive_stats_from_info(repo, {"archives": []}, db)
 
     assert db.rollbacks == 1
+
+
+@pytest.mark.unit
+def test_naive_times_resolve_through_the_given_zone():
+    """Borg emits naive local wall clock; the agent's reported zone converts
+    it - assuming UTC pushed last_backup into the future on non-UTC agents."""
+    newest = _newest_archive_time(
+        [{"name": "a1", "time": "2026-09-02T12:45:14"}],
+        timezone_name="Europe/Berlin",
+    )
+
+    assert newest == datetime(2026, 9, 2, 10, 45, 14)
+
+
+@pytest.mark.unit
+def test_numeric_epoch_times_go_through_the_shared_parser():
+    newest = _newest_archive_time([{"name": "a1", "time": 1788345914}])
+
+    assert newest == datetime(2026, 9, 2, 10, 45, 14)
+
+
+@pytest.mark.unit
+def test_the_zero_epoch_is_a_valid_time_and_wins_over_start():
+    newest = _newest_archive_time(
+        [{"name": "a1", "time": 0, "start": "2026-09-02T12:45:14+00:00"}]
+    )
+
+    assert newest == datetime(1970, 1, 1, 0, 0, 0)


### PR DESCRIPTION
## Problem

Borg emits archive timestamps in the local time of the machine that created the archive, with no UTC offset. The stats refresh (`_parse_borg_archive_time`) and the info-driven archive sync (`_newest_archive_time`) declared those naive values to be UTC, so `repository.last_backup` is wrong by the machine's UTC offset on every deployment that does not run in UTC. The direction depends on the zone: east of UTC (UTC+X) the value lands in the future — the dashboard shows the last backup "in about 2 hours" — while west of UTC (UTC−X) it lands in the past, making backups look hours older than they are, which can falsely trip stale-backup monitoring. The `borg_repository_last_backup_timestamp` metric is off by the same amount either way. Because the refresh runs after backups complete, it also overwrites the correct value the job-completion path had just written.

This affects every execution variant, not just managed agents: both parse sites feed `last_backup` for all repositories — the stats refresh in its server-executed branch (`update_repository_stats`) and its agent branch (`_update_agent_repository_stats`), and the Borg 2 info-driven sync (`sync_archive_stats_from_info`) on the server-managed and agent branches of the v1 and v2 info routes. What differs per variant is only which machine's local time the archive carries: the server, the agent, or — for remote direct execution — the remote host.

## Changes

- Naive borg archive times are now parsed in the zone of the machine that created the archive:
  - Agents report their IANA zone with register, heartbeat and the session hello (detected from `TZ`, `/etc/timezone`, or the `/etc/localtime` symlink; only names `zoneinfo` can resolve are reported). The server validates the name, stores it on the agent (`agent_machines.timezone`, new Alembic revision, nullable), and uses it when interpreting archive times of agent repositories.
  - The server-executed stats listing already runs borg under `TZ=UTC` (`_repository_stats_borg_env`), so that path parses its timestamps explicitly as UTC — preserving the existing behavior. Everywhere else the server's local zone is the fallback: the info-driven sync for server-executed repositories (whose listings render in the server's zone), and agents that have not reported a zone (older agent versions keep working unchanged). Known limitation: archives created via remote direct execution carry the remote host's local time; with no channel for that host's zone they are interpreted in the server's zone, which is exact whenever both share a timezone and otherwise still bounded by the offset difference (strictly better than assuming UTC).
- A shared `parse_borg_archive_time` helper now backs both the stats refresh and the info sync. Using the IANA zone rather than a fixed offset keeps archives from either side of a DST switch correct; Unix-epoch values and offset-carrying ISO strings are unaffected.
- A heartbeat or hello without a zone never erases a stored one; an unresolvable name is dropped rather than stored.

## Migration

`b9d2c5e7f1a4` adds the nullable `agent_machines.timezone` column via `batch_alter_table` (third schema revision after the Alembic baseline). Verified beyond CI: a full ladder walk on SQLite — the batch table rebuild carries existing rows and all `ix_agent_machines_*` indexes, `downgrade` drops only the column — and the revision has been applied as an incremental upgrade on live PostgreSQL deployments. CI exercises it on both backends on every run: the fresh-install test walks baseline→head on SQLite, and the unit-test job's `postgres:16` service container (`BORG_TEST_POSTGRES_URL`) builds the target schema on Postgres.

## Follow-up (out of scope here)

Remote direct execution is the one creator of archives whose zone has no reporting channel yet: those archives carry the remote host's local time and are interpreted in the server's zone (see the limitation note above). The parser already takes the zone as a parameter, so extending exactness to that path only needs the remote host's zone to be captured with the SSH connection (analogous to the agent's reporting) and passed through — left as a follow-up to keep this PR focused.

## Tests

Parser: zone-based conversion, DST handled per archive date, server-local fallback and invalid-zone fallback (under a pinned `TZ`), offset strings unchanged. Stats refresh: an agent repository's naive archive times are converted with the agent's reported zone. Info sync: naive times resolve through the given zone. Agents API: register persists a valid zone, drops an invalid one; heartbeat updates the zone but keeps it when omitted. Agent: `TZ` detection. The previous test pinning naive-equals-UTC behavior is replaced. Affected suites green (repositories, info sync, agent runtime, agents API, db-upgrade/Alembic ladder); ruff check and format clean.
