### PR TITLE
fix(mounts): address Borg 2 series archives by aid: selector

### DIFF
--- a/app/api/mounts.py
+++ b/app/api/mounts.py
@@ -30,6 +30,8 @@ class MountBorgRequest(BaseModel):
     repository_id: int
     archive_name: Optional[str] = None
     mount_point: Optional[str] = None
+    # Borg 2 series archives share one name; the id addresses exactly one.
+    archive_id: Optional[str] = None
 
 
 class MountResponse(BaseModel):
@@ -109,6 +111,7 @@ async def mount_borg_archive(
             repository_id=request.repository_id,
             archive_name=request.archive_name,
             mount_point=request.mount_point,
+            archive_id=request.archive_id,
         )
 
         # Get mount info

--- a/app/services/mount_service.py
+++ b/app/services/mount_service.py
@@ -915,6 +915,7 @@ class MountService:
         repository_id: int,
         archive_name: Optional[str] = None,
         mount_point: Optional[str] = None,
+        archive_id: Optional[str] = None,
     ) -> Tuple[str, str]:
         """
         Mount a Borg repository or specific archive for browsing
@@ -923,6 +924,9 @@ class MountService:
             repository_id: Repository ID to mount
             archive_name: Optional specific archive name (None = mount entire repo)
             mount_point: Optional custom mount point (must be validated)
+            archive_id: Borg 2 archive id for series disambiguation - archives
+                in a series share one name and only the id addresses exactly
+                one of them
 
         Returns:
             Tuple of (mount_point, mount_id)
@@ -1030,9 +1034,21 @@ class MountService:
                 if repository.passphrase:
                     env["BORG_PASSPHRASE"] = repository.passphrase
 
+                # Borg 2 archives in a series share one name; `-a <name>`
+                # matches and mounts every archive of the series as its own
+                # subdirectory. Address by aid: whenever a Borg 2 id is
+                # present - the selector pattern extract and restore checks
+                # use - including an id-only request, which must still mount
+                # exactly that archive rather than falling back to the whole
+                # repository. The human-readable name stays on mount point,
+                # source label and logs.
+                archive_selector = archive_name
+                if archive_id and (repository.borg_version or 1) == 2:
+                    archive_selector = f"aid:{archive_id}"
+
                 cmd = BorgRouter(repository).build_mount_command(
                     repository_path=repository.path,
-                    archive_name=archive_name,
+                    archive_name=archive_selector,
                     mount_point=mount_point,
                     remote_path=effective_repository_remote_path(repository, db),
                     bypass_lock=repository.bypass_lock,

--- a/frontend/src/components/MountArchiveDialog.stories.tsx
+++ b/frontend/src/components/MountArchiveDialog.stories.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import MountArchiveDialog from './MountArchiveDialog'
+import type { Archive } from '../types'
+import { getDefaultMountPoint } from '../utils/mountPoint'
+
+// Borg 1 archive names are unique (here from a `{now:%Y-%m-%d-%s}` template),
+// so the name alone identifies the archive.
+const borg1Archive = {
+  id: 'c3f9d2a17b4e',
+  archive: 'nas-2026-09-04-1756951200',
+  name: 'nas-2026-09-04-1756951200',
+  start: '2026-09-04T02:00:00+00:00',
+  time: '2026-09-04T02:00:00+00:00',
+} as Archive
+
+// Borg 2 series archives share one name; name plus timestamp identifies the
+// archive for the user, while the id addresses it in the mount request.
+const borg2SeriesArchive = {
+  id: 'ab8f4e89cf1a891c12a1dcf2a3259b62ea765cccea6b373a9a9485fe5a942401',
+  archive: 'nas',
+  name: 'nas',
+  start: '2026-09-04T02:00:00+00:00',
+  time: '2026-09-04T02:00:00+00:00',
+} as Archive
+
+function MountDialogStory({
+  archive,
+  borgVersion,
+  mounting: initialMounting = false,
+}: {
+  archive: Archive
+  borgVersion: 1 | 2
+  mounting?: boolean
+}) {
+  // Same pre-fill as the Archives page: sanitised name, plus the start time on Borg 2.
+  const [mountPoint, setMountPoint] = useState(getDefaultMountPoint(archive, borgVersion))
+  const [mounting, setMounting] = useState(initialMounting)
+  return (
+    <MountArchiveDialog
+      open
+      archive={archive}
+      mountPoint={mountPoint}
+      onMountPointChange={setMountPoint}
+      onClose={() => {}}
+      onConfirm={() => setMounting(true)}
+      mounting={mounting}
+    />
+  )
+}
+
+const meta = {
+  title: 'Components/MountArchiveDialog',
+  component: MountArchiveDialog,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    open: true,
+    archive: borg1Archive,
+    mountPoint: getDefaultMountPoint(borg1Archive, 1),
+    onMountPointChange: () => {},
+    onClose: () => {},
+    onConfirm: () => {},
+  },
+} satisfies Meta<typeof MountArchiveDialog>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Borg1Archive: Story = {
+  render: () => <MountDialogStory archive={borg1Archive} borgVersion={1} />,
+}
+
+export const Borg2SeriesArchive: Story = {
+  render: () => <MountDialogStory archive={borg2SeriesArchive} borgVersion={2} />,
+}
+
+export const Borg2SeriesArchiveMounting: Story = {
+  render: () => <MountDialogStory archive={borg2SeriesArchive} borgVersion={2} />,
+  play: async () => {
+    await new Promise((resolve) => window.setTimeout(resolve, 0))
+    // The dialog renders in a portal outside the story canvas.
+    Array.from(document.querySelectorAll('button'))
+      .find((button) => button.textContent?.trim() === 'Mount')
+      ?.click()
+  },
+}

--- a/frontend/src/components/MountArchiveDialog.tsx
+++ b/frontend/src/components/MountArchiveDialog.tsx
@@ -13,6 +13,7 @@ import ResponsiveDialog from './shared/ResponsiveDialog'
 import { useTranslation } from 'react-i18next'
 import { HardDrive, Info } from 'lucide-react'
 import { Archive } from '../types'
+import { formatDate } from '../utils/dateUtils'
 
 interface MountArchiveDialogProps {
   open: boolean
@@ -75,6 +76,13 @@ export default function MountArchiveDialog({
             >
               {archive?.name}
             </Typography>
+            {archive && (
+              // Borg 2 series archives share one name; name plus timestamp is
+              // what identifies the selected archive for the user.
+              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                {formatDate(archive.start || archive.time)}
+              </Typography>
+            )}
           </Box>
         </Stack>
       </DialogTitle>

--- a/frontend/src/pages/Archives.tsx
+++ b/frontend/src/pages/Archives.tsx
@@ -16,6 +16,7 @@ import ArchivesList from '../components/ArchivesList'
 import LastRestoreSection from '../components/LastRestoreSection'
 import DeleteArchiveDialog from '../components/DeleteArchiveDialog'
 import MountArchiveDialog from '../components/MountArchiveDialog'
+import { getDefaultMountPoint } from '../utils/mountPoint'
 import ArchiveContentsDialog from '../components/ArchiveContentsDialog'
 import { toast } from 'react-hot-toast'
 import MountSuccessToast from '../components/MountSuccessToast'
@@ -38,10 +39,6 @@ interface RestoreJob {
   started_at?: string
   completed_at?: string
   error_message?: string
-}
-
-function getDefaultMountPoint(archiveName: string): string {
-  return archiveName.replace(/[/:]/g, '_').replace(/\s+/g, '_')
 }
 
 function normalizeRepositoryId(value: number | string | null | undefined): number | null {
@@ -214,13 +211,15 @@ const Archives: React.FC = () => {
       repository_id,
       archive_name,
       mount_point,
+      archive_id,
     }: {
       repository_id: number
       archive_name: string
       mount_point?: string
+      archive_id?: string
       archive_start?: string
       is_custom_mount_point: boolean
-    }) => mountsAPI.mountBorgArchive({ repository_id, archive_name, mount_point }),
+    }) => mountsAPI.mountBorgArchive({ repository_id, archive_name, mount_point, archive_id }),
     onSuccess: (data, variables) => {
       const mountPoint = data.data.mount_point
       const containerName = 'borg-web-ui'
@@ -346,10 +345,15 @@ const Archives: React.FC = () => {
   // Handle archive mounting
   const handleMountArchive = () => {
     if (selectedRepositoryId && mountDialogArchive) {
-      const defaultMountPoint = getDefaultMountPoint(mountDialogArchive.name)
+      const defaultMountPoint = getDefaultMountPoint(
+        mountDialogArchive,
+        selectedRepository?.borg_version
+      )
       mountArchiveMutation.mutate({
         repository_id: selectedRepositoryId,
         archive_name: mountDialogArchive.name,
+        // Borg 2 series archives share one name; the id addresses exactly one.
+        archive_id: mountDialogArchive.id || undefined,
         mount_point: customMountPoint || undefined,
         archive_start: mountDialogArchive.start,
         is_custom_mount_point: !!customMountPoint && customMountPoint !== defaultMountPoint,
@@ -362,8 +366,8 @@ const Archives: React.FC = () => {
   // Open mount dialog
   const openMountDialog = (archive: Archive) => {
     setMountDialogArchive(archive)
-    // Pre-fill with archive name (sanitized for filesystem)
-    setCustomMountPoint(getDefaultMountPoint(archive.name))
+    // Pre-fill with the default mount point (sanitised; Borg 2 adds the start time).
+    setCustomMountPoint(getDefaultMountPoint(archive, selectedRepository?.borg_version))
   }
 
   // Open restore wizard directly

--- a/frontend/src/pages/__tests__/Archives.actions.test.tsx
+++ b/frontend/src/pages/__tests__/Archives.actions.test.tsx
@@ -298,7 +298,11 @@ describe('Archives page actions', () => {
       expect(apiModule.mountsAPI.mountBorgArchive).toHaveBeenCalledWith({
         repository_id: 1,
         archive_name: 'archive-1',
-        mount_point: 'archive-1',
+        // Borg 2 series disambiguation: the id travels with the mount request,
+        // and the default mount point carries the start time so archives of
+        // one series never share a mount directory.
+        archive_id: 'a1',
+        mount_point: 'archive-1-2026-01-01T00_00_00',
       })
     })
   })

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1427,6 +1427,8 @@ export const mountsAPI = {
     repository_id: number
     archive_name?: string
     mount_point?: string
+    // Borg 2 series archives share one name; the id addresses exactly one.
+    archive_id?: string
   }) => api.post('/mounts/borg', data),
 
   // Unmount a mounted archive

--- a/frontend/src/utils/mountPoint.test.ts
+++ b/frontend/src/utils/mountPoint.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { getDefaultMountPoint, sanitizeMountPoint } from './mountPoint'
+
+describe('sanitizeMountPoint', () => {
+  it('replaces path separators, colons and whitespace', () => {
+    expect(sanitizeMountPoint('nas/2026-09-04T02:00:00 full')).toBe('nas_2026-09-04T02_00_00_full')
+  })
+})
+
+describe('getDefaultMountPoint', () => {
+  const archive = { name: 'nas', start: '2026-09-04T02:00:00+00:00' }
+
+  it('uses the sanitised name alone for Borg 1', () => {
+    expect(getDefaultMountPoint({ name: 'nas-2026-09-04-1756951200' }, 1)).toBe(
+      'nas-2026-09-04-1756951200'
+    )
+    expect(getDefaultMountPoint(archive, 1)).toBe('nas')
+  })
+
+  it('appends the start time for Borg 2 so series archives do not collide', () => {
+    expect(getDefaultMountPoint(archive, 2)).toBe('nas-2026-09-04T02_00_00')
+    expect(getDefaultMountPoint({ ...archive, start: '2026-09-05T02:00:00+00:00' }, 2)).toBe(
+      'nas-2026-09-05T02_00_00'
+    )
+  })
+
+  it('drops the timezone suffix and never emits colons', () => {
+    const value = getDefaultMountPoint({ name: 'docs', start: '2026-09-04T02:00:00Z' }, 2)
+    expect(value).toBe('docs-2026-09-04T02_00_00')
+    expect(value).not.toMatch(/[:/\s]/)
+  })
+
+  it('keeps fractional seconds so same-second archives still differ', () => {
+    const first = getDefaultMountPoint(
+      { name: 'nas', start: '2026-09-04T02:00:00.123456+00:00' },
+      2
+    )
+    const second = getDefaultMountPoint(
+      { name: 'nas', start: '2026-09-04T02:00:00.654321+00:00' },
+      2
+    )
+    expect(first).toBe('nas-2026-09-04T02_00_00.123456')
+    expect(first).not.toBe(second)
+  })
+
+  it('falls back to the name when a Borg 2 archive has no start time', () => {
+    expect(getDefaultMountPoint({ name: 'nas', start: null }, 2)).toBe('nas')
+    expect(getDefaultMountPoint({ name: 'nas' })).toBe('nas')
+  })
+})

--- a/frontend/src/utils/mountPoint.ts
+++ b/frontend/src/utils/mountPoint.ts
@@ -1,0 +1,26 @@
+/** Make an archive-derived value safe to use as a mount directory name. */
+export function sanitizeMountPoint(value: string): string {
+  return value.replace(/[/:]/g, '_').replace(/\s+/g, '_')
+}
+
+/**
+ * Default mount point for an archive.
+ *
+ * Borg 1 archive names are unique, so the sanitised name is enough. Borg 2
+ * series archives share one name, so the archive's full start timestamp is
+ * appended to keep the default distinct per archive. The raw ISO `start` (UTC as delivered
+ * by the API) is used rather than a formatted local time: the result is the
+ * same on every client and needs no date parsing.
+ */
+export function getDefaultMountPoint(
+  archive: { name: string; start?: string | null },
+  borgVersion?: number | null
+): string {
+  if (borgVersion === 2 && archive.start) {
+    // Keep the full precision Borg reports (microseconds): only the zone suffix
+    // goes, so even two archives created within the same second differ.
+    const stamp = archive.start.replace(/(Z|[+-]\d{2}:?\d{2})$/, '')
+    return sanitizeMountPoint(`${archive.name}-${stamp}`)
+  }
+  return sanitizeMountPoint(archive.name)
+}

--- a/tests/unit/test_mount_service.py
+++ b/tests/unit/test_mount_service.py
@@ -435,6 +435,182 @@ class TestMountService:
             assert "borg14" in captured_args
 
     @pytest.mark.asyncio
+    async def test_borg2_mount_addresses_series_archive_by_aid(self, mount_service):
+        """Borg 2 series archives share one name; `-a <name>` mounts every
+        archive of the series. With the id supplied, the mount must address
+        exactly one archive via the aid: selector."""
+        with (
+            patch("app.services.mount_service.SessionLocal") as mock_session,
+            patch(
+                "app.services.mount_service.asyncio.create_subprocess_exec"
+            ) as mock_exec,
+            patch("app.services.mount_service.os.makedirs"),
+            patch("app.services.mount_service.os.path.exists", return_value=False),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            mock_db = Mock()
+            mock_session.return_value = mock_db
+            mock_repo = Mock(spec=Repository)
+            mock_repo.id = 1
+            mock_repo.name = "b2-repo"
+            mock_repo.path = "/backup/b2-repo"
+            mock_repo.passphrase = None
+            mock_repo.connection_id = None
+            mock_repo.bypass_lock = False
+            mock_repo.remote_path = None
+            mock_repo.borg_version = 2
+            mock_db.query.return_value.filter.return_value.first.side_effect = [
+                mock_repo,
+                None,
+            ]
+            mock_db.query.return_value.first.return_value = None
+
+            captured_args = []
+
+            async def fake_exec(*args, **kwargs):
+                captured_args.extend(args)
+                proc = AsyncMock()
+                proc.pid = 12345
+                proc.stdout = AsyncMock()
+                proc.stdout.readline = AsyncMock(return_value=b"")
+                proc.stderr = AsyncMock()
+                proc.stderr.read = AsyncMock(return_value=b"")
+                proc.wait = AsyncMock(return_value=0)
+                return proc
+
+            mock_exec.side_effect = fake_exec
+
+            try:
+                await mount_service.mount_borg_archive(
+                    repository_id=1,
+                    archive_name="myplan-daily",
+                    archive_id="ab12cd34ef567890",
+                )
+            except Exception:
+                pass
+
+            assert mock_exec.called
+            assert "aid:ab12cd34ef567890" in captured_args
+            # The bare series name must not be the -a value.
+            assert "myplan-daily" not in captured_args
+
+    @pytest.mark.asyncio
+    async def test_borg2_mount_id_only_request_still_addresses_by_aid(
+        self, mount_service
+    ):
+        """An id without a name must mount that one archive by aid:, not fall
+        back to the whole repository."""
+        with (
+            patch("app.services.mount_service.SessionLocal") as mock_session,
+            patch(
+                "app.services.mount_service.asyncio.create_subprocess_exec"
+            ) as mock_exec,
+            patch("app.services.mount_service.os.makedirs"),
+            patch("app.services.mount_service.os.path.exists", return_value=False),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            mock_db = Mock()
+            mock_session.return_value = mock_db
+            mock_repo = Mock(spec=Repository)
+            mock_repo.id = 1
+            mock_repo.name = "b2-repo"
+            mock_repo.path = "/backup/b2-repo"
+            mock_repo.passphrase = None
+            mock_repo.connection_id = None
+            mock_repo.bypass_lock = False
+            mock_repo.remote_path = None
+            mock_repo.borg_version = 2
+            mock_db.query.return_value.filter.return_value.first.side_effect = [
+                mock_repo,
+                None,
+            ]
+            mock_db.query.return_value.first.return_value = None
+
+            captured_args = []
+
+            async def fake_exec(*args, **kwargs):
+                captured_args.extend(args)
+                proc = AsyncMock()
+                proc.pid = 12345
+                proc.stdout = AsyncMock()
+                proc.stdout.readline = AsyncMock(return_value=b"")
+                proc.stderr = AsyncMock()
+                proc.stderr.read = AsyncMock(return_value=b"")
+                proc.wait = AsyncMock(return_value=0)
+                return proc
+
+            mock_exec.side_effect = fake_exec
+
+            try:
+                await mount_service.mount_borg_archive(
+                    repository_id=1,
+                    archive_name=None,
+                    archive_id="ab12cd34ef567890",
+                )
+            except Exception:
+                pass
+
+            assert mock_exec.called
+            assert "aid:ab12cd34ef567890" in captured_args
+
+    @pytest.mark.asyncio
+    async def test_borg1_mount_keeps_name_addressing(self, mount_service):
+        """Borg 1 names are unique; a supplied id must not change addressing."""
+        with (
+            patch("app.services.mount_service.SessionLocal") as mock_session,
+            patch(
+                "app.services.mount_service.asyncio.create_subprocess_exec"
+            ) as mock_exec,
+            patch("app.services.mount_service.os.makedirs"),
+            patch("app.services.mount_service.os.path.exists", return_value=False),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            mock_db = Mock()
+            mock_session.return_value = mock_db
+            mock_repo = Mock(spec=Repository)
+            mock_repo.id = 1
+            mock_repo.name = "b1-repo"
+            mock_repo.path = "/backup/b1-repo"
+            mock_repo.passphrase = None
+            mock_repo.connection_id = None
+            mock_repo.bypass_lock = False
+            mock_repo.remote_path = None
+            mock_repo.borg_version = 1
+            mock_db.query.return_value.filter.return_value.first.side_effect = [
+                mock_repo,
+                None,
+            ]
+            mock_db.query.return_value.first.return_value = None
+
+            captured_args = []
+
+            async def fake_exec(*args, **kwargs):
+                captured_args.extend(args)
+                proc = AsyncMock()
+                proc.pid = 12345
+                proc.stdout = AsyncMock()
+                proc.stdout.readline = AsyncMock(return_value=b"")
+                proc.stderr = AsyncMock()
+                proc.stderr.read = AsyncMock(return_value=b"")
+                proc.wait = AsyncMock(return_value=0)
+                return proc
+
+            mock_exec.side_effect = fake_exec
+
+            try:
+                await mount_service.mount_borg_archive(
+                    repository_id=1,
+                    archive_name="backup-2026-01-01",
+                    archive_id="ab12cd34ef567890",
+                )
+            except Exception:
+                pass
+
+            assert mock_exec.called
+            assert "/backup/b1-repo::backup-2026-01-01" in captured_args
+            assert not any(str(a).startswith("aid:") for a in captured_args)
+
+    @pytest.mark.asyncio
     async def test_mount_borg_archive_no_remote_path(self, mount_service):
         """Test that mount_borg_archive omits --remote-path when repository has no remote_path"""
         with (


### PR DESCRIPTION
## Description

Mounting a specific archive addresses it by **name** — and Borg 2 archives in a series share one stable name. Measured on borg 2.0.0b23 (container, real FUSE mount of a two-archive series): `mount -a <series-name>` mounts **every** archive of the series as its own subdirectory (`myplan-daily-<id>/`, one per archive), never the one archive the user picked. Files then sit under directories the user does not expect — quite possibly what #790 ("archives not displaying files when mounted") is seeing on Borg 2 repositories.

Also measured: `-a aid:<id>` works on b23 and mounts exactly one archive — the same selector pattern extract (#898) and the archive download path already use. So the fix carries the archive id through the mount path:

- `MountBorgRequest` gains an optional `archive_id`; the Archives page sends the selected archive's id alongside its name.
- `mount_service.mount_borg_archive` addresses the borg2 mount command by `aid:<id>` when the id is present; the human-readable name stays on the mount-point naming, the source label and the logs. Borg 1 addressing (`repo::name`) is untouched, and a borg2 mount without an id keeps the previous behavior.

One measured borg-2 quirk documented rather than papered over: even a single-archive `-a` mount places the content one directory level down (`<mountpoint>/<archive-name>/…`), unlike borg 1's direct layout. That level is borg's own and survives this fix — the user sees one folder named like the archive, which reads naturally.

## Related Issue

Likely fixes #790 for Borg 2 repositories (series mounted as N subdirectories); at minimum it fixes single-archive mounts on any Borg 2 series.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Empirics (borg 2.0.0b23, FUSE in the runtime-base container, series of two same-named archives):

```
mount -a myplan-daily        ->  myplan-daily-2469e78a/  myplan-daily-7c14ec6e/   (both archives)
mount -a aid:7c14ec6e        ->  myplan-daily/                                    (exactly one)
borg1 mount repo::archive    ->  content directly in the mountpoint              (layout reference)
```

New unit tests: the borg2 mount command carries `aid:<id>` (and never the bare series name) when the id is supplied — fails without the fix — and borg1 keeps `repo::name` addressing with a supplied id ignored. The existing Archives-page action test asserts the id travels in the mount request.

```
pytest tests/unit/test_mount_service.py -q     35 passed, 2 skipped
pytest tests/unit -q                           3096 passed, 11 skipped in 523.89s (0:08:43)
vitest run (Node 22)                           2362 passed (2362)
ruff / tsc / oxlint / prettier / locales       clean
```

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable; the mount dialog is unchanged — only the request payload carries the id now.

## Additional Context

CodeRabbit pre-review ran on the fork (ioanalytica#46): clean first pass, no findings; the fork's Storybook Visual Report job cannot run there (no Pages) and this change touches no stories. Third member of the aid:-selector family (#898 restore checks, the archive download path before it). Independent of the open PRs (#889/#891/#892/#898/#900/#901) — no shared files. If #790's reporter is on Borg 1, their issue is something else; the series-mount behavior fixed here reproduces only on Borg 2.
