### PR TITLE
fix(notifications): notify when no valid source paths remain

### DIFF
--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -2006,6 +2006,19 @@ class BackupService:
                 mqtt_service.sync_state_with_db(
                     db, reason="backup failed: no valid source paths"
                 )
+
+                # This early return never reaches the shared failure epilogue,
+                # so the notification has to go out here.
+                try:
+                    await notification_service.send_backup_failure(
+                        db, repository, job.error_message, job_id, job_name
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Failed to send backup failure notification",
+                        error=str(e),
+                    )
+
                 return
             logger.info(
                 "Source paths prepared",

--- a/tests/unit/test_backup_service_mocks.py
+++ b/tests/unit/test_backup_service_mocks.py
@@ -1508,3 +1508,63 @@ async def test_execute_backup_rejects_observe_mode(
 
     assert job.status == "failed"
     assert job.error_message == json.dumps({"key": "backend.errors.borg.unknownError"})
+
+
+@pytest.mark.asyncio
+async def test_empty_source_paths_failure_sends_notification(
+    backup_service_fixture, mock_db_session
+):
+    # The no-valid-source-paths early return (all SSH mounts failed) never
+    # reaches the shared failure epilogue, so it must notify on its own (#858).
+    job_id = 858
+    repo = Repository(
+        id=1,
+        path="/backups/repo",
+        name="Repo",
+        source_directories='["ssh://backup@gone.example:22/data"]',
+    )
+    job = BackupJob(id=job_id, status="pending")
+
+    def query_side_effect(model):
+        m = MagicMock()
+        if model == BackupJob:
+            m.filter.return_value.first.return_value = job
+        elif model == Repository:
+            m.filter.return_value.first.return_value = repo
+        elif model == SystemSettings:
+            m.first.return_value = SystemSettings()
+        elif model == RepositoryScript:
+            m.filter.return_value.count.return_value = 0
+        return m
+
+    mock_db_session.query.side_effect = query_side_effect
+    notifications = _notification_service_mock()
+
+    with (
+        patch("app.services.backup_service.SessionLocal", return_value=mock_db_session),
+        patch(
+            "app.services.backup_service.BorgRouter.validate_local_repository_access",
+            return_value=None,
+        ),
+        patch.object(
+            backup_service_fixture,
+            "_prepare_source_paths",
+            AsyncMock(return_value=([], [])),
+        ),
+        patch.object(
+            backup_service_fixture,
+            "_calculate_and_update_size_background",
+            new=AsyncMock(),
+        ),
+        patch("app.services.backup_service.mqtt_service", MagicMock()),
+        patch("app.services.backup_service.notification_service", notifications),
+    ):
+        await backup_service_fixture.execute_backup(
+            job_id, repo.path, db=mock_db_session
+        )
+
+    assert job.status == "failed"
+    assert "failedPrepareSourcePaths" in (job.error_message or "")
+    notifications.send_backup_failure.assert_awaited_once()
+    notified_error = notifications.send_backup_failure.await_args.args[2]
+    assert "failedPrepareSourcePaths" in notified_error


### PR DESCRIPTION
## Description

The reporter's diagnosis in #858 is exactly right: the `if not processed_source_paths:` early return in `BackupService.execute_backup` marks the job failed, commits, and returns — without ever calling `notification_service.send_backup_failure()`. It is the only failure path in the server-side runner with that gap: pre-hook failures notify inline, post-hook and borg failures fall through to the shared epilogue, and the outer exception handler notifies too. This one returns before any of those.

The path triggers when the processed source list comes back empty — in practice, when every source is an SSH URL and every mount fails (a dead source host), since local paths pass through unvalidated. That is precisely the "backup never even started" case failure notifications exist for, and it was the silent one.

The fix mirrors the pre-hook failure block: send the failure notification (best-effort, log on error) before the early return.

## Related Issue

Fixes #858

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

The regression test drives `execute_backup` into the empty-source-paths return and asserts the job fails with `failedPrepareSourcePaths` *and* that `send_backup_failure` went out with that error. Verified against the previous implementation: the test fails without the fix.

```
pytest tests/unit/test_backup_service_mocks.py -q
29 passed

pytest tests/unit -q
2819 passed, 11 skipped in 472.82s (0:07:52)

ruff check app tests && ruff format --check app tests
All checks passed! / 503 files already formatted
```

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable; backend change.

## Additional Context

The reporter tested on 2.2.6 with both NTFY and email — for anyone else reproducing: only backups whose sources are exclusively SSH URLs can hit this path; a plan with local paths fails later inside borg and notifies through the shared epilogue. Agent-executed jobs notify through their own path since #870.
