### PR TITLE
fix(archive-index): drop B-tree indexes on the unbounded path column

### DIFF
--- a/app/database/alembic/versions/e4f5a6b7c8d9_drop_archive_change_path_indexes.py
+++ b/app/database/alembic/versions/e4f5a6b7c8d9_drop_archive_change_path_indexes.py
@@ -1,0 +1,39 @@
+"""drop archive_changes raw-path indexes
+
+The `path` column is unbounded Text. PostgreSQL caps a B-tree entry at about
+a third of a page (~2.7 KB, measured after compressing the value), so indexing
+the raw path makes the INSERT of a change row fail outright for a long archived
+path that does not compress well - hash-heavy names, for example. archive_id
+keeps its own index for per-archive reads; the repository-wide exact-path
+lookup drives off that FK index and filters path.
+
+The downgrade does not recreate the indexes. Once this revision has run the
+table may hold paths beyond that limit, and CREATE INDEX over such rows fails
+on PostgreSQL - a downgrade that can abort halfway is worse than one that
+leaves two performance-only indexes absent. A reverted deployment stays
+correct without them (exact-path lookups just lose their dedicated index).
+
+Revision ID: e4f5a6b7c8d9
+Revises: d3e4f5a6b7c8
+Create Date: 2026-09-04
+"""
+
+from alembic import op
+
+revision = "e4f5a6b7c8d9"
+down_revision = "d3e4f5a6b7c8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("archive_changes") as batch:
+        batch.drop_index("ix_archive_changes_archive_path")
+        batch.drop_index("ix_archive_changes_path")
+
+
+def downgrade() -> None:
+    # Deliberately no-op: rows with paths past the B-tree entry limit may exist
+    # by now, and recreating either index over them fails on PostgreSQL.
+    # See the module docstring.
+    pass

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -1525,10 +1525,13 @@ class ArchiveChange(Base):
     owner_changed = Column(Boolean, nullable=False, default=False)
     summary_count = Column(Integer, nullable=True)
 
-    __table_args__ = (
-        Index("ix_archive_changes_archive_path", "archive_id", "path"),
-        Index("ix_archive_changes_path", "path"),
-    )
+    # No B-tree index on the unbounded `path` Text column: PostgreSQL caps a
+    # B-tree entry at ~1/3 of a page (~2.7 KB, after compressing the value), so
+    # a long archived path that does not compress well makes the INSERT of its
+    # own change row fail. archive_id keeps its own index
+    # (Column index=True) for the per-archive reads; the repository-wide
+    # "which archives touched this exact path" lookup drives off that FK index
+    # and filters path, which stays correct without a dedicated path index.
 
 
 class SystemSettings(Base):

--- a/tests/unit/test_api_archive_index.py
+++ b/tests/unit/test_api_archive_index.py
@@ -806,3 +806,32 @@ class TestWideCompareWindow:
 
         assert r.status_code == 200
         assert {c["path"] for c in r.json()["changes"]} == {"a"}
+
+
+@pytest.mark.unit
+def test_archive_changes_has_no_btree_index_on_the_unbounded_path():
+    """`path` is unbounded Text; a B-tree index over it makes the INSERT of a
+    change row for a long archived path fail (PostgreSQL entry-size limit).
+    No index may reference the raw path column at all - alone, inside a
+    composite, or within an expression such as lower(path) - while archive_id
+    keeps its own index for per-archive reads."""
+    from sqlalchemy import Column
+    from sqlalchemy.sql import visitors
+
+    table = ArchiveChange.__table__
+    path = table.c.path
+
+    def referenced_columns(index):
+        return {
+            element
+            for expression in index.expressions
+            for element in visitors.iterate(expression)
+            if isinstance(element, Column)
+        }
+
+    for index in table.indexes:
+        assert path not in referenced_columns(index), (
+            f"index {index.name} references the unbounded path column"
+        )
+    assert not path.index
+    assert any({c.name for c in idx.columns} == {"archive_id"} for idx in table.indexes)

