### PR TITLE
fix(retention): take job log files along when purging rows

### DIFF
--- a/app/services/job_history_retention.py
+++ b/app/services/job_history_retention.py
@@ -37,8 +37,10 @@ the file; the manual cleanup endpoint runs VACUUM for that.
 from __future__ import annotations
 
 import re
-from datetime import timedelta
+from datetime import timedelta, timezone
 from pathlib import Path
+
+from app.config import settings as app_config
 from typing import Dict, Iterable, Optional
 
 import structlog
@@ -127,15 +129,58 @@ def _older_than(model, cutoff):
     return (timestamp < cutoff,)
 
 
+def _referenced_log_files(db: Session, paths: list[str]) -> set:
+    """The subset of paths some surviving row still names.
+
+    log_file_path carries no uniqueness guarantee, so an expired row and a
+    retained one can point at the same file - deleting by the expired row
+    alone would take the retained row's log with it.
+    """
+    referenced: set = set()
+    if not paths:
+        return referenced
+    for model, _ in _JOB_TABLES:
+        column = getattr(model, "log_file_path", None)
+        if column is None:
+            continue
+        for (path,) in db.query(column).filter(column.in_(paths)):
+            referenced.add(path)
+    return referenced
+
+
 def _delete_chunked(db: Session, model, filters) -> int:
-    """Delete matching rows in CHUNK_SIZE batches, committing per batch."""
+    """Delete matching rows in CHUNK_SIZE batches, committing per batch.
+
+    Rows that name a log file take it with them: paths are captured before
+    the delete and unlinked only after the commit, so a failed commit never
+    leaves a surviving row pointing at a vanished file. Unlink errors are
+    tolerated - retention must not fail over a file the filesystem already
+    lost.
+    """
+    log_column = getattr(model, "log_file_path", None)
     total = 0
     while True:
-        ids = [row[0] for row in db.query(model.id).filter(*filters).limit(CHUNK_SIZE)]
+        log_files: list[str] = []
+        if log_column is not None:
+            rows = (
+                db.query(model.id, log_column).filter(*filters).limit(CHUNK_SIZE).all()
+            )
+            ids = [row[0] for row in rows]
+            log_files = [row[1] for row in rows if row[1]]
+        else:
+            ids = [
+                row[0] for row in db.query(model.id).filter(*filters).limit(CHUNK_SIZE)
+            ]
         if not ids:
             return total
         db.query(model).filter(model.id.in_(ids)).delete(synchronize_session=False)
         db.commit()
+        still_referenced = _referenced_log_files(db, log_files)
+        for path in set(log_files) - still_referenced:
+            try:
+                Path(path).unlink(missing_ok=True)
+            except OSError:
+                pass
         total += len(ids)
 
 
@@ -223,11 +268,51 @@ def purge_operation_log_files(db: Session, filters) -> int:
         total += len(rows)
 
 
-def purge_job_rows(db: Session, cutoff) -> int:
-    """Delete finished job rows older than cutoff (all job tables)."""
+def sweep_orphaned_log_files(db: Session, cutoff) -> int:
+    """Unlink job-log files that no row references anymore.
+
+    Rows purged before file cleanup existed - and any crash between a
+    chunk's commit and its unlink - leave files behind that no DB-driven
+    pass can ever find again. Swept here by age (file mtime against the
+    row-retention cutoff), restricted to *.log inside the log directory,
+    and never touching a file some live row still names.
+    """
+    log_dir = Path(app_config.data_dir) / "logs"
+    if not log_dir.is_dir():
+        return 0
+
+    referenced: set = set()
+    for model, _ in _JOB_TABLES:
+        column = getattr(model, "log_file_path", None)
+        if column is None:
+            continue
+        for (path,) in db.query(column).filter(column.isnot(None)):
+            referenced.add(path)
+
+    cutoff_ts = (
+        cutoff if cutoff.tzinfo else cutoff.replace(tzinfo=timezone.utc)
+    ).timestamp()
     total = 0
-    # The rows are about to go; their log files must go with them.
-    purge_operation_log_files(db, _older_than(Operation, cutoff))
+    for file in log_dir.glob("*.log"):
+        try:
+            if str(file) in referenced:
+                continue
+            if file.stat().st_mtime >= cutoff_ts:
+                continue
+            file.unlink(missing_ok=True)
+            total += 1
+        except OSError:
+            continue
+    return total
+
+
+def purge_job_rows(db: Session, cutoff) -> int:
+    """Delete finished job rows older than cutoff (all job tables).
+
+    _delete_chunked takes each row's log file with it, uniformly for every
+    model that names one - no per-model special case.
+    """
+    total = 0
     for model, _ in _JOB_TABLES:
         total += _delete_chunked(db, model, _older_than(model, cutoff))
     # Retry lineage rows carry only SET NULL pointers at their jobs; once the
