### PR TITLE
feat(archives): support {utcnow} in archive name templates

### DIFF
--- a/app/utils/archive_names.py
+++ b/app/utils/archive_names.py
@@ -6,6 +6,7 @@ This module centralizes archive name generation and sanitization.
 """
 
 import re
+from datetime import datetime, timezone
 from typing import Optional
 
 TIME_PLACEHOLDER_PATTERN = re.compile(
@@ -58,7 +59,12 @@ def build_archive_name(
         job_name:       Raw job name (may contain spaces/slashes).
         repo_name:      Raw repo name (may contain spaces/slashes). Optional.
         template:       Archive name template with {job_name}, {repo_name},
-                        {now}, {date}, {time}, {timestamp} placeholders.
+                        {now}, {utcnow}, {date}, {time}, {timestamp}
+                        placeholders. {now}/{date}/{time} render in the
+                        creating process's local zone; {utcnow} is the UTC
+                        sibling for names that must sort consistently across
+                        mixed-zone fleets. Formatted variants ({now:%Y...})
+                        pass through for borg's own expansion.
         timestamp:      ISO datetime string for {now} placeholder and default name.
         date:           Date string for {date} placeholder (YYYY-MM-DD).
         time_str:       Time string for {time} placeholder (HH:MM:SS).
@@ -87,6 +93,14 @@ def build_archive_name(
                 )
         else:
             archive_name = archive_name.replace("{now}", timestamp)
+            if "{utcnow}" in archive_name:
+                # Same shape as the {now} timestamps the callers build
+                # (millisecond precision keeps rapid runs unique), rendered
+                # in UTC instead of the creating process's zone.
+                archive_name = archive_name.replace(
+                    "{utcnow}",
+                    datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3],
+                )
             if date is not None:
                 archive_name = archive_name.replace("{date}", date)
             if time_str is not None:

--- a/frontend/src/components/ArchiveNameTemplateInput.stories.tsx
+++ b/frontend/src/components/ArchiveNameTemplateInput.stories.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box } from '@mui/material'
+import ArchiveNameTemplateInput from './ArchiveNameTemplateInput'
+
+const meta = {
+  title: 'Components/ArchiveNameTemplateInput',
+  component: ArchiveNameTemplateInput,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof ArchiveNameTemplateInput>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+function InteractiveTemplate({ value, jobName }: { value: string; jobName?: string }) {
+  // Local state keeps the input interactive; the effect re-syncs it when
+  // the value arrives from the Controls panel.
+  const [current, setCurrent] = useState(value)
+  useEffect(() => setCurrent(value), [value])
+  return (
+    <Box sx={{ width: 560 }}>
+      <ArchiveNameTemplateInput value={current} onChange={setCurrent} jobName={jobName} />
+    </Box>
+  )
+}
+
+export const LocalTimeTemplate: Story = {
+  args: { value: '{job_name}-{now}', jobName: 'nightly-plan', onChange: () => {} },
+  render: (args) => <InteractiveTemplate value={args.value} jobName={args.jobName} />,
+}
+
+export const UtcTemplate: Story = {
+  args: { value: '{job_name}-{utcnow}', jobName: 'nightly-plan', onChange: () => {} },
+  render: (args) => <InteractiveTemplate value={args.value} jobName={args.jobName} />,
+}
+
+export const LocalVersusUtcPreview: Story = {
+  // The two placeholders side by side make the zone difference visible in
+  // the preview: {now} renders in the creating machine's local time,
+  // {utcnow} in UTC.
+  args: { value: '{now}-vs-{utcnow}', jobName: 'nightly-plan', onChange: () => {} },
+  render: (args) => <InteractiveTemplate value={args.value} jobName={args.jobName} />,
+}

--- a/frontend/src/components/ArchiveNameTemplateInput.tsx
+++ b/frontend/src/components/ArchiveNameTemplateInput.tsx
@@ -18,17 +18,25 @@ const ArchiveNameTemplateInput: React.FC<ArchiveNameTemplateInputProps> = ({
   jobName = 'example-job',
 }) => {
   const { t } = useTranslation()
-  // Generate preview of archive name with current timestamp
+  // Generate preview of archive name with current timestamp.
+  // {now}/{date}/{time} render in the creating machine's local time (matching
+  // the backend and borg's own expansion); {utcnow} renders in UTC. The
+  // formats mirror the backend expansion exactly, millisecond precision
+  // included, so the preview matches the generated archive name.
   const previewName = useMemo(() => {
     const now = new Date()
+    const pad = (n: number) => String(n).padStart(2, '0')
+    const pad3 = (n: number) => String(n).padStart(3, '0')
     const timestamp = Math.floor(now.getTime() / 1000)
-    const date = now.toISOString().split('T')[0]
-    const time = now.toTimeString().split(' ')[0].replace(/:/g, '-')
-    const isoString = now.toISOString().replace(/[:.]/g, '-').slice(0, -5)
+    const date = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
+    const time = now.toTimeString().split(' ')[0]
+    const localIso = `${date}T${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}.${pad3(now.getMilliseconds())}`
+    const utcIso = now.toISOString().slice(0, -1)
 
     return value
       .replace(/{job_name}/g, jobName)
-      .replace(/{now}/g, isoString)
+      .replace(/{utcnow}/g, utcIso)
+      .replace(/{now}/g, localIso)
       .replace(/{date}/g, date)
       .replace(/{time}/g, time)
       .replace(/{timestamp}/g, String(timestamp))

--- a/frontend/src/components/__tests__/ArchiveNameTemplateInput.test.tsx
+++ b/frontend/src/components/__tests__/ArchiveNameTemplateInput.test.tsx
@@ -1,3 +1,8 @@
+// Pin a non-UTC, DST-free zone (UTC+14) before anything touches Date: the
+// UTC assertions below must fail for a local-clock implementation even when
+// the test runner itself happens to run in UTC.
+process.env.TZ = 'Pacific/Kiritimati'
+
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import ArchiveNameTemplateInput from '../ArchiveNameTemplateInput'
@@ -30,7 +35,9 @@ describe('ArchiveNameTemplateInput', () => {
     render(<ArchiveNameTemplateInput {...defaultProps} />)
 
     expect(
-      screen.getByText(/Available placeholders: {job_name}, {now}, {date}, {time}, {timestamp}/i)
+      screen.getByText(
+        /Available placeholders: {job_name}, {now}, {utcnow}, {date}, {time}, {timestamp}/i
+      )
     ).toBeInTheDocument()
   })
 
@@ -77,8 +84,8 @@ describe('ArchiveNameTemplateInput', () => {
   it('generates preview with time placeholder', () => {
     render(<ArchiveNameTemplateInput value="{time}" onChange={vi.fn()} />)
 
-    // Time format should be HH-MM-SS
-    const preview = screen.getByText(/\d{2}-\d{2}-\d{2}/)
+    // Time format should be HH:MM:SS, as the backend produces it
+    const preview = screen.getByText(/\d{2}:\d{2}:\d{2}/)
     expect(preview).toBeInTheDocument()
   })
 
@@ -93,9 +100,25 @@ describe('ArchiveNameTemplateInput', () => {
   it('generates preview with now placeholder', () => {
     render(<ArchiveNameTemplateInput value="{now}" onChange={vi.fn()} />)
 
-    // Now format should be ISO string with replacements
-    const preview = screen.getByText(/\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}/)
+    // Now format mirrors the backend: ISO with milliseconds, local time
+    const preview = screen.getByText(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}/)
     expect(preview).toBeInTheDocument()
+  })
+
+  it('generates preview with utcnow placeholder', () => {
+    // Frozen clock plus the module-level non-UTC TZ pin: the exact-value
+    // assertion fails for a local-clock implementation (17:04 local there).
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-02T03:04:05.678Z'))
+    try {
+      render(<ArchiveNameTemplateInput value="{utcnow}" onChange={vi.fn()} />)
+
+      const preview = screen.getByText(/2026-01-02T03:04:05\.678/)
+      expect(preview).toBeInTheDocument()
+      expect(preview.textContent).not.toContain('{utcnow}')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('generates preview with multiple placeholders', () => {
@@ -107,7 +130,7 @@ describe('ArchiveNameTemplateInput', () => {
       />
     )
 
-    const preview = screen.getByText(/test-job-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}/)
+    const preview = screen.getByText(/test-job-\d{4}-\d{2}-\d{2}-\d{2}:\d{2}:\d{2}/)
     expect(preview).toBeInTheDocument()
   })
 

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -3685,7 +3685,7 @@
   },
   "archiveNameTemplate": {
     "label": "Archivnamen-Vorlage",
-    "hint": "Archivbenennung anpassen. Verfügbare Platzhalter: {job_name}, {now}, {date}, {time}, {timestamp}",
+    "hint": "Archivbenennung anpassen. Verfügbare Platzhalter: {job_name}, {now}, {utcnow}, {date}, {time}, {timestamp}. {now}, {date} und {time} verwenden die lokale Zeit der erstellenden Maschine, {utcnow} verwendet UTC, {timestamp} ist Unix-Zeit. Die Vorschau verwendet die Browser-Uhr.",
     "preview": "Vorschau:"
   },
   "remoteMachineCard": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -3682,7 +3682,7 @@
   },
   "archiveNameTemplate": {
     "label": "Archive Name Template",
-    "hint": "Customize archive naming. Available placeholders: {job_name}, {now}, {date}, {time}, {timestamp}",
+    "hint": "Customize archive naming. Available placeholders: {job_name}, {now}, {utcnow}, {date}, {time}, {timestamp}. {now}, {date} and {time} use the creating machine's local time, {utcnow} uses UTC, and {timestamp} is Unix time. The preview uses your browser's clock.",
     "preview": "Preview:"
   },
   "remoteMachineCard": {

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -3682,7 +3682,7 @@
   },
   "archiveNameTemplate": {
     "label": "Plantilla de nombre de archivo",
-    "hint": "Personaliza la nomenclatura del archivo. Marcadores disponibles: {job_name}, {now}, {date}, {time}, {timestamp}",
+    "hint": "Personaliza la nomenclatura del archivo. Marcadores disponibles: {job_name}, {now}, {utcnow}, {date}, {time}, {timestamp}. {now}, {date} y {time} usan la hora local de la máquina que crea el archivo, {utcnow} usa UTC y {timestamp} es tiempo Unix. La vista previa usa el reloj del navegador.",
     "preview": "Vista previa:"
   },
   "remoteMachineCard": {

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -3685,7 +3685,7 @@
   },
   "archiveNameTemplate": {
     "label": "Template Nome Archivio",
-    "hint": "Personalizza la denominazione dell'archivio. Segnaposto disponibili: {job_name}, {now}, {date}, {time}, {timestamp}",
+    "hint": "Personalizza la denominazione dell'archivio. Segnaposto disponibili: {job_name}, {now}, {utcnow}, {date}, {time}, {timestamp}. {now}, {date} e {time} usano l'ora locale della macchina che crea l'archivio, {utcnow} usa UTC e {timestamp} è tempo Unix. L'anteprima usa l'orologio del browser.",
     "preview": "Anteprima:"
   },
   "remoteMachineCard": {

--- a/tests/unit/test_archive_name_sanitization.py
+++ b/tests/unit/test_archive_name_sanitization.py
@@ -1,4 +1,9 @@
+from datetime import datetime, timezone
+from unittest.mock import patch
+
 from app.utils.archive_names import sanitize_archive_component, build_archive_name
+
+_FROZEN_UTC = datetime(2026, 1, 2, 3, 4, 5, 678000, tzinfo=timezone.utc)
 
 
 # ==========================================
@@ -191,3 +196,53 @@ class TestBuildArchiveName:
             stable_series=True,
         )
         assert result == "nightly-plan-primary-repo"
+
+
+class TestUtcnowPlaceholder:
+    def test_utcnow_expands_to_the_exact_utc_instant(self):
+        # Frozen clock: assert the exact value, not just its shape - a
+        # local-clock implementation would produce a different string.
+        with patch("app.utils.archive_names.datetime") as mock_dt:
+            mock_dt.now.return_value = _FROZEN_UTC
+            result = build_archive_name(
+                job_name="my job",
+                repo_name=None,
+                template="{job_name}-{utcnow}",
+                timestamp="2025-01-01T12:00:00",
+            )
+        # A regression to datetime.now() without timezone.utc must not pass.
+        mock_dt.now.assert_called_once_with(timezone.utc)
+        assert result == "my-job-2026-01-02T03:04:05.678"
+
+    def test_utcnow_and_now_can_coexist(self):
+        with patch("app.utils.archive_names.datetime") as mock_dt:
+            mock_dt.now.return_value = _FROZEN_UTC
+            result = build_archive_name(
+                job_name="job",
+                repo_name=None,
+                template="{now}-vs-{utcnow}",
+                timestamp="2025-01-01T12:00:00",
+            )
+        mock_dt.now.assert_called_once_with(timezone.utc)
+        assert result == "2025-01-01T12:00:00-vs-2026-01-02T03:04:05.678"
+
+    def test_formatted_utcnow_passes_through_for_borg(self):
+        # {utcnow:%Y-%m-%d} is borg's own placeholder syntax - left for borg
+        # to expand, exactly like formatted {now:...} today.
+        result = build_archive_name(
+            job_name="job",
+            repo_name=None,
+            template="{job_name}-{utcnow:%Y-%m-%d}",
+            timestamp="2025-01-01T12:00:00",
+        )
+        assert result == "job-{utcnow:%Y-%m-%d}"
+
+    def test_stable_series_strips_utcnow(self):
+        result = build_archive_name(
+            job_name="job",
+            repo_name=None,
+            template="{job_name}-{utcnow}",
+            timestamp="2025-01-01T12:00:00",
+            stable_series=True,
+        )
+        assert result == "job"


### PR DESCRIPTION
## Description

Archive names built from `{now}` templates render in the creating process's local zone, while the timestamps shown next to them are UTC — across mixed-zone fleets the names neither sort consistently with each other nor line up with those timestamps. Nothing is functionally wrong (nothing parses times back out of names); this makes the UTC alternative available and the zone behavior visible, as suggested in the issue.

**`{utcnow}` everywhere.** Borg expands `{utcnow}` natively, so agent- and remote-executed templates support it already. The gap was the server-side builder: `build_archive_name` replaced only `{now}`, so a server-executed plan using `{utcnow}` would have carried the literal into the stored job row. It now expands bare `{utcnow}` in the same shape the callers build for `{now}` (millisecond precision keeps rapid runs unique), rendered in UTC. Formatted variants (`{utcnow:%Y-...}`, like `{now:%Y-...}` today) still pass through for borg's own expansion, and the Borg 2 stable-series stripping already knew `{utcnow}` — now there's a test holding that.

**The zone behavior is documented where templates are typed.** The template input's helper text now lists `{utcnow}` and says plainly: time placeholders use the creating machine's local time; `{utcnow}` uses UTC (all four locales).

**Preview drift fixed in passing.** The input's live preview rendered `{now}` (and `{date}`) via `toISOString()` — i.e. in UTC, exactly what `{now}` does *not* do. The preview now renders `{now}`/`{date}`/`{time}` in local time and `{utcnow}` in UTC, so what the user sees matches what borg and the server actually produce.

## Related Issue

Fixes #887

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Backend: `{utcnow}` expands to a UTC timestamp, coexists with `{now}`, formatted `{utcnow:...}` passes through untouched, stable-series strips it. Frontend: helper text lists the new placeholder, preview expands `{utcnow}` and no literal remains.

Borg's native expansion measured on 1.4.5 (the pass-through path agents and remote sources use): under `TZ=Asia/Tokyo`, `borg create ::test-{utcnow}` names the archive `test-2026-09-03T16:35:53` (UTC) while `::test-{now}` names it `test-2026-09-04T01:35:53` — local Tokyo time, a different calendar day. That is exactly the mixed-zone sorting problem `{utcnow}` avoids.

```
pytest tests/unit -q
2822 passed, 11 skipped in 476.37s (0:07:56)

vitest run (Node 22)
2316 passed (2316)

ruff check app tests && ruff format --check app tests — clean
tsc --noEmit / eslint --max-warnings 0 / prettier --check / check:locales (4660 keys ×4) — all clean
```

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Helper text and preview only; the template input renders as before with an extended hint.

## Additional Context

Independent of the other timezone PRs (#889/#891/#892) — no shared files, no ordering constraint; mergeable in any order. CodeRabbit pre-review ran on the fork (ioanalytica#43): one round (frozen-clock UTC assertion, millisecond-precision preview, browser-clock label, {timestamp} clarification — all addressed), final pass clean. Deliberately NOT changed: the default templates stay on `{now}` — existing fleets keep their naming, and switching defaults to UTC naming is a product decision this PR leaves open.
