### PR TITLE
fix: send an agent real rclone credentials, not the redacted ones

### DIFF
--- a/app/services/rclone_repository_service.py
+++ b/app/services/rclone_repository_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import configparser
 import os
 import shlex
 import shutil
@@ -297,8 +298,38 @@ class RcloneRepositoryService:
             raise ValueError("SSH cloud mirror mount did not return a mount point")
         return mount_point, mount_id, mount_service
 
+    def _rclone_config_section(self, remote: RcloneRemote) -> dict[str, str]:
+        """Read a remote's real values from the server's rclone.conf.
+
+        redacted_config stores secrets as "***" for display, so it cannot be
+        used to build a working config for an agent.
+        """
+        config_path = remote.config_path or str(
+            Path(settings.rclone_config_root) / "rclone.conf"
+        )
+        parser = configparser.RawConfigParser()
+        try:
+            with open(config_path, encoding="utf-8") as handle:
+                parser.read_file(handle)
+        except (OSError, configparser.Error):
+            return {}
+        if not parser.has_section(remote.name):
+            return {}
+        return dict(parser.items(remote.name))
+
     def _agent_rclone_config(self, remote: RcloneRemote) -> dict[str, str]:
-        values = dict(remote.redacted_config or {})
+        # The agent writes these into its own rclone.conf and runs rclone
+        # against it, so the values have to be the real ones. Building this
+        # from redacted_config sent "***" as token, client_id and
+        # client_secret, and rclone failed before touching the network with
+        # "invalid character '*' looking for beginning of value" -- which
+        # surfaces only as "exited with code 1".
+        values = self._rclone_config_section(remote)
+        if not values:
+            # No readable section: fall back to what is known rather than
+            # sending nothing, so a misconfigured path fails in rclone with
+            # a message about the remote instead of a missing type.
+            values = dict(remote.redacted_config or {})
         values["type"] = str(values.get("type") or remote.provider).strip()
         return {
             str(key): _stringify_config_value(value)

--- a/app/services/rclone_repository_service.py
+++ b/app/services/rclone_repository_service.py
@@ -311,7 +311,10 @@ class RcloneRepositoryService:
         try:
             with open(config_path, encoding="utf-8") as handle:
                 parser.read_file(handle)
-        except (OSError, configparser.Error):
+        # UnicodeError too: a config with non-UTF-8 bytes raises
+        # UnicodeDecodeError, which is a ValueError rather than an OSError and
+        # would otherwise escape and fail the whole stats refresh.
+        except (OSError, UnicodeError, configparser.Error):
             return {}
         if not parser.has_section(remote.name):
             return {}

--- a/tests/unit/test_agent_rclone_config.py
+++ b/tests/unit/test_agent_rclone_config.py
@@ -1,0 +1,68 @@
+import pytest
+
+from app.database.models import RcloneRemote
+from app.services.rclone_repository_service import rclone_repository_service
+
+CONFIG = """[gdrive]
+type = drive
+scope = drive
+token = {"access_token":"real-token"}
+client_id = real-client-id
+client_secret = real-client-secret
+"""
+
+
+def _remote(config_path):
+    return RcloneRemote(
+        name="gdrive",
+        provider="drive",
+        config_path=str(config_path),
+        redacted_config={
+            "type": "drive",
+            "scope": "drive",
+            "token": "***",
+            "client_id": "***",
+            "client_secret": "***",
+        },
+    )
+
+
+@pytest.mark.unit
+def test_agent_config_sends_real_credentials(tmp_path):
+    # The agent writes these into its own rclone.conf and runs rclone against
+    # it. Built from redacted_config the secrets arrive as the literal "***",
+    # and rclone dies before any network call with
+    # "invalid character '*' looking for beginning of value".
+    config_path = tmp_path / "rclone.conf"
+    config_path.write_text(CONFIG, encoding="utf-8")
+
+    values = rclone_repository_service._agent_rclone_config(_remote(config_path))
+
+    assert values["token"] == '{"access_token":"real-token"}'
+    assert values["client_id"] == "real-client-id"
+    assert values["client_secret"] == "real-client-secret"
+    assert "***" not in values.values()
+
+
+@pytest.mark.unit
+def test_agent_config_keeps_the_remote_type(tmp_path):
+    # type is what tells rclone which backend to use; without it the remote is
+    # unusable even when the credentials are right.
+    config_path = tmp_path / "rclone.conf"
+    config_path.write_text(CONFIG, encoding="utf-8")
+
+    values = rclone_repository_service._agent_rclone_config(_remote(config_path))
+
+    assert values["type"] == "drive"
+
+
+@pytest.mark.unit
+def test_agent_config_falls_back_when_the_file_is_unreadable(tmp_path):
+    # A missing or unreadable config should not send an empty section: the
+    # provider is still known, so rclone can report a useful error about the
+    # remote rather than a missing type.
+    remote = _remote(tmp_path / "does-not-exist.conf")
+
+    values = rclone_repository_service._agent_rclone_config(remote)
+
+    assert values["type"] == "drive"

--- a/tests/unit/test_agent_rclone_config.py
+++ b/tests/unit/test_agent_rclone_config.py
@@ -111,3 +111,17 @@ def test_agent_config_falls_back_when_the_file_is_malformed(tmp_path):
 
     assert values["type"] == "drive"
     assert values["token"] == "***"
+
+
+@pytest.mark.unit
+def test_agent_config_falls_back_when_the_file_is_not_utf8(tmp_path):
+    # Non-UTF-8 bytes raise UnicodeDecodeError, which is a ValueError and not
+    # an OSError, so it escaped the handler and propagated out of the stats
+    # refresh instead of falling back.
+    config_path = tmp_path / "rclone.conf"
+    config_path.write_bytes(b"[gdrive]\ntype = drive\ntoken = \xff\xfe binary\n")
+
+    values = rclone_repository_service._agent_rclone_config(_remote(config_path))
+
+    assert values["type"] == "drive"
+    assert values["token"] == "***"

--- a/tests/unit/test_agent_rclone_config.py
+++ b/tests/unit/test_agent_rclone_config.py
@@ -66,3 +66,10 @@ def test_agent_config_falls_back_when_the_file_is_unreadable(tmp_path):
     values = rclone_repository_service._agent_rclone_config(remote)
 
     assert values["type"] == "drive"
+    # The whole stored section is carried over, not just the type: an
+    # implementation that dropped redacted_config and set only the provider
+    # would still produce a "type" and would pass on that assertion alone.
+    assert values["scope"] == "drive"
+    assert values["token"] == "***"
+    assert values["client_id"] == "***"
+    assert values["client_secret"] == "***"

--- a/tests/unit/test_agent_rclone_config.py
+++ b/tests/unit/test_agent_rclone_config.py
@@ -73,3 +73,41 @@ def test_agent_config_falls_back_when_the_file_is_unreadable(tmp_path):
     assert values["token"] == "***"
     assert values["client_id"] == "***"
     assert values["client_secret"] == "***"
+
+
+@pytest.mark.unit
+def test_agent_config_falls_back_when_the_file_cannot_be_read(tmp_path, monkeypatch):
+    # The more likely failure in practice: the file exists but the process
+    # cannot read it. rclone.conf holds credentials and is normally 0600, so a
+    # server running as another user hits PermissionError rather than a
+    # missing path. It is an OSError like any other and must not escape.
+    config_path = tmp_path / "rclone.conf"
+    config_path.write_text(CONFIG, encoding="utf-8")
+
+    real_open = open
+
+    def _deny(path, *args, **kwargs):
+        if str(path) == str(config_path):
+            raise PermissionError(13, "Permission denied")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", _deny)
+
+    values = rclone_repository_service._agent_rclone_config(_remote(config_path))
+
+    assert values["type"] == "drive"
+    assert values["scope"] == "drive"
+    assert values["token"] == "***"
+
+
+@pytest.mark.unit
+def test_agent_config_falls_back_when_the_file_is_malformed(tmp_path):
+    # A truncated or hand-edited rclone.conf raises configparser.Error rather
+    # than OSError, and must fall back the same way instead of propagating.
+    config_path = tmp_path / "rclone.conf"
+    config_path.write_text("this is not an ini file\n= broken\n", encoding="utf-8")
+
+    values = rclone_repository_service._agent_rclone_config(_remote(config_path))
+
+    assert values["type"] == "drive"
+    assert values["token"] == "***"


### PR DESCRIPTION
## Description

The rclone config sent to an agent for `repository.rclone_sync` is built from `remote.redacted_config`, so `token`, `client_id` and `client_secret` arrive as the literal string `***`. The agent writes them into its own rclone.conf and rclone fails before touching the network:

```
invalid character '*' looking for beginning of value
```

which surfaces only as `repository.rclone_sync exited with code 1`.

`redacted_config` exists for display, and it is the only config the `RcloneRemote` row carries — the real values live in the server's rclone.conf. This reads the remote's section from there instead.

If that file is missing or unreadable, the previous behaviour is kept as a fallback, so a misconfigured path still fails inside rclone with a message about the remote rather than sending a section with no `type` at all.

Worth noting this only shows up after #867 is fixed, since without that mapping the mirror never gets far enough to fail this way.

## Related Issue

Fixes #868

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

Running this against three agent-executed repositories mirroring to Google Drive. My own workaround until now was giving each agent its own rclone credentials through the environment, which is what made the cause visible — `RCLONE_CONFIG_<REMOTE>_<KEY>` overrides the config file, so the mirrors worked while the config the server sent was still unusable.

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

The tests cover real values reaching the agent, `type` being preserved, and the unreadable-file fallback. Checked against the previous implementation to confirm the first one fails when the config is built from `redacted_config`.

```
tests/unit/test_agent_rclone_config.py ...                               [100%]
3 passed

tests/unit
2743 passed, 11 skipped
```

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

One thing I'd like your view on: this sends real credentials to the agent, which is what makes the mirror work, but you may prefer a different shape — obscured values, a scoped token per agent, or having the agent hold its own remote config and the server send only the remote name. Happy to rework it if one of those fits the direction better.