@@ -448,6 +533,9 @@ def run_retention(db: Session, settings: Optional[SystemSettings] = None) -> Dic
             else 0
         ),
         "job_rows_deleted": purge_job_rows(db, now - timedelta(days=row_days)),
+        "orphaned_log_files_deleted": sweep_orphaned_log_files(
+            db, now - timedelta(days=row_days)
+        ),
         "pruned_archive_records_removed": sweep_pruned_archive_records(db),
     }
     if any(results.values()):

--- a/tests/unit/test_job_history_retention.py
+++ b/tests/unit/test_job_history_retention.py
@@ -555,3 +555,193 @@ def test_operation_log_files_follow_both_retention_windows(db, tmp_path):
     # Fresh row: untouched.
     assert db.get(Operation, fresh_id).log_file_path == str(fresh_log)
     assert fresh_log.exists()
+
+
+@pytest.mark.unit
+def test_row_purge_takes_log_files_along_for_every_model(db, tmp_path):
+    # #895: deleting expired rows must unlink their log_file_path files -
+    # uniformly, not as an Operation-only special case.
+    from app.database.models import CheckJob, CompactJob, Repository, RestoreCheckJob
+
+    settings = _settings(db)
+    repo = Repository(
+        name="Retention Repo",
+        path="/tmp/retention-repo",
+        encryption="none",
+        repository_type="local",
+    )
+    db.add(repo)
+    db.commit()
+    old = utc_now() - timedelta(days=120)
+    fresh = utc_now() - timedelta(days=10)
+
+    expired_files = []
+    kept_file = tmp_path / "kept_check.log"
+    kept_file.write_text("keep me", encoding="utf-8")
+    missing_file = tmp_path / "already_gone.log"  # never created
+
+    for index, model in enumerate((CheckJob, CompactJob, RestoreCheckJob)):
+        log_file = tmp_path / f"expired_{index}.log"
+        log_file.write_text("old log", encoding="utf-8")
+        expired_files.append(log_file)
+        db.add(
+            model(
+                repository_id=repo.id,
+                status="completed",
+                completed_at=old,
+                created_at=old,
+                log_file_path=str(log_file),
+            )
+        )
+    # An expired row whose file is already gone must not break the purge.
+    db.add(
+        CheckJob(
+            repository_id=repo.id,
+            status="failed",
+            completed_at=old,
+            created_at=old,
+            log_file_path=str(missing_file),
+        )
+    )
+    # A row inside the window keeps row AND file.
+    db.add(
+        CheckJob(
+            repository_id=repo.id,
+            status="completed",
+            completed_at=fresh,
+            created_at=fresh,
+            log_file_path=str(kept_file),
+        )
+    )
+    db.commit()
+
+    run_retention(db, settings)
+
+    db.expunge_all()
+    for log_file in expired_files:
+        assert not log_file.exists()
+    assert kept_file.exists()
+    from app.database.models import CheckJob as CheckJobModel
+
+    assert db.query(CheckJobModel).count() == 1
+
+
+@pytest.mark.unit
+def test_orphaned_log_files_are_swept_by_age_unless_referenced(
+    db, tmp_path, monkeypatch
+):
+    # Files whose rows were purged before file cleanup existed have no row
+    # pointing at them anymore - only an age-based filesystem sweep can
+    # reclaim them. Referenced and young files must survive.
+    import os
+    import time as time_module
+
+    from app.database.models import CheckJob
+    from app.services.job_history_retention import sweep_orphaned_log_files
+
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    monkeypatch.setattr(
+        "app.services.job_history_retention.app_config.data_dir", str(tmp_path)
+    )
+
+    old_ts = time_module.time() - 200 * 86400
+
+    orphan_old = log_dir / "check_job_1_20260101_000000.log"
+    orphan_old.write_text("orphan", encoding="utf-8")
+    os.utime(orphan_old, (old_ts, old_ts))
+
+    referenced_old = log_dir / "check_job_2_20260101_000000.log"
+    referenced_old.write_text("still referenced", encoding="utf-8")
+    os.utime(referenced_old, (old_ts, old_ts))
+
+    orphan_young = log_dir / "check_job_3_20260901_000000.log"
+    orphan_young.write_text("young orphan", encoding="utf-8")
+
+    not_a_log = log_dir / "notes.txt"
+    not_a_log.write_text("keep", encoding="utf-8")
+    os.utime(not_a_log, (old_ts, old_ts))
+
+    repo = Repository(
+        name="Sweep Repo",
+        path="/tmp/sweep-repo",
+        encryption="none",
+        repository_type="local",
+    )
+    db.add(repo)
+    db.commit()
+    db.add(
+        CheckJob(
+            repository_id=repo.id,
+            status="completed",
+            completed_at=utc_now(),
+            created_at=utc_now(),
+            log_file_path=str(referenced_old),
+        )
+    )
+    db.commit()
+
+    removed = sweep_orphaned_log_files(db, utc_now() - timedelta(days=90))
+
+    assert removed == 1
+    assert not orphan_old.exists()
+    assert referenced_old.exists()
+    assert orphan_young.exists()
+    assert not_a_log.exists()
+
+
+@pytest.mark.unit
+def test_shared_log_file_survives_when_a_live_row_still_references_it(db, tmp_path):
+    # log_file_path is not unique: an expired and a retained row can name the
+    # same file - purging the expired row must not take the survivor's log.
+    from app.database.models import CheckJob
+
+    settings = _settings(db)
+    old = utc_now() - timedelta(days=120)
+    fresh = utc_now() - timedelta(days=10)
+
+    shared = tmp_path / "shared_check.log"
+    shared.write_text("shared", encoding="utf-8")
+    solo = tmp_path / "solo_check.log"
+    solo.write_text("solo", encoding="utf-8")
+
+    repo = Repository(
+        name="Shared Log Repo",
+        path="/tmp/shared-log-repo",
+        encryption="none",
+        repository_type="local",
+    )
+    db.add(repo)
+    db.commit()
+    db.add_all(
+        [
+            CheckJob(
+                repository_id=repo.id,
+                status="completed",
+                completed_at=old,
+                created_at=old,
+                log_file_path=str(shared),
+            ),
+            CheckJob(
+                repository_id=repo.id,
+                status="completed",
+                completed_at=fresh,
+                created_at=fresh,
+                log_file_path=str(shared),
+            ),
+            CheckJob(
+                repository_id=repo.id,
+                status="completed",
+                completed_at=old,
+                created_at=old,
+                log_file_path=str(solo),
+            ),
+        ]
+    )
+    db.commit()
+
+    run_retention(db, settings)
+
+    db.expunge_all()
+    assert shared.exists()
+    assert not solo.exists()


