### PR TITLE
fix: report repository size for Borg 2 agent repositories

### DIFF
--- a/agent/borg_ui_agent/repository_ops.py
+++ b/agent/borg_ui_agent/repository_ops.py
@@ -40,6 +40,7 @@ REPOSITORY_JOB_KINDS = {
     "repository.prune",
     "repository.compact",
     "repository.rclone_sync",
+    "repository.disk_usage",
 }
 
 # Kill a streaming extract only when no bytes have flowed for this long — a
@@ -107,6 +108,13 @@ class RepositoryOperationPayload:
         return cmd
 
     def build_command(self, *, rclone_config_path: Optional[str] = None) -> list[str]:
+        if self.job_kind == "repository.disk_usage":
+            if not self.repository_path:
+                raise ValueError(
+                    "repository.disk_usage requires a repository path"
+                )
+            return ["du", "-sb", "--", self.repository_path]
+
         if self.job_kind == "repository.rclone_sync":
             rclone = _rclone_operation(self.operation)
             remote_name = _require_non_empty_string(
@@ -517,6 +525,7 @@ def execute_repository_operation_job(
         "repository.list_archives",
         "repository.delete_archive",
         "repository.break_lock",
+        "repository.disk_usage",
     }:
         try:
             return _execute_short_repository_operation(

--- a/agent/borg_ui_agent/runtime.py
+++ b/agent/borg_ui_agent/runtime.py
@@ -41,6 +41,7 @@ DEFAULT_CAPABILITIES = [
     "repository.prune",
     "repository.compact",
     "repository.rclone_sync",
+    "repository.disk_usage",
     "agent.list_scripts",
     "script.run",
 ]
@@ -63,6 +64,7 @@ JOB_HANDLERS = {
     "repository.prune": execute_repository_operation_job,
     "repository.compact": execute_repository_operation_job,
     "repository.rclone_sync": execute_repository_operation_job,
+    "repository.disk_usage": execute_repository_operation_job,
 }
 
 

--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -874,7 +874,8 @@ async def _update_agent_repository_stats(repository: Repository, db: Session) ->
             rinfo = json.loads((rinfo_result or {}).get("stdout") or "{}")
             encryption_mode = (rinfo.get("encryption") or {}).get("mode")
             # Borg 1 `info --json` exposes repo-level dedup size in cache.stats;
-            # Borg 2 `repo-info --json` does not (remote size is unknowable).
+            # Borg 2 `repo-info --json` does not. For Borg 2 the size comes
+            # from the agent instead, below.
             stats = (rinfo.get("cache") or {}).get("stats") or {}
             size_bytes = stats.get("unique_csize") or stats.get("unique_size")
             if isinstance(size_bytes, (int, float)) and size_bytes > 0:
@@ -885,6 +886,35 @@ async def _update_agent_repository_stats(repository: Repository, db: Session) ->
                 repository=repository.name,
                 error=str(e),
             )
+
+        # Borg 2 reports no size through repo-info, so ask the agent to
+        # measure the repository directory it already holds locally. Guarded
+        # on total_size so Borg 1 repositories keep using cache.stats above.
+        if total_size is None:
+            try:
+                du_job = queue_agent_repository_operation_job(
+                    db, repository, job_kind="repository.disk_usage"
+                )
+                await dispatch_agent_job_best_effort(
+                    db, du_job, repository_id=repository.id
+                )
+                du_result = await wait_for_agent_repository_operation_job(
+                    db, du_job.id, timeout_seconds=timeouts["info_timeout"]
+                )
+                du_meta = du_result or {}
+                if du_meta.get("return_code", 0) == 0:
+                    # `du -sb` prints "<bytes>\t<path>".
+                    stdout = (du_meta.get("stdout") or "").strip()
+                    first = stdout.split("\n")[0] if stdout else ""
+                    fields = first.split()
+                    if fields and fields[0].isdigit() and int(fields[0]) > 0:
+                        total_size = format_bytes(int(fields[0]))
+            except Exception as e:
+                logger.warning(
+                    "agent disk-usage for stats refresh failed",
+                    repository=repository.name,
+                    error=str(e),
+                )
 
         if list_ok:
             repository.archive_count = archive_count

--- a/app/services/job_admission.py
+++ b/app/services/job_admission.py
@@ -36,6 +36,7 @@ OPERATION_REPOSITORY_LIST_ARCHIVES = "repository.list_archives"
 OPERATION_REPOSITORY_LIST_ARCHIVE_CONTENTS = "repository.list_archive_contents"
 OPERATION_REPOSITORY_EXTRACT_ARCHIVE_FILE = "repository.extract_archive_file"
 OPERATION_BREAK_LOCK = "break_lock"
+OPERATION_DISK_USAGE = "repository.disk_usage"
 # Sentinel for an active repository agent job whose kind we don't recognize.
 # Classed WRITE so admission fails closed -- an unknown job might hold a borg
 # lock, and break_lock must never run alongside it.
@@ -77,6 +78,8 @@ READ_OPERATIONS = {
     OPERATION_REPOSITORY_LIST_ARCHIVES,
     OPERATION_REPOSITORY_LIST_ARCHIVE_CONTENTS,
     OPERATION_REPOSITORY_EXTRACT_ARCHIVE_FILE,
+    # du reads directory metadata only and takes no repository lock.
+    OPERATION_DISK_USAGE,
 }
 
 AGENT_JOB_KIND_OPERATIONS = {
@@ -93,6 +96,7 @@ AGENT_JOB_KIND_OPERATIONS = {
     "repository.list_archive_contents": OPERATION_REPOSITORY_LIST_ARCHIVE_CONTENTS,
     "repository.extract_archive_file": OPERATION_REPOSITORY_EXTRACT_ARCHIVE_FILE,
     "repository.restore": OPERATION_RESTORE,
+    "repository.disk_usage": OPERATION_DISK_USAGE,
 }
 
 MAINTENANCE_MODEL_OPERATIONS = {

--- a/app/services/job_admission.py
+++ b/app/services/job_admission.py
@@ -44,6 +44,11 @@ OPERATION_UNKNOWN_REPOSITORY = "repository.unknown"
 
 OPERATION_CLASS_REPOSITORY_WRITE = "repository_write"
 OPERATION_CLASS_REPOSITORY_READ = "repository_read"
+# Observation: reads metadata ABOUT the repository without opening it, so it
+# holds no borg lock and conflicts with nothing. Distinct from
+# repository_read, which does open the repository and must therefore still
+# yield to a write.
+OPERATION_CLASS_REPOSITORY_OBSERVE = "repository_observe"
 
 DEFAULT_MANUAL_BACKUP_LIMIT = 1
 DEFAULT_SCHEDULED_BACKUP_LIMIT = 2
@@ -78,7 +83,11 @@ READ_OPERATIONS = {
     OPERATION_REPOSITORY_LIST_ARCHIVES,
     OPERATION_REPOSITORY_LIST_ARCHIVE_CONTENTS,
     OPERATION_REPOSITORY_EXTRACT_ARCHIVE_FILE,
-    # du reads directory metadata only and takes no repository lock.
+}
+
+# du stats the repository directory; it never opens the repository, so it
+# neither takes a borg lock nor needs to wait for one.
+OBSERVE_OPERATIONS = {
     OPERATION_DISK_USAGE,
 }
 
@@ -129,6 +138,8 @@ def operation_class_for(operation: str) -> str:
         return OPERATION_CLASS_REPOSITORY_WRITE
     if operation in READ_OPERATIONS:
         return OPERATION_CLASS_REPOSITORY_READ
+    if operation in OBSERVE_OPERATIONS:
+        return OPERATION_CLASS_REPOSITORY_OBSERVE
     raise ValueError(f"Unknown repository operation: {operation}")
 
 
@@ -360,6 +371,14 @@ def ensure_repository_admission(
             )
 
     for active in active_work:
+        # An observation neither takes a lock nor waits for one, so it is
+        # skipped from both sides: it never blocks a backup, and it can start
+        # while anything else is running.
+        if OPERATION_CLASS_REPOSITORY_OBSERVE in (
+            requested_class,
+            active.operation_class,
+        ):
+            continue
         conflicts = requested_class == OPERATION_CLASS_REPOSITORY_WRITE or (
             requested_class == OPERATION_CLASS_REPOSITORY_READ
             and active.operation_class == OPERATION_CLASS_REPOSITORY_WRITE

--- a/app/services/repository_executor.py
+++ b/app/services/repository_executor.py
@@ -36,6 +36,7 @@ REPOSITORY_OPERATION_CAPABILITIES = {
     "repository.prune",
     "repository.compact",
     "repository.rclone_sync",
+    "repository.disk_usage",
 }
 
 

--- a/tests/unit/test_repository_disk_usage.py
+++ b/tests/unit/test_repository_disk_usage.py
@@ -71,8 +71,7 @@ def test_disk_usage_is_an_observation():
     # holds no borg lock. It is not a plain read either: a read still has to
     # yield to a write, and there is nothing for this to yield to.
     assert (
-        operation_class_for(OPERATION_DISK_USAGE)
-        == OPERATION_CLASS_REPOSITORY_OBSERVE
+        operation_class_for(OPERATION_DISK_USAGE) == OPERATION_CLASS_REPOSITORY_OBSERVE
     )
 
 

--- a/tests/unit/test_repository_disk_usage.py
+++ b/tests/unit/test_repository_disk_usage.py
@@ -1,5 +1,7 @@
 import pytest
 
+from app.core.security import get_password_hash
+from app.database.models import AgentJob, AgentMachine, Repository
 from agent.borg_ui_agent.repository_ops import (
     REPOSITORY_JOB_KINDS,
     RepositoryOperationPayload,
@@ -7,8 +9,10 @@ from agent.borg_ui_agent.repository_ops import (
 from agent.borg_ui_agent.runtime import DEFAULT_CAPABILITIES, JOB_HANDLERS
 from app.services.job_admission import (
     AGENT_JOB_KIND_OPERATIONS,
-    OPERATION_CLASS_REPOSITORY_READ,
+    OPERATION_BACKUP,
+    OPERATION_CLASS_REPOSITORY_OBSERVE,
     OPERATION_DISK_USAGE,
+    ensure_repository_admission,
     operation_class_for,
 )
 from app.services.repository_executor import REPOSITORY_OPERATION_CAPABILITIES
@@ -62,8 +66,52 @@ def test_disk_usage_is_admitted_and_dispatchable():
 
 
 @pytest.mark.unit
-def test_disk_usage_is_a_read_operation():
-    # du opens nothing in the repository and takes no lock. Classed as a
-    # write it would block a backup queued behind it with
-    # repositoryOperationActive.
-    assert operation_class_for(OPERATION_DISK_USAGE) == OPERATION_CLASS_REPOSITORY_READ
+def test_disk_usage_is_an_observation():
+    # du stats the repository directory and never opens the repository, so it
+    # holds no borg lock. It is not a plain read either: a read still has to
+    # yield to a write, and there is nothing for this to yield to.
+    assert (
+        operation_class_for(OPERATION_DISK_USAGE)
+        == OPERATION_CLASS_REPOSITORY_OBSERVE
+    )
+
+
+@pytest.mark.unit
+def test_backup_can_queue_while_disk_usage_is_active(db_session):
+    # A requested write conflicts with ANY active work, so before disk usage
+    # became an observation an in-flight size check refused the backup behind
+    # it with repositoryOperationActive. The stats refresh runs on a timer, so
+    # that collision would land on scheduled backups at random.
+    agent = AgentMachine(
+        name="Agent",
+        agent_id="agt_disk_usage",
+        token_hash=get_password_hash("agent-secret"),
+        token_prefix="agent-secret",
+        status="online",
+    )
+    repo = Repository(
+        name="RepoDiskUsage",
+        path="/repos/disk-usage",
+        encryption="none",
+        repository_type="local",
+        executor_type="agent",
+    )
+    db_session.add_all([agent, repo])
+    db_session.flush()
+    repo.agent_machine_id = agent.id
+    db_session.add(
+        AgentJob(
+            agent_machine_id=agent.id,
+            job_type="repository",
+            status="queued",
+            payload={
+                "schema_version": 1,
+                "job_kind": JOB_KIND,
+                "repository": {"id": repo.id, "path": repo.path},
+            },
+        )
+    )
+    db_session.commit()
+
+    # No exception: the backup is admitted.
+    ensure_repository_admission(db_session, repo, OPERATION_BACKUP)

--- a/tests/unit/test_repository_disk_usage.py
+++ b/tests/unit/test_repository_disk_usage.py
@@ -1,0 +1,69 @@
+import pytest
+
+from agent.borg_ui_agent.repository_ops import (
+    REPOSITORY_JOB_KINDS,
+    RepositoryOperationPayload,
+)
+from agent.borg_ui_agent.runtime import DEFAULT_CAPABILITIES, JOB_HANDLERS
+from app.services.job_admission import (
+    AGENT_JOB_KIND_OPERATIONS,
+    OPERATION_CLASS_REPOSITORY_READ,
+    OPERATION_DISK_USAGE,
+    operation_class_for,
+)
+from app.services.repository_executor import REPOSITORY_OPERATION_CAPABILITIES
+
+JOB_KIND = "repository.disk_usage"
+
+
+def _payload(repository_path):
+    return RepositoryOperationPayload(
+        job_kind=JOB_KIND,
+        repository_path=repository_path,
+        borg_version=2,
+        operation={},
+    )
+
+
+@pytest.mark.unit
+def test_disk_usage_measures_the_repository_in_bytes():
+    # -b so the server formats the number itself rather than parsing a
+    # human-readable suffix, and -- so a path starting with a dash cannot be
+    # read as an option.
+    cmd = _payload("/srv/borg/repo-example").build_command()
+    assert cmd == ["du", "-sb", "--", "/srv/borg/repo-example"]
+
+
+@pytest.mark.unit
+def test_disk_usage_requires_a_repository_path():
+    # Without a path du would measure the working directory and return a
+    # plausible but wrong number.
+    with pytest.raises(ValueError):
+        _payload("").build_command()
+
+
+@pytest.mark.unit
+def test_disk_usage_is_advertised_and_handled_by_the_agent():
+    # The server only offers a job kind the agent advertises, and only runs
+    # one it has a handler for. Adding either alone is a silent no-op.
+    assert JOB_KIND in REPOSITORY_JOB_KINDS
+    assert JOB_KIND in DEFAULT_CAPABILITIES
+    assert JOB_KIND in JOB_HANDLERS
+
+
+@pytest.mark.unit
+def test_disk_usage_is_admitted_and_dispatchable():
+    # Missing from AGENT_JOB_KIND_OPERATIONS, admission raises KeyError.
+    # Missing from REPOSITORY_OPERATION_CAPABILITIES, the server answers
+    # 400 unsupportedJobKind before any agent is asked -- which reads as an
+    # out-of-date agent even though the agent advertises the capability.
+    assert AGENT_JOB_KIND_OPERATIONS[JOB_KIND] == OPERATION_DISK_USAGE
+    assert JOB_KIND in REPOSITORY_OPERATION_CAPABILITIES
+
+
+@pytest.mark.unit
+def test_disk_usage_is_a_read_operation():
+    # du opens nothing in the repository and takes no lock. Classed as a
+    # write it would block a backup queued behind it with
+    # repositoryOperationActive.
+    assert operation_class_for(OPERATION_DISK_USAGE) == OPERATION_CLASS_REPOSITORY_READ


### PR DESCRIPTION
## Description

Agent-executed Borg 2 repositories always show `Total size: N/A`.

`_update_agent_repository_stats` reads the size from `cache.stats.unique_csize`, which is a Borg 1 shape. Borg 2's `repo-info --json` returns only `cache.path`, `encryption`, `repository` and `security_dir`, so `size_bytes` is always `None`:

```
top-level keys: ['cache', 'encryption', 'repository', 'security_dir']
cache keys:     ['path']
```

Server-local repositories are unaffected, because `calculate_total_size_bytes` runs `du` on them — but that path handles only a repository with `host` set or a local path, and an agent repository is neither, so nothing measures it.

This adds a `repository.disk_usage` job kind that runs `du -sb` on the agent, which is already executing commands on the machine that holds the repository. It is guarded on `total_size` still being unset, so Borg 1 repositories keep using `cache.stats` exactly as before.

`compact --stats` also reports on-disk pack size, but borg refuses `--stats` together with `--dry-run`, and a real `compact` rewrites the repository — not something that should run on a scheduled stats refresh.

Two details worth calling out for review:

- The job kind is registered in **all four** places it has to be — `DEFAULT_CAPABILITIES` and `JOB_HANDLERS` in the agent, `AGENT_JOB_KIND_OPERATIONS` in admission, and `REPOSITORY_OPERATION_CAPABILITIES` in the executor. With the last one missing the server answers `400 unsupportedJobKind` before any agent is asked, which reads as an out-of-date agent even though the agent advertises the capability correctly.
- It is classed as a **read**. Anything absent from `READ_OPERATIONS` is treated as `repository_write`, and a write-classed size probe would block a backup queued behind it with `repositoryOperationActive`.

Cost is small: about 9 ms on a 42.6 GiB repository (932 files), since Borg 2 packs into a few large files.

## Related Issue

Fixes #874

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

Running these changes against four repositories — three agent-executed, one server-local. All four now report a size; the largest reads `42.61 GB`, matching `du -sb` on that machine. Before the change the three agent repositories showed `N/A` and the server-local one was correct.

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

`tests/unit/test_repository_disk_usage.py` covers the command built (`du -sb --`, bytes rather than a human-readable suffix), the empty-path guard, agent advertisement and handler registration, admission and dispatch registration, and the read classification. Each test was checked against a deliberately broken version of the code to confirm it fails.

```
tests/unit/test_repository_disk_usage.py .....                           [100%]
5 passed

tests/unit
2745 passed, 11 skipped
```

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

One note on documentation: I updated the comment above `cache.stats` that said the remote size is unknowable, since that is no longer true once the agent measures it. I did not find user-facing docs describing the size field, but happy to add something if there is a page it belongs on.
