### PR TITLE
fix(restore-check): address Borg 2 series archives by aid: selector

### DIFF
--- a/app/services/restore_check_service.py
+++ b/app/services/restore_check_service.py
@@ -87,6 +87,24 @@ def _get_archive_name(archive: dict | str | None) -> str:
     return ""
 
 
+def _get_archive_selector(archive: dict | str | None, repository) -> str:
+    """Selector that resolves to exactly one archive.
+
+    Borg 2 archives in a series share one name and are told apart by id, so
+    extract needs the aid: selector - a bare series name matches every
+    archive in the series and borg refuses to pick one. Borg 1 names are
+    unique and are passed as-is.
+    """
+    name = _get_archive_name(archive)
+    if getattr(repository, "borg_version", 1) != 2:
+        return name
+    if isinstance(archive, dict):
+        archive_id = archive.get("id")
+        if isinstance(archive_id, str) and archive_id:
+            return f"aid:{archive_id}"
+    return name
+
+
 # Upper bounds so a delegated restore-check cannot wait on the agent forever:
 # fail if the job is never claimed (agent offline) or goes silent (agent died).
 _AGENT_OP_CLAIM_TIMEOUT_SECONDS = 120
@@ -238,6 +256,7 @@ class RestoreCheckService:
             archives = await BorgRouter(repository).list_archives(env=env)
             archive = _select_latest_archive(archives)
             archive_name = _get_archive_name(archive)
