### PR TITLE
fix(frontend): drop tsconfig baseUrl removed in TypeScript 7

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,8 +22,8 @@
     "noFallthroughCasesInSwitch": true,
     "ignoreDeprecations": "6.0",
 
-    /* Path mapping */
-    "baseUrl": ".",
+    /* Path mapping — paths are relative to this file (baseUrl was removed in
+       TypeScript 7); the "@/*" alias resolves to ./src/* without it. */
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Description

Unblocks the TypeScript 7 bump (#826). TypeScript 7 — the native compiler — removed the `baseUrl` compiler option, so as soon as #826's dependency resolves, both `Frontend / Build` and `Frontend / Code Quality` fail immediately:

```
tsconfig.json(26,5): error TS5102: Option 'baseUrl' has been removed.
Please remove it from your configuration.
```

That is the *only* thing TS 7 flags (confirmed against #826's CI run — the same TS5102 in both jobs, nothing else).

The `"@/*"` path alias never needed `baseUrl`: since TypeScript 5.4 path mappings resolve relative to the `tsconfig.json`, and the values here are already relative (`./src/*`). Removing `baseUrl` keeps the alias resolving and stays compatible with the TypeScript 6 currently on `main` — so this can land ahead of the bump and let #826 turn green on its own, rather than being carried inside Dependabot's PR (which we can't push to).

## Related Issue

Unblocks #826 (chore(deps-dev): bump typescript 6.0.3 → 7.0.2).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Verified the full gate set under **both** TypeScript versions — 6.0.3 (current `main`) and 7.0.2 (the #826 bump):

```
tsc --noEmit            clean on TS 6 and TS 7
vite build              clean on both
oxlint --deny-warnings  clean on both
prettier --check        clean
check:locales           4727 keys × 4 locales
vitest run (Node 22)    2362 passed (2362)
```

The `@/*` alias is in real use (e.g. `import { buildDownloadUrl } from '@/utils/downloadUrl'`) and resolves correctly after the change.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable; build configuration change.

## Additional Context

Merge order: this first, then #826 — after this lands, Dependabot's bump has no remaining errors. If you'd rather fold it into #826 directly, the one-line change is easy to cherry-pick. Independent of the open timezone PRs — no shared files.
