### PR TITLE
feat(plan): contextual upgrade links and trial countdown

### DIFF
--- a/frontend/src/components/LicensingTab.stories.tsx
+++ b/frontend/src/components/LicensingTab.stories.tsx
@@ -1,0 +1,75 @@
+import { useMemo } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box } from '@mui/material'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import LicensingTab from './LicensingTab'
+import type { SystemInfo } from '../hooks/useSystemInfo'
+import type { Plan } from '../core/features'
+
+function systemInfo(plan: Plan): SystemInfo {
+  return {
+    app_version: '1.0.0',
+    borg_version: '1.4.0',
+    borg2_version: null,
+    plan,
+    features: {},
+    entitlement: {
+      status: 'none',
+      access_level: plan,
+      is_full_access: false,
+      full_access_consumed: false,
+      expires_at: null,
+      starts_at: null,
+      instance_id: 'inst_story',
+      ui_state: 'community',
+      last_refresh_at: null,
+      last_refresh_error: null,
+    },
+  }
+}
+
+function createLicensingQueryClient(plan: Plan) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  })
+  queryClient.setQueryData(['system-info'], systemInfo(plan))
+  return queryClient
+}
+
+function LicensingTabStory({ plan }: { plan: Plan }) {
+  const queryClient = useMemo(() => createLicensingQueryClient(plan), [plan])
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Box sx={{ maxWidth: 640, mx: 'auto', p: 3 }}>
+        <LicensingTab />
+      </Box>
+    </QueryClientProvider>
+  )
+}
+
+const meta = {
+  title: 'Components/LicensingTab',
+  component: LicensingTab,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof LicensingTab>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+/** Pro plan: the buy link sells the next tier up (Enterprise). */
+export const ProWithUpgradeLink: Story = {
+  render: () => <LicensingTabStory plan="pro" />,
+}
+
+/** Enterprise plan: there is no tier above it, so no buy link is rendered. */
+export const EnterpriseNoUpgradeLink: Story = {
+  render: () => <LicensingTabStory plan="enterprise" />,
+}

--- a/frontend/src/components/LicensingTab.tsx
+++ b/frontend/src/components/LicensingTab.tsx
@@ -18,6 +18,7 @@ import { usePlan } from '../hooks/usePlan'
 import { translateBackendKey } from '../utils/translateBackendKey'
 import { useAnalytics } from '../hooks/useAnalytics'
 import { BUY_URL } from '../utils/externalLinks'
+import { PLAN_LABEL, nextPlanAbove } from '../core/features'
 import PlanInfoDrawer from './PlanInfoDrawer'
 
 export default function LicensingTab() {
@@ -122,6 +123,8 @@ export default function LicensingTab() {
     refreshMutation.isPending || activateMutation.isPending || deactivateMutation.isPending
   const isFullAccess = entitlement?.is_full_access && entitlement.status === 'active'
   const activePaidLicense = entitlement?.ui_state === 'paid_active'
+  // The buy link sells the tier above the current plan; Enterprise has none.
+  const upgradePlan = nextPlanAbove(plan)
   const statusLabel = isFullAccess
     ? t('plan.fullAccessLabel')
     : plan === 'community'
@@ -333,21 +336,23 @@ export default function LicensingTab() {
             >
               {t('plan.licenseManagementHelp')}
             </Typography>
-            <Link
-              href={BUY_URL}
-              target="_blank"
-              rel="noreferrer"
-              underline="hover"
-              sx={{
-                alignSelf: 'flex-start',
-                fontSize: '0.95rem',
-                fontWeight: 600,
-                lineHeight: 1.4,
-              }}
-              onClick={handleBuyClick}
-            >
-              {t('plan.buyLink', { plan: statusLabel })}
-            </Link>
+            {upgradePlan && (
+              <Link
+                href={BUY_URL}
+                target="_blank"
+                rel="noreferrer"
+                underline="hover"
+                sx={{
+                  alignSelf: 'flex-start',
+                  fontSize: '0.95rem',
+                  fontWeight: 600,
+                  lineHeight: 1.4,
+                }}
+                onClick={handleBuyClick}
+              >
+                {t('plan.buyLink', { plan: PLAN_LABEL[upgradePlan] })}
+              </Link>
+            )}
             <Link
               component="button"
               underline="hover"

--- a/frontend/src/components/LicensingTab.tsx
+++ b/frontend/src/components/LicensingTab.tsx
@@ -17,7 +17,7 @@ import { licensingAPI } from '../services/api'
 import { usePlan } from '../hooks/usePlan'
 import { translateBackendKey } from '../utils/translateBackendKey'
 import { useAnalytics } from '../hooks/useAnalytics'
-import { BUY_URL } from '../utils/externalLinks'
+import { buildBuyUrl } from '../utils/externalLinks'
 import { PLAN_LABEL, nextPlanAbove } from '../core/features'
 import PlanInfoDrawer from './PlanInfoDrawer'
 
@@ -165,6 +165,7 @@ export default function LicensingTab() {
     trackPlan(EventAction.VIEW, {
       ...analyticsContext,
       operation: 'open_buy_link',
+      selected_plan: upgradePlan,
     })
   }
 
@@ -338,7 +339,7 @@ export default function LicensingTab() {
             </Typography>
             {upgradePlan && (
               <Link
-                href={BUY_URL}
+                href={buildBuyUrl({ plan: upgradePlan, src: 'app-licensing' })}
                 target="_blank"
                 rel="noreferrer"
                 underline="hover"

--- a/frontend/src/components/PlanBadge.stories.tsx
+++ b/frontend/src/components/PlanBadge.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Stack } from '@mui/material'
+import PlanBadge from './PlanBadge'
+import type { EntitlementInfo } from '../hooks/useSystemInfo'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+function fullAccess(daysLeft: number): EntitlementInfo {
+  return {
+    status: 'active',
+    access_level: 'full_access',
+    is_full_access: true,
+    full_access_consumed: true,
+    expires_at: new Date(Date.now() + daysLeft * DAY_MS).toISOString(),
+    starts_at: new Date(Date.now() - (60 - daysLeft) * DAY_MS).toISOString(),
+    instance_id: 'inst_story',
+    ui_state: 'full_access_active',
+    last_refresh_at: null,
+    last_refresh_error: null,
+  }
+}
+
+const meta = {
+  title: 'Components/PlanBadge',
+  component: PlanBadge,
+  parameters: { layout: 'centered' },
+  args: { onClick: () => {} },
+} satisfies Meta<typeof PlanBadge>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Community: Story = {
+  args: { plan: 'community' },
+}
+
+export const Pro: Story = {
+  args: { plan: 'pro' },
+}
+
+/** More than 14 days left: the badge only says Full Access. */
+export const FullAccessEarly: Story = {
+  args: { plan: 'community', entitlement: fullAccess(40) },
+}
+
+/** Fewer than 14 days left: the badge adds the remaining-days countdown. */
+export const FullAccessCountdown: Story = {
+  args: { plan: 'community', entitlement: fullAccess(5) },
+}
+
+export const AllStates: Story = {
+  args: { plan: 'community' },
+  render: () => (
+    <Stack spacing={1.5} sx={{ p: 3, alignItems: 'flex-start' }}>
+      <PlanBadge plan="community" onClick={() => {}} />
+      <PlanBadge plan="pro" onClick={() => {}} />
+      <PlanBadge plan="enterprise" onClick={() => {}} />
+      <PlanBadge plan="community" entitlement={fullAccess(40)} onClick={() => {}} />
+      <PlanBadge plan="community" entitlement={fullAccess(5)} onClick={() => {}} />
+    </Stack>
+  ),
+}

--- a/frontend/src/components/PlanBadge.tsx
+++ b/frontend/src/components/PlanBadge.tsx
@@ -17,7 +17,7 @@ export default function PlanBadge({ plan, entitlement, onClick }: PlanBadgeProps
   const color = isFullAccess ? PLAN_COLOR.enterprise : PLAN_COLOR[plan]
   const daysLeft = fullAccessDaysLeft(isFullAccess ? entitlement?.expires_at : null)
   const label = isFullAccess
-    ? daysLeft !== null && daysLeft <= FULL_ACCESS_COUNTDOWN_THRESHOLD_DAYS
+    ? daysLeft !== null && daysLeft < FULL_ACCESS_COUNTDOWN_THRESHOLD_DAYS
       ? `${t('plan.fullAccessLabel')} · ${t('plan.daysShort', { count: daysLeft })}`
       : t('plan.fullAccessLabel')
     : PLAN_LABEL[plan]

--- a/frontend/src/components/PlanBadge.tsx
+++ b/frontend/src/components/PlanBadge.tsx
@@ -3,6 +3,7 @@ import { ChevronRight } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Plan, PLAN_COLOR, PLAN_LABEL } from '../core/features'
 import type { EntitlementInfo } from '../hooks/useSystemInfo'
+import { FULL_ACCESS_COUNTDOWN_THRESHOLD_DAYS, fullAccessDaysLeft } from '../utils/fullAccess'
 
 interface PlanBadgeProps {
   plan: Plan
@@ -14,7 +15,12 @@ export default function PlanBadge({ plan, entitlement, onClick }: PlanBadgeProps
   const { t } = useTranslation()
   const isFullAccess = entitlement?.is_full_access && entitlement.status === 'active'
   const color = isFullAccess ? PLAN_COLOR.enterprise : PLAN_COLOR[plan]
-  const label = isFullAccess ? t('plan.fullAccessLabel') : PLAN_LABEL[plan]
+  const daysLeft = fullAccessDaysLeft(isFullAccess ? entitlement?.expires_at : null)
+  const label = isFullAccess
+    ? daysLeft !== null && daysLeft <= FULL_ACCESS_COUNTDOWN_THRESHOLD_DAYS
+      ? `${t('plan.fullAccessLabel')} · ${t('plan.daysShort', { count: daysLeft })}`
+      : t('plan.fullAccessLabel')
+    : PLAN_LABEL[plan]
 
   return (
     <Box

--- a/frontend/src/components/PlanInfoDrawer.stories.tsx
+++ b/frontend/src/components/PlanInfoDrawer.stories.tsx
@@ -4,6 +4,7 @@ import { Box, CssBaseline } from '@mui/material'
 import { ThemeProvider } from '@mui/material/styles'
 import { darkTheme } from '../theme'
 import PlanInfoDrawer from './PlanInfoDrawer'
+import type { EntitlementInfo } from '../hooks/useSystemInfo'
 
 const featureMap = {
   borg_v2: 'pro',
@@ -14,6 +15,34 @@ const featureMap = {
   managed_agents: 'pro',
   rbac: 'enterprise',
 } as const
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+const fullAccessEndingSoon: EntitlementInfo = {
+  status: 'active',
+  access_level: 'full_access',
+  is_full_access: true,
+  full_access_consumed: true,
+  expires_at: new Date(Date.now() + 6 * DAY_MS).toISOString(),
+  starts_at: new Date(Date.now() - 54 * DAY_MS).toISOString(),
+  instance_id: 'inst_story',
+  ui_state: 'full_access_active',
+  last_refresh_at: null,
+  last_refresh_error: null,
+}
+
+const fullAccessExpired: EntitlementInfo = {
+  status: 'expired',
+  access_level: 'community',
+  is_full_access: false,
+  full_access_consumed: true,
+  expires_at: null,
+  starts_at: null,
+  instance_id: 'inst_story',
+  ui_state: 'full_access_expired',
+  last_refresh_at: null,
+  last_refresh_error: null,
+}
 
 function PlanInfoDrawerStory(args: ComponentProps<typeof PlanInfoDrawer>) {
   const hostRef = useRef<HTMLDivElement>(null)
@@ -76,4 +105,30 @@ export const DarkCommunityUpgradeDrawer: Story = {
       <PlanInfoDrawerStory {...args} />
     </ThemeProvider>
   ),
+}
+
+/** Six days of full access left: countdown banner plus the trial-sourced buy link. */
+export const FullAccessEndingSoonDrawer: Story = {
+  args: {
+    open: true,
+    plan: 'community',
+    appVersion: '2.0.2',
+    features: featureMap,
+    entitlement: fullAccessEndingSoon,
+    onClose: () => {},
+  },
+  render: (args) => <PlanInfoDrawerStory {...args} />,
+}
+
+/** Full access has ended: warning with the "Restore Pro features" action and the expiry offer link. */
+export const FullAccessExpiredDrawer: Story = {
+  args: {
+    open: true,
+    plan: 'community',
+    appVersion: '2.0.2',
+    features: featureMap,
+    entitlement: fullAccessExpired,
+    onClose: () => {},
+  },
+  render: (args) => <PlanInfoDrawerStory {...args} />,
 }

--- a/frontend/src/components/PlanInfoDrawer.stories.tsx
+++ b/frontend/src/components/PlanInfoDrawer.stories.tsx
@@ -120,7 +120,31 @@ export const FullAccessEndingSoonDrawer: Story = {
   render: (args) => <PlanInfoDrawerStory {...args} />,
 }
 
-/** Full access has ended: warning with the "Restore Pro features" action and the expiry offer link. */
+/** Already on Pro: the footer sells Enterprise, never Pro again. */
+export const ProPlanDrawer: Story = {
+  args: {
+    open: true,
+    plan: 'pro',
+    appVersion: '2.0.2',
+    features: featureMap,
+    onClose: () => {},
+  },
+  render: (args) => <PlanInfoDrawerStory {...args} />,
+}
+
+/** Enterprise: nothing above it, so there is no upgrade button. */
+export const EnterprisePlanDrawer: Story = {
+  args: {
+    open: true,
+    plan: 'enterprise',
+    appVersion: '2.0.2',
+    features: featureMap,
+    onClose: () => {},
+  },
+  render: (args) => <PlanInfoDrawerStory {...args} />,
+}
+
+/** Full access has ended: warning with the "Restore Pro features" button under the text and the expiry offer link. */
 export const FullAccessExpiredDrawer: Story = {
   args: {
     open: true,

--- a/frontend/src/components/PlanInfoDrawer.tsx
+++ b/frontend/src/components/PlanInfoDrawer.tsx
@@ -13,7 +13,7 @@ import {
 import { useTheme } from '@mui/material/styles'
 import { X, Check, Sparkles, Clock } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import type { Plan } from '../core/features'
+import { nextPlanAbove, type Plan } from '../core/features'
 import { useAnalytics } from '../hooks/useAnalytics'
 import type { EntitlementInfo } from '../hooks/useSystemInfo'
 import { usePlanContent } from '../hooks/usePlanContent'
@@ -93,13 +93,6 @@ function normalizePlan(plan: Plan | string | null | undefined): Plan {
 }
 
 const PLAN_RANK: Record<Plan, number> = { community: 0, pro: 1, enterprise: 2 }
-
-// The tier directly above the current plan, or null on the top tier.
-function nextPlanAbove(plan: Plan): 'pro' | 'enterprise' | null {
-  if (plan === 'community') return 'pro'
-  if (plan === 'pro') return 'enterprise'
-  return null
-}
 
 export default function PlanInfoDrawer({
   open,

--- a/frontend/src/components/PlanInfoDrawer.tsx
+++ b/frontend/src/components/PlanInfoDrawer.tsx
@@ -92,6 +92,15 @@ function normalizePlan(plan: Plan | string | null | undefined): Plan {
   return 'community'
 }
 
+const PLAN_RANK: Record<Plan, number> = { community: 0, pro: 1, enterprise: 2 }
+
+// The tier directly above the current plan, or null on the top tier.
+function nextPlanAbove(plan: Plan): 'pro' | 'enterprise' | null {
+  if (plan === 'community') return 'pro'
+  if (plan === 'pro') return 'enterprise'
+  return null
+}
+
 export default function PlanInfoDrawer({
   open,
   onClose,
@@ -206,10 +215,15 @@ export default function PlanInfoDrawer({
     }
   }, [initialSelectedPlan, normalizedPlan, open])
 
-  // The footer link always sells Pro unless the user is browsing Enterprise on the
-  // Upgrade tab. The same value drives the href, the label, and the analytics event.
-  const buyPlan: 'pro' | 'enterprise' =
-    activeTab === 'upgrade' && selectedPlan === 'enterprise' ? 'enterprise' : 'pro'
+  // The footer sells the tier above the current plan, or the plan being browsed on
+  // the Upgrade tab when that is higher than what the instance already has. On
+  // Enterprise there is nothing to sell, so the footer button is hidden. The same
+  // value drives the href, the label, and the analytics event.
+  const browsedUpgrade =
+    activeTab === 'upgrade' && PLAN_RANK[selectedPlan] > PLAN_RANK[normalizedPlan]
+      ? (selectedPlan as 'pro' | 'enterprise')
+      : null
+  const buyPlan: 'pro' | 'enterprise' | null = browsedUpgrade ?? nextPlanAbove(normalizedPlan)
   const buySource = isFullAccess
     ? 'app-trial'
     : entitlement?.ui_state === 'full_access_expired'
@@ -218,12 +232,46 @@ export default function PlanInfoDrawer({
   const buyOffer = entitlement?.ui_state === 'full_access_expired' ? 'expired' : undefined
 
   const handleBuyClick = () => {
+    if (!buyPlan) return
     trackPlan(EventAction.VIEW, {
       surface: 'plan_drawer',
       operation: 'open_buy_link',
       selected_plan: buyPlan,
     })
   }
+
+  // Shown at the top of both tabs once full access has ended. The CTA sits under
+  // the text rather than in the Alert action slot, which squeezed the message to
+  // one word per line inside the narrow drawer.
+  const expiredNotice = (
+    <Alert
+      severity="warning"
+      sx={{ mb: 2, fontSize: '0.75rem', '& .MuiAlert-message': { width: '100%' } }}
+    >
+      {t('plan.fullAccessExpiredNotice')}
+      <Button
+        color="inherit"
+        variant="outlined"
+        size="small"
+        fullWidth
+        component="a"
+        href={buildBuyUrl({ plan: 'pro', src: 'app-expired', offer: 'expired' })}
+        target="_blank"
+        rel="noreferrer"
+        onClick={() =>
+          trackPlan(EventAction.VIEW, {
+            surface: 'plan_drawer',
+            operation: 'open_buy_link',
+            selected_plan: 'pro',
+            context: 'full_access_expired',
+          })
+        }
+        sx={{ mt: 1.25, fontWeight: 700 }}
+      >
+        {t('plan.expiredUpgradeCta')}
+      </Button>
+    </Alert>
+  )
 
   const yourPlanTabColor = color
   const upgradeTabColor = selectedColor
@@ -347,35 +395,7 @@ export default function PlanInfoDrawer({
         <Box sx={{ flex: 1, overflowY: 'auto', px: 2.5, py: 2 }}>
           {activeTab === 'your-plan' && (
             <>
-              {entitlement?.ui_state === 'full_access_expired' && (
-                <Alert
-                  severity="warning"
-                  sx={{ mb: 2, fontSize: '0.75rem', alignItems: 'center' }}
-                  action={
-                    <Button
-                      color="inherit"
-                      size="small"
-                      component="a"
-                      href={buildBuyUrl({ plan: 'pro', src: 'app-expired', offer: 'expired' })}
-                      target="_blank"
-                      rel="noreferrer"
-                      onClick={() =>
-                        trackPlan(EventAction.VIEW, {
-                          surface: 'plan_drawer',
-                          operation: 'open_buy_link',
-                          selected_plan: 'pro',
-                          context: 'full_access_expired',
-                        })
-                      }
-                      sx={{ whiteSpace: 'nowrap', fontWeight: 700 }}
-                    >
-                      {t('plan.expiredUpgradeCta')}
-                    </Button>
-                  }
-                >
-                  {t('plan.fullAccessExpiredNotice')}
-                </Alert>
-              )}
+              {entitlement?.ui_state === 'full_access_expired' && expiredNotice}
               {entitlement?.last_refresh_error && (
                 <Alert severity="warning" sx={{ mb: 2, fontSize: '0.75rem' }}>
                   {t('plan.lastRefreshError', { error: entitlement.last_refresh_error })}
@@ -488,35 +508,7 @@ export default function PlanInfoDrawer({
 
           {activeTab === 'upgrade' && (
             <>
-              {entitlement?.ui_state === 'full_access_expired' && (
-                <Alert
-                  severity="warning"
-                  sx={{ mb: 2, fontSize: '0.75rem', alignItems: 'center' }}
-                  action={
-                    <Button
-                      color="inherit"
-                      size="small"
-                      component="a"
-                      href={buildBuyUrl({ plan: 'pro', src: 'app-expired', offer: 'expired' })}
-                      target="_blank"
-                      rel="noreferrer"
-                      onClick={() =>
-                        trackPlan(EventAction.VIEW, {
-                          surface: 'plan_drawer',
-                          operation: 'open_buy_link',
-                          selected_plan: 'pro',
-                          context: 'full_access_expired',
-                        })
-                      }
-                      sx={{ whiteSpace: 'nowrap', fontWeight: 700 }}
-                    >
-                      {t('plan.expiredUpgradeCta')}
-                    </Button>
-                  }
-                >
-                  {t('plan.fullAccessExpiredNotice')}
-                </Alert>
-              )}
+              {entitlement?.ui_state === 'full_access_expired' && expiredNotice}
               {entitlement?.last_refresh_error && (
                 <Alert severity="warning" sx={{ mb: 2, fontSize: '0.75rem' }}>
                   {t('plan.lastRefreshError', { error: entitlement.last_refresh_error })}
@@ -862,17 +854,19 @@ export default function PlanInfoDrawer({
               </Typography>
             </Box>
           )}
-          <Button
-            component="a"
-            href={buildBuyUrl({ plan: buyPlan, src: buySource, offer: buyOffer })}
-            target="_blank"
-            rel="noreferrer"
-            variant="contained"
-            fullWidth
-            onClick={handleBuyClick}
-          >
-            {t('plan.buyLink', { plan: planLabel(buyPlan) })}
-          </Button>
+          {buyPlan && (
+            <Button
+              component="a"
+              href={buildBuyUrl({ plan: buyPlan, src: buySource, offer: buyOffer })}
+              target="_blank"
+              rel="noreferrer"
+              variant="contained"
+              fullWidth
+              onClick={handleBuyClick}
+            >
+              {t('plan.buyLink', { plan: planLabel(buyPlan) })}
+            </Button>
+          )}
         </Box>
       </Box>
     </Drawer>

--- a/frontend/src/components/PlanInfoDrawer.tsx
+++ b/frontend/src/components/PlanInfoDrawer.tsx
@@ -18,7 +18,7 @@ import { useAnalytics } from '../hooks/useAnalytics'
 import type { EntitlementInfo } from '../hooks/useSystemInfo'
 import { usePlanContent } from '../hooks/usePlanContent'
 import { compareVersions } from '../utils/announcements'
-import { BUY_URL } from '../utils/externalLinks'
+import { buildBuyUrl } from '../utils/externalLinks'
 import { getPlanDrawerColors } from './planDrawerColors'
 
 interface PlanInfoDrawerProps {
@@ -337,7 +337,31 @@ export default function PlanInfoDrawer({
           {activeTab === 'your-plan' && (
             <>
               {entitlement?.ui_state === 'full_access_expired' && (
-                <Alert severity="warning" sx={{ mb: 2, fontSize: '0.75rem' }}>
+                <Alert
+                  severity="warning"
+                  sx={{ mb: 2, fontSize: '0.75rem', alignItems: 'center' }}
+                  action={
+                    <Button
+                      color="inherit"
+                      size="small"
+                      component="a"
+                      href={buildBuyUrl({ plan: 'pro', src: 'app-expired', offer: 'expired' })}
+                      target="_blank"
+                      rel="noreferrer"
+                      onClick={() =>
+                        trackPlan(EventAction.VIEW, {
+                          surface: 'plan_drawer',
+                          operation: 'open_buy_link',
+                          selected_plan: 'pro',
+                          context: 'full_access_expired',
+                        })
+                      }
+                      sx={{ whiteSpace: 'nowrap', fontWeight: 700 }}
+                    >
+                      {t('plan.expiredUpgradeCta')}
+                    </Button>
+                  }
+                >
                   {t('plan.fullAccessExpiredNotice')}
                 </Alert>
               )}
@@ -454,7 +478,31 @@ export default function PlanInfoDrawer({
           {activeTab === 'upgrade' && (
             <>
               {entitlement?.ui_state === 'full_access_expired' && (
-                <Alert severity="warning" sx={{ mb: 2, fontSize: '0.75rem' }}>
+                <Alert
+                  severity="warning"
+                  sx={{ mb: 2, fontSize: '0.75rem', alignItems: 'center' }}
+                  action={
+                    <Button
+                      color="inherit"
+                      size="small"
+                      component="a"
+                      href={buildBuyUrl({ plan: 'pro', src: 'app-expired', offer: 'expired' })}
+                      target="_blank"
+                      rel="noreferrer"
+                      onClick={() =>
+                        trackPlan(EventAction.VIEW, {
+                          surface: 'plan_drawer',
+                          operation: 'open_buy_link',
+                          selected_plan: 'pro',
+                          context: 'full_access_expired',
+                        })
+                      }
+                      sx={{ whiteSpace: 'nowrap', fontWeight: 700 }}
+                    >
+                      {t('plan.expiredUpgradeCta')}
+                    </Button>
+                  }
+                >
                   {t('plan.fullAccessExpiredNotice')}
                 </Alert>
               )}
@@ -805,7 +853,15 @@ export default function PlanInfoDrawer({
           )}
           <Button
             component="a"
-            href={BUY_URL}
+            href={buildBuyUrl({
+              plan: activeTab === 'upgrade' && selectedPlan === 'enterprise' ? 'enterprise' : 'pro',
+              src: isFullAccess
+                ? 'app-trial'
+                : entitlement?.ui_state === 'full_access_expired'
+                  ? 'app-expired'
+                  : 'app-drawer',
+              offer: entitlement?.ui_state === 'full_access_expired' ? 'expired' : undefined,
+            })}
             target="_blank"
             rel="noreferrer"
             variant="contained"

--- a/frontend/src/components/PlanInfoDrawer.tsx
+++ b/frontend/src/components/PlanInfoDrawer.tsx
@@ -206,11 +206,22 @@ export default function PlanInfoDrawer({
     }
   }, [initialSelectedPlan, normalizedPlan, open])
 
+  // The footer link always sells Pro unless the user is browsing Enterprise on the
+  // Upgrade tab. The same value drives the href, the label, and the analytics event.
+  const buyPlan: 'pro' | 'enterprise' =
+    activeTab === 'upgrade' && selectedPlan === 'enterprise' ? 'enterprise' : 'pro'
+  const buySource = isFullAccess
+    ? 'app-trial'
+    : entitlement?.ui_state === 'full_access_expired'
+      ? 'app-expired'
+      : 'app-drawer'
+  const buyOffer = entitlement?.ui_state === 'full_access_expired' ? 'expired' : undefined
+
   const handleBuyClick = () => {
     trackPlan(EventAction.VIEW, {
       surface: 'plan_drawer',
       operation: 'open_buy_link',
-      selected_plan: selectedPlan,
+      selected_plan: buyPlan,
     })
   }
 
@@ -853,24 +864,14 @@ export default function PlanInfoDrawer({
           )}
           <Button
             component="a"
-            href={buildBuyUrl({
-              plan: activeTab === 'upgrade' && selectedPlan === 'enterprise' ? 'enterprise' : 'pro',
-              src: isFullAccess
-                ? 'app-trial'
-                : entitlement?.ui_state === 'full_access_expired'
-                  ? 'app-expired'
-                  : 'app-drawer',
-              offer: entitlement?.ui_state === 'full_access_expired' ? 'expired' : undefined,
-            })}
+            href={buildBuyUrl({ plan: buyPlan, src: buySource, offer: buyOffer })}
             target="_blank"
             rel="noreferrer"
             variant="contained"
             fullWidth
             onClick={handleBuyClick}
           >
-            {t('plan.buyLink', {
-              plan: planLabel(activeTab === 'upgrade' ? selectedPlan : 'pro'),
-            })}
+            {t('plan.buyLink', { plan: planLabel(buyPlan) })}
           </Button>
         </Box>
       </Box>

--- a/frontend/src/components/__tests__/LicensingTab.test.tsx
+++ b/frontend/src/components/__tests__/LicensingTab.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderWithProviders, screen, userEvent, waitFor } from '../../test/test-utils'
 import LicensingTab from '../LicensingTab'
-import { BUY_URL } from '../../utils/externalLinks'
+import { buildBuyUrl } from '../../utils/externalLinks'
 
 const { refreshMock, activateMock, deactivateMock, trackPlanMock, invalidateQueriesMock } =
   vi.hoisted(() => ({
@@ -165,14 +165,17 @@ describe('LicensingTab', () => {
     // The mocked plan is Pro, so the link must sell Enterprise, not Pro again.
     const buyLink = screen.getByRole('link', { name: /upgrade to enterprise/i })
     expect(screen.queryByRole('link', { name: /upgrade to pro/i })).not.toBeInTheDocument()
-    expect(buyLink).toHaveAttribute('href', BUY_URL)
+    expect(buyLink).toHaveAttribute(
+      'href',
+      buildBuyUrl({ plan: 'enterprise', src: 'app-licensing' })
+    )
     buyLink.addEventListener('click', (event) => event.preventDefault())
 
     await user.click(buyLink)
 
     expect(trackPlanMock).toHaveBeenCalledWith(
       'View',
-      expect.objectContaining({ operation: 'open_buy_link' })
+      expect.objectContaining({ operation: 'open_buy_link', selected_plan: 'enterprise' })
     )
   })
 })

--- a/frontend/src/components/__tests__/LicensingTab.test.tsx
+++ b/frontend/src/components/__tests__/LicensingTab.test.tsx
@@ -162,7 +162,9 @@ describe('LicensingTab', () => {
 
     renderWithProviders(<LicensingTab />)
 
-    const buyLink = screen.getByRole('link', { name: /upgrade to pro/i })
+    // The mocked plan is Pro, so the link must sell Enterprise, not Pro again.
+    const buyLink = screen.getByRole('link', { name: /upgrade to enterprise/i })
+    expect(screen.queryByRole('link', { name: /upgrade to pro/i })).not.toBeInTheDocument()
     expect(buyLink).toHaveAttribute('href', BUY_URL)
     buyLink.addEventListener('click', (event) => event.preventDefault())
 

--- a/frontend/src/components/__tests__/PlanBadge.test.tsx
+++ b/frontend/src/components/__tests__/PlanBadge.test.tsx
@@ -1,6 +1,21 @@
 import { describe, expect, it, vi } from 'vitest'
 import { renderWithProviders, screen, userEvent } from '../../test/test-utils'
 import PlanBadge from '../PlanBadge'
+import type { EntitlementInfo } from '../../hooks/useSystemInfo'
+
+function fullAccessEntitlement(expires: string): EntitlementInfo {
+  return {
+    status: 'active',
+    access_level: 'full_access',
+    is_full_access: true,
+    full_access_consumed: false,
+    expires_at: expires,
+    starts_at: null,
+    instance_id: null,
+    last_refresh_at: null,
+    last_refresh_error: null,
+  }
+}
 
 describe('PlanBadge', () => {
   it('renders the current plan label and handles clicks', async () => {
@@ -19,11 +34,7 @@ describe('PlanBadge full access countdown', () => {
   it('shows days left once the trial is inside the countdown window', () => {
     const expires = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString()
     renderWithProviders(
-      <PlanBadge
-        plan="community"
-        entitlement={{ status: 'active', is_full_access: true, expires_at: expires } as never}
-        onClick={() => {}}
-      />
+      <PlanBadge plan="community" entitlement={fullAccessEntitlement(expires)} onClick={() => {}} />
     )
     expect(screen.getByText(/Full Access · 5 days left/)).toBeInTheDocument()
   })
@@ -31,11 +42,7 @@ describe('PlanBadge full access countdown', () => {
   it('shows the plain label at exactly the threshold', () => {
     const expires = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000 + 60_000).toISOString()
     renderWithProviders(
-      <PlanBadge
-        plan="community"
-        entitlement={{ status: 'active', is_full_access: true, expires_at: expires } as never}
-        onClick={() => {}}
-      />
+      <PlanBadge plan="community" entitlement={fullAccessEntitlement(expires)} onClick={() => {}} />
     )
     expect(screen.getByText('Full Access')).toBeInTheDocument()
   })
@@ -43,11 +50,7 @@ describe('PlanBadge full access countdown', () => {
   it('hides the countdown while the trial has plenty of time left', () => {
     const expires = new Date(Date.now() + 40 * 24 * 60 * 60 * 1000).toISOString()
     renderWithProviders(
-      <PlanBadge
-        plan="community"
-        entitlement={{ status: 'active', is_full_access: true, expires_at: expires } as never}
-        onClick={() => {}}
-      />
+      <PlanBadge plan="community" entitlement={fullAccessEntitlement(expires)} onClick={() => {}} />
     )
     expect(screen.getByText('Full Access')).toBeInTheDocument()
   })

--- a/frontend/src/components/__tests__/PlanBadge.test.tsx
+++ b/frontend/src/components/__tests__/PlanBadge.test.tsx
@@ -14,3 +14,29 @@ describe('PlanBadge', () => {
     expect(onClick).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('PlanBadge full access countdown', () => {
+  it('shows days left once the trial is inside the countdown window', () => {
+    const expires = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString()
+    renderWithProviders(
+      <PlanBadge
+        plan="community"
+        entitlement={{ status: 'active', is_full_access: true, expires_at: expires } as never}
+        onClick={() => {}}
+      />
+    )
+    expect(screen.getByText(/Full Access · 5 days left/)).toBeInTheDocument()
+  })
+
+  it('hides the countdown while the trial has plenty of time left', () => {
+    const expires = new Date(Date.now() + 40 * 24 * 60 * 60 * 1000).toISOString()
+    renderWithProviders(
+      <PlanBadge
+        plan="community"
+        entitlement={{ status: 'active', is_full_access: true, expires_at: expires } as never}
+        onClick={() => {}}
+      />
+    )
+    expect(screen.getByText('Full Access')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/PlanBadge.test.tsx
+++ b/frontend/src/components/__tests__/PlanBadge.test.tsx
@@ -28,6 +28,18 @@ describe('PlanBadge full access countdown', () => {
     expect(screen.getByText(/Full Access · 5 days left/)).toBeInTheDocument()
   })
 
+  it('shows the plain label at exactly the threshold', () => {
+    const expires = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000 + 60_000).toISOString()
+    renderWithProviders(
+      <PlanBadge
+        plan="community"
+        entitlement={{ status: 'active', is_full_access: true, expires_at: expires } as never}
+        onClick={() => {}}
+      />
+    )
+    expect(screen.getByText('Full Access')).toBeInTheDocument()
+  })
+
   it('hides the countdown while the trial has plenty of time left', () => {
     const expires = new Date(Date.now() + 40 * 24 * 60 * 60 * 1000).toISOString()
     renderWithProviders(

--- a/frontend/src/components/__tests__/PlanInfoDrawer.test.tsx
+++ b/frontend/src/components/__tests__/PlanInfoDrawer.test.tsx
@@ -417,4 +417,32 @@ describe('PlanInfoDrawer', () => {
       buildBuyUrl({ plan: 'pro', src: 'app-expired', offer: 'expired' })
     )
   })
+
+  it('sells Enterprise, not Pro, to an instance already on Pro', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(
+      <PlanInfoDrawer open={true} onClose={vi.fn()} plan="pro" features={featureMap} />
+    )
+
+    expect(screen.queryByRole('link', { name: /upgrade to pro/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /upgrade to enterprise/i })).toHaveAttribute(
+      'href',
+      buildBuyUrl({ plan: 'enterprise', src: 'app-drawer' })
+    )
+
+    // The Upgrade tab opens on the Pro column for a Pro instance; it must not
+    // offer to buy Pro again.
+    await user.click(screen.getByText('Upgrade'))
+    expect(screen.queryByRole('link', { name: /upgrade to pro/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /upgrade to enterprise/i })).toBeInTheDocument()
+  })
+
+  it('shows no upgrade button on Enterprise', () => {
+    renderWithProviders(
+      <PlanInfoDrawer open={true} onClose={vi.fn()} plan="enterprise" features={featureMap} />
+    )
+
+    expect(screen.queryByRole('link', { name: /upgrade to/i })).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/__tests__/PlanInfoDrawer.test.tsx
+++ b/frontend/src/components/__tests__/PlanInfoDrawer.test.tsx
@@ -3,7 +3,7 @@ import { renderWithProviders, screen, userEvent } from '../../test/test-utils'
 import { darkTheme, theme } from '../../theme'
 import PlanInfoDrawer from '../PlanInfoDrawer'
 import { getPlanDrawerContrastPairs } from '../planDrawerColors'
-import { BUY_URL } from '../../utils/externalLinks'
+import { buildBuyUrl } from '../../utils/externalLinks'
 import type { Plan } from '../../core/features'
 
 type Rgb = [number, number, number]
@@ -379,13 +379,42 @@ describe('PlanInfoDrawer', () => {
       <PlanInfoDrawer open={true} onClose={vi.fn()} plan="community" features={featureMap} />
     )
 
-    expect(screen.getByRole('link', { name: /upgrade to pro/i })).toHaveAttribute('href', BUY_URL)
+    expect(screen.getByRole('link', { name: /upgrade to pro/i })).toHaveAttribute(
+      'href',
+      buildBuyUrl({ plan: 'pro', src: 'app-drawer' })
+    )
 
     await user.click(screen.getByText('Enterprise'))
 
     expect(screen.getByRole('link', { name: /upgrade to enterprise/i })).toHaveAttribute(
       'href',
-      BUY_URL
+      buildBuyUrl({ plan: 'enterprise', src: 'app-drawer' })
+    )
+  })
+
+  it('offers a direct upgrade with the expiry offer once full access has ended', () => {
+    renderWithProviders(
+      <PlanInfoDrawer
+        open={true}
+        onClose={vi.fn()}
+        plan="community"
+        features={featureMap}
+        entitlement={
+          {
+            status: 'expired',
+            is_full_access: false,
+            full_access_consumed: true,
+            ui_state: 'full_access_expired',
+            expires_at: null,
+          } as never
+        }
+      />
+    )
+
+    const cta = screen.getByRole('link', { name: /restore pro features/i })
+    expect(cta).toHaveAttribute(
+      'href',
+      buildBuyUrl({ plan: 'pro', src: 'app-expired', offer: 'expired' })
     )
   })
 })

--- a/frontend/src/core/features.ts
+++ b/frontend/src/core/features.ts
@@ -38,6 +38,13 @@ export const PLAN_COLOR: Record<Plan, string> = {
   enterprise: '#f59e0b',
 }
 
+/** The tier directly above the current plan, or null on the top tier. */
+export function nextPlanAbove(plan: Plan): 'pro' | 'enterprise' | null {
+  if (plan === 'community') return 'pro'
+  if (plan === 'pro') return 'enterprise'
+  return null
+}
+
 export function planIncludes(current: Plan, required: Plan): boolean {
   return PLAN_RANK[current] >= PLAN_RANK[required]
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -5769,7 +5769,10 @@
     "upgradeNudgeAfterTitle": "Schalten Sie mehr mit Pro oder Enterprise frei",
     "upgradeNudgePro": "Pro",
     "upgradeNudgeEnterprise": "Enterprise",
-    "viewUpgradeOptions": "Upgrade-Optionen anzeigen"
+    "viewUpgradeOptions": "Upgrade-Optionen anzeigen",
+    "expiredUpgradeCta": "Pro-Funktionen wiederherstellen",
+    "daysShort_one": "noch {{count}} Tag",
+    "daysShort_other": "noch {{count}} Tage"
   },
   "licensing": {
     "title": "Lizenzierung",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -5769,7 +5769,10 @@
     "upgradeNudgeAfterTitle": "Unlock more on Pro or Enterprise",
     "upgradeNudgePro": "Pro",
     "upgradeNudgeEnterprise": "Enterprise",
-    "viewUpgradeOptions": "View upgrade options"
+    "viewUpgradeOptions": "View upgrade options",
+    "expiredUpgradeCta": "Restore Pro features",
+    "daysShort_one": "{{count}} day left",
+    "daysShort_other": "{{count}} days left"
   },
   "licensing": {
     "title": "Licensing",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -5769,7 +5769,10 @@
     "upgradeNudgeAfterTitle": "Desbloquea más con Pro o Enterprise",
     "upgradeNudgePro": "Pro",
     "upgradeNudgeEnterprise": "Enterprise",
-    "viewUpgradeOptions": "Ver opciones de mejora"
+    "viewUpgradeOptions": "Ver opciones de mejora",
+    "expiredUpgradeCta": "Recuperar funciones Pro",
+    "daysShort_one": "queda {{count}} día",
+    "daysShort_other": "quedan {{count}} días"
   },
   "licensing": {
     "title": "Licencias",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -5769,7 +5769,10 @@
     "upgradeNudgeAfterTitle": "Sblocca di più con Pro o Enterprise",
     "upgradeNudgePro": "Pro",
     "upgradeNudgeEnterprise": "Enterprise",
-    "viewUpgradeOptions": "Visualizza le opzioni di upgrade"
+    "viewUpgradeOptions": "Visualizza le opzioni di upgrade",
+    "expiredUpgradeCta": "Ripristina le funzioni Pro",
+    "daysShort_one": "{{count}} giorno rimasto",
+    "daysShort_other": "{{count}} giorni rimasti"
   },
   "licensing": {
     "title": "Licenze",

--- a/frontend/src/utils/externalLinks.ts
+++ b/frontend/src/utils/externalLinks.ts
@@ -1,1 +1,16 @@
 export const BUY_URL = 'https://borgui.com/buy'
+
+export type BuyLinkContext = {
+  plan?: 'pro' | 'enterprise'
+  src: string
+  offer?: 'expired'
+}
+
+/** Buy link with the context the storefront uses to prefill, scroll, and apply offers. */
+export function buildBuyUrl({ plan, src, offer }: BuyLinkContext): string {
+  const params = new URLSearchParams()
+  if (plan) params.set('plan', plan)
+  params.set('src', src)
+  if (offer) params.set('offer', offer)
+  return `${BUY_URL}?${params.toString()}`
+}

--- a/frontend/src/utils/fullAccess.ts
+++ b/frontend/src/utils/fullAccess.ts
@@ -1,0 +1,12 @@
+/** Show the remaining-days countdown in the plan badge once the trial is inside this window. */
+export const FULL_ACCESS_COUNTDOWN_THRESHOLD_DAYS = 14
+
+export function fullAccessDaysLeft(
+  expiresAt: string | null | undefined,
+  now: number = Date.now()
+): number | null {
+  if (!expiresAt) return null
+  const ms = new Date(expiresAt).getTime() - now
+  if (!Number.isFinite(ms)) return null
+  return Math.max(0, Math.ceil(ms / (1000 * 60 * 60 * 24)))
+}

--- a/frontend/src/utils/fullAccess.ts
+++ b/frontend/src/utils/fullAccess.ts
@@ -1,4 +1,4 @@
-/** Show the remaining-days countdown in the plan badge once the trial is inside this window. */
+/** Show the remaining-days countdown in the plan badge once fewer than this many days remain. */
 export const FULL_ACCESS_COUNTDOWN_THRESHOLD_DAYS = 14
 
 export function fullAccessDaysLeft(


### PR DESCRIPTION
## Why
Every install runs 60 days with full access, then drops to Community with a single warning line and no action. That moment is the highest-intent point for a Pro purchase and it was silent. The sidebar badge also gave no warning that the trial was ending.

## What
- `buildBuyUrl()` adds `plan`, `src`, and `offer` query parameters to every in-app buy link. The storefront (karanhudia/borg-ui-license-platform#2) uses them to scroll to the plan, track the source, and apply a returning-user discount.
- Expired state in the plan drawer shows a **Restore Pro features** action.
- `PlanBadge` shows "Full Access · N days left" once fewer than 14 days remain (helper in `utils/fullAccess.ts`).
- New strings in en, de, es, it.

## Tests
- `PlanBadge.test.tsx`: countdown shown inside the window, hidden outside it.
- `PlanInfoDrawer.test.tsx`: contextual hrefs for Pro and Enterprise; expired CTA carries `offer=expired`.
- `tsc --noEmit`, eslint and oxlint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 0 changed, 22 added, 0 removed, 510 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-905/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/33941533392
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- `components-licensingtab--enterprise-no-upgrade-link--mobile.png`
- `components-licensingtab--enterprise-no-upgrade-link.png`
- `components-licensingtab--pro-with-upgrade-link--mobile.png`
- `components-licensingtab--pro-with-upgrade-link.png`
- `components-planbadge--all-states--mobile.png`
- `components-planbadge--all-states.png`
- `components-planbadge--community--mobile.png`
- `components-planbadge--community.png`
- `components-planbadge--full-access-countdown--mobile.png`
- `components-planbadge--full-access-countdown.png`
- `components-planbadge--full-access-early--mobile.png`
- `components-planbadge--full-access-early.png`
- `components-planbadge--pro--mobile.png`
- `components-planbadge--pro.png`
- `components-planinfodrawer--enterprise-plan-drawer--mobile.png`
- `components-planinfodrawer--enterprise-plan-drawer.png`
- `components-planinfodrawer--full-access-ending-soon-drawer--mobile.png`
- `components-planinfodrawer--full-access-ending-soon-drawer.png`
- `components-planinfodrawer--full-access-expired-drawer--mobile.png`
- `components-planinfodrawer--full-access-expired-drawer.png`
- `components-planinfodrawer--pro-plan-drawer--mobile.png`
- `components-planinfodrawer--pro-plan-drawer.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->