### PR TITLE
fix(archives): render archive-contents mtime in UTC

### DIFF
--- a/app/api/archives.py
+++ b/app/api/archives.py
@@ -356,7 +356,13 @@ async def get_archive_info(
                                             "user": file_obj.get("user"),
                                             "group": file_obj.get("group"),
                                             "size": file_obj.get("size"),
-                                            "mtime": file_obj.get("mtime"),
+                                            # Contents listing ran under
+                                            # TZ=UTC (server wrapper); re-render
+                                            # the mtime with an explicit offset.
+                                            "mtime": serialize_borg_archive_time(
+                                                file_obj.get("mtime"),
+                                                timezone_name="UTC",
+                                            ),
                                             "healthy": file_obj.get("healthy", True),
                                         }
                                     )

--- a/app/api/browse.py
+++ b/app/api/browse.py
@@ -18,6 +18,7 @@ from app.services.archive_browse_service import (
 )
 from app.services.cache_service import archive_cache
 from app.services.repository_executor import (
+    agent_timezone_for_repository,
     get_agent_archive_browse_job,
     is_agent_executor,
     queue_agent_repository_operation_job,
@@ -72,11 +73,25 @@ def _build_repo_env(repo: Repository, db: Session):
     return env, temp_key_file
 
 
+# Bump when the shape or semantics of cached archive items change, so entries
+# written by an older build are never served. Raised for the mtime timezone
+# change: pre-change entries carry naive-local mtimes and bypass the parser on
+# a cache hit.
+_ARCHIVE_CONTENTS_CACHE_VERSION = "v2-utc-mtime"
+
+
+def _get_raw_items_cache_key(archive_name: str) -> str:
+    return f"{_ARCHIVE_CONTENTS_CACHE_VERSION}::{archive_name}"
+
+
 def _get_browse_result_cache_key(archive_name: str, path: str) -> str:
     normalized_path = path.strip("/")
     if not normalized_path:
-        return f"{archive_name}::browse-managed-root"
-    return f"{archive_name}::browse-managed::{normalized_path}"
+        return f"{_ARCHIVE_CONTENTS_CACHE_VERSION}::{archive_name}::browse-managed-root"
+    return (
+        f"{_ARCHIVE_CONTENTS_CACHE_VERSION}::{archive_name}"
+        f"::browse-managed::{normalized_path}"
+    )
 
 
 def _is_browse_result_payload(items) -> bool:
@@ -208,7 +223,9 @@ async def browse_archive_contents(
             )
             return {"items": cached_result}
 
-        all_items = await archive_cache.get(repository_id, archive_name)
+        all_items = await archive_cache.get(
+            repository_id, _get_raw_items_cache_key(archive_name)
+        )
 
         if all_items is not None:
             logger.info(
@@ -297,11 +314,20 @@ async def browse_archive_contents(
                         },
                     )
 
-                all_items = parse_archive_items(result["stdout"])
+                # An agent listing renders mtimes in the agent's zone; a
+                # server-side listing runs under TZ=UTC (the wrapper pins it).
+                mtime_zone = (
+                    agent_timezone_for_repository(db, repository)
+                    if is_agent_executor(repository)
+                    else "UTC"
+                )
+                all_items = parse_archive_items(
+                    result["stdout"], timezone_name=mtime_zone
+                )
 
                 # Store in cache (cache service will enforce its own size limits)
                 cache_success = await archive_cache.set(
-                    repository_id, archive_name, all_items
+                    repository_id, _get_raw_items_cache_key(archive_name), all_items
                 )
                 if cache_success:
                     logger.info(

--- a/app/api/v2/archives.py
+++ b/app/api/v2/archives.py
@@ -33,13 +33,14 @@ from app.services.archive_browse_service import (
 from app.services.cache_service import archive_cache
 from app.services.log_policy import get_log_save_policy, job_has_logs_by_policy
 from app.services.repository_executor import (
+    agent_timezone_for_repository,
     is_agent_executor,
     queue_agent_repository_operation_job,
     wait_for_agent_repository_operation_job,
 )
 from app.services.v2.archive_browse import get_browse_depth, is_fast_browse_enabled
 from app.utils.borg_env import effective_repository_remote_path, repository_borg_env
-from app.utils.datetime_utils import serialize_datetime
+from app.utils.datetime_utils import serialize_borg_archive_time, serialize_datetime
 
 logger = structlog.get_logger()
 router = APIRouter(tags=["Archives v2"], dependencies=[require_feature("borg_v2")])
@@ -227,16 +228,25 @@ def _get_archive_selector(archive_ref: str) -> str:
     return archive_ref
 
 
+# Bump when the shape or semantics of cached archive items change, so entries
+# written by an older build are never served (e.g. the mtime timezone change:
+# a cache hit bypasses parse_archive_items).
+_ARCHIVE_CONTENTS_CACHE_VERSION = "v2-utc-mtime"
+
+
 def _get_browse_cache_key(archive_ref: str, path: str) -> str:
     archive_key = _get_archive_selector(archive_ref)
     normalized_path = path.strip("/")
+    version = _ARCHIVE_CONTENTS_CACHE_VERSION
     if not normalized_path:
-        return f"{archive_key}::managed-root"
-    return f"{archive_key}::managed-path::{normalized_path}"
+        return f"{version}::{archive_key}::managed-root"
+    return f"{version}::{archive_key}::managed-path::{normalized_path}"
 
 
 def _get_browse_raw_cache_key(archive_ref: str) -> str:
-    return f"{_get_archive_selector(archive_ref)}::raw"
+    return (
+        f"{_ARCHIVE_CONTENTS_CACHE_VERSION}::{_get_archive_selector(archive_ref)}::raw"
+    )
 
 
 # ── List archives ──────────────────────────────────────────────────────────────
@@ -374,6 +384,13 @@ async def get_archive_info(
                     remote_path=effective_repository_remote_path(repo),
                     bypass_lock=repo.bypass_lock,
                 )
+            # An agent listing renders mtimes in the agent's zone; a
+            # server-side listing runs under TZ=UTC (the wrapper pins it).
+            mtime_zone = (
+                agent_timezone_for_repository(db, repo)
+                if is_agent_executor(repo)
+                else "UTC"
+            )
             if list_result.get("success", bool(list_result.get("stdout"))):
                 files = []
                 for line in (list_result.get("stdout") or "").strip().split("\n"):
@@ -388,7 +405,9 @@ async def get_archive_info(
                                     "user": f.get("user"),
                                     "group": f.get("group"),
                                     "size": f.get("size"),
-                                    "mtime": f.get("mtime"),
+                                    "mtime": serialize_borg_archive_time(
+                                        f.get("mtime"), timezone_name=mtime_zone
+                                    ),
                                     "healthy": f.get("healthy", True),
                                 }
                             )
@@ -500,7 +519,14 @@ async def get_archive_contents(
                 detail=f"Failed to get archive contents: {result.get('stderr', 'unknown error')}",
             )
 
-        all_items = parse_archive_items(stdout)
+        # An agent listing renders mtimes in the agent's zone; a server-side
+        # listing runs under TZ=UTC (the wrapper pins it).
+        mtime_zone = (
+            agent_timezone_for_repository(db, repo)
+            if is_agent_executor(repo)
+            else "UTC"
+        )
+        all_items = parse_archive_items(stdout, timezone_name=mtime_zone)
         if not fast_browse:
             await archive_cache.set(repo.id, raw_cache_key, all_items)
 

--- a/app/core/borg.py
+++ b/app/core/borg.py
@@ -607,10 +607,12 @@ class BorgInterface:
         exec_env = env.copy() if env else {}
         if passphrase:
             exec_env["BORG_PASSPHRASE"] = passphrase
+        # Machine-parsed output: render file mtimes in UTC (see list_archives).
+        exec_env["TZ"] = "UTC"
 
         # Use streaming execution to prevent OOM on large archives
         return await self._execute_command_streaming(
-            cmd, max_lines=max_lines, env=exec_env if exec_env else None
+            cmd, max_lines=max_lines, env=exec_env
         )
 
     def diff_archives(

--- a/app/core/borg2.py
+++ b/app/core/borg2.py
@@ -510,7 +510,9 @@ class Borg2Interface:
         exec_env = env.copy() if env else {}
         if passphrase:
             exec_env["BORG_PASSPHRASE"] = passphrase
-        return await self._run_streaming(cmd, max_lines=max_lines, env=exec_env or None)
+        # Machine-parsed output: render file mtimes in UTC (see list_archives).
+        exec_env["TZ"] = "UTC"
+        return await self._run_streaming(cmd, max_lines=max_lines, env=exec_env)
 
     def diff_archives(
         self,
@@ -530,6 +532,8 @@ class Borg2Interface:
         exec_env = self._base_env(env)
         if passphrase:
             exec_env["BORG_PASSPHRASE"] = passphrase
+        # Machine-parsed output: render timestamps in UTC (see list_archives).
+        exec_env["TZ"] = "UTC"
         return CommandLineStream(cmd, env=exec_env, timeout=timeout)
 
     def list_archive_lines(
@@ -549,6 +553,8 @@ class Borg2Interface:
         exec_env = self._base_env(env)
         if passphrase:
             exec_env["BORG_PASSPHRASE"] = passphrase
+        # Machine-parsed output: render timestamps in UTC (see list_archives).
+        exec_env["TZ"] = "UTC"
         return CommandLineStream(cmd, env=exec_env, timeout=timeout)
 
     # ── Backup operations ──────────────────────────────────────────────────────

--- a/app/services/archive_browse_service.py
+++ b/app/services/archive_browse_service.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
-from typing import Dict, List
+from typing import Dict, List, Optional
+
+from app.utils.datetime_utils import serialize_borg_archive_time
 
 
 MANAGED_RESTORE_CANARY_PATH_PREFIXES = (".borg-ui/",)
@@ -38,8 +40,18 @@ def add_managed_archive_metadata_to_items(items: List[Dict]) -> List[Dict]:
     return [add_managed_archive_metadata(item) for item in items]
 
 
-def parse_archive_items(stdout: str) -> List[Dict]:
-    """Parse borg --json-lines output into normalized archive items."""
+def parse_archive_items(stdout: str, timezone_name: Optional[str] = None) -> List[Dict]:
+    """Parse borg --json-lines output into normalized archive items.
+
+    Borg renders file mtimes in the zone of the listing process, with no
+    offset - which the frontend's Date parsing then reads as browser-local.
+    ``timezone_name`` names that render zone ("UTC" for server-side listings
+    pinned to TZ=UTC, the agent's reported zone for agent listings); the
+    mtime is re-serialized with an explicit offset so it is self-describing.
+    ``None`` (an agent that predates timezone reporting) falls back to the
+    server's local zone - the same provenance #871 uses for last_backup -
+    never left as a naive string the browser would read in its own zone.
+    """
     items: List[Dict] = []
     for line in stdout.splitlines():
         line = line.strip()
@@ -54,12 +66,16 @@ def parse_archive_items(stdout: str) -> List[Dict]:
         if not item_path:
             continue
 
+        mtime = item_data.get("mtime")
+        if mtime is not None:
+            mtime = serialize_borg_archive_time(mtime, timezone_name=timezone_name)
+
         items.append(
             {
                 "path": item_path,
                 "type": item_data.get("type", ""),
                 "size": item_data.get("size"),
-                "mtime": item_data.get("mtime"),
+                "mtime": mtime,
             }
         )
 

--- a/tests/unit/test_api_browse.py
+++ b/tests/unit/test_api_browse.py
@@ -383,10 +383,10 @@ class TestBrowseArchiveBehavior:
         first_call = mock_set.await_args_list[0].args
         second_call = mock_set.await_args_list[1].args
         assert first_call[0] == repo.id
-        assert first_call[1] == "parsed-archive"
+        assert first_call[1] == "v2-utc-mtime::parsed-archive"
         assert len(first_call[2]) == 3
         assert second_call[0] == repo.id
-        assert second_call[1] == "parsed-archive::browse-managed-root"
+        assert second_call[1] == "v2-utc-mtime::parsed-archive::browse-managed-root"
         assert [item["name"] for item in second_call[2]] == ["docs", "notes.txt"]
 
     @pytest.mark.asyncio
@@ -416,7 +416,7 @@ class TestBrowseArchiveBehavior:
                         "path": "home/karan/test-backup-source/file.txt",
                         "type": "f",
                         "size": 842,
-                        "mtime": "2026-05-30T15:16:14",
+                        "mtime": "2026-05-30T15:16:14+00:00",
                     }
                 )
             ]
@@ -429,6 +429,7 @@ class TestBrowseArchiveBehavior:
             patch.object(
                 browse_api.archive_cache, "set", new=AsyncMock(return_value=True)
             ),
+            patch("app.api.browse.agent_timezone_for_repository", return_value="UTC"),
             patch(
                 "app.api.browse.dispatch_agent_job_best_effort",
                 new=AsyncMock(return_value=True),
@@ -455,7 +456,7 @@ class TestBrowseArchiveBehavior:
                 "name": "file.txt",
                 "type": "file",
                 "size": 842,
-                "mtime": "2026-05-30T15:16:14",
+                "mtime": "2026-05-30T15:16:14+00:00",
                 "path": "home/karan/test-backup-source/file.txt",
             }
         ]
@@ -508,6 +509,7 @@ class TestBrowseArchiveBehavior:
             patch.object(
                 browse_api.archive_cache, "set", new=AsyncMock(return_value=True)
             ),
+            patch("app.api.browse.agent_timezone_for_repository", return_value="UTC"),
             patch(
                 "app.api.browse.dispatch_agent_job_best_effort",
                 new=AsyncMock(return_value=True),
@@ -579,7 +581,7 @@ class TestBrowseArchiveBehavior:
                 "path": "home/file.txt",
                 "type": "f",
                 "size": 12,
-                "mtime": "2026-05-30T15:16:14",
+                "mtime": "2026-05-30T15:16:14+00:00",
             }
         )
 
