### PR TITLE
fix(activity): apply status filter before the row limit

### DIFF
--- a/app/api/activity.py
+++ b/app/api/activity.py
@@ -329,12 +329,15 @@ async def list_recent_activity(
 
     # Fetch backup jobs
     if not job_type or job_type == "backup":
+        # Filter in SQL, before the limit: "status=failed" must return the
+        # newest failed jobs, not the failed jobs among the newest rows.
+        backup_query = db.query(BackupJob)
+        if status:
+            backup_query = backup_query.filter(BackupJob.status == status)
         backup_jobs = (
-            db.query(BackupJob).order_by(BackupJob.started_at.desc()).limit(limit).all()
+            backup_query.order_by(BackupJob.started_at.desc()).limit(limit).all()
         )
         for job in backup_jobs:
-            if status and job.status != status:
-                continue
             # Get repository name from path
             repo = (
                 db.query(Repository).filter(Repository.path == job.repository).first()
@@ -400,7 +403,9 @@ async def list_recent_activity(
 
     # Availability Plan skips are plan-run records, not BackupJobs: Borg was never
     # invoked, so they must be added independently to Activity.
-    if not job_type or job_type == "availability_check":
+    if (not job_type or job_type == "availability_check") and (
+        not status or status == "skipped"
+    ):
         plan_skips = (
             db.query(BackupPlanRun)
             .filter(
@@ -412,8 +417,6 @@ async def list_recent_activity(
             .all()
         )
         for run in plan_skips:
-            if status and status != "skipped":
-                continue
             plan = (
                 db.get(BackupPlan, run.backup_plan_id) if run.backup_plan_id else None
             )
@@ -449,8 +452,6 @@ async def list_recent_activity(
             .all()
         )
         for skip in automation_skips:
-            if status and status != "skipped":
-                continue
             schedule = db.get(ScheduledJob, skip.scheduled_job_id)
             activities.append(
                 {
@@ -475,15 +476,13 @@ async def list_recent_activity(
 
     # Fetch restore jobs
     if not job_type or job_type == "restore":
+        restore_query = db.query(RestoreJob)
+        if status:
+            restore_query = restore_query.filter(RestoreJob.status == status)
         restore_jobs = (
-            db.query(RestoreJob)
-            .order_by(RestoreJob.started_at.desc())
-            .limit(limit)
-            .all()
+            restore_query.order_by(RestoreJob.started_at.desc()).limit(limit).all()
         )
         for job in restore_jobs:
-            if status and job.status != status:
-                continue
             # Get repository name from path
             repo = (
                 db.query(Repository).filter(Repository.path == job.repository).first()
@@ -515,10 +514,11 @@ async def list_recent_activity(
 
     # Fetch check jobs
     if not job_type or job_type == "check":
-        check_jobs = db.query(CheckJob).order_by(CheckJob.id.desc()).limit(limit).all()
+        check_query = db.query(CheckJob)
+        if status:
+            check_query = check_query.filter(CheckJob.status == status)
+        check_jobs = check_query.order_by(CheckJob.id.desc()).limit(limit).all()
         for job in check_jobs:
-            if status and job.status != status:
-                continue
             # Get repository name from repository_id, with fallback to stored path
             repo = (
                 db.query(Repository).filter(Repository.id == job.repository_id).first()
@@ -559,15 +559,15 @@ async def list_recent_activity(
 
     # Fetch restore check jobs
     if not job_type or job_type == "restore_check":
+        restore_check_query = db.query(RestoreCheckJob)
+        if status:
+            restore_check_query = restore_check_query.filter(
+                RestoreCheckJob.status == status
+            )
         restore_check_jobs = (
-            db.query(RestoreCheckJob)
-            .order_by(RestoreCheckJob.id.desc())
-            .limit(limit)
-            .all()
+            restore_check_query.order_by(RestoreCheckJob.id.desc()).limit(limit).all()
         )
         for job in restore_check_jobs:
-            if status and job.status != status:
-                continue
             repo = (
                 db.query(Repository).filter(Repository.id == job.repository_id).first()
             )
@@ -609,15 +609,13 @@ async def list_recent_activity(
 
     # Fetch compact jobs
     if not job_type or job_type == "compact":
+        compact_query = db.query(CompactJob)
+        if status:
+            compact_query = compact_query.filter(CompactJob.status == status)
         compact_jobs = (
-            db.query(CompactJob)
-            .order_by(CompactJob.started_at.desc())
-            .limit(limit)
-            .all()
+            compact_query.order_by(CompactJob.started_at.desc()).limit(limit).all()
         )
         for job in compact_jobs:
-            if status and job.status != status:
-                continue
             # Get repository name from repository_id, with fallback to stored path
             repo = (
                 db.query(Repository).filter(Repository.id == job.repository_id).first()
@@ -659,12 +657,11 @@ async def list_recent_activity(
 
     # Fetch prune jobs
     if not job_type or job_type == "prune":
-        prune_jobs = (
-            db.query(PruneJob).order_by(PruneJob.started_at.desc()).limit(limit).all()
-        )
+        prune_query = db.query(PruneJob)
+        if status:
+            prune_query = prune_query.filter(PruneJob.status == status)
+        prune_jobs = prune_query.order_by(PruneJob.started_at.desc()).limit(limit).all()
         for job in prune_jobs:
-            if status and job.status != status:
-                continue
             # Get repository name from repository_id, with fallback to stored path
             repo = (
                 db.query(Repository).filter(Repository.id == job.repository_id).first()
@@ -706,15 +703,15 @@ async def list_recent_activity(
 
     # Fetch package install jobs
     if not job_type or job_type == "package":
+        package_query = db.query(PackageInstallJob)
+        if status:
+            package_query = package_query.filter(PackageInstallJob.status == status)
         package_jobs = (
-            db.query(PackageInstallJob)
-            .order_by(PackageInstallJob.started_at.desc())
+            package_query.order_by(PackageInstallJob.started_at.desc())
             .limit(limit)
             .all()
         )
         for job in package_jobs:
-            if status and job.status != status:
-                continue
             # Get package name from package_id
             package = (
                 db.query(InstalledPackage)
@@ -752,15 +749,13 @@ async def list_recent_activity(
 
     # Fetch script executions
     if not job_type or job_type == "script_execution":
+        script_query = db.query(ScriptExecution)
+        if status:
+            script_query = script_query.filter(ScriptExecution.status == status)
         script_executions = (
-            db.query(ScriptExecution)
-            .order_by(ScriptExecution.started_at.desc())
-            .limit(limit)
-            .all()
+            script_query.order_by(ScriptExecution.started_at.desc()).limit(limit).all()
         )
         for execution in script_executions:
-            if status and execution.status != status:
-                continue
             script_name = _script_execution_display_name(execution)
             backup_plan_name = None
             if execution.backup_plan:
@@ -808,16 +803,13 @@ async def list_recent_activity(
             if job_type in RCLONE_ACTIVITY_OPERATIONS
             else list(RCLONE_ACTIVITY_OPERATIONS.values())
         )
-        rclone_jobs = (
-            db.query(RcloneSyncJob)
-            .filter(RcloneSyncJob.operation.in_(operations))
-            .order_by(RcloneSyncJob.id.desc())
-            .limit(limit)
-            .all()
+        rclone_query = db.query(RcloneSyncJob).filter(
+            RcloneSyncJob.operation.in_(operations)
         )
+        if status:
+            rclone_query = rclone_query.filter(RcloneSyncJob.status == status)
+        rclone_jobs = rclone_query.order_by(RcloneSyncJob.id.desc()).limit(limit).all()
         for job in rclone_jobs:
-            if status and job.status != status:
-                continue
             repo = (
                 db.query(Repository).filter(Repository.id == job.repository_id).first()
             )

--- a/tests/unit/test_api_activity.py
+++ b/tests/unit/test_api_activity.py
@@ -2173,3 +2173,76 @@ class TestGetJobLogsPlaceholderOffset:
         assert data["lines"][0]["content"] == "Creating archive..."
         assert data["lines"][1]["content"] == "Files: 100 new, 0 changed"
         assert data["lines"][2]["content"] == "Duration: 2.34 seconds"
+
+
+@pytest.mark.unit
+class TestRecentActivityStatusFilter:
+    def test_status_filter_reaches_past_the_row_limit(
+        self, test_client, admin_headers, test_db
+    ):
+        """status=failed must return the newest FAILED jobs, not the failed
+        jobs among the newest rows: a failure buried under more than `limit`
+        newer successes has to stay findable."""
+        from app.database.models import BackupJob
+
+        base = datetime(2026, 9, 1, 12, 0, 0)
+        failed = BackupJob(
+            repository="/repo/buried",
+            status="failed",
+            error_message="borg create exited with code 2",
+            started_at=base,
+        )
+        test_db.add(failed)
+        test_db.add_all(
+            BackupJob(
+                repository="/repo/busy",
+                status="completed",
+                started_at=base + timedelta(minutes=i + 1),
+            )
+            for i in range(6)
+        )
+        test_db.commit()
+
+        response = test_client.get(
+            "/api/activity/recent?status=failed&limit=5", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        items = response.json()
+        assert [item["status"] for item in items] == ["failed"]
+        assert items[0]["error_message"] == "borg create exited with code 2"
+
+    def test_skipped_filter_still_returns_availability_skips(
+        self, test_client, admin_headers, test_db
+    ):
+        from app.database.models import BackupPlan, BackupPlanRun
+
+        occurred_at = datetime(2026, 9, 1, 12, 0, 0)
+        plan = BackupPlan(
+            name="Skip filter plan",
+            source_directories='["/srv/skip"]',
+            schedule_enabled=True,
+            schedule_mode="availability",
+        )
+        test_db.add(plan)
+        test_db.flush()
+        test_db.add(
+            BackupPlanRun(
+                backup_plan_id=plan.id,
+                trigger="availability",
+                status="skipped",
+                skip_reason="source_unavailable",
+                started_at=occurred_at,
+                completed_at=occurred_at,
+                created_at=occurred_at,
+            )
+        )
+        test_db.commit()
+
+        response = test_client.get(
+            "/api/activity/recent?status=skipped", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        items = response.json()
+        assert items and all(item["status"] == "skipped" for item in items)


### PR DESCRIPTION
## Problem

The recent-activity endpoint (`/api/activity/recent`) fetches the newest `limit` rows per lane and only then drops non-matching statuses in Python. Filtering by status therefore searches *within* the newest rows instead of returning the newest *matching* rows. On a busy instance (hourly plans across a dozen repositories produce hundreds of entries per day) a failed backup slides out of the newest-200 window within hours — after that, `status=failed` returns nothing, although the job row and its logs still exist. The Activity page then has no way to reach the failure at all: the filter is forwarded to the API, but the API applies it after the cut.

## Changes

The status filter becomes part of each lane's SQL query, before ordering and limit, so `status=failed` returns the newest failed jobs regardless of how many successes came after them. Applied uniformly to all eight status-carrying lanes (backup, restore, check, restore-check, compact, prune, script executions, package installs, rclone). The two availability-skip lanes, whose entries carry the synthetic status `skipped`, skip their queries entirely for any other status filter instead of discarding every row afterwards. Behavior without a status filter is unchanged, as is the combined sort-and-truncate of the merged result.

## Tests

Two new tests in `tests/unit/test_api_activity.py`: a failed backup buried under more than `limit` newer successes is returned by `status=failed` (fails on the previous code), and `status=skipped` still returns the availability-skip lanes after their new lane-level guard. Full activity suite green; ruff check and format clean.