+            archive_selector = _get_archive_selector(archive, repository)
             if not archive_name:
                 job.status = "needs_backup" if use_canary else "failed"
                 job.error_message = (
@@ -308,7 +327,7 @@ class RestoreCheckService:
             async def run_extract(paths: list[str]) -> int | None:
                 cmd = BorgRouter(repository).build_restore_extract_command(
                     repository_path=repository.path,
-                    archive_name=archive_name,
+                    archive_name=archive_selector,
                     paths=paths,
                     remote_path=effective_repository_remote_path(repository),
                     bypass_lock=repository.bypass_lock,
@@ -520,6 +539,7 @@ class RestoreCheckService:
 
         archive = _select_latest_archive(archives)
         archive_name = _get_archive_name(archive)
+        archive_selector = _get_archive_selector(archive, repository)
         if not archive_name:
             job.status = "needs_backup" if use_canary else "failed"
             job.error_message = (
@@ -574,7 +594,7 @@ class RestoreCheckService:
         )
 
         operation: dict = {
-            "archive": archive_name,
+            "archive": archive_selector,
             "paths": restore_paths,
             "target": {"type": "temp"},
         }
@@ -605,7 +625,7 @@ class RestoreCheckService:
             return
 
         await dispatch_agent_job_best_effort(
-            db, agent_job, repository_id=repository.id, archive=archive_name
+            db, agent_job, repository_id=repository.id, archive=archive_selector
         )
 
         try:

--- a/tests/unit/test_restore_check_service.py
+++ b/tests/unit/test_restore_check_service.py
@@ -363,3 +363,129 @@ async def test_restore_check_canary_without_archives_saves_actionable_logs(
     assert "Mode: Canary" in log_text
     assert "Run a backup" in log_text
     verification.close()
+
+
+class FakeBorg2SeriesRouter(FakeBorgRouter):
+    """A Borg 2 series: every archive shares the name, ids differ."""
+
+    captured_extract_archives: list[str] = []
+
+    async def list_archives(self, env=None):
+        return [
+            {
+                "name": "myplan-daily",
+                "id": "ab12cd34ef56ab12",
+                "start": "2026-01-01T00:00:00Z",
+            },
+            {
+                "name": "myplan-daily",
+                "id": "ef56gh78ab12cd34",
+                "start": "2026-01-02T00:00:00Z",
+            },
+        ]
+
+    def build_restore_extract_command(
+        self,
+        repository_path,
+        archive_name,
+        paths,
+        remote_path=None,
+        bypass_lock=False,
+    ):
+        FakeBorg2SeriesRouter.captured_extract_archives.append(archive_name)
+        return ["borg2", "extract", archive_name, *paths]
+
+
+class TestArchiveSelector:
+    def test_borg2_series_archives_are_addressed_by_aid(self):
+        from app.services.restore_check_service import _get_archive_selector
+
+        repo = Repository(borg_version=2)
+        archive = {"name": "myplan-daily", "id": "ab12cd34ef56ab12"}
+
+        assert _get_archive_selector(archive, repo) == "aid:ab12cd34ef56ab12"
+
+    def test_borg2_without_id_falls_back_to_the_name(self):
+        from app.services.restore_check_service import _get_archive_selector
+
+        repo = Repository(borg_version=2)
+
+        assert _get_archive_selector({"name": "solo"}, repo) == "solo"
+
+    def test_borg1_keeps_the_unique_name(self):
+        from app.services.restore_check_service import _get_archive_selector
+
+        repo = Repository(borg_version=1)
+        archive = {"name": "backup-2026-01-01", "id": "ab12cd34ef56ab12"}
+
+        assert _get_archive_selector(archive, repo) == "backup-2026-01-01"
+
+    def test_string_entries_pass_through(self):
+        from app.services.restore_check_service import _get_archive_selector
+
+        assert (
+            _get_archive_selector("backup-1", Repository(borg_version=2)) == "backup-1"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_borg2_restore_check_extracts_by_aid_selector(
+    db_session, testing_session_local
+):
+    # A series name matches every archive in the series - borg refuses the
+    # extract (#863). The check must address the LATEST archive by aid:.
+    repo = Repository(
+        name="Borg2 Series Repo",
+        path="/tmp/restore-check-b2",
+        encryption="none",
+        compression="lz4",
+        repository_type="local",
+        bypass_lock=True,
+        borg_version=2,
+    )
+    db_session.add(repo)
+    db_session.commit()
+    db_session.refresh(repo)
+    job = RestoreCheckJob(
+        repository_id=repo.id,
+        repository_path=repo.path,
+        status="pending",
+        full_archive=True,
+    )
+    db_session.add(job)
+    db_session.commit()
+    db_session.refresh(job)
+
+    service = RestoreCheckService()
+    process = FakeRestoreCheckProcess(returncode=0)
+    FakeBorg2SeriesRouter.captured_extract_archives = []
+
+    with (
+        patch("app.services.restore_check_service.SessionLocal", testing_session_local),
+        patch("app.services.restore_check_service.BorgRouter", FakeBorg2SeriesRouter),
+        patch(
+            "app.services.restore_check_service.build_repository_borg_env",
+            return_value=({}, None),
+        ),
+        patch("app.services.restore_check_service.cleanup_temp_key_file"),
+        patch(
+            "app.services.restore_check_service.get_process_start_time",
+            return_value=123456,
+        ),
+        patch(
+            "app.services.restore_check_service.asyncio.create_subprocess_exec",
+            return_value=process,
+        ),
+    ):
+        await service.execute_restore_check(job.id, repo.id)
+
+    verification = testing_session_local()
+    refreshed_job = verification.get(RestoreCheckJob, job.id)
+
+    # The newest archive of the series, addressed by id - never by the name.
+    assert FakeBorg2SeriesRouter.captured_extract_archives == ["aid:ef56gh78ab12cd34"]
+    assert refreshed_job.status == "completed"
+    # The job row keeps the human-readable series name for display.
+    assert refreshed_job.archive_name == "myplan-daily"
+    verification.close()


### PR DESCRIPTION
## Description

Exactly the failure @dolifer diagnosed in #863: the restore check identifies its target archive by **name**, and for Borg 2 repositories the UI deliberately builds a *stable series name* — so every archive in the series shares one name and `borg extract` refuses to resolve it once the series has more than one archive (`repository.restore exited with code 4`). Every Borg 2 repository therefore reports `RESTORE: Failed` from the second backup on, indistinguishable from a genuinely unrestorable repository.

The fix separates *display* from *addressing*, using the same `aid:` pattern the archive download path already uses (`_archive_extract_selector`): a new `_get_archive_selector` returns `aid:<id>` for Borg 2 archives (falling back to the name when no id is present) and the unique name as-is for Borg 1. Both restore paths address by selector now — the server-side `build_restore_extract_command` and the agent operation payload (`repository.restore` passes the archive string verbatim into `borg extract`, so `aid:` flows through with no agent change) — while `job.archive_name`, logs and notifications keep the human-readable series name.

## Related Issue

Fixes #863

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

New: selector unit tests (Borg 2 dict → `aid:`, no-id fallback, Borg 1 name, string pass-through) and an execute-path test with a two-archive series asserting the extract is addressed as `aid:<latest-id>` — never the series name — while the job row keeps the display name. Verified against the previous implementation: 5 tests fail without the fix.

```
pytest tests/unit/test_restore_check_service.py -q
11 passed

pytest tests/unit -q
2954 passed, 11 skipped in 490.36s (0:08:10)

ruff check app tests && ruff format --check app tests — clean
```

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable; backend change.

## Additional Context

CodeRabbit pre-review ran on the fork (ioanalytica#44): clean first pass, no findings. The latest-archive *selection* itself (`_select_latest_archive`, string max over rendered timestamps) is unchanged — within a single listing all values share one render zone, so the ordering is stable; the addressing was the broken half. Independent of the open timezone PRs (#889/#891/#892) and of the operations-runner work — no shared files.