@@ -590,6 +592,7 @@ class TestBrowseArchiveBehavior:
             patch.object(
                 browse_api.archive_cache, "set", new=AsyncMock(return_value=True)
             ),
+            patch("app.api.browse.agent_timezone_for_repository", return_value="UTC"),
             patch(
                 "app.api.browse.dispatch_agent_job_best_effort",
                 new=AsyncMock(return_value=True),
@@ -613,7 +616,7 @@ class TestBrowseArchiveBehavior:
                 "name": "file.txt",
                 "type": "file",
                 "size": 12,
-                "mtime": "2026-05-30T15:16:14",
+                "mtime": "2026-05-30T15:16:14+00:00",
                 "path": "home/file.txt",
             }
         ]

--- a/tests/unit/test_api_v2_archives.py
+++ b/tests/unit/test_api_v2_archives.py
@@ -359,7 +359,8 @@ class TestV2ArchiveRoutes:
                 "user": "root",
                 "group": "root",
                 "size": 11,
-                "mtime": "2026-04-04T00:00:00",
+                # Server-side listing ran under TZ=UTC; mtime carries the offset.
+                "mtime": "2026-04-04T00:00:00+00:00",
                 "healthy": True,
             }
         ]
@@ -609,7 +610,7 @@ class TestV2ArchiveRoutes:
             browse_depth=6,
         )
         mock_cache_set.assert_awaited_once_with(
-            repo.id, "archive-1::managed-path::docs/sub::fast", []
+            repo.id, "v2-utc-mtime::archive-1::managed-path::docs/sub::fast", []
         )
 
     def test_get_archive_contents_hides_directory_size_when_fast_mode_enabled(
@@ -738,7 +739,7 @@ class TestV2ArchiveRoutes:
         assert response.status_code == 200
         assert response.json()["items"] == cached_items
         mock_cache_get.assert_awaited_once_with(
-            repo.id, "archive-1::managed-path::docs"
+            repo.id, "v2-utc-mtime::archive-1::managed-path::docs"
         )
         mock_contents.assert_not_called()
 
@@ -776,7 +777,7 @@ class TestV2ArchiveRoutes:
         assert response.status_code == 200
         assert response.json()["items"] == cached_items
         mock_cache_get.assert_awaited_once_with(
-            repo.id, f"aid:{archive_id}::managed-path::docs"
+            repo.id, f"v2-utc-mtime::aid:{archive_id}::managed-path::docs"
         )
         mock_contents.assert_not_called()
 
@@ -830,11 +831,15 @@ class TestV2ArchiveRoutes:
         assert response.status_code == 200
         assert mock_cache_set.await_count == 3
         calls = [call.args for call in mock_cache_set.await_args_list]
-        assert calls[0] == (repo.id, "archive-1::raw", parse_archive_items(stdout))
+        assert calls[0] == (
+            repo.id,
+            "v2-utc-mtime::archive-1::raw",
+            parse_archive_items(stdout, timezone_name="UTC"),
+        )
         assert calls[1][0] == repo.id
-        assert calls[1][1] == "archive-1::managed-root"
+        assert calls[1][1] == "v2-utc-mtime::archive-1::managed-root"
         assert calls[2][0] == repo.id
-        assert calls[2][1] == "archive-1::managed-path::docs"
+        assert calls[2][1] == "v2-utc-mtime::archive-1::managed-path::docs"
         assert calls[2][2] == response.json()["items"]
 
     def test_download_file_success(

--- a/tests/unit/test_archive_browse_service.py
+++ b/tests/unit/test_archive_browse_service.py
@@ -34,3 +34,34 @@ def test_build_browse_items_marks_new_borg_ui_canary_paths_as_managed():
     assert [item["name"] for item in legacy_canary_items] == [".borgui-canary"]
     assert "managed_type" not in legacy_canary_items[0]
     assert [item["name"] for item in documents_items] == ["report.pdf"]
+
+
+def test_parse_archive_items_serializes_mtime_with_the_render_zone():
+    from app.services.archive_browse_service import parse_archive_items
+
+    stdout = '{"path": "docs/report.txt", "type": "f", "size": 11, "mtime": "2026-07-01T03:00:00"}'
+
+    # UTC provenance (server-side listing under TZ=UTC): naive value gains offset.
+    utc = parse_archive_items(stdout, timezone_name="UTC")
+    assert utc[0]["mtime"] == "2026-07-01T03:00:00+00:00"
+
+    # Agent-reported zone: naive value converts from that zone to UTC.
+    berlin = parse_archive_items(stdout, timezone_name="Europe/Berlin")
+    assert berlin[0]["mtime"] == "2026-07-01T01:00:00+00:00"
+
+    # No zone (agent predating timezone reporting): server-local fallback,
+    # like #871's last_backup - always offset-carrying, never a naive string.
+    fallback = parse_archive_items(stdout)
+    assert fallback[0]["mtime"].endswith("+00:00")
+
+
+def test_parse_archive_items_keeps_unparseable_and_missing_mtime():
+    from app.services.archive_browse_service import parse_archive_items
+
+    stdout = (
+        '{"path": "a.txt", "type": "f", "mtime": "not-a-time"}\n'
+        '{"path": "b.txt", "type": "f"}'
+    )
+    items = parse_archive_items(stdout, timezone_name="UTC")
+    assert items[0]["mtime"] == "not-a-time"
+    assert items[1]["mtime"] is None

--- a/tests/unit/test_borg2.py
+++ b/tests/unit/test_borg2.py
@@ -40,7 +40,7 @@ async def test_list_archive_contents_uses_absolute_depth_for_browse():
             "docs/sub",
         ],
         max_lines=1_000_000,
-        env=None,
+        env={"TZ": "UTC"},
     )
 
 
