### PR TITLE
fix(security): encrypt repository passphrase at rest

### DIFF
--- a/app/database/alembic/versions/7de0064b0d99_encrypt_repository_passphrase.py
+++ b/app/database/alembic/versions/7de0064b0d99_encrypt_repository_passphrase.py
@@ -1,0 +1,78 @@
+"""encrypt repository passphrase
+
+Encrypts every existing plaintext ``repositories.passphrase`` value in place
+so it matches the new ``EncryptedString`` column type in
+app.database.models.Repository. Purely a data transform: the column stays a
+plain String, so no schema change is needed, and the ORM's encrypt-on-write /
+decrypt-on-read now applies to every row going forward.
+
+Idempotent: a value that already decrypts successfully is assumed to already
+be encrypted and is left untouched, so re-running this migration (or running
+it against a database seeded after the model change already shipped) is
+safe.
+
+Revision ID: 7de0064b0d99
+Revises: e4f5a6b7c8d9
+Create Date: 2026-09-05 11:54:02.514854
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from app.core.security import decrypt_secret, encrypt_secret
+
+
+# revision identifiers, used by Alembic.
+revision: str = "7de0064b0d99"
+down_revision: Union[str, Sequence[str], None] = "e4f5a6b7c8d9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _is_already_encrypted(value: str) -> bool:
+    try:
+        decrypt_secret(value)
+        return True
+    except Exception:
+        return False
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    rows = connection.execute(
+        sa.text("SELECT id, passphrase FROM repositories WHERE passphrase IS NOT NULL")
+    ).fetchall()
+
+    migrated = 0
+    for row_id, passphrase in rows:
+        if not passphrase or _is_already_encrypted(passphrase):
+            continue
+        connection.execute(
+            sa.text("UPDATE repositories SET passphrase = :value WHERE id = :id"),
+            {"value": encrypt_secret(passphrase), "id": row_id},
+        )
+        migrated += 1
+
+    print(f"✓ Encrypted {migrated} repository passphrase(s)")
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    rows = connection.execute(
+        sa.text("SELECT id, passphrase FROM repositories WHERE passphrase IS NOT NULL")
+    ).fetchall()
+
+    reverted = 0
+    for row_id, passphrase in rows:
+        if not passphrase or not _is_already_encrypted(passphrase):
+            continue
+        connection.execute(
+            sa.text("UPDATE repositories SET passphrase = :value WHERE id = :id"),
+            {"value": decrypt_secret(passphrase), "id": row_id},
+        )
+        reverted += 1
+
+    print(f"✓ Decrypted {reverted} repository passphrase(s)")

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -15,12 +15,38 @@ from sqlalchemy import (
     func,
 )
 from sqlalchemy.orm import relationship
+from sqlalchemy.types import TypeDecorator
 from app.database.database import Base
 from app.utils.schedule_time import get_container_timezone
 
 
 # Canonical naive-UTC "now" for column defaults (see its docstring).
 from app.utils.datetime_utils import utc_now  # noqa: E402,F401
+
+
+class EncryptedString(TypeDecorator):
+    """Transparently Fernet-encrypts a string column at rest.
+
+    Imports app.core.security lazily: that module imports models from here,
+    so a module-level import would be circular.
+    """
+
+    impl = String
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if not value:
+            return value
+        from app.core.security import encrypt_secret
+
+        return encrypt_secret(value)
+
+    def process_result_value(self, value, dialect):
+        if not value:
+            return value
+        from app.core.security import decrypt_secret
+
+        return decrypt_secret(value)
 
 
 class User(Base):
@@ -240,8 +266,8 @@ class Repository(Base):
     encryption = Column(String, default="repokey")
     compression = Column(String, default="lz4")
     passphrase = Column(
-        String, nullable=True
-    )  # Borg repository passphrase (for encrypted repos)
+        EncryptedString, nullable=True
+    )  # Borg repository passphrase (for encrypted repos), encrypted at rest
     has_keyfile = Column(
         Boolean, default=False
     )  # Whether repository has a keyfile (keyfile/keyfile-blake2 encryption)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -49,6 +49,41 @@ def test_repository_model_defaults():
 
 
 @pytest.mark.unit
+def test_repository_passphrase_encrypted_at_rest(db_session, db_engine):
+    """Repository.passphrase must be stored encrypted, not in plaintext."""
+    from sqlalchemy import text
+
+    repo = Repository(
+        name="Encrypted Repo", path="/tmp/encrypted-repo", passphrase="supersecret"
+    )
+    db_session.add(repo)
+    db_session.commit()
+    db_session.refresh(repo)
+
+    # Reading back through the ORM decrypts transparently.
+    assert repo.passphrase == "supersecret"
+
+    # The raw column value on disk must never be the plaintext passphrase.
+    with db_engine.connect() as connection:
+        raw_value = connection.execute(
+            text("SELECT passphrase FROM repositories WHERE id = :id"), {"id": repo.id}
+        ).scalar()
+    assert raw_value != "supersecret"
+    assert raw_value is not None
+
+
+@pytest.mark.unit
+def test_repository_passphrase_none_stays_none(db_session):
+    """A repository with no passphrase must round-trip as None, not raise."""
+    repo = Repository(name="No Passphrase Repo", path="/tmp/no-passphrase-repo")
+    db_session.add(repo)
+    db_session.commit()
+    db_session.refresh(repo)
+
+    assert repo.passphrase is None
+
+
+@pytest.mark.unit
 def test_user_model_creation():
     """Test User model instantiation"""
     user = User(username="testuser", password_hash="hashed_pwd_123", is_active=True)

--- a/tests/unit/test_repository_passphrase_encryption_migration.py
+++ b/tests/unit/test_repository_passphrase_encryption_migration.py
@@ -1,0 +1,92 @@
+"""Tests for revision 7de0064b0d99 (encrypt repository passphrase at rest)."""
+
+import importlib
+
+from alembic import command
+import sqlalchemy as sa
+from sqlalchemy import text
+import pytest
+
+from app.core.security import encrypt_secret
+from app.database.db_upgrade import _alembic_config, _engine
+from app.database.models import Repository
+
+_migration_module = importlib.import_module(
+    "app.database.alembic.versions.7de0064b0d99_encrypt_repository_passphrase"
+)
+_is_already_encrypted = _migration_module._is_already_encrypted
+
+REVISION = "7de0064b0d99"
+PREVIOUS = "e4f5a6b7c8d9"
+PLAINTEXT = "supersecret"
+
+
+def _migrate(url, target, *, down=False):
+    engine = _engine(url)
+    config = _alembic_config(url)
+    with engine.connect() as connection:
+        config.attributes["connection"] = connection
+        (command.downgrade if down else command.upgrade)(config, target)
+        connection.commit()
+    engine.dispose()
+
+
+def _insert_plaintext_repository(url):
+    """Insert a repository row with a plain-String bind for passphrase,
+    bypassing the ORM's EncryptedString column type so the row lands exactly
+    as a pre-migration database would have stored it: plaintext. Column
+    defaults for the other NOT NULL fields still come from Repository's own
+    Core table (via insert().values()), so this only overrides passphrase."""
+    engine = _engine(url)
+    with engine.begin() as connection:
+        result = connection.execute(
+            Repository.__table__.insert().values(
+                name="r",
+                path="/srv/r",
+                passphrase=sa.bindparam(
+                    "passphrase", value=PLAINTEXT, type_=sa.String()
+                ),
+            )
+        )
+        row_id = result.inserted_primary_key[0]
+    engine.dispose()
+    return row_id
+
+
+def _raw_passphrase(url, row_id):
+    engine = _engine(url)
+    with engine.connect() as connection:
+        value = connection.execute(
+            text("SELECT passphrase FROM repositories WHERE id = :id"), {"id": row_id}
+        ).scalar()
+    engine.dispose()
+    return value
+
+
+@pytest.mark.unit
+def test_upgrade_encrypts_existing_plaintext_passphrase(tmp_path):
+    url = f"sqlite:///{tmp_path / 'borg.db'}"
+    _migrate(url, PREVIOUS)
+    row_id = _insert_plaintext_repository(url)
+
+    _migrate(url, REVISION)
+
+    assert _raw_passphrase(url, row_id) != PLAINTEXT
+
+
+@pytest.mark.unit
+def test_downgrade_decrypts_passphrase_back_to_plaintext(tmp_path):
+    url = f"sqlite:///{tmp_path / 'borg.db'}"
+    _migrate(url, PREVIOUS)
+    row_id = _insert_plaintext_repository(url)
+    _migrate(url, REVISION)
+
+    _migrate(url, PREVIOUS, down=True)
+
+    assert _raw_passphrase(url, row_id) == PLAINTEXT
+
+
+@pytest.mark.unit
+def test_is_already_encrypted_distinguishes_plaintext_from_ciphertext():
+    assert _is_already_encrypted(encrypt_secret(PLAINTEXT)) is True
+    assert _is_already_encrypted(PLAINTEXT) is False


### PR DESCRIPTION
Repository.passphrase was stored in plaintext, unlike SSH private keys which already use encrypt_secret/decrypt_secret. Adds an EncryptedString TypeDecorator so every existing read/write site keeps working unchanged, plus an Alembic migration (data-only, idempotent) to encrypt existing rows.

Fix 1 of 2 from docs/superpowers/specs/2026-09-05-security-hardening-passphrase-hostkey.md.

## Description
<!-- Provide a clear and concise description of your changes -->


## Related Issue
<!-- Link to the issue this PR addresses -->
Fixes #


## Type of Change
<!-- Mark the relevant option with an 'x' -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring


## Testing
<!-- Describe the tests you ran to verify your changes -->

- [ ] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All existing tests pass


## Checklist
<!-- Mark completed items with an 'x' -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes


## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->


## Additional Context
<!-- Add any other context about the PR here -->


---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU Affero General Public License v3.0 (AGPL-3.0), the same license as this project.
