### PR TITLE
test(config): derive SSH dirs without reloading app.config

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -278,6 +278,16 @@ class Settings(BaseSettings):
             self.rclone_cache_root = f"{self.data_dir}/rclone-cache"
 
 
+def derive_ssh_dirs(settings: "Settings", env: Mapping[str, str]) -> None:
+    """Derive the SSH key directories from data_dir and the environment.
+
+    Kept out of the module body so it can be exercised on a fresh Settings
+    without re-importing the module.
+    """
+    settings.ssh_keys_dir = f"{settings.data_dir}/ssh_keys"
+    settings.ssh_home_dir = resolve_ssh_home_dir(env, settings.ssh_keys_dir)
+
+
 # Create settings instance
 settings = Settings()
 
@@ -295,8 +305,7 @@ if not os.getenv("RCLONE_CACHE_ROOT"):
 settings.database_url = resolve_database_url(os.environ, settings.data_dir)
 
 # 2. SSH keys directory - always derived from data_dir
-settings.ssh_keys_dir = f"{settings.data_dir}/ssh_keys"
-settings.ssh_home_dir = resolve_ssh_home_dir(os.environ, settings.ssh_keys_dir)
+derive_ssh_dirs(settings, os.environ)
 
 # 3. Log file - always derived from data_dir
 settings.log_file = f"{settings.data_dir}/logs/borg-ui.log"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -198,22 +198,18 @@ def test_resolve_secret_key_file_lives_under_data_dir():
 
 
 @pytest.mark.unit
-def test_module_settings_ssh_home_dir_derives_from_ssh_keys_dir(monkeypatch):
-    """With no SSH_HOME_DIR in the environment the two settings are the same dir."""
-    import importlib
+def test_module_settings_ssh_home_dir_derives_from_ssh_keys_dir():
+    """With no SSH_HOME_DIR in the environment the two settings are the same dir.
 
-    monkeypatch.delenv("SSH_HOME_DIR", raising=False)
+    Exercised through derive_ssh_dirs on a fresh Settings. Reloading app.config
+    instead would rebuild the module-level `settings` object and re-run its
+    side effects underneath every module that already imported it.
+    """
+    from app.config import derive_ssh_dirs
 
-    import app.config as config_module
+    settings = Settings()
+    settings.data_dir = "/opt/borg-ui/data"
+    derive_ssh_dirs(settings, {})
 
-    importlib.reload(config_module)
-    try:
-        assert (
-            config_module.settings.ssh_keys_dir
-            == f"{config_module.settings.data_dir}/ssh_keys"
-        )
-        assert (
-            config_module.settings.ssh_home_dir == config_module.settings.ssh_keys_dir
-        )
-    finally:
-        importlib.reload(config_module)
+    assert settings.ssh_keys_dir == "/opt/borg-ui/data/ssh_keys"
+    assert settings.ssh_home_dir == settings.ssh_keys_dir


### PR DESCRIPTION
## Description

Fixes #914. `test_config.py::test_module_settings_ssh_home_dir_derives_from_ssh_keys_dir` reloaded `app.config` twice to check the module-level derivation of `ssh_keys_dir` / `ssh_home_dir`. A reload re-executes the whole module: it builds a **new** `settings` object, re-derives `data_dir` and `database_url` from whatever the environment holds at that moment, and re-runs the secret-key side effects. The `finally` reload does not restore anything — it creates a third object. Modules that bound `settings` at import time (`app/api/source_discovery.py` among them) and code that reads `app.config.settings` afterwards then disagree, and the three source-discovery scan tests fail whenever they share a process with this test (`assert 3 == 2`, an extra `sqlite` engine). CI is sharded four ways, so it only shows up when the two land in the same shard — as it did on #906's run.

The change keeps the test's intent without the reload:

- `app/config.py`: the two derivation lines move into `derive_ssh_dirs(settings, env)`; the module calls it once with `os.environ`, exactly as before.
- `tests/unit/test_config.py`: the test builds a fresh `Settings()`, sets `data_dir`, calls `derive_ssh_dirs(settings, {})` and asserts the same two facts. No module state is touched.

## Related Issue

Fixes #914. Unblocks CI on #906 (Backend / Unit Tests 4/4).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

Reproduction on `main` (`56ecef2f`) and result with this change:

```
# main: the polluter followed by the affected scan tests
pytest tests/unit/test_config.py::test_module_settings_ssh_home_dir_derives_from_ssh_keys_dir \
       tests/unit/test_source_discovery.py
→ 3 failed, 34 passed

# this branch, same command
→ 37 passed

pytest tests/unit/test_config.py tests/unit/test_deploy_ssh_key_script.py tests/unit/test_source_discovery.py
→ 59 passed (main: 3 failed, 56 passed)

pytest tests/unit -q
3144 passed, 13 skipped in 503.80s (0:08:23)  (main: 3 failed)

ruff check / ruff format --check — clean
```

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable; test/config change.

## Additional Context

`importlib.reload` was the only reload in the unit suite. `tests/fixtures/api.py` patches `settings.database_url` on the imported object per test, which is exactly the kind of shared state a reload silently replaces.
