### PR TITLE
fix: allow cloud mirrors on managed-agent repositories

### DIFF
--- a/app/services/job_admission.py
+++ b/app/services/job_admission.py
@@ -37,6 +37,7 @@ OPERATION_REPOSITORY_LIST_ARCHIVE_CONTENTS = "repository.list_archive_contents"
 OPERATION_REPOSITORY_EXTRACT_ARCHIVE_FILE = "repository.extract_archive_file"
 OPERATION_BREAK_LOCK = "break_lock"
 OPERATION_DISK_USAGE = "repository.disk_usage"
+OPERATION_RCLONE_SYNC = "repository.rclone_sync"
 # Sentinel for an active repository agent job whose kind we don't recognize.
 # Classed WRITE so admission fails closed -- an unknown job might hold a borg
 # lock, and break_lock must never run alongside it.
@@ -83,6 +84,9 @@ READ_OPERATIONS = {
     OPERATION_REPOSITORY_LIST_ARCHIVES,
     OPERATION_REPOSITORY_LIST_ARCHIVE_CONTENTS,
     OPERATION_REPOSITORY_EXTRACT_ARCHIVE_FILE,
+    # rclone reads the repository and writes only to the remote, so it
+    # cannot corrupt local state the way a write operation can.
+    OPERATION_RCLONE_SYNC,
 }
 
 # du stats the repository directory; it never opens the repository, so it
@@ -106,6 +110,7 @@ AGENT_JOB_KIND_OPERATIONS = {
     "repository.extract_archive_file": OPERATION_REPOSITORY_EXTRACT_ARCHIVE_FILE,
     "repository.restore": OPERATION_RESTORE,
     "repository.disk_usage": OPERATION_DISK_USAGE,
+    "repository.rclone_sync": OPERATION_RCLONE_SYNC,
 }
 
 MAINTENANCE_MODEL_OPERATIONS = {

--- a/tests/unit/test_job_admission.py
+++ b/tests/unit/test_job_admission.py
@@ -115,7 +115,9 @@ def test_rclone_sync_is_mapped_and_classed_as_a_read():
     # "Unsupported agent repository operation: repository.rclone_sync",
     # never reaching the agent that supports it.
     assert AGENT_JOB_KIND_OPERATIONS["repository.rclone_sync"] == OPERATION_RCLONE_SYNC
-    assert operation_for_agent_job_kind("repository.rclone_sync") == OPERATION_RCLONE_SYNC
+    assert (
+        operation_for_agent_job_kind("repository.rclone_sync") == OPERATION_RCLONE_SYNC
+    )
     # rclone reads the repository and writes only to the remote. It also has
     # to be in one of the two sets: operation_class_for() raises on an
     # operation it cannot classify, so the mapping alone would still fail.

--- a/tests/unit/test_job_admission.py
+++ b/tests/unit/test_job_admission.py
@@ -4,11 +4,15 @@ from fastapi import HTTPException
 from app.core.security import get_password_hash
 from app.database.models import AgentJob, AgentMachine, Repository
 from app.services.job_admission import (
+    AGENT_JOB_KIND_OPERATIONS,
     OPERATION_BACKUP,
     OPERATION_BREAK_LOCK,
+    OPERATION_CLASS_REPOSITORY_READ,
     OPERATION_CLASS_REPOSITORY_WRITE,
+    OPERATION_RCLONE_SYNC,
     ensure_repository_admission,
     operation_class_for,
+    operation_for_agent_job_kind,
 )
 
 
@@ -110,13 +114,6 @@ def test_rclone_sync_is_mapped_and_classed_as_a_read():
     # cloud mirror on an agent repository is rejected at admission with
     # "Unsupported agent repository operation: repository.rclone_sync",
     # never reaching the agent that supports it.
-    from app.services.job_admission import (
-        AGENT_JOB_KIND_OPERATIONS,
-        OPERATION_CLASS_REPOSITORY_READ,
-        OPERATION_RCLONE_SYNC,
-        operation_for_agent_job_kind,
-    )
-
     assert AGENT_JOB_KIND_OPERATIONS["repository.rclone_sync"] == OPERATION_RCLONE_SYNC
     assert operation_for_agent_job_kind("repository.rclone_sync") == OPERATION_RCLONE_SYNC
     # rclone reads the repository and writes only to the remote. It also has

--- a/tests/unit/test_job_admission.py
+++ b/tests/unit/test_job_admission.py
@@ -102,3 +102,24 @@ def test_break_lock_fails_closed_against_unknown_active_repository_job(db_sessio
         ensure_repository_admission(db_session, repo, OPERATION_BREAK_LOCK)
 
     assert exc.value.status_code == 409
+
+
+@pytest.mark.unit
+def test_rclone_sync_is_mapped_and_classed_as_a_read():
+    # Without the mapping, operation_for_agent_job_kind() raises and every
+    # cloud mirror on an agent repository is rejected at admission with
+    # "Unsupported agent repository operation: repository.rclone_sync",
+    # never reaching the agent that supports it.
+    from app.services.job_admission import (
+        AGENT_JOB_KIND_OPERATIONS,
+        OPERATION_CLASS_REPOSITORY_READ,
+        OPERATION_RCLONE_SYNC,
+        operation_for_agent_job_kind,
+    )
+
+    assert AGENT_JOB_KIND_OPERATIONS["repository.rclone_sync"] == OPERATION_RCLONE_SYNC
+    assert operation_for_agent_job_kind("repository.rclone_sync") == OPERATION_RCLONE_SYNC
+    # rclone reads the repository and writes only to the remote. It also has
+    # to be in one of the two sets: operation_class_for() raises on an
+    # operation it cannot classify, so the mapping alone would still fail.
+    assert operation_class_for(OPERATION_RCLONE_SYNC) == OPERATION_CLASS_REPOSITORY_READ


### PR DESCRIPTION
## Description

Enabling a cloud mirror on an agent-executed repository saves fine, then every sync fails within milliseconds:

```
Unsupported agent repository operation: repository.rclone_sync
```

`AGENT_JOB_KIND_OPERATIONS` in `job_admission.py` has no entry for `repository.rclone_sync`, so `operation_for_agent_job_kind()` raises and the job is rejected at admission. Nothing reaches the agent.

Everything else for the feature is already in place, which is what makes this look like an oversight rather than an unfinished feature — the executor allows the kind for dispatch, and both agent modules handle it.

The operation also needs classifying. `operation_class_for()` raises on an operation in neither `READ_OPERATIONS` nor `WRITE_OPERATIONS`, so adding the mapping on its own just moves the failure one step later. rclone reads the repository and writes only to the remote, so it sits with the reads — the same shape as `restore`, which also reads the repository and writes elsewhere.

## Related Issue

Fixes #867

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

Running this against three agent-executed repositories mirroring to Google Drive. Before the change every sync was rejected at admission; after it the mirrors run and complete.

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

The test covers both halves — the mapping and the classification — because either one missing produces a different failure. Both were checked against a deliberately broken version of the code to confirm the test fails.

```
tests/unit/test_job_admission.py ....                                    [100%]
4 passed

tests/unit
2741 passed, 11 skipped
```

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