--- a/tests/unit/test_archive_change_path_index_migration.py
+++ b/tests/unit/test_archive_change_path_index_migration.py
@@ -1,0 +1,144 @@
+"""Tests for revision e4f5a6b7c8d9 (drop the archive_changes raw-path indexes).
+
+The B-tree entry-size limit only exists on PostgreSQL, so both the failure the
+revision fixes and the reason its downgrade leaves the indexes absent can only
+be proven there; those tests are skipped unless BORG_TEST_POSTGRES_URL is set.
+The SQLite test pins the downgrade policy itself, which holds on any dialect.
+"""
+
+import os
+import random
+import string
+from datetime import datetime
+
+import pytest
+from alembic import command
+from sqlalchemy import inspect, text
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.orm import sessionmaker
+
+from app.database.db_upgrade import _alembic_config, _engine
+from app.database.models import Archive, ArchiveChange, Repository
+
+REVISION = "e4f5a6b7c8d9"
+PREVIOUS = "d3e4f5a6b7c8"
+PATH_INDEXES = {"ix_archive_changes_path", "ix_archive_changes_archive_path"}
+# Past PostgreSQL's ~2.7 KB B-tree entry limit. Index entries are compressed
+# before that check, so the value must not compress: a repetitive "x" * 4096
+# shrinks to a few bytes and fits. Seeded, so every run inserts the same path.
+LONG_PATH = "/" + "".join(
+    random.Random(2026).choices(string.ascii_letters + string.digits, k=4096)
+)
+
+POSTGRES_URL = os.getenv("BORG_TEST_POSTGRES_URL")
+requires_postgres = pytest.mark.skipif(
+    not POSTGRES_URL, reason="BORG_TEST_POSTGRES_URL is not set"
+)
+
+
+def _migrate(url, target, *, down=False):
+    engine = _engine(url)
+    config = _alembic_config(url)
+    with engine.connect() as connection:
+        config.attributes["connection"] = connection
+        (command.downgrade if down else command.upgrade)(config, target)
+        connection.commit()
+    engine.dispose()
+
+
+def _path_indexes(url):
+    engine = _engine(url)
+    names = {i["name"] for i in inspect(engine).get_indexes("archive_changes")}
+    engine.dispose()
+    return names & PATH_INDEXES
+
+
+def _insert_long_path(url):
+    """One change row whose path is longer than a B-tree entry may be.
+
+    Rolled back on failure: an aborted transaction left open would keep its
+    locks on archive_changes and block the DDL that follows.
+    """
+    engine = _engine(url)
+    session = sessionmaker(bind=engine)()
+    try:
+        repo = Repository(name="r", path="/srv/r")
+        session.add(repo)
+        session.flush()
+        archive = Archive(
+            repository_id=repo.id,
+            borg_id="b",
+            name="a",
+            series="s",
+            start=datetime(2026, 9, 4),
+        )
+        session.add(archive)
+        session.flush()
+        session.add(
+            ArchiveChange(archive_id=archive.id, path=LONG_PATH, change="added")
+        )
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def _stored_paths(url):
+    engine = _engine(url)
+    session = sessionmaker(bind=engine)()
+    paths = [row.path for row in session.query(ArchiveChange)]
+    session.close()
+    engine.dispose()
+    return paths
+
+
+def _reset_postgres():
+    engine = _engine(POSTGRES_URL)
+    with engine.begin() as conn:
+        conn.execute(text("DROP SCHEMA public CASCADE"))
+        conn.execute(text("CREATE SCHEMA public"))
+    engine.dispose()
+
+
+@pytest.mark.unit
+def test_downgrade_leaves_the_path_indexes_absent_and_keeps_long_rows(tmp_path):
+    """The downgrade policy: never recreate the indexes. Once the revision has
+    run, rows past the entry limit may exist, and recreating an index over
+    them fails on PostgreSQL; leaving two performance-only indexes absent is
+    the safe reversal."""
+    url = f"sqlite:///{tmp_path / 'borg.db'}"
+    _migrate(url, REVISION)
+    assert _path_indexes(url) == set()
+
+    _insert_long_path(url)
+    _migrate(url, PREVIOUS, down=True)
+
+    assert _path_indexes(url) == set()
+    assert _stored_paths(url) == [LONG_PATH]
+
+
+@pytest.mark.unit
+@requires_postgres
+def test_the_entry_limit_is_real_and_the_downgrade_survives_long_rows():
+    """Proven end to end on PostgreSQL: with the indexes in place the insert of
+    a long path fails (the bug this revision fixes), after the revision it
+    succeeds, and the downgrade then completes over that row instead of
+    failing on CREATE INDEX."""
+    _reset_postgres()
+    _migrate(POSTGRES_URL, PREVIOUS)
+    assert _path_indexes(POSTGRES_URL) == PATH_INDEXES
+
+    with pytest.raises(DBAPIError, match="exceeds btree"):
+        _insert_long_path(POSTGRES_URL)
+    assert _stored_paths(POSTGRES_URL) == []
+
+    _migrate(POSTGRES_URL, REVISION)
+    _insert_long_path(POSTGRES_URL)
+    assert _stored_paths(POSTGRES_URL) == [LONG_PATH]
+
+    _migrate(POSTGRES_URL, PREVIOUS, down=True)
+    assert _path_indexes(POSTGRES_URL) == set()
+    assert _stored_paths(POSTGRES_URL) == [LONG_PATH]