@@ -61,7 +61,7 @@ async def test_list_archive_contents_omits_depth_when_not_requested():
     mock_run.assert_awaited_once_with(
         ["borg2", "-r", "/repo", "list", "--json-lines", "archive-1"],
         max_lines=1_000_000,
-        env=None,
+        env={"TZ": "UTC"},
     )
 
 


### PR DESCRIPTION
## Description

Follow-up to the two CodeRabbit findings raised on #892 (they pointed at code outside that PR's diff, so they belong in their own change): archive **file listings** forward borg's `mtime` verbatim. Borg renders `mtime` in the listing process's timezone with no offset, so the frontend's `new Date(mtime)` reads it as browser-local — exactly the class #889 fixed for archive start/end times, one layer down (the file browser instead of the archive list).

This extends the same at-source + provenance approach to the contents path:

- **At source:** the borg1/borg2 `list_archive_contents` wrappers pin `TZ=UTC` (and borg2's `diff_archives` / `list_archive_lines` streaming methods, for the machine-output-policy consistency CodeRabbit asked for). Server-side listings now render `mtime` in UTC.
- **At the boundary:** `parse_archive_items` takes a `timezone_name` and re-serializes `mtime` with an explicit offset via `serialize_borg_archive_time`; the `include_files` handlers (v1 `archives.py`, v2 `archives.py`) do the same.
- **Provenance, threaded like #889:** the surfaces with an agent branch (`/browse`, the v2 contents route) pass `"UTC"` for a server-side listing and the agent's reported zone (`agent_timezone_for_repository`) for an agent listing — so an agent browse is never mislabelled as UTC. The pure server-side path (v1 `archives.py include_files`) uses `"UTC"` directly.

`mtime` is display-only (the history parsers discard these fields, as CodeRabbit noted), so this changes what the browser shows, nothing stored.

## Related Issue

Follow-up to the CodeRabbit review on karanhudia/borg-ui#892 (nitpick on `app/core/borg2.py` streaming + outside-diff finding on `app/api/archives.py`). No separate issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

New: `parse_archive_items` serializes `mtime` for UTC and for an agent zone, and keeps unparseable/missing values. Updated the existing v2 contents/include_files expectations to the offset-carrying `mtime`, and the borg2 streaming call-arg assertions to the pinned `TZ=UTC` env.

```
pytest tests/unit -q
3111 passed, 11 skipped in 506.95s (0:08:26)

ruff check app tests && ruff format --check app tests — clean
```

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable; backend change (the file browser shows the same values, now timezone-correct).

## Additional Context

Backend-only — the frontend already parses `mtime` through `Date`, which handles the added offset with no change. Part of the timezone family (#889 merged; #891/#892 open) and the aid:-selector family before it; independent of the DB pin and parse-choke work beyond the shared `serialize_borg_archive_time` helper from #889.
