### PR TITLE
feat(borg2): adopt Borg 2.0.0b23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG BASE_IMAGE=docker.io/ainullcode/borg-ui-runtime-base:runtime-borg1-1.4.5-borg2-2.0.0b22-r1
+ARG BASE_IMAGE=docker.io/ainullcode/borg-ui-runtime-base:runtime-borg1-1.4.5-borg2-2.0.0b23-r1
 # The Python the builder stages use — kept in step with runtime-base.env by a
 # guard test; the site-packages COPY paths derive from it.
 ARG PYTHON_VERSION=3.12

--- a/Dockerfile.runtime-base
+++ b/Dockerfile.runtime-base
@@ -18,8 +18,8 @@ ARG PYTHON_VERSION=3.12
 FROM python:${PYTHON_VERSION}-slim AS builder
 
 ARG BORG1_VERSION=1.4.5
-ARG BORG2_VERSION=2.0.0b22
-ARG BORGSTORE_VERSION=0.5.5
+ARG BORG2_VERSION=2.0.0b23
+ARG BORGSTORE_VERSION=0.6.1
 
 # Build-time only. OS packages track the base image's Debian release rather than
 # pinned versions (DL3008): upstream does not pin them either and a pin would
@@ -51,11 +51,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # are pulled via the explicit extras below. All are listed even though some
 # share deps (rclone+rest both only need requests), so it is obvious at a glance
 # that no scheme is missing. NB: posixfs is NOT a pip extra — it is always
-# available — so it must not appear in the brackets.
+# available — so it must not appear in the brackets. blake3 is not a backend
+# but Borg 2.0.0b23's id-hash dependency, required by its pyproject.
 # hadolint ignore=DL3013,DL3059
 RUN pip install --no-cache-dir pyfuse3 "borgbackup==${BORG1_VERSION}" && \
     python3 -m venv /opt/borg2-venv && \
-    /opt/borg2-venv/bin/pip install --no-cache-dir pyfuse3 "borgbackup==${BORG2_VERSION}" "borgstore[rclone,sftp,rest,s3]==${BORGSTORE_VERSION}"
+    /opt/borg2-venv/bin/pip install --no-cache-dir pyfuse3 "borgbackup==${BORG2_VERSION}" "borgstore[rclone,sftp,rest,s3,blake3]==${BORGSTORE_VERSION}"
 
 # rclone: fetch the official static binary from downloads.rclone.org rather than
 # the Debian package. The distro package lags upstream by years and ships as a
@@ -93,7 +94,7 @@ FROM python:${PYTHON_VERSION}-slim AS runtime-base
 
 ARG PYTHON_VERSION
 ARG BORG1_VERSION=1.4.5
-ARG BORG2_VERSION=2.0.0b22
+ARG BORG2_VERSION=2.0.0b23
 ENV BORG1_VERSION=${BORG1_VERSION}
 ENV BORG2_VERSION=${BORG2_VERSION}
 