### PR DESCRIPTION
## Description

The second CodeRabbit finding surfaced on #897. `archive_changes.path` is an unbounded `Text` column, and it was covered by two B-tree indexes (`ix_archive_changes_path` and the composite `ix_archive_changes_archive_path`). PostgreSQL caps a B-tree entry at roughly a third of a page (~2.7 KB, measured after compressing the value), so a sufficiently long archived path that does not compress well — hash-heavy names, for example — makes the **INSERT of its own change row fail**, and the history index silently loses that archive's changes. Reproduced on PostgreSQL 16:

```
psycopg.errors.ProgramLimitExceeded: index row size 4120 exceeds btree version 4 maximum 2704 for index "ix_archive_changes_archive_path"
```

This drops both raw-path indexes (model + Alembic migration). The lookups stay correct:

- **Per-archive reads** (`filter(ArchiveChange.archive_id == ...)`, the delete/replace paths) keep the `archive_id` index (declared on the column).
- **Repository-wide exact-path lookup** (`join(Archive).filter(Archive.repository_id == ..., ArchiveChange.path == path)`) drives off the `archive_id` FK index via the join and filters `path`; it never seeked the raw-path B-tree efficiently across a repository anyway.
- The path **search** (`func.lower(path) LIKE ...`) and `ORDER BY path` never used a plain B-tree on `path` to begin with, so nothing there regresses.

**Downgrade policy.** The downgrade deliberately does not recreate the indexes: once the revision has run, rows past the entry limit may exist, and `CREATE INDEX` over them fails on PostgreSQL — a downgrade that can abort halfway is worse than one that leaves two performance-only indexes absent. A reverted deployment stays correct without them. (A conditional recreate — only when no row exceeds the limit — is possible, but data-dependent DDL keyed to a page-size-dependent threshold seemed worse than a documented no-op; open to switching.)

I went with dropping the indexes rather than adding a bounded `path_hash` column: it removes the failure with no new schema surface on this actively-evolving table, and doesn't foreclose a deliberate indexing strategy (hash column, or a trigram/expression index for the search) later.

## Related Issue

CodeRabbit finding relayed on #897 (ArchiveChange indexes the raw path).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

`tests/unit/test_archive_change_path_index_migration.py`:

- **SQLite** pins the downgrade policy: upgrade → insert a long path → downgrade completes, the path indexes stay absent, the row survives.
- **PostgreSQL-gated** (`BORG_TEST_POSTGRES_URL`, the `test_db_upgrade.py` pattern) proves the chain end to end on postgres:16: with the indexes in place the insert fails with the error above (the bug), after the revision it succeeds, and the downgrade then completes over that row. Run against the previous downgrade, the same test fails at exactly that `CREATE INDEX`. The test uses a seeded, incompressible path because PostgreSQL compresses index entries before the size check — a repetitive 4 KB path shrinks to a few bytes and fits.

The model guard test (`test_api_archive_index.py`) walks every index's expressions and rejects any that references the `path` column by identity — plain, composite in any position, or inside an expression — so the index cannot be re-added silently.

```
pytest tests/unit -q   (BORG_TEST_POSTGRES_URL set, postgres:16)
3123 passed, 8 skipped in 513.34s (0:08:33)

ruff check / ruff format --check — clean
```

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable; schema/index change.

## Additional Context

The migration chains off the current head (`d3e4f5a6b7c8`). Companion to #910 (the other #897 review finding, the import-connect rollback); independent of it — no shared files.
