### PR TITLE
fix: let a reconnecting agent reclaim its job before the reaper fails it

### DIFF
--- a/agent/borg_ui_agent/session.py
+++ b/agent/borg_ui_agent/session.py
@@ -372,12 +372,43 @@ class AgentSessionRuntime:
                     continue
                 message = json.loads(raw_message)
                 if isinstance(message, dict) and message.get("type") == "command":
-                    worker = threading.Thread(
-                        target=self._handle_command,
-                        args=(outbox, message, closing),
-                        daemon=True,
+                    # Register the cancel event here, before the worker thread
+                    # even exists, not inside _handle_command. _handle_command
+                    # registers deep into its own body (after the ack, after
+                    # every early-return command), so a session that drops
+                    # between worker.start() and that point leaves the worker
+                    # with no entry in _cancel_events: the disconnect branch
+                    # below can't signal it (it only iterates existing
+                    # entries) and the next hello's running_job_ids omits it,
+                    # so the server requeues and redispatches the job onto a
+                    # new worker while this one is still executing it --
+                    # double-running a durable operation. Only register for a
+                    # message that will actually reach a job handler (mirrors
+                    # _handle_command's own dispatch conditions below) --
+                    # registering unconditionally would leave ids for
+                    # early-return commands (filesystem.browse, cancel, ...)
+                    # stuck in _cancel_events forever, since nothing would
+                    # ever unregister them.
+                    job_id = self._job_id_for_dispatch(message)
+                    cancel_event = (
+                        self._register_cancel(job_id) if job_id is not None else None
                     )
-                    worker.start()
+                    try:
+                        worker = threading.Thread(
+                            target=self._handle_command,
+                            args=(outbox, message, closing),
+                            kwargs={"cancel_event": cancel_event},
+                            daemon=True,
+                        )
+                        worker.start()
+                    except Exception:
+                        # The thread never ran, so nothing will ever reach
+                        # _handle_command's finally to unregister this id --
+                        # do it here or it leaks in _cancel_events (and hello)
+                        # permanently.
+                        if job_id is not None:
+                            self._unregister_cancel(job_id)
+                        raise
                     workers.append(worker)
                     workers = [w for w in workers if w.is_alive()]
                 handled += 1
@@ -494,16 +525,49 @@ class AgentSessionRuntime:
         with self._registry_lock:
             return sorted(self._cancel_events.keys())
 
+    @staticmethod
+    def _job_id_for_dispatch(message: dict[str, Any]) -> Optional[int]:
+        """Return the job id if, and only if, this message will reach a job
+        handler in _handle_command below -- i.e. it survives every one of
+        that method's early returns. Used by the session loop to register the
+        cancel event before the worker thread starts (see the register-before-
+        start comment in run_session); kept in lockstep with _handle_command's
+        own dispatch conditions on purpose, since a mismatch would either miss
+        the registration (the race this exists to close) or register an id
+        that nothing ever unregisters (a permanent phantom in hello)."""
+        command = str(message.get("command") or "")
+        if command in (
+            "filesystem.browse",
+            "diagnostics.run",
+            "agent.repository_defaults",
+            "agent.list_scripts",
+            "cancel",
+        ):
+            return None
+        raw_job_id = message.get("job_id")
+        job_id = int(raw_job_id) if raw_job_id is not None else None
+        if job_id is None or get_job_handler(command) is None:
+            return None
+        return job_id
+
     def _handle_command(
         self,
         outbox: "queue.Queue[str]",
         message: dict[str, Any],
         closing: Optional[threading.Event] = None,
+        cancel_event: Optional[threading.Event] = None,
     ) -> None:
         """Handle one server command (runs in a worker thread): ack it, then run
         the matching handler with cooperative cancellation wired in. Outgoing
         frames go to ``outbox`` for the session thread to write; ``closing``
-        suppresses them once the owning session has been torn down."""
+        suppresses them once the owning session has been torn down.
+
+        ``cancel_event`` is the event the session loop already registered for
+        this job via _job_id_for_dispatch/_register_cancel, closing the
+        register-before-start race (see run_session). It defaults to None so
+        direct callers (tests, or any future caller that predates this) keep
+        working: this method then falls back to registering it itself, same
+        as before this fix."""
         command_id = str(message.get("command_id") or "")
         command = str(message.get("command") or "")
         raw_job_id = message.get("job_id")
@@ -560,7 +624,11 @@ class AgentSessionRuntime:
             )
             return
 
-        cancel_event = self._register_cancel(job_id)
+        # Normally already registered by the session loop before this thread
+        # even started (see _job_id_for_dispatch); only register here when a
+        # caller invoked this method directly without doing that (e.g. a test).
+        if cancel_event is None:
+            cancel_event = self._register_cancel(job_id)
         try:
             result = handler(
                 {"id": job_id, "type": command, "payload": payload},

--- a/agent/borg_ui_agent/session.py
+++ b/agent/borg_ui_agent/session.py
@@ -470,11 +470,29 @@ class AgentSessionRuntime:
                 "agent_version": __version__,
                 "borg_versions": borg_versions,
                 "capabilities": get_capabilities(),
-                "running_job_ids": [],
+                # The server treats this as authoritative: on this path it
+                # requeues-and-redispatches any "claimed"/undelivered job absent
+                # from the list, regardless of age (see
+                # ignore_age_for_undelivered in app/api/agents.py). _cancel_events
+                # lives on this instance, not the session, so a worker whose
+                # cancellation is still cooperative-pending survives a dropped
+                # socket and keeps running here. Reporting an empty list on
+                # reconnect would tell the server "I have nothing," and it would
+                # requeue and redispatch a job this agent is still executing —
+                # double-running a durable operation.
+                "running_job_ids": self._running_job_ids(),
             }
         )
         with self._writing(socket):
             socket.send(message)
+
+    def _running_job_ids(self) -> list[int]:
+        """Snapshot of job ids with a live worker on this agent instance right
+        now (registered in _register_cancel, cleared in _unregister_cancel's
+        finally). Taken under _registry_lock; the lock is released before this
+        returns so hello's I/O never runs while holding it."""
+        with self._registry_lock:
+            return sorted(self._cancel_events.keys())
 
     def _handle_command(
         self,

--- a/app/api/agents.py
+++ b/app/api/agents.py
@@ -63,7 +63,21 @@ FINAL_AGENT_JOB_STATUSES = {
 }
 
 
-STALE_AGENT_JOB_REQUEUE_AFTER = timedelta(minutes=15)
+# MUST STAY BELOW agent_job_reaper.AGENT_JOB_REAP_AFTER.
+#
+# A job claimed just before an agent's socket drops is never delivered: it
+# sits "claimed" with started_at NULL until something recovers it.
+# _requeue_stale_agent_jobs runs on the agent's hello and on every heartbeat
+# and would recover it, but only for rows older than this window — so while
+# the two windows were equal the reaper always failed the job first and the
+# reconnect had nothing left to requeue.
+#
+# Two minutes gives a reconnecting agent room to reclaim its own work well
+# before the reaper acts. It is safe to be this short because the requeue
+# already skips any job the agent reports in running_job_ids and any job
+# whose own activity is newer than the cutoff, so a genuinely running
+# operation is never requeued however long it takes.
+STALE_AGENT_JOB_REQUEUE_AFTER = timedelta(minutes=2)
 REPOSITORY_OPERATION_JOB_MODELS = {
     "check": CheckJob,
     "compact": CompactJob,

--- a/app/api/agents.py
+++ b/app/api/agents.py
@@ -67,16 +67,30 @@ FINAL_AGENT_JOB_STATUSES = {
 #
 # A job claimed just before an agent's socket drops is never delivered: it
 # sits "claimed" with started_at NULL until something recovers it.
-# _requeue_stale_agent_jobs runs on the agent's hello and on every heartbeat
-# and would recover it, but only for rows older than this window — so while
-# the two windows were equal the reaper always failed the job first and the
-# reconnect had nothing left to requeue.
+# _requeue_stale_agent_jobs runs on the REST /heartbeat path (polling agents)
+# and on the WebSocket session's hello (session agents reconnecting), but the
+# two paths now lean on this window differently.
 #
-# Two minutes gives a reconnecting agent room to reclaim its own work well
-# before the reaper acts. It is safe to be this short because the requeue
-# already skips any job the agent reports in running_job_ids and any job
-# whose own activity is newer than the cutoff, so a genuinely running
-# operation is never requeued however long it takes.
+# On /heartbeat this window is still the whole story: a polling agent's own
+# claim→start gap is real work in progress, not a dropped delivery, so a job
+# only requeues once it has sat idle longer than this.
+#
+# At hello it is not needed for the case it was originally sized for. A
+# session agent that just said hello cannot have a delivery in flight that
+# predates its own hello — so an undelivered claimed job (started_at NULL)
+# the agent does not list in running_job_ids is requeued regardless of age
+# on that path. This window still applies to every other job seen at hello
+# (running jobs, and claimed jobs still reported as running). Without this
+# split, a reconnect inside the window found the stranded job "too fresh"
+# and had no further chance to recover it until the next disconnect or the
+# reaper — session heartbeats are WS messages that never call this function,
+# so hello was the only opportunity.
+#
+# Two minutes gives a polling agent room to reclaim its own work well before
+# the reaper acts. It is safe to be this short because the requeue already
+# skips any job the agent reports in running_job_ids and any job whose own
+# activity is newer than the cutoff, so a genuinely running operation is
+# never requeued however long it takes.
 STALE_AGENT_JOB_REQUEUE_AFTER = timedelta(minutes=2)
 REPOSITORY_OPERATION_JOB_MODELS = {
     "check": CheckJob,
@@ -323,6 +337,7 @@ def _requeue_stale_agent_jobs(
     *,
     now: datetime,
     running_job_ids: list[int],
+    ignore_age_for_undelivered: bool = False,
 ) -> None:
     running_ids = set(running_job_ids)
     stale_cutoff = now - STALE_AGENT_JOB_REQUEUE_AFTER
@@ -337,7 +352,10 @@ def _requeue_stale_agent_jobs(
     for job in jobs:
         if job.id in running_ids:
             continue
-        if _job_activity_at(job) > stale_cutoff:
+
+        undelivered = job.status == "claimed" and job.started_at is None
+        skip_age_check = ignore_age_for_undelivered and undelivered
+        if not skip_age_check and _job_activity_at(job) > stale_cutoff:
             continue
 
         if _is_request_scoped_repository_job(job):
@@ -1109,6 +1127,7 @@ async def session(websocket: WebSocket, db: Session = Depends(get_db)):
             current_agent,
             now=now,
             running_job_ids=hello.running_job_ids,
+            ignore_age_for_undelivered=True,
         )
         db.commit()
 

--- a/tests/unit/test_agent_hello_undelivered_requeue.py
+++ b/tests/unit/test_agent_hello_undelivered_requeue.py
@@ -1,0 +1,188 @@
+"""An undelivered claimed job must recover on the very next hello.
+
+_requeue_stale_agent_jobs only requeued a "claimed" job once it had sat idle
+past STALE_AGENT_JOB_REQUEUE_AFTER. For a polling agent that is right — its
+own claim -> start gap is real work in progress. But a session agent's hello
+carries running_job_ids, which is already an authoritative "I don't have this
+job": a fresh session cannot have a delivery in flight that predates its own
+hello. Without ignoring the age window on that path, a reconnect inside the
+window found the stranded job "too fresh" and had no further chance to
+recover it until the next disconnect or the reaper, because session
+heartbeats are WS messages that never call this function.
+
+ignore_age_for_undelivered=True (passed only from the WS hello call site)
+lets an undelivered claimed job (started_at NULL) absent from
+running_job_ids requeue regardless of age. Every other job — one the agent
+still reports running, or one already started — keeps the age check.
+"""
+
+from datetime import timedelta
+
+import pytest
+
+from app.api.agents import (
+    STALE_AGENT_JOB_REQUEUE_AFTER,
+    _requeue_stale_agent_jobs,
+    _now_utc,
+)
+from app.core.security import get_password_hash
+from app.database.models import AgentJob, AgentMachine
+
+
+def _create_agent(db_session):
+    agent = AgentMachine(
+        name="Hello Agent",
+        agent_id="agt_hello",
+        token_hash=get_password_hash("secret"),
+        token_prefix="secret"[:20],
+        status="online",
+        capabilities=[],
+    )
+    db_session.add(agent)
+    db_session.commit()
+    db_session.refresh(agent)
+    return agent
+
+
+def _create_claimed_job(db_session, agent, *, age, started_at=None, job_type="backup"):
+    now = _now_utc()
+    claimed_at = now - age
+    job = AgentJob(
+        agent_machine_id=agent.id,
+        job_type=job_type,
+        status="claimed",
+        payload={},
+        claimed_at=claimed_at,
+        started_at=started_at,
+        created_at=claimed_at,
+        updated_at=claimed_at,
+    )
+    db_session.add(job)
+    db_session.commit()
+    db_session.refresh(job)
+    return job
+
+
+def _create_request_scoped_job(db_session, agent, *, age):
+    now = _now_utc()
+    claimed_at = now - age
+    job = AgentJob(
+        agent_machine_id=agent.id,
+        job_type="repository",
+        status="claimed",
+        payload={"job_kind": "repository.info"},
+        claimed_at=claimed_at,
+        started_at=None,
+        created_at=claimed_at,
+        updated_at=claimed_at,
+    )
+    db_session.add(job)
+    db_session.commit()
+    db_session.refresh(job)
+    return job
+
+
+@pytest.mark.unit
+def test_hello_requeues_young_undelivered_job_absent_from_running_ids(db_session):
+    # This is the regression the reviewer flagged: with the 2-minute window,
+    # a job stranded seconds before a quick reconnect used to be too fresh to
+    # requeue at hello, and hello was the only chance before the reaper.
+    agent = _create_agent(db_session)
+    job = _create_claimed_job(
+        db_session,
+        agent,
+        age=timedelta(seconds=5),
+        started_at=None,
+    )
+    assert timedelta(seconds=5) < STALE_AGENT_JOB_REQUEUE_AFTER
+
+    _requeue_stale_agent_jobs(
+        db_session,
+        agent,
+        now=_now_utc(),
+        running_job_ids=[],
+        ignore_age_for_undelivered=True,
+    )
+    db_session.commit()
+    db_session.refresh(job)
+
+    assert job.status == "queued"
+    assert job.claimed_at is None
+    assert job.started_at is None
+
+
+@pytest.mark.unit
+def test_hello_does_not_requeue_a_job_the_agent_reports_running(db_session):
+    # running_job_ids is authoritative in the other direction too: even an
+    # undelivered-looking claimed job must not be requeued while the agent
+    # says it still has it.
+    agent = _create_agent(db_session)
+    job = _create_claimed_job(
+        db_session,
+        agent,
+        age=timedelta(seconds=5),
+        started_at=None,
+    )
+
+    _requeue_stale_agent_jobs(
+        db_session,
+        agent,
+        now=_now_utc(),
+        running_job_ids=[job.id],
+        ignore_age_for_undelivered=True,
+    )
+    db_session.commit()
+    db_session.refresh(job)
+
+    assert job.status == "claimed"
+    assert job.claimed_at is not None
+
+
+@pytest.mark.unit
+def test_heartbeat_path_keeps_the_age_window_for_undelivered_jobs(db_session):
+    # The REST /heartbeat path serves polling agents, whose own claim->start
+    # gap is real work in progress, not a dropped delivery. The flag defaults
+    # to False there, so a young undelivered job must NOT be requeued.
+    agent = _create_agent(db_session)
+    job = _create_claimed_job(
+        db_session,
+        agent,
+        age=timedelta(seconds=5),
+        started_at=None,
+    )
+    assert timedelta(seconds=5) < STALE_AGENT_JOB_REQUEUE_AFTER
+
+    _requeue_stale_agent_jobs(
+        db_session,
+        agent,
+        now=_now_utc(),
+        running_job_ids=[],
+    )
+    db_session.commit()
+    db_session.refresh(job)
+
+    assert job.status == "claimed"
+    assert job.claimed_at is not None
+
+
+@pytest.mark.unit
+def test_hello_still_fails_request_scoped_repository_job_terminally(db_session):
+    # A request-scoped repository job (e.g. repository.info) has no durable
+    # record and no receiver left once the session drops. Even on the hello
+    # path with ignore_age_for_undelivered=True, it must be failed terminally
+    # rather than requeued.
+    agent = _create_agent(db_session)
+    job = _create_request_scoped_job(db_session, agent, age=timedelta(seconds=5))
+
+    _requeue_stale_agent_jobs(
+        db_session,
+        agent,
+        now=_now_utc(),
+        running_job_ids=[],
+        ignore_age_for_undelivered=True,
+    )
+    db_session.commit()
+    db_session.refresh(job)
+
+    assert job.status == "failed"
+    assert job.completed_at is not None

--- a/tests/unit/test_agent_job_requeue_window.py
+++ b/tests/unit/test_agent_job_requeue_window.py
@@ -1,0 +1,17 @@
+import pytest
+
+from app.api.agents import STALE_AGENT_JOB_REQUEUE_AFTER
+from app.services.agent_job_reaper import AGENT_JOB_REAP_AFTER
+
+
+@pytest.mark.unit
+def test_requeue_window_is_shorter_than_the_reap_window():
+    # A job claimed just before an agent's socket drops is never delivered and
+    # sits "claimed" with started_at NULL. _requeue_stale_agent_jobs runs on
+    # the agent's hello and on every heartbeat and can recover it, but only
+    # for rows older than the requeue window.
+    #
+    # While the two windows were equal the reaper always won: by the time a
+    # reconnecting agent was allowed to reclaim its own work, the job had
+    # already been failed. The requeue has to become eligible first.
+    assert STALE_AGENT_JOB_REQUEUE_AFTER < AGENT_JOB_REAP_AFTER

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -728,6 +728,78 @@ def test_session_runtime_connects_with_websocket_url_and_sends_hello(monkeypatch
 
 
 @pytest.mark.unit
+def test_session_hello_reports_a_worker_still_registered_from_a_prior_session(
+    patch_session_platform,
+):
+    """running_job_ids must reflect live workers, not just this session.
+
+    _cancel_events lives on the AgentSessionRuntime instance (created once in
+    __init__), not per-session, so a worker started before a reconnect is
+    still registered here. If hello reported [] anyway, the server would
+    treat the job as not-in-flight and requeue + redispatch it onto a fresh
+    worker while the old one is still running — double execution of a
+    durable operation. Simulate that surviving worker by registering its
+    cancel event directly, the same way _handle_command does before running
+    a handler.
+    """
+    from agent.borg_ui_agent.session import AgentSessionRuntime
+
+    socket = FakeWebSocket([])
+    runtime = AgentSessionRuntime(
+        AgentConfig("https://borgui.example.com", "agt_123", "secret"),
+        connect=lambda *args, **kwargs: socket,
+    )
+    runtime._register_cancel(77)
+
+    runtime.run_session(max_messages=0)
+
+    assert socket.sent[0]["type"] == "hello"
+    assert socket.sent[0]["running_job_ids"] == [77]
+
+
+@pytest.mark.unit
+def test_session_hello_reports_empty_list_when_idle(patch_session_platform):
+    """The ordinary case: no worker registered, hello must still say so
+    explicitly (not merely by omission) so the server's age-window skip for
+    a "still running" job never fires spuriously."""
+    from agent.borg_ui_agent.session import AgentSessionRuntime
+
+    socket = FakeWebSocket([])
+    runtime = AgentSessionRuntime(
+        AgentConfig("https://borgui.example.com", "agt_123", "secret"),
+        connect=lambda *args, **kwargs: socket,
+    )
+
+    runtime.run_session(max_messages=0)
+
+    assert socket.sent[0]["running_job_ids"] == []
+
+
+@pytest.mark.unit
+def test_session_hello_stops_reporting_a_job_once_its_handler_finished(
+    patch_session_platform,
+):
+    """A job id must drop out of running_job_ids once _unregister_cancel has
+    run (the handler's finally, i.e. the worker is actually done) — otherwise
+    a completed job would keep looking "still running" to the server forever
+    and the requeue-on-hello recovery for a genuinely stranded job would
+    never kick in for it."""
+    from agent.borg_ui_agent.session import AgentSessionRuntime
+
+    socket = FakeWebSocket([])
+    runtime = AgentSessionRuntime(
+        AgentConfig("https://borgui.example.com", "agt_123", "secret"),
+        connect=lambda *args, **kwargs: socket,
+    )
+    runtime._register_cancel(77)
+    runtime._unregister_cancel(77)
+
+    runtime.run_session(max_messages=0)
+
+    assert socket.sent[0]["running_job_ids"] == []
+
+
+@pytest.mark.unit
 def test_session_runtime_sends_app_heartbeat_while_idle(monkeypatch):
     from agent.borg_ui_agent.session import AgentSessionRuntime
 

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -800,6 +800,230 @@ def test_session_hello_stops_reporting_a_job_once_its_handler_finished(
 
 
 @pytest.mark.unit
+def test_session_loop_registers_cancel_before_worker_thread_starts(monkeypatch):
+    """The startup race this fix closes: _handle_command used to register the
+    cancel event deep in its own body -- after enqueueing the command_ack and
+    after every early-return command check -- so a session that dropped
+    between worker.start() and that point left the worker with no entry in
+    _cancel_events. The disconnect branch in run_session only iterates
+    *existing* _cancel_events entries -- it can't signal a worker that was
+    never registered -- and the next hello's running_job_ids omits it, so the
+    server (see ignore_age_for_undelivered in app/api/agents.py) requeues and
+    redispatches the job onto a fresh worker while the original keeps
+    executing it: double execution of a durable operation.
+
+    Assert the registration is a property of *dispatch itself*, not of
+    thread timing: block the worker at the very first thing _handle_command
+    does (the command_ack enqueue), well before it would reach its own
+    _register_cancel call, then check _cancel_events from the main thread
+    while the worker is still parked there. If registration only happened
+    inside _handle_command (the pre-fix shape), the id would still be
+    missing at this point -- this reproduces the actual gap, not just a
+    handler that hasn't started yet.
+    """
+    from agent.borg_ui_agent.session import AgentSessionRuntime, SessionCommandClient
+
+    worker_parked = threading.Event()
+    release_worker = threading.Event()
+    real_enqueue = SessionCommandClient.enqueue
+
+    def blocking_enqueue(self, payload):
+        # The command_ack enqueue is the first thing _handle_command does --
+        # parking here reproduces "worker thread exists but has not reached
+        # any registration call yet", the exact window the race lived in.
+        if payload.get("type") == "command_ack":
+            worker_parked.set()
+            release_worker.wait(timeout=5)
+        return real_enqueue(self, payload)
+
+    def fake_handler(job, client, *, should_cancel=None):
+        return SimpleNamespace(job_id=job["id"], status="completed", message="done")
+
+    monkeypatch.setattr(SessionCommandClient, "enqueue", blocking_enqueue)
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.detect_platform",
+        lambda: {"hostname": "host.local", "os": "linux", "arch": "amd64"},
+    )
+    monkeypatch.setattr("agent.borg_ui_agent.session.detect_borg_binaries", lambda: [])
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.get_job_handler",
+        lambda command: fake_handler if command == "backup.create" else None,
+    )
+
+    socket = FakeWebSocket(
+        [
+            {
+                "type": "command",
+                "command_id": "cmd-race",
+                "command": "backup.create",
+                "job_id": 99,
+                "payload": {},
+            }
+        ]
+    )
+    runtime = AgentSessionRuntime(
+        AgentConfig("https://borgui.example.com", "agt_123", "secret"),
+        connect=lambda *args, **kwargs: socket,
+        http_client=RecordingHttpClient(),
+    )
+
+    session_thread = threading.Thread(
+        target=runtime.run_session, kwargs={"max_messages": 1}
+    )
+    session_thread.start()
+    try:
+        # Wait for the worker to actually be running and parked at its first
+        # instruction, rather than sleeping a fixed duration.
+        assert worker_parked.wait(timeout=5)
+        # The job id must already be visible to hello / the disconnect path
+        # at this point -- registered by the session loop before the worker
+        # thread was even started, not by the worker once it got around to it.
+        assert runtime._running_job_ids() == [99]
+    finally:
+        release_worker.set()
+        session_thread.join(timeout=5)
+
+    # And it drops out again once the worker (and _handle_command's finally)
+    # has actually finished.
+    assert runtime._running_job_ids() == []
+
+
+@pytest.mark.unit
+def test_session_loop_does_not_register_non_job_commands(
+    patch_session_platform, monkeypatch
+):
+    """filesystem.browse, cancel, and a job_id: None message all return early
+    from _handle_command without ever calling _register_cancel. If the
+    session loop registered every incoming command up front (the naive fix),
+    these ids would sit in _cancel_events forever -- nothing unregisters
+    them -- and hello would report phantom running jobs permanently, which
+    would permanently defeat the requeue recovery this branch exists to
+    provide. That is worse than the race being fixed."""
+    from agent.borg_ui_agent.session import AgentSessionRuntime
+
+    socket = FakeWebSocket(
+        [
+            {
+                "type": "command",
+                "command_id": "cmd-browse",
+                "command": "filesystem.browse",
+                "job_id": 201,
+                "payload": {"path": "/"},
+            },
+            {
+                "type": "command",
+                "command_id": "cmd-cancel",
+                "command": "cancel",
+                "job_id": 202,
+                "payload": {"job_id": 202},
+            },
+            {
+                "type": "command",
+                "command_id": "cmd-none",
+                "command": "backup.create",
+                "job_id": None,
+                "payload": {},
+            },
+        ]
+    )
+
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.browse_filesystem",
+        lambda path, include_hidden=False: {
+            "success": True,
+            "current_path": path,
+            "parent_path": "/",
+            "items": [],
+        },
+    )
+
+    runtime = AgentSessionRuntime(
+        AgentConfig("https://borgui.example.com", "agt_123", "secret"),
+        connect=lambda *args, **kwargs: socket,
+        http_client=RecordingHttpClient(),
+    )
+    runtime.run_session(max_messages=3)
+
+    assert runtime._cancel_events == {}
+    assert runtime._running_job_ids() == []
+
+
+@pytest.mark.unit
+def test_session_loop_does_not_register_unsupported_command(patch_session_platform):
+    """A command with no registered job handler also returns early from
+    _handle_command (the unsupported_command path) without registering --
+    the dispatch predicate the session loop uses must agree, or this id would
+    leak into _cancel_events with nothing to ever remove it."""
+    from agent.borg_ui_agent.session import AgentSessionRuntime
+
+    socket = FakeWebSocket(
+        [
+            {
+                "type": "command",
+                "command_id": "cmd-unknown",
+                "command": "totally.unknown",
+                "job_id": 303,
+                "payload": {},
+            },
+        ]
+    )
+    runtime = AgentSessionRuntime(
+        AgentConfig("https://borgui.example.com", "agt_123", "secret"),
+        connect=lambda *args, **kwargs: socket,
+        http_client=RecordingHttpClient(),
+    )
+    runtime.run_session(max_messages=1)
+
+    assert runtime._cancel_events == {}
+    assert runtime._running_job_ids() == []
+
+
+@pytest.mark.unit
+def test_session_loop_unregisters_after_job_command_completes(monkeypatch):
+    """After a normal job command dispatched through the real session loop
+    (register-before-start, not the direct _register_cancel call the other
+    hello tests use) finishes, its id must be gone from _cancel_events --
+    otherwise it would be reported by hello forever."""
+    from agent.borg_ui_agent.session import AgentSessionRuntime
+
+    def fake_handler(job, client, *, should_cancel=None):
+        return SimpleNamespace(job_id=job["id"], status="completed", message="done")
+
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.detect_platform",
+        lambda: {"hostname": "host.local", "os": "linux", "arch": "amd64"},
+    )
+    monkeypatch.setattr("agent.borg_ui_agent.session.detect_borg_binaries", lambda: [])
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.get_job_handler",
+        lambda command: fake_handler if command == "backup.create" else None,
+    )
+
+    socket = FakeWebSocket(
+        [
+            {
+                "type": "command",
+                "command_id": "cmd-done",
+                "command": "backup.create",
+                "job_id": 404,
+                "payload": {},
+            }
+        ]
+    )
+    runtime = AgentSessionRuntime(
+        AgentConfig("https://borgui.example.com", "agt_123", "secret"),
+        connect=lambda *args, **kwargs: socket,
+        http_client=RecordingHttpClient(),
+    )
+    # Clean exit (max_messages reached) joins in-flight workers before
+    # returning, so _handle_command's finally has already run by here.
+    runtime.run_session(max_messages=1)
+
+    assert runtime._cancel_events == {}
+    assert runtime._running_job_ids() == []
+
+
+@pytest.mark.unit
 def test_session_runtime_sends_app_heartbeat_while_idle(monkeypatch):
     from agent.borg_ui_agent.session import AgentSessionRuntime
 


### PR DESCRIPTION
## Description

If an agent's websocket drops in the moment between a job being created and delivered, the job is marked `claimed` with `started_at` NULL and the agent never receives it.

`_requeue_stale_agent_jobs` runs on the agent's hello and on every heartbeat, so a reconnect *should* recover exactly this case. But it only considers rows older than `STALE_AGENT_JOB_REQUEUE_AFTER`, which was 15 minutes — the same as the reaper's `AGENT_JOB_REAP_AFTER`. The job became eligible for requeue at the same moment it became eligible to be failed, and the reaper won.

This lowers the requeue window to 2 minutes so a reconnecting agent gets a chance first, and documents the constraint next to the constant: it has to stay below the reap window.

Shortening it is safe because the requeue is already guarded on two things — it skips any job the agent reports in `running_job_ids`, and any job whose own activity is newer than the cutoff. A genuinely running operation is never requeued, however long it runs.

## What it looked like in practice

My home agent runs behind a residential connection that drops fairly often, and roughly half of the hourly stats jobs on that repository were stranded this way.

Each stranded job held the repository lock for the full 15 minutes, so anything queued behind it was refused with `repositoryOperationActive`. A nightly backup and the cloud mirror both silently didn't run for two days, while the dashboard showed the repository as online and synced — the only visible symptom was the size and last-backup fields going stale.

## Related Issue

Fixes #869

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

Running this against an agent whose connection drops several times a day. Jobs that would previously have been failed by the reaper are now picked up on the next heartbeat.

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

The test asserts the *relationship* between the two windows rather than either literal value, since it is the ordering that matters — if someone later tunes either constant, the invariant is what should hold. Checked against the previous values to confirm it fails when the two are equal.

```
tests/unit/test_agent_job_requeue_window.py .                            [100%]
1 passed

tests/unit
2741 passed, 11 skipped
```

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

Two minutes is a judgement call — happy to change it if you'd rather have a different margin, or express it as a fraction of the reap window instead of an independent constant.
