### PR TITLE
fix(import): roll the session back when post-import enqueue fails

### DIFF
--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -2469,6 +2469,11 @@ async def _create_agent_repository_record(
 
             record_import_connect(db, repository, user_id=current_user.id)
         except Exception as e:
+            # A failed flush/chain build leaves the session unusable and may
+            # leave a half-flushed import_connect row that a later commit on
+            # this same session would persist without its follow-ups. Roll the
+            # session back before continuing best-effort.
+            db.rollback()
             logger.warning(
                 "Failed to enqueue post-import operations",
                 repository=repository.name,
@@ -3862,6 +3867,11 @@ async def import_repository(
 
             record_import_connect(db, repository, user_id=current_user.id)
         except Exception as e:
+            # A failed flush/chain build leaves the session unusable and may
+            # leave a half-flushed import_connect row that a later commit on
+            # this same session would persist without its follow-ups. Roll the
+            # session back before continuing best-effort.
+            db.rollback()
             logger.warning(
                 "Failed to enqueue post-import operations",
                 repository=repository.name,

--- a/app/services/operations/enqueue.py
+++ b/app/services/operations/enqueue.py
@@ -137,6 +137,16 @@ def record_import_connect(
     from app.services.operations.executors import registered_kinds
     from app.services.operations.followups import chain_for, history_enabled
 
+    # Resolve the chain before the row exists: the plan lookup behind
+    # history_enabled commits the session, and a flushed import_connect row
+    # committed that way would outlive a failure in the enqueue step below as
+    # an orphan without its follow-ups, beyond the reach of the caller's
+    # rollback.
+    kinds = chain_for(
+        "import_connect",
+        available=registered_kinds(),
+        history=history_enabled(db),
+    )
     now = utc_now()
     op = Operation(
         repository_id=repository.id,
@@ -153,11 +163,6 @@ def record_import_connect(
     )
     db.add(op)
     db.flush()
-    kinds = chain_for(
-        "import_connect",
-        available=registered_kinds(),
-        history=history_enabled(db),
-    )
     if kinds:
         enqueue_chain(
             db,

--- a/tests/unit/test_api_repositories_import_operations.py
+++ b/tests/unit/test_api_repositories_import_operations.py
@@ -128,3 +128,126 @@ async def test_agent_import_records_operation_and_followups(test_db):
     assert {o.run_id for o in operations} == {operations[0].run_id}
     assert [o.trigger for o in operations] == ["import", "followup", "followup"]
     assert [o.triggered_by_user_id for o in operations] == [user.id] * 3
+
+
+def _rollback_spy(session):
+    """Count rollbacks on the request session without changing their effect."""
+    calls = {"n": 0}
+    real_rollback = session.rollback
+
+    def counting_rollback(*args, **kwargs):
+        calls["n"] += 1
+        return real_rollback(*args, **kwargs)
+
+    return calls, counting_rollback
+
+
+# The failure is injected into the enqueue step that runs AFTER the recorder
+# has added and flushed the import_connect row: the row genuinely sits in the
+# session when the rollback must happen. Failing the recorder itself would
+# leave nothing to roll back and prove nothing.
+_CHAIN_FAILURE = patch(
+    "app.services.operations.enqueue.enqueue_chain",
+    side_effect=RuntimeError("chain build failed"),
+)
+
+
+@pytest.mark.unit
+def test_import_records_failure_rolls_back_the_session(
+    test_client, test_db, admin_headers, tmp_path
+):
+    """If building the follow-up chain raises after import_connect has been
+    flushed, the endpoint must roll the session back before continuing
+    best-effort - otherwise the half-flushed row is committed later without
+    its follow-ups, and the session is left unusable (#897 review finding)."""
+    import app.services.operations.executors.index  # noqa: F401
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    (repo_path / "config").write_text("[repository]\n", encoding="utf-8")
+    verify_result = {"success": True, "info": {"encryption": {"mode": "none"}}}
+    rollback_calls, counting_rollback = _rollback_spy(test_db)
+
+    with (
+        patch(
+            "app.api.repositories.verify_existing_repository",
+            new=AsyncMock(return_value=verify_result),
+        ),
+        patch("app.core.borg_router.BorgRouter.update_stats", new=AsyncMock()),
+        patch(
+            "app.api.repositories.mqtt_service.sync_state_with_db", return_value=None
+        ),
+        _CHAIN_FAILURE,
+        patch.object(test_db, "rollback", counting_rollback),
+    ):
+        response = test_client.post(
+            "/api/repositories/import",
+            json={
+                "name": "imported-rollback",
+                "path": str(repo_path),
+                "encryption": "none",
+                "compression": "lz4",
+            },
+            headers=admin_headers,
+        )
+
+    # Best-effort: the import still succeeds despite the follow-up failure ...
+    assert response.status_code in (200, 201), response.text
+    # ... the session was rolled back to contain it ...
+    assert rollback_calls["n"] >= 1
+    # ... which discards the flushed import_connect row instead of leaving it
+    # for a later commit, while the repository committed before it survives.
+    assert (
+        test_db.query(Operation).filter(Operation.kind == "import_connect").all() == []
+    )
+    assert test_db.query(Repository).filter_by(name="imported-rollback").one()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_agent_import_failure_rolls_back_the_session(test_db):
+    """The agent import path records import_connect through the same recorder
+    and must roll back the same way when the enqueue step fails after the
+    flush."""
+    import app.services.operations.executors.index  # noqa: F401
+    from app.api.repositories import RepositoryImport, _create_agent_repository_record
+    from app.core.security import get_password_hash
+    from app.database.models import AgentMachine, User
+
+    agent = AgentMachine(
+        name="Rollback Agent",
+        agent_id="agt_rollback",
+        token_hash=get_password_hash("borgui_agent_secret"),
+        token_prefix="borgui_agent_secret"[:20],
+        status="online",
+        capabilities=["repository.init"],
+    )
+    user = User(
+        username="rollback-importer", password_hash=get_password_hash("x"), role="admin"
+    )
+    test_db.add_all([agent, user])
+    test_db.commit()
+    payload = RepositoryImport(
+        name="agent-rollback",
+        path="/srv/agent-rollback",
+        encryption="none",
+        compression="lz4",
+        agent_machine_id=agent.id,
+        execution_target="agent",
+    )
+    rollback_calls, counting_rollback = _rollback_spy(test_db)
+
+    with (
+        patch(
+            "app.api.repositories.mqtt_service.sync_state_with_db", return_value=None
+        ),
+        _CHAIN_FAILURE,
+        patch.object(test_db, "rollback", counting_rollback),
+    ):
+        await _create_agent_repository_record(payload, user, test_db, imported=True)
+
+    assert rollback_calls["n"] >= 1
+    assert (
+        test_db.query(Operation).filter(Operation.kind == "import_connect").all() == []
+    )
+    assert test_db.query(Repository).filter_by(name="agent-rollback").one()


### PR DESCRIPTION
## Description

Addresses one of the two CodeRabbit findings surfaced on #897. Both post-import `record_import_connect` call sites — the agent-creation path and the import path in `app/api/repositories.py` — caught a failure, logged it, and continued on the same session **without rolling back**.

Writing a regression test that fails the enqueue step *after* the flush showed the problem is worse than a dirty session: `record_import_connect` did `db.add(op); db.flush()` and only then resolved the follow-up chain — and the plan lookup behind `history_enabled(db)` commits the session (`get_effective_plan_value` → `db.commit()`). The `import_connect` row was therefore already committed when `enqueue_chain` ran, so a failure there left a **completed `import_connect` without its follow-ups**, beyond the reach of any rollback in the caller.

Two changes:

- `record_import_connect` resolves the chain kinds **before** the row exists, then adds / flushes / enqueues / commits. A failure in the enqueue step now leaves the row uncommitted.
- Both `except` blocks in `app/api/repositories.py` call `db.rollback()` before continuing best-effort, which discards that row and returns the session to a clean state. The import itself still succeeds (the repository was committed before this step).

Not touched, but worth knowing: the licensing lookup commits on every read, so any recorder that flushes before asking for the plan inherits the same hazard.

## Related Issue

CodeRabbit finding relayed on karanhudia/borg-ui#897 (record_import_connect failure leaves the session dirty).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Two regression tests in `tests/unit/test_api_repositories_import_operations.py` inject the failure into `enqueue_chain`, i.e. after the real recorder has flushed the `import_connect` row, and assert: the request/call still succeeds, the session was rolled back, no `import_connect` operation remains, and the repository committed before it survives — one through `POST /api/repositories/import`, one through `_create_agent_repository_record`.

Both halves of the fix are necessary; the tests were run against each combination:

- neither (upstream/main): fail — no rollback
- rollback only: fail — the row was already committed by the plan lookup
- reorder only: fail — no rollback
- both: pass

```
pytest tests/unit -q
3119 passed, 11 skipped in 511.16s (0:08:31)

ruff check app tests && ruff format --check app tests — clean
```

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable; backend change.

## Additional Context

Companion to #911 (the other #897 review finding, the `archive_changes` path indexes); independent of it — no shared files.