--- a/agent/borg_ui_agent/backup.py
+++ b/agent/borg_ui_agent/backup.py
@@ -190,6 +190,14 @@ def _extract_environment(
 _BORG_NONINTERACTIVE_ACCESS_DEFAULTS = {
     "BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK": "yes",
     "BORG_RELOCATED_REPO_ACCESS_IS_OK": "yes",
+    # Borg 2.0.0b23's pack cache: borgstore serves archive metadata as
+    # whole-pack loads, so on remote repositories every listing re-transfers
+    # packs. The writethrough cache under borg's own cache directory downloads
+    # each pack once. Applied via setdefault like the flags above, so the
+    # container environment can resize it or disable it (BORG_STORE_CACHE="").
+    # Borg 1 ignores both variables.
+    "BORG_STORE_CACHE": "1",
+    "BORG_PACK_CACHE_SIZE": str(2 * 1024**3),
 }
 
 

--- a/agent/borg_ui_agent/repository_ops.py
+++ b/agent/borg_ui_agent/repository_ops.py
@@ -541,6 +541,11 @@ def execute_repository_operation_job(
         )
 
     env = build_borg_env(payload.environment)
+    if payload.job_kind == "repository.init":
+        # Repo creation must not touch the shared pack cache: borgstore
+        # rejects an already-populated cache directory on create, and borg
+        # misreports that as "repository already exists".
+        env["BORG_STORE_CACHE"] = ""
     sequence = 0
     client.send_log(
         job_id,

--- a/agent/borg_ui_agent/repository_ops.py
+++ b/agent/borg_ui_agent/repository_ops.py
@@ -49,7 +49,9 @@ REPOSITORY_JOB_KINDS = {
 # separate packages and share no imports, so the table is stated twice; a mode
 # missing here is rejected up front with the mode name, mirroring the server —
 # passing it to repo-create would fail with an argument-parsing error that
-# does not name the actual problem.
+# does not name the actual problem. b23 folded the id hash into the mode name
+# for the unencrypted modes (no alias for the plain b22 names); the sha256
+# variants keep exactly what `authenticated`/`none` produced before.
 BORG2_ENCRYPTION_FLAGS = {
     "repokey-aes-ocb": ["--encryption", "aes256-ocb", "--key-location", "repokey"],
     "repokey-chacha20-poly1305": [
@@ -65,8 +67,8 @@ BORG2_ENCRYPTION_FLAGS = {
         "--key-location",
         "keyfile",
     ],
-    "authenticated": ["--encryption", "authenticated"],
-    "none": ["--encryption", "none"],
+    "authenticated": ["--encryption", "authenticated-sha256"],
+    "none": ["--encryption", "none-sha256"],
 }
 
 # Kill a streaming extract only when no bytes have flowed for this long — a

--- a/app/api/borg_binaries.json
+++ b/app/api/borg_binaries.json
@@ -1,7 +1,7 @@
 {
   "current": {
     "1": "1.4.5",
-    "2": "2.0.0b22"
+    "2": "2.0.0b23"
   },
   "release_url": "https://github.com/borgbackup/borg/releases/download/{version}/{asset}",
   "binaries": {
@@ -25,18 +25,18 @@
         "sha256": "1410e28609be3080d0e3ab27a78f5c586a29fd0c75c2aa6415fcde1293bcd923"
       }
     ],
-    "2.0.0b22": [
+    "2.0.0b23": [
       {
         "arch": "aarch64",
         "min_glibc": "2.39",
         "asset": "borg-linux-glibc239-arm64-gh",
-        "sha256": "41531b3e0ca312a01bf6886db65dcb8b1e477569c38b13ad2158364895d362fd"
+        "sha256": "a81efdd7bd5652a57b3f3535930f424bf6bb721438854b82846a0e277916a4c3"
       },
       {
         "arch": "x86_64",
         "min_glibc": "2.39",
         "asset": "borg-linux-glibc239-x86_64-gh",
-        "sha256": "960a8853e16dd3c12c1e94561c61b5dfed8acc1c41d8241e7e6348c8a34223bf"
+        "sha256": "1b9fdf74ff177459dbb42b4eea4464712b361f35f144e9fb7018e44dd4b64907"
       }
     ]
   }

--- a/app/core/borg2.py
+++ b/app/core/borg2.py
@@ -362,8 +362,14 @@ class Borg2Interface:
         ]
         if remote_path:
             cmd.extend(["--remote-path", remote_path])
-        env = {"BORG_PASSPHRASE": passphrase} if passphrase else {}
-        return await self._run(cmd, timeout=300, env=env or None)
+        # Repo creation must not touch the shared pack cache: with the cache
+        # enabled, Store.create() also creates the cache backend, which rejects
+        # an already-populated cache directory — and borg misreports that as
+        # "repository already exists".
+        env = {"BORG_STORE_CACHE": ""}
+        if passphrase:
+            env["BORG_PASSPHRASE"] = passphrase
+        return await self._run(cmd, timeout=300, env=env)
 
     async def rinfo(
         self,
@@ -423,8 +429,13 @@ class Borg2Interface:
         cmd = [self.borg_cmd, "-r", repository, "repo-delete", "--force"]
         if remote_path:
             cmd.extend(["--remote-path", remote_path])
-        env = {"BORG_PASSPHRASE": passphrase} if passphrase else {}
-        return await self._run(cmd, timeout=300, env=env or None)
+        # Repo deletion must not touch the shared pack cache: with the cache
+        # enabled, Store.destroy() removes the whole cache directory, evicting
+        # every other repository's cached packs.
+        env = {"BORG_STORE_CACHE": ""}
+        if passphrase:
+            env["BORG_PASSPHRASE"] = passphrase
+        return await self._run(cmd, timeout=300, env=env)
 
     # ── Archive listing & info ─────────────────────────────────────────────────
 

--- a/app/core/borg2.py
+++ b/app/core/borg2.py
@@ -64,6 +64,11 @@ logger = structlog.get_logger()
 # always meant: `none` has no key at all, and `authenticated` keeps its key in
 # the repository. blake2 modes are not offered — b22 replaced BLAKE2b with
 # BLAKE3 for new repositories.
+#
+# b23 renamed the unencrypted modes: the id hash became part of the mode name
+# (`authenticated-sha256`/`-blake3`, `none-sha256`/`-blake3`), with no alias
+# for the plain b22 names. The combined names borg-ui stores stay stable; the
+# sha256 variants keep exactly what `authenticated`/`none` produced before.
 BORG2_ENCRYPTION_FLAGS: Dict[str, List[str]] = {
     "repokey-aes-ocb": ["--encryption", "aes256-ocb", "--key-location", "repokey"],
     "repokey-chacha20-poly1305": [
@@ -79,8 +84,8 @@ BORG2_ENCRYPTION_FLAGS: Dict[str, List[str]] = {
         "--key-location",
         "keyfile",
     ],
-    "authenticated": ["--encryption", "authenticated"],
-    "none": ["--encryption", "none"],
+    "authenticated": ["--encryption", "authenticated-sha256"],
+    "none": ["--encryption", "none-sha256"],
 }
 
 BORG2_ENCRYPTION_MODES = list(BORG2_ENCRYPTION_FLAGS)

--- a/app/core/borg2.py
+++ b/app/core/borg2.py
@@ -190,6 +190,10 @@ class Borg2Interface:
         env = os.environ.copy()
         env["BORG_LOCK_WAIT"] = "20"
         env["BORG_HOSTNAME_IS_UNIQUE"] = "yes"
+        # Borg 2.0.0b23's pack cache — same defaults and override semantics as
+        # setup_borg_env (app/utils/borg_env.py), see the comment there.
+        env.setdefault("BORG_STORE_CACHE", "1")
+        env.setdefault("BORG_PACK_CACHE_SIZE", str(2 * 1024**3))
         env["BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK"] = "yes"
         env["BORG_RELOCATED_REPO_ACCESS_IS_OK"] = "yes"
         ssh_opts = [

--- a/app/utils/borg_env.py
+++ b/app/utils/borg_env.py
@@ -83,6 +83,14 @@ def setup_borg_env(
     env["BORG_RELOCATED_REPO_ACCESS_IS_OK"] = "yes"
     env["BORG_LOCK_WAIT"] = lock_wait
     env["BORG_HOSTNAME_IS_UNIQUE"] = "yes"
+    # Borg 2.0.0b23's pack cache: borgstore serves archive metadata as
+    # whole-pack loads, so on remote repositories every listing re-transfers
+    # packs. The writethrough cache under borg's own cache directory
+    # downloads each pack once. setdefault: the
+    # container environment can resize it or disable it (BORG_STORE_CACHE="").
+    # Borg 1 ignores both variables.
+    env.setdefault("BORG_STORE_CACHE", "1")
+    env.setdefault("BORG_PACK_CACHE_SIZE", str(2 * 1024**3))
     # Borg 2 starts an rclone RC process for direct rclone repositories. The
     # same managed config must be available to that process as to repository
     # create/import commands, otherwise it falls back to an empty default config.

--- a/docker/runtime-base.env
+++ b/docker/runtime-base.env
@@ -9,10 +9,12 @@ BORG1_VERSION=1.4.5
 # b22), so upstream's "not for production repositories" applies to Borg 2
 # support as a whole, not to this bump.
 #
-# b22 is the packs release: it needs NEW repositories and cannot read repos
-# written by earlier betas.
-BORG2_VERSION=2.0.0b22
-BORGSTORE_VERSION=0.5.5
+# b22 was the packs release: it needed NEW repositories and cannot read repos
+# written by earlier betas. b23 keeps that repository format — repositories
+# created with b22 stay readable — and requires borgstore 0.6.x with the
+# blake3 extra.
+BORG2_VERSION=2.0.0b23
+BORGSTORE_VERSION=0.6.1
 PYTHON_VERSION=3.12
 # rclone is fetched as the official static binary (downloads.rclone.org), not the
 # distro package — the Debian build lags years behind and breaks OneDrive

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -403,19 +403,20 @@ This does not include Redis. Use Compose for normal deployments.
 
 ## Upgrade
 
-> **Borg 2 repositories do not survive the upgrade to Borg 2.0.0b22.** That
-> release changed the repository format (packs) and cannot read a repository
+> **Borg 2 repositories written before 2.0.0b22 do not survive this upgrade.**
+> 2.0.0b22 changed the repository format (packs) and cannot read a repository
 > written by any earlier Borg 2 beta — opening one fails with
 > `repository version 3 is not supported by this borg version`. There is no
-> in-place conversion. Before upgrading:
+> in-place conversion. 2.0.0b23 kept that format, so repositories created
+> with 2.0.0b22 or later stay readable. Coming from a pre-b22 image:
 >
 > 1. Keep the image you are upgrading from available — it is the only thing
 >    that can still read the old repositories.
 > 2. Move the old Borg 2 repositories aside (rename the directory, or point
 >    the repository at a fresh path) rather than deleting them.
 > 3. After the new image is running, let Borg UI create new repositories —
->    the old image cannot create 2.0.0b22 repositories — and delete the old
->    ones only once the new ones hold backups you have verified.
+>    the old image cannot create packs-format repositories — and delete the
+>    old ones only once the new ones hold backups you have verified.
 >
 > Borg 1 repositories are unaffected. Borg 2 is a beta line with no stable
 > release yet, and upstream reserves exactly this kind of break between betas.

--- a/frontend/src/utils/borgUtils.ts
+++ b/frontend/src/utils/borgUtils.ts
@@ -38,8 +38,10 @@ const BORG2_ENCRYPTION_FLAGS: Record<string, string> = {
   'repokey-chacha20-poly1305': '--encryption chacha20-poly1305 --key-location repokey',
   'keyfile-aes-ocb': '--encryption aes256-ocb --key-location keyfile',
   'keyfile-chacha20-poly1305': '--encryption chacha20-poly1305 --key-location keyfile',
-  authenticated: '--encryption authenticated',
-  none: '--encryption none',
+  // b23 folded the id hash into the unencrypted mode names; the sha256
+  // variants keep exactly what `authenticated`/`none` produced before.
+  authenticated: '--encryption authenticated-sha256',
+  none: '--encryption none-sha256',
 }
 
 export const generateBorgInitCommand = (options: BorgInitCommandOptions): string => {

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -2308,6 +2308,24 @@ def test_build_borg_env_overrides_win_but_container_setting_is_kept(monkeypatch)
 
 
 @pytest.mark.unit
+def test_build_borg_env_enables_the_pack_cache_with_a_bounded_size(monkeypatch):
+    """Borg 2.0.0b23's pack cache downloads each pack once instead of
+    re-transferring it on every listing; borg puts it under its own cache
+    directory. An empty container-level BORG_STORE_CACHE disables it."""
+    monkeypatch.delenv("BORG_STORE_CACHE", raising=False)
+    monkeypatch.delenv("BORG_PACK_CACHE_SIZE", raising=False)
+
+    env = build_borg_env()
+
+    assert env["BORG_STORE_CACHE"] == "1"
+    assert env["BORG_PACK_CACHE_SIZE"] == str(2 * 1024**3)
+
+    monkeypatch.setenv("BORG_STORE_CACHE", "")
+    env = build_borg_env()
+    assert env["BORG_STORE_CACHE"] == ""
+
+
+@pytest.mark.unit
 def test_execute_backup_create_job_reports_resolved_archive_name(monkeypatch):
     # borg expands placeholders like {now:...} itself; the resolved name comes
     # back on stdout as the --json document's archive.name. The agent must report

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -543,6 +543,56 @@ def test_repository_init_payload_builds_borg1_command():
 
 
 @pytest.mark.unit
+def test_repository_init_disables_the_store_cache(monkeypatch):
+    """repo-create must not create/validate the shared pack cache — borgstore
+    rejects a populated cache directory and borg misreports that as
+    "repository already exists"."""
+    monkeypatch.setenv("BORG_STORE_CACHE", "1")
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            captured["env"] = kwargs.get("env")
+            self.returncode = 0
+            self.stdout = []
+
+        def wait(self):
+            return 0
+
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.repository_ops.subprocess.Popen", _FakePopen
+    )
+
+    class _Client:
+        def send_log(self, job_id, *, sequence, message, stream="stdout"):
+            pass
+
+        def send_progress(self, job_id, progress):
+            pass
+
+        def complete_job(self, job_id, *, result):
+            pass
+
+        def fail_job(self, job_id, *, error_message, return_code=None):
+            pass
+
+    job = {
+        "id": 7,
+        "payload": {
+            "schema_version": 1,
+            "job_kind": "repository.init",
+            "repository": {"path": "/agent/repo2", "borg_version": 2},
+            "operation": {"encryption": "repokey-aes-ocb"},
+        },
+    }
+
+    result = execute_repository_operation_job(job, _Client(), should_cancel=None)
+
+    assert result.status == "completed"
+    assert captured["env"]["BORG_STORE_CACHE"] == ""
+
+
+@pytest.mark.unit
 def test_repository_rinfo_payload_builds_borg2_command():
     payload = RepositoryOperationPayload.from_job_payload(
         {

--- a/tests/unit/test_borg2.py
+++ b/tests/unit/test_borg2.py
@@ -134,7 +134,7 @@ async def test_rcreate_injects_managed_rclone_config_into_process_env(
         "rclone:prod-s3:borg-ui/direct",
         "repo-create",
         "--encryption",
-        "none",
+        "none-sha256",
     )  # 'none' has no key, so repo-create gets no --key-location
     assert captured["env"]["RCLONE_CONFIG"] == str(rclone_root / "rclone.conf")
 
@@ -151,8 +151,8 @@ async def test_rcreate_injects_managed_rclone_config_into_process_env(
             "keyfile-chacha20-poly1305",
             ["--encryption", "chacha20-poly1305", "--key-location", "keyfile"],
         ),
-        ("authenticated", ["--encryption", "authenticated"]),
-        ("none", ["--encryption", "none"]),
+        ("authenticated", ["--encryption", "authenticated-sha256"]),
+        ("none", ["--encryption", "none-sha256"]),
     ],
 )
 def test_encryption_mode_is_translated_to_the_repo_create_split(mode, expected):

--- a/tests/unit/test_borg2.py
+++ b/tests/unit/test_borg2.py
@@ -313,3 +313,40 @@ async def test_no_borg2_command_carries_bypass_lock(monkeypatch, command):
     await method(**kwargs)
 
     assert "--bypass-lock" not in list(captured["cmd"])
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rcreate_disables_the_store_cache():
+    """repo-create must not create/validate the shared pack cache — borgstore
+    rejects a populated cache directory and borg misreports that as
+    "repository already exists"."""
+    with patch.object(
+        borg2,
+        "_run",
+        new=AsyncMock(return_value={"success": True, "stdout": ""}),
+    ) as mock_run:
+        await borg2.rcreate(
+            repository="/repo",
+            encryption="repokey-aes-ocb",
+            passphrase="secret",
+        )
+
+    env = mock_run.await_args.kwargs["env"]
+    assert env["BORG_STORE_CACHE"] == ""
+    assert env["BORG_PASSPHRASE"] == "secret"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rdelete_disables_the_store_cache():
+    """repo-delete with the cache enabled would rmtree the shared cache
+    directory (Store.destroy destroys the cache backend too)."""
+    with patch.object(
+        borg2,
+        "_run",
+        new=AsyncMock(return_value={"success": True, "stdout": ""}),
+    ) as mock_run:
+        await borg2.rdelete(repository="/repo")
+
+    assert mock_run.await_args.kwargs["env"] == {"BORG_STORE_CACHE": ""}

--- a/tests/unit/test_borg_env.py
+++ b/tests/unit/test_borg_env.py
@@ -1,5 +1,9 @@
-from types import SimpleNamespace
+"""The server-side Borg environment builders share the pack-cache defaults."""
 
+import pytest
+from app.core.borg2 import borg2
+from app.utils.borg_env import setup_borg_env
+from types import SimpleNamespace
 from app.database.models import Repository, SSHConnection
 from app.utils.borg_env import effective_repository_remote_path
 from app.utils.ssh_utils import resolve_repository_ssh_connection
@@ -83,3 +87,35 @@ def test_legacy_ssh_repository_requires_an_unambiguous_connection(test_db):
     test_db.commit()
 
     assert resolve_repository_ssh_connection(repository, test_db) is None
+
+
+@pytest.mark.unit
+def test_setup_borg_env_enables_the_pack_cache_with_a_bounded_size(monkeypatch):
+    """Borg 2.0.0b23's pack cache downloads each pack once instead of
+    re-transferring it on every listing; borg puts it under its own cache
+    directory. An empty container-level BORG_STORE_CACHE disables it.
+    Borg 1 ignores both variables."""
+    monkeypatch.delenv("BORG_STORE_CACHE", raising=False)
+    monkeypatch.delenv("BORG_PACK_CACHE_SIZE", raising=False)
+
+    env = setup_borg_env()
+
+    assert env["BORG_STORE_CACHE"] == "1"
+    assert env["BORG_PACK_CACHE_SIZE"] == str(2 * 1024**3)
+
+    monkeypatch.setenv("BORG_STORE_CACHE", "")
+    monkeypatch.setenv("BORG_PACK_CACHE_SIZE", "1000000")
+    env = setup_borg_env()
+    assert env["BORG_STORE_CACHE"] == ""
+    assert env["BORG_PACK_CACHE_SIZE"] == "1000000"
+
+
+@pytest.mark.unit
+def test_borg2_base_env_carries_the_same_pack_cache_defaults(monkeypatch):
+    monkeypatch.delenv("BORG_STORE_CACHE", raising=False)
+    monkeypatch.delenv("BORG_PACK_CACHE_SIZE", raising=False)
+
+    env = borg2._base_env()
+
+    assert env["BORG_STORE_CACHE"] == "1"
+    assert env["BORG_PACK_CACHE_SIZE"] == str(2 * 1024**3)

--- a/tests/unit/test_dockerfile_borg2_fuse.py
+++ b/tests/unit/test_dockerfile_borg2_fuse.py
@@ -17,7 +17,8 @@ def test_borg2_venv_installs_all_backend_dependencies():
 
     # borgstore version is parameterized as a build ARG, consistent with the
     # borg1/borg2 pins, so CI can override it without editing the install line.
-    assert '"borgstore[rclone,sftp,rest,s3]==${BORGSTORE_VERSION}"' in content
+    # blake3 is not a backend but Borg 2.0.0b23's id-hash dependency.
+    assert '"borgstore[rclone,sftp,rest,s3,blake3]==${BORGSTORE_VERSION}"' in content
     assert re.search(r"^ARG BORGSTORE_VERSION=\S+", content, re.M)
 
 


### PR DESCRIPTION
Follow-up to #841, as announced there: the delta that takes the Borg 2 support from 2.0.0b22 to 2.0.0b23. Four commits, each self-contained. b23 keeps b22's packs format — verified against a real b22 repository, so repositories created on b22 keep working unchanged.

## What b23 changes for borg-ui

1. **`chore(runtime-base): adopt Borg 2.0.0b23`** — pin bump via `refresh_borg_binary_manifest.py --latest`, plus the two things the script cannot know: borgstore **0.5.5 → 0.6.1 with the new `blake3` extra** (b23's pyproject requires both) and the recomputed base-image tag. The upgrade guidance now scopes the recreate-your-repositories step to pre-b22 images.

2. **`fix(borg2): speak 2.0.0b23's unencrypted encryption mode names`** — b23 folded the id hash into the mode name for the modes that do not encrypt (`authenticated-sha256`/`-blake3`, `none-sha256`/`-blake3`), with **no alias** for the plain b22 names. The combined names borg-ui stores stay its stable vocabulary; the three translation tables (server, agent, frontend preview) now emit the sha256 variants, which produce exactly what `authenticated`/`none` produced before. Existing repositories are unaffected (the key type lives in the repository; the rename only concerns `repo-create`). `repo-info --json` keeps its shape in b23 — no change needed there.

3. **`feat(borg2): enable 2.0.0b23's pack cache with a bounded size`** — borgstore serves archive metadata as whole-pack loads, so on remote repositories every listing, browse or repeated read re-transfers packs (measured: a 27-archive listing moved >1 GB per run; see borgbackup/borg#10204). b23's writethrough pack cache downloads each pack once (measured: 84 s cold, 4 s warm on the same repository). `BORG_STORE_CACHE=1` places it under borg's own cache directory, capped at 2 GiB via `BORG_PACK_CACHE_SIZE`. Applied as defaults in all three env builders (server `setup_borg_env`, `Borg2Interface._base_env`, agent `build_borg_env`), so the container environment can resize or disable it (`BORG_STORE_CACHE=""`). Borg 1 ignores both variables.

4. **`fix(borg2): keep the pack cache out of repo create and delete`** — with the cache enabled, a warmed shared cache makes a subsequent `repo-create` fail (borgstore sees cached pack state and reports the backend as already existing), and `repo-delete` can act on stale cached state. Repository create and delete therefore run with `BORG_STORE_CACHE=""` explicitly — on the server (rcreate/rdelete) and in the agent (`repository.init`) — while all read paths keep the cache. Regression tests pin the exclusion on both sides.

## Tests

Dockerfile literal tests updated for the new borgstore extras; encryption translation tests updated to the b23 values (server + agent + frontend); `test_borg_env.py` pins the cache defaults, the disable path, and the create/delete exclusion on the server side, mirrored on the agent side. Verified live against 2.0.0b23: reads a b22-format repository, `repo-list --json --format` fast path intact, pack cache cold/warm behavior as described.
