### PR TITLE
fix: run machine-parsed borg invocations under TZ=UTC

### DIFF
--- a/agent/borg_ui_agent/borg.py
+++ b/agent/borg_ui_agent/borg.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import platform
 import re
 import shutil
@@ -8,7 +7,6 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Optional
-from zoneinfo import ZoneInfo
 
 
 @dataclass(frozen=True)
@@ -27,44 +25,16 @@ class BorgBinary:
         }
 
 
-def detect_timezone() -> Optional[str]:
-    """The machine's IANA zone name, best effort.
-
-    Borg writes archive timestamps in this machine's local time with no
-    offset; reporting the zone lets the server interpret them correctly.
-    Only a name zoneinfo can resolve is reported - DST needs the zone, a
-    bare offset would misplace archives from the other half of the year.
-    """
-    candidates = [os.environ.get("TZ")]
-    try:
-        candidates.append(Path("/etc/timezone").read_text(encoding="utf-8").strip())
-    except OSError:
-        pass
-    try:
-        # /etc/localtime -> .../zoneinfo/<Area/City> on most distributions.
-        target = Path("/etc/localtime").resolve()
-        parts = target.parts
-        if "zoneinfo" in parts:
-            candidates.append("/".join(parts[parts.index("zoneinfo") + 1 :]))
-    except OSError:
-        pass
-    for name in candidates:
-        if not name:
-            continue
-        try:
-            ZoneInfo(name)
-        except Exception:
-            continue
-        return name
-    return None
-
-
 def detect_platform() -> dict:
     return {
         "hostname": platform.node(),
         "os": platform.system().lower() or "unknown",
         "arch": platform.machine() or "unknown",
-        "timezone": detect_timezone(),
+        # The zone borg renders machine-parsed output in, which this agent
+        # pins to TZ=UTC (repository_ops.MACHINE_PARSED_JOB_KINDS). The server
+        # interprets naive listing timestamps with this value; agents that
+        # predate the pin report their detected machine zone instead.
+        "timezone": "UTC",
     }
 
 

--- a/agent/borg_ui_agent/repository_ops.py
+++ b/agent/borg_ui_agent/repository_ops.py
@@ -43,6 +43,17 @@ REPOSITORY_JOB_KINDS = {
     "repository.disk_usage",
 }
 
+# Kinds whose stdout the server parses timestamps out of. These run under
+# TZ=UTC so borg1's naive rendering is UTC wall clock; borg2 renders an
+# explicit offset either way. Contents listings (browse) stay in the machine
+# zone - their mtimes are relayed for display, not interpreted.
+MACHINE_PARSED_JOB_KINDS = {
+    "repository.info",
+    "repository.rinfo",
+    "repository.archive_info",
+    "repository.list_archives",
+}
+
 # Borg 2.0.0b22 split repo-create's single --encryption value into the cipher,
 # where the key is stored, and the id hash. The server sends the combined mode
 # name it stores, so the agent translates it the same way the server does for
@@ -549,6 +560,11 @@ def execute_repository_operation_job(
         )
 
     env = build_borg_env(payload.environment)
+    if payload.job_kind in MACHINE_PARSED_JOB_KINDS:
+        # The server parses timestamps out of these outputs; pin the render
+        # zone so they come out UTC. Applied after the server-sent overrides:
+        # the reported machine timezone is "UTC" on the same contract.
+        env["TZ"] = "UTC"
     if payload.job_kind == "repository.init":
         # Repo creation must not touch the shared pack cache: borgstore
         # rejects an already-populated cache directory on create, and borg

