### PR TITLE
fix(ssh): derive SSH key deploy and secret paths from settings for native installs

### DIFF
--- a/app/api/ssh_keys.py
+++ b/app/api/ssh_keys.py
@@ -7,7 +7,9 @@ import math
 import structlog
 import os
 import subprocess
+import sys
 import asyncio
+from pathlib import Path
 import tempfile
 import time
 
@@ -28,6 +30,12 @@ from app.utils.datetime_utils import serialize_datetime
 from app.utils.ssh_host_validation import normalize_ssh_host
 from app.utils.ssh_utils import ssh_key_auth_args, write_ssh_key_to_tempfile
 import hashlib
+
+# Located relative to this package rather than a fixed /app/... path so the
+# deploy step also works when the app is installed somewhere else (LXC).
+DEPLOY_SSH_KEY_SCRIPT = (
+    Path(__file__).resolve().parents[1] / "scripts" / "deploy_ssh_key.py"
+)
 
 logger = structlog.get_logger()
 router = APIRouter(tags=["ssh-keys"], dependencies=[Depends(authorize_request)])
@@ -619,7 +627,7 @@ async def generate_ssh_key(
         # Deploy SSH key immediately to filesystem
         try:
             deploy_result = subprocess.run(
-                ["python3", "/app/app/scripts/deploy_ssh_key.py"],
+                [sys.executable, str(DEPLOY_SSH_KEY_SCRIPT)],
                 capture_output=True,
                 text=True,
                 timeout=10,
@@ -794,17 +802,18 @@ async def import_ssh_key(
             user=current_user.username,
         )
 
-        # Deploy SSH key to filesystem (this will write to /home/borg/.ssh)
+        # Deploy SSH key to filesystem (writes to settings.ssh_home_dir)
         try:
             deploy_result = subprocess.run(
-                ["python3", "/app/app/scripts/deploy_ssh_key.py"],
+                [sys.executable, str(DEPLOY_SSH_KEY_SCRIPT)],
                 capture_output=True,
                 text=True,
                 timeout=10,
             )
             if deploy_result.returncode == 0:
                 logger.info(
-                    "Imported SSH key deployed to /home/borg/.ssh",
+                    "Imported SSH key deployed to filesystem",
+                    ssh_home_dir=settings.ssh_home_dir,
                     stdout=deploy_result.stdout,
                 )
             else:
@@ -2407,7 +2416,7 @@ async def delete_ssh_key(
 
         # Remove key files from filesystem
         try:
-            ssh_dir = os.path.join(settings.ssh_keys_dir or "/home/borg/.ssh")
+            ssh_dir = settings.ssh_home_dir
             private_key_path = os.path.join(ssh_dir, f"id_{key_type}")
             public_key_path = os.path.join(ssh_dir, f"id_{key_type}.pub")
 

--- a/app/config.py
+++ b/app/config.py
@@ -57,6 +57,27 @@ def resolve_database_url(env: Mapping[str, str], data_dir: str) -> str:
     return f"postgresql+psycopg://{user}:{password}@{host}:{port}/{name}"
 
 
+def resolve_ssh_home_dir(env: Mapping[str, str], ssh_keys_dir: str) -> str:
+    """Directory the system SSH key pair is deployed to on disk.
+
+    Defaults to ssh_keys_dir (``$DATA_DIR/ssh_keys``), so a native install
+    (for example the Proxmox LXC running from /opt/borg-ui as root) keeps its
+    keys next to the rest of its data without any extra configuration.
+
+    SSH_HOME_DIR overrides it. The Docker entrypoint exports it as
+    /home/borg/.ssh: normally that is a symlink to /data/ssh_keys, so both names
+    are the same directory, but when a user bind-mounts /home/borg/.ssh the
+    entrypoint keeps the mount and the keys must still land there so plain
+    ``ssh`` in hooks finds them under ~/.ssh.
+    """
+    return env.get("SSH_HOME_DIR") or ssh_keys_dir
+
+
+def resolve_secret_key_file(data_dir: str) -> Path:
+    """Path of the persisted auto-generated SECRET_KEY under data_dir."""
+    return Path(data_dir) / ".secret_key"
+
+
 class Settings(BaseSettings):
     """Application settings"""
 
@@ -112,6 +133,7 @@ class Settings(BaseSettings):
 
     # SSH keys directory - auto-derived from data_dir
     ssh_keys_dir: str = ""  # Will be auto-derived from data_dir
+    ssh_home_dir: str = ""  # Where the system key is deployed; see resolve_ssh_home_dir
 
     # Logging settings
     log_level: str = "INFO"
@@ -274,12 +296,13 @@ settings.database_url = resolve_database_url(os.environ, settings.data_dir)
 
 # 2. SSH keys directory - always derived from data_dir
 settings.ssh_keys_dir = f"{settings.data_dir}/ssh_keys"
+settings.ssh_home_dir = resolve_ssh_home_dir(os.environ, settings.ssh_keys_dir)
 
 # 3. Log file - always derived from data_dir
 settings.log_file = f"{settings.data_dir}/logs/borg-ui.log"
 
 # 4. SECRET_KEY - auto-generate on first run if not provided
-secret_key_file = Path(settings.data_dir) / ".secret_key"
+secret_key_file = resolve_secret_key_file(settings.data_dir)
 env_secret_key = os.getenv("SECRET_KEY")
 
 if env_secret_key:

--- a/app/scripts/delete_ssh_key.py
+++ b/app/scripts/delete_ssh_key.py
@@ -154,7 +154,7 @@ def delete_ssh_key(key_id=None, key_name=None, is_system=False, force=False):
         print(f"✓ Deleted SSH key: {found_name} (ID: {found_id})")
 
         # Remove key files from filesystem
-        ssh_dir = Path("/home/borg/.ssh")
+        ssh_dir = Path(settings.ssh_home_dir)
         private_key_file = ssh_dir / f"id_{key_type}"
         public_key_file = ssh_dir / f"id_{key_type}.pub"
 

--- a/app/scripts/deploy_ssh_key.py
+++ b/app/scripts/deploy_ssh_key.py
@@ -2,35 +2,36 @@
 """
 Deploy SSH keys from database to filesystem on container startup.
 This ensures SSH keys are always available for borg operations.
+
+All paths come from app.config: the key pair is written to
+settings.ssh_home_dir and decrypted with settings.secret_key, so the same
+script works in Docker (DATA_DIR=/data, SSH_HOME_DIR=/home/borg/.ssh) and in a
+native install where the data directory lives elsewhere.
 """
 
 import os
-import base64
-import hashlib
 import sys
 import pwd
 import grp
 from pathlib import Path
-from cryptography.fernet import Fernet
+
+# Run as a file (`python3 deploy_ssh_key.py`), so the repository root is not on
+# sys.path by itself.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from app.config import settings  # noqa: E402
+from app.core.security import decrypt_secret  # noqa: E402
 
 
 def deploy_ssh_keys():
-    """Deploy SSH keys from database to /home/borg/.ssh/"""
+    """Deploy SSH keys from database to settings.ssh_home_dir."""
     try:
-        # Create .ssh directory for borg user
-        ssh_dir = Path("/home/borg/.ssh")
+        # Create the SSH directory the keys are deployed to. In Docker this is
+        # /home/borg/.ssh, which the entrypoint symlinks to $DATA_DIR/ssh_keys;
+        # elsewhere it defaults to $DATA_DIR/ssh_keys directly.
+        ssh_dir = Path(settings.ssh_home_dir)
         ssh_dir.mkdir(parents=True, exist_ok=True)
         ssh_dir.chmod(0o700)
-
-        # Read SECRET_KEY
-        secret_key_file = Path("/data/.secret_key")
-        if not secret_key_file.exists():
-            print("⚠️  No SECRET_KEY file found, skipping SSH key deployment")
-            return
-
-        secret_key = secret_key_file.read_text().strip()
-        digest = hashlib.sha256(secret_key.encode("utf-8")).digest()
-        fernet = Fernet(base64.urlsafe_b64encode(digest))
 
         # Read the system SSH key from whichever database the app is configured
         # for. Going through the ORM (not a hardcoded sqlite3 path) means this
@@ -54,14 +55,8 @@ def deploy_ssh_keys():
             key.key_type,
             key.public_key,
         )
-        try:
-            private_key = fernet.decrypt(encrypted_key.encode()).decode()
-        except Exception:
-            legacy_key = secret_key.encode("utf-8")[:32]
-            if len(legacy_key) != 32:
-                raise
-            legacy_fernet = Fernet(base64.urlsafe_b64encode(legacy_key))
-            private_key = legacy_fernet.decrypt(encrypted_key.encode()).decode()
+        # Same SECRET_KEY derivation (and legacy fallback) the app encrypts with.
+        private_key = decrypt_secret(encrypted_key)
 
         # Write private key
         key_file = ssh_dir / f"id_{key_type}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,7 +66,11 @@ echo "[$(date)] Borg cache directory setup complete"
 
 # Setup SSH home directory to persist across container updates.
 # Plain ssh commands in pre/post-backup hooks use ~/.ssh/known_hosts by default.
-SSH_HOME_DIR=/home/borg/.ssh
+# Exported: app.config reads SSH_HOME_DIR as the directory the system key is
+# deployed to (deploy_ssh_key.py, key deletion cleanup). Without it the app
+# falls back to $DATA_DIR/ssh_keys, which is the same directory here unless
+# the user bind-mounted /home/borg/.ssh.
+export SSH_HOME_DIR=/home/borg/.ssh
 PERSISTENT_SSH_DIR=/data/ssh_keys
 
 is_mountpoint() {

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -198,9 +198,22 @@ def test_resolve_secret_key_file_lives_under_data_dir():
 
 
 @pytest.mark.unit
-def test_module_settings_ssh_home_dir_derives_from_ssh_keys_dir():
-    """With no SSH_HOME_DIR in the test env the two settings are the same dir."""
-    from app.config import settings
+def test_module_settings_ssh_home_dir_derives_from_ssh_keys_dir(monkeypatch):
+    """With no SSH_HOME_DIR in the environment the two settings are the same dir."""
+    import importlib
 
-    assert settings.ssh_keys_dir == f"{settings.data_dir}/ssh_keys"
-    assert settings.ssh_home_dir == settings.ssh_keys_dir
+    monkeypatch.delenv("SSH_HOME_DIR", raising=False)
+
+    import app.config as config_module
+
+    importlib.reload(config_module)
+    try:
+        assert (
+            config_module.settings.ssh_keys_dir
+            == f"{config_module.settings.data_dir}/ssh_keys"
+        )
+        assert (
+            config_module.settings.ssh_home_dir == config_module.settings.ssh_keys_dir
+        )
+    finally:
+        importlib.reload(config_module)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -158,3 +158,49 @@ class TestResolveDatabaseUrl:
 @pytest.mark.unit
 def test_index_history_max_rows_default():
     assert Settings().index_history_max_rows == 200000
+
+
+@pytest.mark.unit
+def test_resolve_ssh_home_dir_defaults_to_ssh_keys_dir():
+    """Native installs (LXC) deploy keys next to the rest of the data."""
+    from app.config import resolve_ssh_home_dir
+
+    assert (
+        resolve_ssh_home_dir({}, "/opt/borg-ui/data/ssh_keys")
+        == "/opt/borg-ui/data/ssh_keys"
+    )
+    assert (
+        resolve_ssh_home_dir({"SSH_HOME_DIR": ""}, "/data/ssh_keys") == "/data/ssh_keys"
+    )
+
+
+@pytest.mark.unit
+def test_resolve_ssh_home_dir_honours_env_override():
+    """Docker exports SSH_HOME_DIR=/home/borg/.ssh from the entrypoint."""
+    from app.config import resolve_ssh_home_dir
+
+    assert (
+        resolve_ssh_home_dir({"SSH_HOME_DIR": "/home/borg/.ssh"}, "/data/ssh_keys")
+        == "/home/borg/.ssh"
+    )
+
+
+@pytest.mark.unit
+def test_resolve_secret_key_file_lives_under_data_dir():
+    from pathlib import Path
+
+    from app.config import resolve_secret_key_file
+
+    assert resolve_secret_key_file("/data") == Path("/data/.secret_key")
+    assert resolve_secret_key_file("/opt/borg-ui/data") == Path(
+        "/opt/borg-ui/data/.secret_key"
+    )
+
+
+@pytest.mark.unit
+def test_module_settings_ssh_home_dir_derives_from_ssh_keys_dir():
+    """With no SSH_HOME_DIR in the test env the two settings are the same dir."""
+    from app.config import settings
+
+    assert settings.ssh_keys_dir == f"{settings.data_dir}/ssh_keys"
+    assert settings.ssh_home_dir == settings.ssh_keys_dir

--- a/tests/unit/test_deploy_ssh_key_script.py
+++ b/tests/unit/test_deploy_ssh_key_script.py
@@ -1,0 +1,126 @@
+"""
+Unit tests for app/scripts/deploy_ssh_key.py path resolution.
+
+No real SSH and no real database: the ORM session is replaced with a stub and
+the deploy directory is a tmp_path wired in through settings.ssh_home_dir.
+"""
+
+import stat
+from types import SimpleNamespace
+
+import pytest
+
+from app.api.ssh_keys import DEPLOY_SSH_KEY_SCRIPT
+from app.config import settings
+from app.core.security import encrypt_secret
+from app.scripts import deploy_ssh_key
+
+PRIVATE_KEY = (
+    "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----\n"
+)
+PUBLIC_KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAItest borg-ui"
+
+
+class _StubQuery:
+    def __init__(self, key):
+        self._key = key
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self._key
+
+
+class _StubSession:
+    def __init__(self, key):
+        self._key = key
+
+    def query(self, *args, **kwargs):
+        return _StubQuery(self._key)
+
+    def close(self):
+        pass
+
+
+def _system_key():
+    return SimpleNamespace(
+        private_key=encrypt_secret(PRIVATE_KEY),
+        key_type="ed25519",
+        public_key=PUBLIC_KEY,
+        is_system_key=True,
+    )
+
+
+def _no_borg_user(name):
+    raise KeyError(name)
+
+
+@pytest.fixture
+def deploy_dir(tmp_path, monkeypatch):
+    """Point the deploy step at a fresh directory, as an LXC DATA_DIR would."""
+    target = tmp_path / "opt" / "borg-ui" / "data" / "ssh_keys"
+    monkeypatch.setattr(settings, "ssh_home_dir", str(target))
+    # No borg user on the test host; mirror the LXC-as-root case explicitly.
+    monkeypatch.setattr(deploy_ssh_key.pwd, "getpwnam", _no_borg_user)
+    return target
+
+
+@pytest.mark.unit
+class TestDeploySshKeyScript:
+    def test_writes_key_pair_into_configured_ssh_home_dir(
+        self, deploy_dir, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "app.database.database.SessionLocal", lambda: _StubSession(_system_key())
+        )
+
+        deploy_ssh_key.deploy_ssh_keys()
+
+        private_key = deploy_dir / "id_ed25519"
+        public_key = deploy_dir / "id_ed25519.pub"
+        assert private_key.read_text() == PRIVATE_KEY
+        assert public_key.read_text() == PUBLIC_KEY
+        assert stat.S_IMODE(deploy_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(private_key.stat().st_mode) == 0o600
+        assert stat.S_IMODE(public_key.stat().st_mode) == 0o644
+
+    def test_only_touches_the_configured_directory(self, deploy_dir, monkeypatch):
+        seen = []
+        real_mkdir = deploy_ssh_key.Path.mkdir
+
+        def recording_mkdir(self, *args, **kwargs):
+            seen.append(str(self))
+            return real_mkdir(self, *args, **kwargs)
+
+        monkeypatch.setattr(deploy_ssh_key.Path, "mkdir", recording_mkdir)
+        monkeypatch.setattr(
+            "app.database.database.SessionLocal", lambda: _StubSession(None)
+        )
+
+        deploy_ssh_key.deploy_ssh_keys()
+
+        # mkdir(parents=True) recurses through the ancestors, so several paths
+        # are recorded; all of them must lie on the configured path and none
+        # may be the old hardcoded /home/borg/.ssh.
+        allowed = {str(deploy_dir), *(str(parent) for parent in deploy_dir.parents)}
+        assert str(deploy_dir) in seen
+        assert set(seen) <= allowed
+        assert not any(path.startswith("/home/borg") for path in seen)
+
+    def test_no_system_key_leaves_directory_empty(self, deploy_dir, monkeypatch):
+        monkeypatch.setattr(
+            "app.database.database.SessionLocal", lambda: _StubSession(None)
+        )
+
+        deploy_ssh_key.deploy_ssh_keys()
+
+        assert deploy_dir.is_dir()
+        assert list(deploy_dir.iterdir()) == []
+
+
+@pytest.mark.unit
+def test_api_locates_deploy_script_relative_to_package():
+    assert DEPLOY_SSH_KEY_SCRIPT.is_file()
+    assert DEPLOY_SSH_KEY_SCRIPT.name == "deploy_ssh_key.py"
+    assert not str(DEPLOY_SSH_KEY_SCRIPT).startswith("/app/app/")


### PR DESCRIPTION
## Summary
- The deploy script, delete script and the ssh_keys API hardcoded `/home/borg/.ssh`, `/data/.secret_key` and `/app/app/scripts/deploy_ssh_key.py`. A non-Docker install (the Proxmox LXC in community-scripts/ProxmoxVED, running under `/opt/borg-ui`) could not deploy or delete the system key.
- New `resolve_ssh_home_dir` (env `SSH_HOME_DIR`, default `settings.ssh_keys_dir`) and `resolve_secret_key_file(data_dir)` in `app/config.py`; `settings.ssh_home_dir` is used everywhere the key lands on disk.
- `deploy_ssh_key.py` decrypts via `app.core.security.decrypt_secret` (same derivation and legacy fallback the app uses) instead of re-deriving Fernet from a fixed file.
- The API locates the deploy script relative to the package and runs it with `sys.executable`.
- `entrypoint.sh` exports `SSH_HOME_DIR=/home/borg/.ssh`, so Docker behaviour is unchanged (including the bind-mounted `/home/borg/.ssh` case).

## Test plan
- [x] `tests/unit/test_config.py`: resolver tests
- [x] `tests/unit/test_deploy_ssh_key_script.py`: deploy script writes only to the configured dir with correct modes, no-key case
- [x] existing ssh key API and deployment unit tests pass
- [ ] Docker image: generate a key, confirm it lands in `/home/borg/.ssh` and `/data/ssh_keys`

🤖 Generated with [Claude Code](https://claude.com/claude-code)