### PR DESCRIPTION
## Description

As specified in #895: `purge_job_rows` deleted expired job rows without removing the `log_file_path` files they named, so retention could clear the database while the log files lived on indefinitely. Only `Operation` rows had file cleanup — exactly the special case the issue asks to avoid.

The fix moves the behavior into `_delete_chunked` itself, uniformly for every model in `_JOB_TABLES` that has a `log_file_path` column: each chunk captures its rows' paths before the delete, commits the deletion, and only then unlinks — so a failed commit never leaves a surviving row pointing at a vanished file — with `missing_ok` and `OSError` tolerance. That is the same safety ordering `purge_jobs_for_pruned_archives` already uses. The `Operation` pre-clear in `purge_job_rows` is gone (the generic path covers it); `purge_operation_log_files` itself stays, because the log-retention window still uses it to drop files while keeping rows.

**Existing leftovers.** Installations have been accumulating orphaned files since the gap existed - rows long purged, files still on disk, and with the rows gone no DB-driven pass can ever find them again. A new `sweep_orphaned_log_files` retention phase reclaims them: `*.log` inside the log directory, file mtime older than the row-retention cutoff, and never a file some live `log_file_path` row still names. Deliberately a recurring retention phase rather than a one-shot migration - deleting filesystem files from an Alembic migration would be the wrong layer (side effects, no rollback), and the sweep also self-heals the one residual leak the fix's own ordering allows (a crash between a chunk's commit and its unlink).

## Related Issue

Fixes #895

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

New tests: (1) `run_retention` over expired rows across three models (CheckJob, CompactJob, RestoreCheckJob) plus one with an already-missing file and one inside the window - expired files are unlinked, the missing file does not break the purge, the fresh row keeps row and file; fails without the fix. (2) The orphan sweep removes an aged unreferenced file while keeping a referenced old file, a young orphan, and a non-.log file.

```
pytest tests/unit/test_job_history_retention.py -q
16 passed

pytest tests/unit -q
2950 passed, 11 skipped in 487.64s (0:08:07) - plus the sweep test added after that run; the retention suite reruns green (16 passed)

ruff check app tests && ruff format --check app tests — clean
```

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable; backend change.

## Additional Context

Independent of the open timezone stack (#889/#891/#892) and of #898 — no shared files; rebased onto current main (#897) before submission. CodeRabbit pre-review ran on the fork (ioanalytica#45): one round (shared log_file_path between an expired and a surviving row — fixed with a post-commit reference check plus regression test), final pass clean.