--- a/app/api/archives.py
+++ b/app/api/archives.py
@@ -43,7 +43,7 @@ from app.utils.borg_env import (
 from app.utils.ssh_utils import (
     resolve_repo_ssh_key_file,  # noqa: F401
 )  # Backward-compatible patch target for tests
-from app.utils.datetime_utils import serialize_datetime
+from app.utils.datetime_utils import serialize_borg_archive_time, serialize_datetime
 
 logger = structlog.get_logger()
 router = APIRouter()
@@ -300,8 +300,14 @@ async def get_archive_info(
             enhanced_info = {
                 "name": archive_info.get("name"),
                 "id": archive_info.get("id"),
-                "start": archive_info.get("start"),
-                "end": archive_info.get("end"),
+                # info_archive runs under TZ=UTC; re-render with an explicit
+                # offset so the frontend does not read the value as local time.
+                "start": serialize_borg_archive_time(
+                    archive_info.get("start"), timezone_name="UTC"
+                ),
+                "end": serialize_borg_archive_time(
+                    archive_info.get("end"), timezone_name="UTC"
+                ),
                 "duration": archive_info.get("duration"),
                 "stats": archive_info.get("stats", {}),
                 # Creation metadata

--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -103,7 +103,11 @@ from app.services.rclone_repository_service import (
     normalize_rclone_relative_path,
     rclone_repository_service,
 )
-from app.utils.datetime_utils import parse_borg_archive_time, serialize_datetime
+from app.utils.datetime_utils import (
+    parse_borg_archive_time,
+    serialize_borg_archive_time,
+    serialize_datetime,
+)
 from app.utils.schedule_time import (
     DEFAULT_SCHEDULE_TIMEZONE,
     InvalidScheduleTimezone,
@@ -482,10 +486,44 @@ def _prepare_repository_borg_env(repository: Repository, db: Session):
 
 
 def _repository_stats_borg_env(env: Dict[str, str]) -> Dict[str, str]:
-    """Return a Borg environment that renders archive timestamps in UTC."""
+    """Return a Borg environment that renders archive timestamps in UTC.
+
+    The machine-parsed wrapper invocations pin TZ=UTC themselves now, so this
+    is redundant for them - kept because the operations runner (#888) builds
+    explicit stats envs through it, and double-pinning is harmless.
+    """
     stats_env = env.copy()
     stats_env["TZ"] = "UTC"
     return stats_env
+
+
+def _normalize_archive_listing_times(
+    archives: List[Any], *, timezone_name: Optional[str]
+) -> List[Any]:
+    """Re-render borg archive timestamps with an explicit UTC offset.
+
+    Borg's own rendering may be naive, which the frontend's Date parsing
+    reads as browser-local time. ``timezone_name`` names the zone borg
+    rendered the listing in ("UTC" for TZ=UTC-forced server listings, the
+    agent-reported zone for agent listings).
+    """
+    normalized = []
+    for archive in archives:
+        if not isinstance(archive, dict):
+            normalized.append(archive)
+            continue
+        updated = dict(archive)
+        for field in ("time", "start", "end"):
+            value = updated.get(field)
+            if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+                continue
+            serialized = serialize_borg_archive_time(value, timezone_name=timezone_name)
+            # Unparseable values keep their raw form rather than dropping
+            # to None - the response never loses information.
+            if isinstance(serialized, str):
+                updated[field] = serialized
+        normalized.append(updated)
+    return normalized
 
 
 def _parse_borg_archive_time(
@@ -587,6 +625,9 @@ async def _run_repository_command(
 ):
     """Execute a repository-scoped Borg command with common SSH/env handling."""
     env, temp_key_file = _prepare_repository_borg_env(repository, db)
+    # Both callers machine-parse the JSON output; pin the render zone so borg1
+    # timestamps come out UTC instead of server-local.
+    env["TZ"] = "UTC"
     try:
         if temp_key_file and log_message:
             logger.info(log_message, **(log_fields or {}))
@@ -961,12 +1002,11 @@ async def update_repository_stats(repository: Repository, db: Session) -> bool:
             system_settings and system_settings.bypass_lock_on_list
         )
         env, temp_key_file = _prepare_repository_borg_env(repository, db)
-        stats_env = _repository_stats_borg_env(env)
 
         router = BorgRouter(repository)
 
         # Get archive list and count
-        archives = await router.list_archives(env=stats_env)
+        archives = await router.list_archives(env=env)
 
         archive_count = 0
         total_size = None
@@ -993,8 +1033,8 @@ async def update_repository_stats(repository: Repository, db: Session) -> bool:
                         continue
 
                     try:
-                        # This listing ran under stats_env (TZ=UTC), so borg
-                        # rendered these timestamps in UTC - not server-local.
+                        # Wrapper listings run under TZ=UTC, so borg rendered
+                        # these timestamps in UTC - not server-local.
                         parsed_time = _parse_borg_archive_time(
                             archive_time, timezone_name="UTC"
                         )
@@ -6071,6 +6111,9 @@ async def list_repository_archives(
             )
             archives_data = _parse_agent_json_result(result)
             archives = archives_data.get("archives", [])
+            archives = _normalize_archive_listing_times(
+                archives, timezone_name=agent_timezone_for_repository(db, repository)
+            )
             archives = enrich_archives_with_backup_metadata(archives, repository, db)
             logger.info(
                 "Agent repository archives listed successfully",
@@ -6117,6 +6160,8 @@ async def list_repository_archives(
         try:
             archives_data = json.loads(stdout.decode())
             archives = archives_data.get("archives", [])
+            # The listing ran under TZ=UTC (_run_repository_command).
+            archives = _normalize_archive_listing_times(archives, timezone_name="UTC")
             archives = enrich_archives_with_backup_metadata(archives, repository, db)
 
             logger.info(

--- a/app/core/borg.py
+++ b/app/core/borg.py
@@ -537,8 +537,11 @@ class BorgInterface:
         exec_env = env.copy() if env else {}
         if passphrase:
             exec_env["BORG_PASSPHRASE"] = passphrase
+        # This output is machine-parsed; borg renders timestamps naive in the
+        # process zone, so pin it to UTC and parse with timezone_name="UTC".
+        exec_env["TZ"] = "UTC"
 
-        return await self._execute_command(cmd, env=exec_env if exec_env else None)
+        return await self._execute_command(cmd, env=exec_env)
 
     async def info_archive(
         self,
@@ -560,8 +563,10 @@ class BorgInterface:
         exec_env = env.copy() if env else {}
         if passphrase:
             exec_env["BORG_PASSPHRASE"] = passphrase
+        # Machine-parsed output: render timestamps in UTC (see list_archives).
+        exec_env["TZ"] = "UTC"
 
-        return await self._execute_command(cmd, env=exec_env if exec_env else None)
+        return await self._execute_command(cmd, env=exec_env)
 
     async def list_archive_contents(
         self,

--- a/app/core/borg2.py
+++ b/app/core/borg2.py
@@ -392,7 +392,10 @@ class Borg2Interface:
         exec_env = env.copy() if env else {}
         if passphrase:
             exec_env["BORG_PASSPHRASE"] = passphrase
-        return await self._run(cmd, timeout=60, env=exec_env or None)
+        # Machine-parsed output: render timestamps in UTC (borg2 timestamps
+        # carry an offset either way; pinned for uniformity with borg1).
+        exec_env["TZ"] = "UTC"
+        return await self._run(cmd, timeout=60, env=exec_env)
 
     async def info_repo(
         self,
@@ -415,7 +418,9 @@ class Borg2Interface:
         exec_env = env.copy() if env else {}
         if passphrase:
             exec_env["BORG_PASSPHRASE"] = passphrase
-        return await self._run(cmd, timeout=timeout, env=exec_env or None)
+        # Machine-parsed output: render timestamps in UTC (see rinfo).
+        exec_env["TZ"] = "UTC"
+        return await self._run(cmd, timeout=timeout, env=exec_env)
 
     async def rdelete(
         self,
@@ -457,7 +462,9 @@ class Borg2Interface:
         exec_env = env.copy() if env else {}
         if passphrase:
             exec_env["BORG_PASSPHRASE"] = passphrase
-        return await self._run(cmd, env=exec_env or None)
+        # Machine-parsed output: render timestamps in UTC (see rinfo).
+        exec_env["TZ"] = "UTC"
+        return await self._run(cmd, env=exec_env)
 
     async def info_archive(
         self,
@@ -475,7 +482,9 @@ class Borg2Interface:
         exec_env = env.copy() if env else {}
         if passphrase:
             exec_env["BORG_PASSPHRASE"] = passphrase
-        return await self._run(cmd, env=exec_env or None)
+        # Machine-parsed output: render timestamps in UTC (see rinfo).
+        exec_env["TZ"] = "UTC"
+        return await self._run(cmd, env=exec_env)
 
     async def list_archive_contents(
         self,

--- a/app/services/repository_info_sync.py
+++ b/app/services/repository_info_sync.py
@@ -71,9 +71,21 @@ def sync_archive_stats_from_info(
     try:
         # Local import: repository_executor pulls in the admission machinery,
         # which must not become an import-time dependency of this module.
-        from app.services.repository_executor import agent_timezone_for_repository
+        from app.services.repository_executor import (
+            agent_timezone_for_repository,
+            is_agent_executor,
+        )
 
-        timezone_name = agent_timezone_for_repository(db, repository)
+        # Two distinct render zones, and the two None cases must stay apart:
+        # an agent listing renders in the agent's zone (reported zone, or the
+        # server-local fallback for agents that never reported one), while a
+        # server-side listing now runs under TZ=UTC - so "UTC" is its
+        # provenance, not the server's own zone.
+        timezone_name = (
+            agent_timezone_for_repository(db, repository)
+            if is_agent_executor(repository)
+            else "UTC"
+        )
         # Full entries only: apply_listing skips one it cannot map and reports
         # the archive behind it as removed, which would drop archive_count and
         # stale last_backup on a partial listing. The check is the mapper

--- a/app/services/repository_wipe_service.py
+++ b/app/services/repository_wipe_service.py
@@ -26,7 +26,7 @@ from app.database.models import (
 from app.services.log_policy import DEFAULT_LOG_SAVE_POLICY, job_has_logs_by_policy
 from app.services.repository_command_lock import run_serialized_repository_command
 from app.utils.borg_env import build_repository_borg_env, cleanup_temp_key_file
-from app.utils.datetime_utils import serialize_datetime
+from app.utils.datetime_utils import serialize_borg_archive_time, serialize_datetime
 
 logger = structlog.get_logger()
 
@@ -82,11 +82,20 @@ def normalize_archive_manifest(
         if isinstance(tags, str):
             tags = [tags]
 
+        # Select on None, not truthiness - the epoch 0 is a valid time.
+        time_value = archive.get("time")
+        if time_value is None:
+            time_value = archive.get("start")
+
         manifest.append(
             {
                 "identity": str(identity_value),
                 "name": _archive_display_name(archive),
-                "time": archive.get("time") or archive.get("start"),
+                # Wipe listings are server-side wrapper calls (TZ=UTC).
+                "time": serialize_borg_archive_time(
+                    time_value,
+                    timezone_name="UTC",
+                ),
                 "id": archive.get("id"),
                 "protected": "@PROT" in tags,
             }

--- a/app/utils/datetime_utils.py
+++ b/app/utils/datetime_utils.py
@@ -70,6 +70,23 @@ def parse_borg_archive_time(
     return dt.astimezone(timezone.utc).replace(tzinfo=None)
 
 
+def serialize_borg_archive_time(
+    value: Any, *, timezone_name: Optional[str] = None
+) -> Optional[str]:
+    """Re-render a borg-rendered timestamp as an ISO-8601 UTC string with offset.
+
+    Borg's own rendering may be naive (borg1), which JavaScript's Date parses
+    as browser-local time; serializing with an explicit offset makes the value
+    self-describing for display. ``timezone_name`` has the same semantics as in
+    parse_borg_archive_time. Unparseable strings are returned unchanged so a
+    response never loses the raw value.
+    """
+    parsed = parse_borg_archive_time(value, timezone_name=timezone_name)
+    if parsed is None:
+        return value if isinstance(value, str) else None
+    return serialize_datetime(parsed)
+
+
 def serialize_datetime(dt: Optional[datetime]) -> Optional[str]:
     """
     Serialize a datetime to ISO format with UTC timezone.

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -2326,6 +2326,53 @@ def test_repository_extract_file_job_returns_base64_content(monkeypatch):
 
 
 @pytest.mark.unit
+def test_machine_parsed_repository_operations_run_under_tz_utc(monkeypatch):
+    import os
+
+    seen_env = {}
+
+    def fake_run(cmd, *, text, capture_output, env, timeout):
+        seen_env.update(env)
+        return SimpleNamespace(returncode=0, stdout='{"archives":[]}', stderr="")
+
+    monkeypatch.setattr("agent.borg_ui_agent.repository_ops.subprocess.run", fake_run)
+    monkeypatch.setenv("TZ", "Europe/Berlin")
+    client = FakeRuntimeClient([])
+
+    result = execute_repository_operation_job(
+        {
+            "id": 92,
+            "payload": {
+                "job_kind": "repository.list_archives",
+                "repository": {"path": "/agent/repo", "borg_version": 1},
+            },
+        },
+        client,
+    )
+
+    # The server parses these timestamps with the reported zone ("UTC"), so
+    # the listing must really render in UTC - even with TZ set on the machine.
+    assert result.status == "completed"
+    assert seen_env["TZ"] == "UTC"
+
+    seen_env.clear()
+    result = execute_repository_operation_job(
+        {
+            "id": 93,
+            "payload": {
+                "job_kind": "repository.break_lock",
+                "repository": {"path": "/agent/repo", "borg_version": 1},
+            },
+        },
+        client,
+    )
+
+    # Non-parsed operations keep the machine zone untouched.
+    assert result.status == "completed"
+    assert seen_env.get("TZ") == os.environ.get("TZ")
+
+
+@pytest.mark.unit
 def test_repository_extract_file_streams_artifact_when_delivery_requested(monkeypatch):
     uploaded = {}
 
@@ -2975,21 +3022,12 @@ def test_cli_unregister_revokes_agent_and_removes_config(
     assert "Unregistered agt_cli" in capsys.readouterr().out
 
 
-class TestTimezoneDetection:
-    def test_valid_tz_env_wins(self, monkeypatch):
-        from agent.borg_ui_agent.borg import detect_platform, detect_timezone
+class TestReportedTimezone:
+    def test_reports_utc_regardless_of_machine_zone(self, monkeypatch):
+        from agent.borg_ui_agent.borg import detect_platform
 
+        # The reported zone is the one borg renders machine-parsed output in,
+        # which the agent pins to UTC - not the machine's own zone.
         monkeypatch.setenv("TZ", "Europe/Berlin")
 
-        assert detect_timezone() == "Europe/Berlin"
-        assert detect_platform()["timezone"] == "Europe/Berlin"
-
-    def test_invalid_tz_env_is_never_reported(self, monkeypatch):
-        from agent.borg_ui_agent.borg import detect_timezone
-
-        # An unresolvable name must not reach the server - it could not
-        # interpret archive times with it. The fallback may still find the
-        # machine's real zone (or nothing); both are acceptable here.
-        monkeypatch.setenv("TZ", "Not/AZone")
-
-        assert detect_timezone() != "Not/AZone"
+        assert detect_platform()["timezone"] == "UTC"

--- a/tests/unit/test_api_repositories_routes.py
+++ b/tests/unit/test_api_repositories_routes.py
@@ -354,7 +354,7 @@ class TestRepositoryHelperContracts:
         not hasattr(__import__("time"), "tzset"), reason="requires POSIX tzset"
     )
     def test_parse_borg_archive_time_utc_zone_is_host_independent(self):
-        # The server stats listing runs borg under TZ=UTC (stats_env), so its
+        # Server listings run borg under TZ=UTC (pinned in the wrappers), so
         # naive timestamps must parse as UTC no matter the server's own zone.
         import os
         import time
@@ -432,6 +432,59 @@ class TestRepositoryHelperContracts:
 
         assert parsed == datetime(2026, 4, 27, 7, 0, 6)
 
+    def test_normalize_archive_listing_times_adds_an_explicit_utc_offset(self):
+        # Naive strings read as browser-local in the frontend; the response
+        # must carry the offset. Non-dict entries pass through untouched.
+        archives = [{"name": "a", "time": "2026-07-01T03:00:00"}, "junk"]
+
+        normalized = repositories_api._normalize_archive_listing_times(
+            archives, timezone_name="UTC"
+        )
+
+        assert normalized[0]["time"] == "2026-07-01T03:00:00+00:00"
+        assert normalized[1] == "junk"
+        # The input listing is not mutated.
+        assert archives[0]["time"] == "2026-07-01T03:00:00"
+
+    def test_normalize_archive_listing_times_applies_the_agent_zone(self):
+        # An old agent renders in its machine zone and reports that zone.
+        archives = [{"name": "a", "start": "2026-07-01T03:00:00"}]
+
+        normalized = repositories_api._normalize_archive_listing_times(
+            archives, timezone_name="Europe/Berlin"
+        )
+
+        assert normalized[0]["start"] == "2026-07-01T01:00:00+00:00"
+
+    def test_normalize_archive_listing_times_serializes_numeric_epochs(self):
+        # Epoch 0 included - falsy but a valid time.
+        archives = [{"name": "a", "time": 0}, {"name": "b", "start": 1767225600}]
+
+        normalized = repositories_api._normalize_archive_listing_times(
+            archives, timezone_name="UTC"
+        )
+
+        assert normalized[0]["time"] == "1970-01-01T00:00:00+00:00"
+        assert normalized[1]["start"] == "2026-01-01T00:00:00+00:00"
+
+    def test_normalize_archive_listing_times_keeps_out_of_range_epochs_raw(self):
+        archives = [{"name": "a", "time": 1e18}]
+
+        normalized = repositories_api._normalize_archive_listing_times(
+            archives, timezone_name="UTC"
+        )
+
+        assert normalized[0]["time"] == 1e18
+
+    def test_normalize_archive_listing_times_keeps_unparseable_strings(self):
+        archives = [{"name": "a", "time": "not-a-timestamp"}]
+
+        normalized = repositories_api._normalize_archive_listing_times(
+            archives, timezone_name="UTC"
+        )
+
+        assert normalized[0]["time"] == "not-a-timestamp"
+
     @pytest.mark.asyncio
     async def test_update_repository_stats_updates_archive_count_size_and_last_backup(
         self, test_db
@@ -467,7 +520,8 @@ class TestRepositoryHelperContracts:
         assert repo.total_size == "2.00 MB"
         assert repo.last_backup == datetime(2024, 2, 1, 12, 0)
         mock_list.assert_awaited_once()
-        assert mock_list.await_args.kwargs["env"]["TZ"] == "UTC"
+        # TZ=UTC is pinned inside the wrapper methods (mocked away here);
+        # test_borg_wrapper / test_borg2 cover the pin itself.
         assert mock_list.await_args.kwargs["env"]["BORG_PASSPHRASE"] == "secret"
         assert mock_size.await_args.kwargs["use_bypass_lock"] is True
         assert mock_size.await_args.kwargs["env"]["BORG_PASSPHRASE"] == "secret"
@@ -557,7 +611,6 @@ class TestRepositoryHelperContracts:
         assert repo.archive_count == 2
         assert repo.last_backup == datetime(2024, 2, 1, 12, 0)
         mock_list.assert_awaited_once()
-        assert mock_list.await_args.kwargs["env"]["TZ"] == "UTC"
 
     @pytest.mark.asyncio
     async def test_update_repository_stats_chooses_latest_archive_by_utc_instant(

--- a/tests/unit/test_borg2.py
+++ b/tests/unit/test_borg2.py
@@ -350,3 +350,27 @@ async def test_rdelete_disables_the_store_cache():
         await borg2.rdelete(repository="/repo")
 
     assert mock_run.await_args.kwargs["env"] == {"BORG_STORE_CACHE": ""}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "method,args",
+    [
+        ("list_archives", ("/repo",)),
+        ("info_archive", ("/repo", "archive-1")),
+        ("rinfo", ("/repo",)),
+        ("info_repo", ("/repo",)),
+    ],
+)
+async def test_machine_parsed_output_renders_timestamps_in_utc(method, args):
+    with patch.object(
+        borg2,
+        "_run",
+        new=AsyncMock(return_value={"success": True, "stdout": ""}),
+    ) as mock_run:
+        await getattr(borg2, method)(*args, passphrase="pw")
+
+    env = mock_run.await_args.kwargs["env"]
+    assert env["TZ"] == "UTC"
+    assert env["BORG_PASSPHRASE"] == "pw"

--- a/tests/unit/test_borg_wrapper.py
+++ b/tests/unit/test_borg_wrapper.py
@@ -176,3 +176,48 @@ class TestBorgRepository:
             # URLs should be valid strings
             assert isinstance(url, str)
             assert len(url) > 0
+
+
+class TestMachineParsedRenderZone:
+    """Machine-parsed listings run under TZ=UTC; human-facing output does not."""
+
+    @pytest.mark.asyncio
+    async def test_list_archives_pins_tz_utc(self):
+        borg = BorgInterface()
+        with patch.object(
+            borg,
+            "_execute_command",
+            new=AsyncMock(return_value={"success": True, "stdout": ""}),
+        ) as mock_execute:
+            await borg.list_archives("/repo", passphrase="pw", env={"BORG_RSH": "ssh"})
+
+        env = mock_execute.await_args.kwargs["env"]
+        assert env["TZ"] == "UTC"
+        assert env["BORG_PASSPHRASE"] == "pw"
+        assert env["BORG_RSH"] == "ssh"
+
+    @pytest.mark.asyncio
+    async def test_info_archive_pins_tz_utc(self):
+        borg = BorgInterface()
+        with patch.object(
+            borg,
+            "_execute_command",
+            new=AsyncMock(return_value={"success": True, "stdout": ""}),
+        ) as mock_execute:
+            await borg.info_archive("/repo", "archive-1")
+
+        assert mock_execute.await_args.kwargs["env"]["TZ"] == "UTC"
+
+    @pytest.mark.asyncio
+    async def test_run_backup_keeps_the_process_zone(self):
+        # create output is parsed for the resolved archive name only; pinning
+        # TZ here would change what {now} archive names render as.
+        borg = BorgInterface()
+        with patch.object(
+            borg,
+            "_execute_command",
+            new=AsyncMock(return_value={"success": True, "stdout": ""}),
+        ) as mock_execute:
+            await borg.run_backup("/repo", ["/data"], passphrase="pw")
+
+        assert "TZ" not in (mock_execute.await_args.kwargs["env"] or {})

--- a/tests/unit/test_repository_info_sync.py
+++ b/tests/unit/test_repository_info_sync.py
@@ -306,3 +306,52 @@ def test_entries_missing_a_name_or_time_do_not_look_like_removals(db, repo):
     # a separate, pre-existing limitation of a partial listing.
     assert db.query(Archive).filter_by(repository_id=repo.id).count() == 2
     assert repo.archive_count == 2
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(
+    not hasattr(__import__("time"), "tzset"), reason="requires POSIX tzset"
+)
+def test_server_side_naive_times_are_read_as_utc_not_server_local():
+    # Server-side listings run under TZ=UTC, so a naive value is UTC wall
+    # clock - it must not be reinterpreted in the server's own zone.
+    import os
+    import time
+
+    repo = FakeRepo(borg_version=2)
+    db = FakeDb()
+    info = {"archives": [{"name": "a", "start": "2026-07-01T03:00:00"}]}
+
+    old_tz = os.environ.get("TZ")
+    os.environ["TZ"] = "Europe/Berlin"
+    time.tzset()
+    try:
+        sync_archive_stats_from_info(repo, info, db)
+    finally:
+        if old_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = old_tz
+        time.tzset()
+
+    assert repo.last_backup == datetime(2026, 7, 1, 3, 0, 0)
+
+
+@pytest.mark.unit
+def test_agent_repos_keep_the_reported_agent_zone():
+    from unittest.mock import patch
+
+    repo = FakeRepo(borg_version=2)
+    repo.executor_type = "agent"
+    repo.agent_machine_id = 7
+    db = FakeDb()
+    info = {"archives": [{"name": "a", "start": "2026-07-01T03:00:00"}]}
+
+    with patch(
+        "app.services.repository_executor.agent_timezone_for_repository",
+        return_value="Europe/Berlin",
+    ):
+        sync_archive_stats_from_info(repo, info, db)
+
+    # CEST is UTC+2 on this date.
+    assert repo.last_backup == datetime(2026, 7, 1, 1, 0, 0)

--- a/tests/unit/test_repository_wipe_service.py
+++ b/tests/unit/test_repository_wipe_service.py
@@ -278,3 +278,13 @@ async def test_execute_marks_compact_failure_after_successful_delete(db_session)
     assert preview.status == "completed_compaction_failed"
     assert preview.phase == "compact_failed"
     assert "compact failed" in (preview.error_message or "")
+
+
+def test_manifest_preserves_epoch_zero_time():
+    # 0 is falsy but a valid epoch - it must win over the start fallback.
+    manifest = normalize_archive_manifest(
+        borg_version=1,
+        archives=[{"name": "a", "time": 0, "start": "2026-05-17T00:00:00"}],
+    )
+
+    assert manifest[0]["time"] == "1970-01-01T00:00:00+00:00"


### PR DESCRIPTION
## Description

Borg renders listing timestamps in the local zone of the invoking process — naive, with no offset, on Borg 1. #871 taught the parse boundary to carry the render zone; this PR pins the render zone itself, as discussed there: every borg invocation whose timestamps the server interprets now runs under `TZ=UTC`, on the server and in the agent alike. The zone-guessing then only remains as the compatibility fallback for agents that predate the change.

**Server.** The borg1/borg2 wrapper methods whose output is machine-parsed (`list_archives`, `info_archive`, borg2 `rinfo`/`info_repo`) pin `TZ=UTC` themselves, as does the raw `repo-list`/`repo-info` command channel behind `/repositories/{id}/archives` and `/repositories/{id}/info`. The caller-level `_repository_stats_borg_env` is gone — the guarantee now sits at the invocation, not at one call site.

**Agent.** The machine-parsed job kinds (`repository.list_archives`, `repository.info`, `repository.rinfo`, `repository.archive_info`) run under `TZ=UTC`, and the agent now reports `"UTC"` as its zone — the field's contract from #871 is "the zone borg renders listings in", and that zone is now pinned. The compatibility matrix needs no version gate:

| | old server | new server |
|---|---|---|
| **old agent** | renders machine zone, reports machine zone ✓ | same ✓ (the #871 fallback) |
| **new agent** | renders UTC, reports "UTC" ✓ | same ✓ |

**Display.** Listing/info responses re-render borg1's (now naive-UTC) timestamps with an explicit `+00:00` offset before they leave the API. Without that, `new Date("2026-09-03T12:00:00")` in the frontend reads the value as browser-local wall clock — which is also why this is a user-visible fix, not just hardening: today the archives table is only correct when the browser's zone happens to match the server's.

**Deliberate boundary — what stays in the process zone:**
- `create`: its parsed output is the resolved archive name only; pinning `TZ` would change what `{now}` templates render, which is #887's discussion, not this PR's.
- Archive-contents listings (browse): file mtimes are relayed for display, not interpreted; pinning them would shift the browse view without a normalization pass to justify it.
- Remote direct execution (SSH sources): tracked separately in #872 — forcing env over SSH interacts with the sudo handling from #844.

## Related Issue

Fixes #884

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [x] ♻️ Refactoring

## Testing

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

New tests: the borg1/borg2 wrapper methods pin `TZ=UTC` (and `run_backup` does not — the #887 boundary), the agent runs machine-parsed kinds under `TZ=UTC` and leaves others in the machine zone, the agent reports `"UTC"` regardless of the machine zone, and `_normalize_archive_listing_times` adds the offset, applies an old agent's reported zone, and passes unparseable values through unchanged.

```
pytest tests/unit -q
2828 passed, 11 skipped in 465.95s (0:07:45)

ruff check app tests && ruff format --check app tests
All checks passed! / 503 files already formatted
```

The rendering contracts themselves stay pinned by `tests/integration/test_borg_timestamp_rendering_integration.py` from #871 (borg1 naive-local, borg2 offset-carrying) — this PR builds on exactly those.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable; backend/agent change.

## Additional Context

One consequence worth calling out: with the render zone pinned, `agent_machines.timezone` no longer describes the machine — a new agent always reports `"UTC"`. Nothing else consumes the field (it exists for listing parse provenance), but if you'd rather keep the machine zone observable alongside, a separate field would be the way; happy to adjust.

The legacy `/archives/list` raw-stdout passthrough now relays UTC-rendered borg1 timestamps as-is. The main archive endpoints normalize; that one has no dict to normalize without parsing and re-serializing the whole document, and its consumers are gone from the frontend — left unchanged deliberately.
