### PR TITLE
fix(security): verify SSH host keys instead of trusting any answer

### DIFF
--- a/app/api/archives.py
+++ b/app/api/archives.py
@@ -42,6 +42,7 @@ from app.utils.borg_env import (
 )
 from app.utils.ssh_utils import (
     resolve_repo_ssh_key_file,  # noqa: F401
+    resolve_repository_ssh_connection,
 )  # Backward-compatible patch target for tests
 from app.utils.datetime_utils import serialize_borg_archive_time, serialize_datetime
 
@@ -51,7 +52,11 @@ router = APIRouter()
 
 def _build_repo_env(repo: Repository, db: Session):
     temp_key_file = resolve_repo_ssh_key_file(repo, db)
-    ssh_opts = get_standard_ssh_opts(include_key_path=temp_key_file)
+    ssh_opts = get_standard_ssh_opts(
+        include_key_path=temp_key_file,
+        connection=resolve_repository_ssh_connection(repo, db),
+        db=db,
+    )
     env = setup_borg_env(passphrase=repo.passphrase, ssh_opts=ssh_opts)
     if remote_path := effective_repository_remote_path(repo):
         env["BORG_REMOTE_PATH"] = remote_path

--- a/app/api/browse.py
+++ b/app/api/browse.py
@@ -31,6 +31,7 @@ from app.utils.borg_env import (
 )
 from app.utils.ssh_utils import (
     resolve_repo_ssh_key_file,
+    resolve_repository_ssh_connection,
 )  # Backward-compatible patch target for tests
 
 logger = structlog.get_logger(__name__)
@@ -68,7 +69,11 @@ ITEM_SIZE_ESTIMATE = 200  # Average bytes per item in memory (conservative estim
 
 def _build_repo_env(repo: Repository, db: Session):
     temp_key_file = resolve_repo_ssh_key_file(repo, db)
-    ssh_opts = get_standard_ssh_opts(include_key_path=temp_key_file)
+    ssh_opts = get_standard_ssh_opts(
+        include_key_path=temp_key_file,
+        connection=resolve_repository_ssh_connection(repo, db),
+        db=db,
+    )
     env = setup_borg_env(passphrase=repo.passphrase, ssh_opts=ssh_opts)
     return env, temp_key_file
 

--- a/app/api/filesystem.py
+++ b/app/api/filesystem.py
@@ -16,7 +16,7 @@ from app.database.database import get_db
 from sqlalchemy.orm import Session
 from app.database.models import SSHConnection, SSHKey
 from app.config import settings
-from app.utils.ssh_host_keys import host_key_ssh_opts
+from app.utils.ssh_host_keys import host_key_ssh_opts_for_host
 from app.utils.datetime_utils import serialize_datetime
 from app.utils.ssh_utils import ssh_key_auth_args
 
@@ -121,7 +121,7 @@ def is_borg_repository_ssh(
             *ssh_key_auth_args(ssh_key_path),
             "-p",
             str(port),
-            *host_key_ssh_opts(None),
+            *host_key_ssh_opts_for_host(host, port, username),
             "-o",
             "ConnectTimeout=5",
             f"{username}@{host}",
@@ -416,7 +416,7 @@ async def browse_ssh_filesystem(
                     *ssh_key_auth_args(temp_key_file),
                     "-P",
                     str(port),
-                    *host_key_ssh_opts(None),
+                    *host_key_ssh_opts_for_host(host, port, username),
                     "-o",
                     "ConnectTimeout=10",
                     f"{username}@{host}",
@@ -717,7 +717,7 @@ async def validate_path(
                         *ssh_key_auth_args(temp_key_file),
                         "-p",
                         str(port),
-                        *host_key_ssh_opts(None),
+                        *host_key_ssh_opts_for_host(host, port, username),
                         "-o",
                         "ConnectTimeout=5",
                         f"{username}@{host}",
@@ -909,7 +909,7 @@ async def create_folder(
                             *ssh_key_auth_args(temp_key_file),
                             "-P",
                             str(port),
-                            *host_key_ssh_opts(None),
+                            *host_key_ssh_opts_for_host(host, port, username),
                             "-o",
                             "ConnectTimeout=10",
                             f"{username}@{host}",

--- a/app/api/filesystem.py
+++ b/app/api/filesystem.py
@@ -16,6 +16,7 @@ from app.database.database import get_db
 from sqlalchemy.orm import Session
 from app.database.models import SSHConnection, SSHKey
 from app.config import settings
+from app.utils.ssh_host_keys import host_key_ssh_opts
 from app.utils.datetime_utils import serialize_datetime
 from app.utils.ssh_utils import ssh_key_auth_args
 
@@ -120,10 +121,7 @@ def is_borg_repository_ssh(
             *ssh_key_auth_args(ssh_key_path),
             "-p",
             str(port),
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "UserKnownHostsFile=/dev/null",
+            *host_key_ssh_opts(None),
             "-o",
             "ConnectTimeout=5",
             f"{username}@{host}",
@@ -418,10 +416,7 @@ async def browse_ssh_filesystem(
                     *ssh_key_auth_args(temp_key_file),
                     "-P",
                     str(port),
-                    "-o",
-                    "StrictHostKeyChecking=no",
-                    "-o",
-                    "UserKnownHostsFile=/dev/null",
+                    *host_key_ssh_opts(None),
                     "-o",
                     "ConnectTimeout=10",
                     f"{username}@{host}",
@@ -722,10 +717,7 @@ async def validate_path(
                         *ssh_key_auth_args(temp_key_file),
                         "-p",
                         str(port),
-                        "-o",
-                        "StrictHostKeyChecking=no",
-                        "-o",
-                        "UserKnownHostsFile=/dev/null",
+                        *host_key_ssh_opts(None),
                         "-o",
                         "ConnectTimeout=5",
                         f"{username}@{host}",
@@ -917,10 +909,7 @@ async def create_folder(
                             *ssh_key_auth_args(temp_key_file),
                             "-P",
                             str(port),
-                            "-o",
-                            "StrictHostKeyChecking=no",
-                            "-o",
-                            "UserKnownHostsFile=/dev/null",
+                            *host_key_ssh_opts(None),
                             "-o",
                             "ConnectTimeout=10",
                             f"{username}@{host}",

--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -103,6 +103,7 @@ from app.services.rclone_repository_service import (
     normalize_rclone_relative_path,
     rclone_repository_service,
 )
+from app.utils.ssh_host_keys import host_key_ssh_opts
 from app.utils.datetime_utils import (
     parse_borg_archive_time,
     serialize_borg_archive_time,
@@ -5963,8 +5964,7 @@ async def check_remote_borg_installation(
         borg_cmd = [
             "ssh",
             *ssh_key_auth_args(temp_key_file),
-            "-o",
-            "StrictHostKeyChecking=no",
+            *host_key_ssh_opts(None),
             "-o",
             "ConnectTimeout=10",
             "-p",

--- a/app/api/restore.py
+++ b/app/api/restore.py
@@ -26,6 +26,7 @@ from app.utils.borg_env import (
 )
 from app.utils.ssh_utils import (
     resolve_repo_ssh_key_file,
+    resolve_repository_ssh_connection,
 )  # Backward-compatible patch target for tests
 
 logger = structlog.get_logger()
@@ -50,7 +51,11 @@ def _restore_job_logs_visible(job: RestoreJob, log_save_policy: str) -> bool:
 
 def _build_repo_env(repo: Repository, db: Session):
     temp_key_file = resolve_repo_ssh_key_file(repo, db)
-    ssh_opts = get_standard_ssh_opts(include_key_path=temp_key_file)
+    ssh_opts = get_standard_ssh_opts(
+        include_key_path=temp_key_file,
+        connection=resolve_repository_ssh_connection(repo, db),
+        db=db,
+    )
     env = setup_borg_env(passphrase=repo.passphrase, ssh_opts=ssh_opts)
     return env, temp_key_file
 

--- a/app/api/source_discovery.py
+++ b/app/api/source_discovery.py
@@ -22,6 +22,7 @@ from app.core.security import get_current_user
 from app.database.database import get_db
 from app.database.models import SSHConnection, SSHKey, User
 from app.services.filesystem_snapshot_service import DEFAULT_SNAPSHOT_STAGING_ROOT
+from app.utils.ssh_host_keys import host_key_ssh_opts
 from app.utils.ssh_utils import ssh_key_auth_args, write_ssh_key_to_tempfile
 
 router = APIRouter()
@@ -1077,8 +1078,7 @@ def _run_remote_mount_size_probe(
         *ssh_key_auth_args(key_file_path),
         "-p",
         str(connection.port or 22),
-        "-o",
-        "StrictHostKeyChecking=accept-new",
+        *host_key_ssh_opts(connection),
         "-o",
         f"ConnectTimeout={max(1, int(timeout_seconds))}",
         f"{connection.username}@{connection.host}",
@@ -1297,8 +1297,7 @@ def _run_remote_container_scan(
         *ssh_key_auth_args(key_file_path),
         "-p",
         str(connection.port or 22),
-        "-o",
-        "StrictHostKeyChecking=accept-new",
+        *host_key_ssh_opts(connection),
         "-o",
         f"ConnectTimeout={max(1, int(timeout_seconds))}",
         f"{connection.username}@{connection.host}",
@@ -1607,10 +1606,7 @@ def _run_remote_database_probe(
         *ssh_key_auth_args(key_file_path),
         "-p",
         str(connection.port or 22),
-        "-o",
-        "StrictHostKeyChecking=no",
-        "-o",
-        "UserKnownHostsFile=/dev/null",
+        *host_key_ssh_opts(connection),
         "-o",
         f"ConnectTimeout={max(1, int(timeout_seconds))}",
         f"{connection.username}@{connection.host}",

--- a/app/api/ssh_keys.py
+++ b/app/api/ssh_keys.py
@@ -2091,18 +2091,29 @@ async def get_connection_host_key(
     return _host_key_response(connection, observed)
 
 
+class HostKeyTrustRequest(BaseModel):
+    """The key the user confirmed in the dialog.
+
+    Required: without it there is nothing to compare a fresh scan against, and
+    "trust whatever answers right now" is the behaviour this feature exists to
+    remove.
+    """
+
+    key: str = Field(min_length=1)
+
+
 @router.post("/connections/{connection_id}/host-key/trust")
 async def trust_connection_host_key(
     connection_id: int,
-    payload: Dict[str, Any] = Body(default_factory=dict),
+    payload: HostKeyTrustRequest,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     """Trust the host key the user just confirmed.
 
-    The key is always re-read from the host and the confirmed fingerprint must
-    still match, so a key that changed between showing the dialog and pressing
-    the button is refused rather than pinned.
+    The key is always re-read from the host and the confirmed key must still
+    match, so one that changed between showing the dialog and pressing the
+    button is refused rather than pinned.
     """
     connection = (
         db.query(SSHConnection).filter(SSHConnection.id == connection_id).first()
@@ -2124,14 +2135,27 @@ async def trust_connection_host_key(
             },
         )
 
-    confirmed = (payload or {}).get("key")
-    if confirmed and confirmed.strip() != observed.strip():
+    if payload.key.strip() != observed.strip():
         raise HTTPException(
             status_code=409,
             detail={"key": "backend.errors.ssh.hostKeyChangedWhileConfirming"},
         )
 
-    pin_host_key(connection, db, observed)
+    try:
+        pin_host_key(connection, db, observed)
+    except Exception as exc:
+        logger.error(
+            "Failed to store a trusted host key",
+            connection_id=connection_id,
+            error=str(exc),
+        )
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "key": "backend.errors.ssh.failedStoreHostKey",
+                "params": {"error": str(exc)},
+            },
+        )
     db.refresh(connection)
 
     logger.info(
@@ -2165,6 +2189,9 @@ async def forget_connection_host_key(
         )
 
     connection.known_host_key = None
+    # Forgetting means the user wants to verify again, so a connection old
+    # enough to pin silently must not do that on its next use either.
+    connection.host_key_trust_on_first_use = False
     connection.updated_at = datetime.utcnow()
     db.commit()
     forget_known_hosts_file(connection)

--- a/app/api/ssh_keys.py
+++ b/app/api/ssh_keys.py
@@ -26,6 +26,16 @@ from app.database.models import (
 from app.core.authorization import authorize_request
 from app.core.security import get_current_user, encrypt_secret, decrypt_secret
 from app.config import settings
+from app.utils.ssh_host_keys import (
+    HOST_KEY_STATUS_UNKNOWN,
+    HostKeyScanError,
+    describe_host_key_status,
+    forget_known_hosts_file,
+    host_key_ssh_opts,
+    key_fingerprint,
+    pin_host_key,
+    scan_host_key_async,
+)
 from app.utils.datetime_utils import serialize_datetime
 from app.utils.ssh_host_validation import normalize_ssh_host
 from app.utils.ssh_utils import ssh_key_auth_args, write_ssh_key_to_tempfile
@@ -86,10 +96,7 @@ async def _run_df_command(
     df_cmd = [
         "ssh",
         *ssh_key_auth_args(temp_key_file),
-        "-o",
-        "StrictHostKeyChecking=no",
-        "-o",
-        "UserKnownHostsFile=/dev/null",
+        *host_key_ssh_opts(connection),
         "-o",
         "LogLevel=ERROR",
         "-o",
@@ -1145,6 +1152,8 @@ async def get_ssh_connections(
                     "last_success": serialize_datetime(conn.last_success),
                     "error_message": conn.error_message,
                     "storage": storage,
+                    "host_key_verified": bool(conn.known_host_key),
+                    "host_key_fingerprint": key_fingerprint(conn.known_host_key),
                     "created_at": serialize_datetime(conn.created_at),
                 }
             )
@@ -1189,10 +1198,7 @@ def _ssh_command_base(
         "ssh",
         "-i",
         key_file_path,
-        "-o",
-        "StrictHostKeyChecking=no",
-        "-o",
-        "UserKnownHostsFile=/dev/null",
+        *host_key_ssh_opts(connection),
         "-o",
         "LogLevel=ERROR",
         "-o",
@@ -2042,6 +2048,141 @@ async def test_existing_connection(
         )
 
 
+def _host_key_response(connection, observed: str | None) -> Dict[str, Any]:
+    """Shape one connection's host-key state for the UI."""
+    return {
+        "connection_id": connection.id,
+        "host": connection.host,
+        "port": connection.port,
+        "status": describe_host_key_status(connection, observed),
+        "trusted_fingerprint": key_fingerprint(connection.known_host_key),
+        "observed_fingerprint": key_fingerprint(observed),
+        "observed_key": observed,
+    }
+
+
+@router.get("/connections/{connection_id}/host-key")
+async def get_connection_host_key(
+    connection_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Report what host key a connection trusts and what the host offers now."""
+    connection = (
+        db.query(SSHConnection).filter(SSHConnection.id == connection_id).first()
+    )
+    if not connection:
+        raise HTTPException(
+            status_code=404,
+            detail={"key": "backend.errors.ssh.sshConnectionNotFound"},
+        )
+
+    try:
+        observed = await scan_host_key_async(connection.host, connection.port or 22)
+    except HostKeyScanError as exc:
+        logger.warning(
+            "Could not read the host key of an SSH connection",
+            connection_id=connection_id,
+            host=connection.host,
+            error=str(exc),
+        )
+        observed = None
+
+    return _host_key_response(connection, observed)
+
+
+@router.post("/connections/{connection_id}/host-key/trust")
+async def trust_connection_host_key(
+    connection_id: int,
+    payload: Dict[str, Any] = Body(default_factory=dict),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Trust the host key the user just confirmed.
+
+    The key is always re-read from the host and the confirmed fingerprint must
+    still match, so a key that changed between showing the dialog and pressing
+    the button is refused rather than pinned.
+    """
+    connection = (
+        db.query(SSHConnection).filter(SSHConnection.id == connection_id).first()
+    )
+    if not connection:
+        raise HTTPException(
+            status_code=404,
+            detail={"key": "backend.errors.ssh.sshConnectionNotFound"},
+        )
+
+    try:
+        observed = await scan_host_key_async(connection.host, connection.port or 22)
+    except HostKeyScanError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "key": "backend.errors.ssh.failedReadHostKey",
+                "params": {"error": str(exc)},
+            },
+        )
+
+    confirmed = (payload or {}).get("key")
+    if confirmed and confirmed.strip() != observed.strip():
+        raise HTTPException(
+            status_code=409,
+            detail={"key": "backend.errors.ssh.hostKeyChangedWhileConfirming"},
+        )
+
+    pin_host_key(connection, db, observed)
+    db.refresh(connection)
+
+    logger.info(
+        "Trusted the host key of an SSH connection",
+        connection_id=connection_id,
+        host=connection.host,
+        fingerprint=key_fingerprint(observed),
+    )
+
+    return {
+        "success": True,
+        "message": "backend.success.ssh.hostKeyTrusted",
+        **_host_key_response(connection, observed),
+    }
+
+
+@router.delete("/connections/{connection_id}/host-key")
+async def forget_connection_host_key(
+    connection_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Forget a pinned host key so the next connection has to verify again."""
+    connection = (
+        db.query(SSHConnection).filter(SSHConnection.id == connection_id).first()
+    )
+    if not connection:
+        raise HTTPException(
+            status_code=404,
+            detail={"key": "backend.errors.ssh.sshConnectionNotFound"},
+        )
+
+    connection.known_host_key = None
+    connection.updated_at = datetime.utcnow()
+    db.commit()
+    forget_known_hosts_file(connection)
+
+    logger.info(
+        "Forgot the pinned host key of an SSH connection",
+        connection_id=connection_id,
+        host=connection.host,
+    )
+
+    return {
+        "success": True,
+        "message": "backend.success.ssh.hostKeyForgotten",
+        "connection_id": connection_id,
+        "status": HOST_KEY_STATUS_UNKNOWN,
+    }
+
+
 @router.post("/connections/{connection_id}/diagnostics")
 async def run_connection_diagnostics(
     connection_id: int,
@@ -2604,8 +2745,7 @@ async def deploy_ssh_key_with_copy_id(
             [
                 "-i",
                 key_file_path,
-                "-o",
-                "StrictHostKeyChecking=no",
+                *host_key_ssh_opts(None),
                 "-o",
                 "ConnectTimeout=10",
                 "-p",
@@ -2775,10 +2915,7 @@ async def test_ssh_key_connection(
             "ssh",
             "-i",
             key_file_path,
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "UserKnownHostsFile=/dev/null",
+            *host_key_ssh_opts(None),
             "-o",
             "LogLevel=ERROR",
             "-o",

--- a/app/api/ssh_keys.py
+++ b/app/api/ssh_keys.py
@@ -35,6 +35,7 @@ from app.utils.ssh_host_keys import (
     key_fingerprint,
     pin_host_key,
     scan_host_key_async,
+    sort_host_key_lines,
 )
 from app.utils.datetime_utils import serialize_datetime
 from app.utils.ssh_host_validation import normalize_ssh_host
@@ -2135,7 +2136,12 @@ async def trust_connection_host_key(
             },
         )
 
-    if payload.key.strip() != observed.strip():
+    # Compare the keys as a set, not as text. A host offering several key
+    # types is the normal case, and the confirmed blob and the fresh scan only
+    # have to describe the same keys, not the same string.
+    if set(sort_host_key_lines(payload.key.splitlines())) != set(
+        sort_host_key_lines(observed.splitlines())
+    ):
         raise HTTPException(
             status_code=409,
             detail={"key": "backend.errors.ssh.hostKeyChangedWhileConfirming"},

--- a/app/core/borg.py
+++ b/app/core/borg.py
@@ -6,6 +6,7 @@ import structlog
 from typing import Dict, List
 from app.config import settings
 from app.core.borg_stream import CommandLineStream
+from app.utils.ssh_host_keys import host_key_ssh_opts
 from app.utils.ssh_utils import public_key_only_ssh_args
 
 logger = structlog.get_logger()
@@ -85,10 +86,7 @@ class BorgInterface:
         # This allows automatic connection to new hosts without manual intervention
         ssh_opts = [
             *public_key_only_ssh_args(),
-            "-o",
-            "StrictHostKeyChecking=no",  # Don't check host keys
-            "-o",
-            "UserKnownHostsFile=/dev/null",  # Don't save host keys
+            *host_key_ssh_opts(None),
             "-o",
             "LogLevel=ERROR",  # Reduce SSH verbosity
         ]
@@ -191,10 +189,7 @@ class BorgInterface:
 
         ssh_opts = [
             *public_key_only_ssh_args(),
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "UserKnownHostsFile=/dev/null",
+            *host_key_ssh_opts(None),
             "-o",
             "LogLevel=ERROR",
         ]

--- a/app/core/borg2.py
+++ b/app/core/borg2.py
@@ -47,6 +47,7 @@ import structlog
 
 from app.config import settings
 from app.core.borg_stream import CommandLineStream
+from app.utils.ssh_host_keys import host_key_ssh_opts
 from app.utils.ssh_utils import public_key_only_ssh_args
 
 logger = structlog.get_logger()
@@ -199,10 +200,7 @@ class Borg2Interface:
         env["BORG_RELOCATED_REPO_ACCESS_IS_OK"] = "yes"
         ssh_opts = [
             *public_key_only_ssh_args(),
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "UserKnownHostsFile=/dev/null",
+            *host_key_ssh_opts(None),
             "-o",
             "LogLevel=ERROR",
         ]

--- a/app/database/alembic/versions/a1c9f4d27b60_add_ssh_connection_known_host_key.py
+++ b/app/database/alembic/versions/a1c9f4d27b60_add_ssh_connection_known_host_key.py
@@ -1,0 +1,34 @@
+"""add ssh_connections.known_host_key
+
+Holds the pinned host key (known_hosts lines) that every SSH invocation for
+that connection verifies against. Null for connections that predate host-key
+verification; those pin the key they see on their next use.
+
+Revision ID: a1c9f4d27b60
+Revises: 7de0064b0d99
+Create Date: 2026-09-05 18:10:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a1c9f4d27b60"
+down_revision: Union[str, Sequence[str], None] = "7de0064b0d99"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "ssh_connections",
+        sa.Column("known_host_key", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("ssh_connections", "known_host_key")

--- a/app/database/alembic/versions/b7e1a3c95d84_add_ssh_connection_host_key_tofu_flag.py
+++ b/app/database/alembic/versions/b7e1a3c95d84_add_ssh_connection_host_key_tofu_flag.py
@@ -1,0 +1,51 @@
+"""add ssh_connections.host_key_trust_on_first_use
+
+Marks the connections that existed before host-key verification did. Those pin
+whatever key answers on their next use: they were already running with no
+verification at all, so recording the current key is strictly better than the
+status quo and does not break an install on upgrade.
+
+Every connection created after this migration defaults to false and needs the
+user to confirm the fingerprint before a key is pinned, which is the moment the
+verification is actually worth something.
+
+Revision ID: b7e1a3c95d84
+Revises: a1c9f4d27b60
+Create Date: 2026-09-05 19:05:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b7e1a3c95d84"
+down_revision: Union[str, Sequence[str], None] = "a1c9f4d27b60"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "ssh_connections",
+        sa.Column("host_key_trust_on_first_use", sa.Boolean(), nullable=True),
+    )
+    connection = op.get_bind()
+    result = connection.execute(
+        sa.text(
+            "UPDATE ssh_connections SET host_key_trust_on_first_use = :value "
+            "WHERE known_host_key IS NULL"
+        ),
+        {"value": True},
+    )
+    print(
+        f"✓ {result.rowcount} existing SSH connection(s) will pin their host key "
+        "on next use"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("ssh_connections", "host_key_trust_on_first_use")

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -518,6 +518,11 @@ class SSHConnection(Base):
     # every SSH invocation. Null means nothing has been trusted yet; see
     # app/utils/ssh_host_keys.py.
     known_host_key = Column(Text, nullable=True)
+    # True only for connections that predate host-key verification: they pin
+    # whatever key answers on their next use, because they were already running
+    # with no verification at all. Connections created since default to False
+    # and need the user to confirm the fingerprint.
+    host_key_trust_on_first_use = Column(Boolean, default=False, nullable=True)
 
     created_at = Column(DateTime, default=utc_now)
     updated_at = Column(DateTime, default=utc_now, onupdate=utc_now)

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -514,6 +514,11 @@ class SSHConnection(Base):
         Boolean, default=False
     )  # Prepend sudo when running borg on remote host
 
+    # Pinned host key (known_hosts lines) used to verify the remote host on
+    # every SSH invocation. Null means nothing has been trusted yet; see
+    # app/utils/ssh_host_keys.py.
+    known_host_key = Column(Text, nullable=True)
+
     created_at = Column(DateTime, default=utc_now)
     updated_at = Column(DateTime, default=utc_now, onupdate=utc_now)
 

--- a/app/services/backup_plan_execution_service.py
+++ b/app/services/backup_plan_execution_service.py
@@ -58,6 +58,7 @@ from app.services.script_executor import execute_script
 from app.services.template_service import get_system_variables
 from app.utils.archive_names import build_archive_name
 from app.utils.script_params import SYSTEM_VARIABLE_PREFIX
+from app.utils.ssh_host_keys import host_key_ssh_opts
 from app.utils.ssh_utils import ssh_key_auth_args, write_ssh_key_to_tempfile
 from app.utils.schedule_time import calculate_next_cron_run, to_utc_naive
 from app.utils.source_locations import decode_source_locations
@@ -1854,10 +1855,7 @@ class BackupPlanExecutionService:
             ssh_cmd = [
                 "ssh",
                 *ssh_key_auth_args(key_file_path),
-                "-o",
-                "StrictHostKeyChecking=no",
-                "-o",
-                "UserKnownHostsFile=/dev/null",
+                *host_key_ssh_opts(source_connection, db),
                 "-o",
                 "ServerAliveInterval=60",
                 "-o",

--- a/app/services/mount_service.py
+++ b/app/services/mount_service.py
@@ -30,6 +30,7 @@ from app.utils.borg_env import effective_repository_remote_path, get_standard_ss
 from app.core.security import decrypt_secret
 from app.database.database import SessionLocal
 from app.database.models import SSHConnection, SSHKey, Repository, SystemSettings
+from app.utils.ssh_host_keys import host_key_ssh_opts
 from app.utils.ssh_utils import (
     resolve_repo_ssh_key_file,
     resolve_repository_ssh_connection,
@@ -1390,10 +1391,7 @@ class MountService:
             cmd = [
                 "ssh",
                 *ssh_key_auth_args(temp_key_file),
-                "-o",
-                "StrictHostKeyChecking=no",
-                "-o",
-                "UserKnownHostsFile=/dev/null",
+                *host_key_ssh_opts(connection),
                 "-o",
                 "ConnectTimeout=10",
                 "-p",
@@ -1471,10 +1469,7 @@ class MountService:
         cmd = [
             "sftp",
             *ssh_key_auth_args(temp_key_file),
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "UserKnownHostsFile=/dev/null",
+            *host_key_ssh_opts(connection),
             "-o",
             "ConnectTimeout=10",
             "-P",
@@ -1585,10 +1580,7 @@ class MountService:
                 diag_ssh = [
                     "ssh",
                     *ssh_key_auth_args(temp_key_file),
-                    "-o",
-                    "StrictHostKeyChecking=no",
-                    "-o",
-                    "UserKnownHostsFile=/dev/null",
+                    *host_key_ssh_opts(connection),
                     "-o",
                     "ConnectTimeout=10",
                     "-p",
@@ -1647,10 +1639,7 @@ class MountService:
                 "-p",
                 str(connection.port),
                 *sshfs_key_auth_options(temp_key_file),
-                "-o",
-                "StrictHostKeyChecking=no",
-                "-o",
-                "UserKnownHostsFile=/dev/null",
+                *host_key_ssh_opts(connection),
                 "-o",
                 "ConnectTimeout=30",
                 "-o",

--- a/app/services/mount_service.py
+++ b/app/services/mount_service.py
@@ -1015,7 +1015,11 @@ class MountService:
                 connection = resolve_repository_ssh_connection(repository, db)
                 if connection:
                     temp_key_file = resolve_repo_ssh_key_file(repository, db)
-                    ssh_opts = get_standard_ssh_opts(include_key_path=temp_key_file)
+                    ssh_opts = get_standard_ssh_opts(
+                        include_key_path=temp_key_file,
+                        connection=connection,
+                        db=db,
+                    )
                     env["BORG_RSH"] = f"ssh {' '.join(ssh_opts)}"
                     logger.info(
                         "Set BORG_RSH for repository connection",

--- a/app/services/remote_backup_service.py
+++ b/app/services/remote_backup_service.py
@@ -24,6 +24,7 @@ from app.config import settings
 from app.core.borg_errors import is_borg_warning_exit_code
 from app.services.log_policy import get_log_save_policy, job_has_logs_by_policy
 from app.services.notification_service import notification_service
+from app.utils.ssh_host_keys import host_key_ssh_opts
 from app.utils.ssh_utils import (
     resolve_repository_ssh_connection,
     ssh_key_auth_args,
@@ -554,10 +555,7 @@ class RemoteBackupService:
                 ssh_cmd = [
                     "ssh",
                     *ssh_key_auth_args(key_file_path),
-                    "-o",
-                    "StrictHostKeyChecking=no",
-                    "-o",
-                    "UserKnownHostsFile=/dev/null",
+                    *host_key_ssh_opts(ssh_connection, db),
                     "-o",
                     "ServerAliveInterval=60",
                     "-o",
@@ -771,10 +769,7 @@ class RemoteBackupService:
                 ssh_cmd = [
                     "ssh",
                     *ssh_key_auth_args(key_file_path),
-                    "-o",
-                    "StrictHostKeyChecking=no",
-                    "-o",
-                    "UserKnownHostsFile=/dev/null",
+                    *host_key_ssh_opts(ssh_connection, db),
                     "-p",
                     str(ssh_connection.port),
                     f"{ssh_connection.username}@{ssh_connection.host}",

--- a/app/utils/borg_env.py
+++ b/app/utils/borg_env.py
@@ -9,7 +9,9 @@ from typing import Iterator, Optional
 from sqlalchemy.orm import object_session
 
 from app.config import settings
+from app.utils.ssh_host_keys import host_key_ssh_opts
 from app.utils.ssh_utils import (
+    find_ssh_connection_for_path,
     public_key_only_ssh_args,
     resolve_repo_ssh_key_file,
     resolve_repository_ssh_connection,
@@ -21,8 +23,15 @@ def get_standard_ssh_opts(
     include_key_path: Optional[str] = None,
     *,
     keepalive: bool = False,
+    connection=None,
+    db=None,
 ) -> list[str]:
-    """Return standard SSH options for Borg operations."""
+    """Return standard SSH options for Borg operations.
+
+    ``connection`` is the SSH connection the command runs against; its pinned
+    host key verifies the remote host. Without one there is no row to pin
+    against, so the key is recorded on first use in a shared known_hosts file.
+    """
     opts: list[str] = []
 
     if include_key_path:
@@ -30,16 +39,8 @@ def get_standard_ssh_opts(
 
     opts.extend(public_key_only_ssh_args(identities_only=bool(include_key_path)))
 
-    opts.extend(
-        [
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "UserKnownHostsFile=/dev/null",
-            "-o",
-            "LogLevel=ERROR",
-        ]
-    )
+    opts.extend(host_key_ssh_opts(connection, db))
+    opts.extend(["-o", "LogLevel=ERROR"])
 
     if keepalive:
         opts.extend(
@@ -151,8 +152,12 @@ def build_repository_borg_env(
 ):
     """Build Borg env for a stored repository and return env + temp key path."""
     temp_key_file = resolve_repo_ssh_key_file(repository, db)
+    connection = resolve_repository_ssh_connection(repository, db) if db else None
     ssh_opts = get_standard_ssh_opts(
-        include_key_path=temp_key_file, keepalive=keepalive
+        include_key_path=temp_key_file,
+        keepalive=keepalive,
+        connection=connection,
+        db=db,
     )
     env = setup_borg_env(
         base_env=base_env,
@@ -180,11 +185,17 @@ def build_ssh_key_borg_env(
 ):
     """Build Borg env for an arbitrary Borg path plus optional SSH key ID."""
     temp_key_file = None
+    connection = None
     if ssh_key_id and path.startswith("ssh://"):
         temp_key_file = resolve_ssh_key_file_by_id(ssh_key_id, db=db)
+    if db is not None and path.startswith("ssh://"):
+        connection = find_ssh_connection_for_path(path, db)
 
     ssh_opts = get_standard_ssh_opts(
-        include_key_path=temp_key_file, keepalive=keepalive
+        include_key_path=temp_key_file,
+        keepalive=keepalive,
+        connection=connection,
+        db=db,
     )
     env = setup_borg_env(
         base_env=base_env,

--- a/app/utils/borg_env.py
+++ b/app/utils/borg_env.py
@@ -9,7 +9,10 @@ from typing import Iterator, Optional
 from sqlalchemy.orm import object_session
 
 from app.config import settings
-from app.utils.ssh_host_keys import host_key_ssh_opts
+from app.utils.ssh_host_keys import (
+    host_key_ssh_opts,
+    host_key_ssh_opts_for_connection_id,
+)
 from app.utils.ssh_utils import (
     find_ssh_connection_for_path,
     public_key_only_ssh_args,
@@ -25,12 +28,16 @@ def get_standard_ssh_opts(
     keepalive: bool = False,
     connection=None,
     db=None,
+    connection_id=None,
 ) -> list[str]:
     """Return standard SSH options for Borg operations.
 
     ``connection`` is the SSH connection the command runs against; its pinned
-    host key verifies the remote host. Without one there is no row to pin
-    against, so the key is recorded on first use in a shared known_hosts file.
+    host key verifies the remote host. A caller that knows only the id passes
+    ``connection_id`` and the row is loaded here, so a repository attached to a
+    pinned connection is never reduced to recording the key on first use just
+    because the caller had no session. With neither there is no row to verify
+    against, and the key is recorded on first use in a shared known_hosts file.
     """
     opts: list[str] = []
 
@@ -39,7 +46,10 @@ def get_standard_ssh_opts(
 
     opts.extend(public_key_only_ssh_args(identities_only=bool(include_key_path)))
 
-    opts.extend(host_key_ssh_opts(connection, db))
+    if connection is None and connection_id is not None:
+        opts.extend(host_key_ssh_opts_for_connection_id(connection_id))
+    else:
+        opts.extend(host_key_ssh_opts(connection, db))
     opts.extend(["-o", "LogLevel=ERROR"])
 
     if keepalive:

--- a/app/utils/fs.py
+++ b/app/utils/fs.py
@@ -7,6 +7,7 @@ import re
 import structlog
 from typing import Optional
 
+from app.utils.ssh_host_keys import host_key_ssh_opts_for_path
 from app.utils.ssh_utils import public_key_only_ssh_args, ssh_key_auth_args
 
 logger = structlog.get_logger()
@@ -136,10 +137,7 @@ async def _du_ssh(
             cmd.extend(public_key_only_ssh_args())
         cmd.extend(
             [
-                "-o",
-                "StrictHostKeyChecking=no",
-                "-o",
-                "UserKnownHostsFile=/dev/null",
+                *host_key_ssh_opts_for_path(path),
                 "-o",
                 "LogLevel=ERROR",
                 "-o",

--- a/app/utils/process_utils.py
+++ b/app/utils/process_utils.py
@@ -490,7 +490,9 @@ def break_repository_lock(repository: Repository) -> bool:
         # remote command and SSH identity, including legacy ssh:// URLs.
         if connection:
             temp_key_file = resolve_repo_ssh_key_file(repository, db)
-            ssh_opts = get_standard_ssh_opts(include_key_path=temp_key_file)
+            ssh_opts = get_standard_ssh_opts(
+                include_key_path=temp_key_file, connection=connection, db=db
+            )
             env["BORG_RSH"] = f"ssh {' '.join(ssh_opts)}"
         elif repository.connection_id:
             ssh_opts = get_standard_ssh_opts()

--- a/app/utils/process_utils.py
+++ b/app/utils/process_utils.py
@@ -495,7 +495,11 @@ def break_repository_lock(repository: Repository) -> bool:
             )
             env["BORG_RSH"] = f"ssh {' '.join(ssh_opts)}"
         elif repository.connection_id:
-            ssh_opts = get_standard_ssh_opts()
+            # The connection could not be resolved here, usually because the
+            # repository arrived without a session. Its id is enough to load
+            # the row and honour its pinned host key, which beats connecting
+            # to a pinned host with verification turned down.
+            ssh_opts = get_standard_ssh_opts(connection_id=repository.connection_id)
             env["BORG_RSH"] = f"ssh {' '.join(ssh_opts)}"
 
         # Execute break-lock command

--- a/app/utils/ssh_host_keys.py
+++ b/app/utils/ssh_host_keys.py
@@ -1,0 +1,434 @@
+"""Host-key pinning for SSH connections (trust on first use).
+
+Every SSH invocation used to pass ``StrictHostKeyChecking=no`` together with
+``UserKnownHostsFile=/dev/null``, which means the remote host was never
+authenticated: anything that could answer on the address was trusted, on every
+connection, forever. This module replaces that bypass for every invocation that
+is bound to a stored :class:`~app.database.models.SSHConnection`.
+
+The model is OpenSSH's own: the first time we talk to a host we record its
+public key, and from then on the key must match or the connection fails. The
+recorded key lives on the connection row (``known_host_key``), so it survives
+container restarts and is visible in the UI.
+
+Two ways a key gets pinned:
+
+* **Explicitly**, from the UI: the user is shown the fingerprint and confirms
+  it before it is stored. That is the path every newly created connection
+  takes, and it is the moment the verification is actually worth something.
+* **Silently**, on first use of a connection that predates this feature. Those
+  connections were already being used with no verification at all, so pinning
+  whatever answers now is strictly better than the status quo, and it avoids
+  breaking every existing install on upgrade. See the design spec.
+
+Once a key is pinned, a change is never absorbed silently in either case: the
+connection fails and the user has to re-verify.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import hashlib
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Optional
+
+import structlog
+
+from app.config import settings
+
+logger = structlog.get_logger()
+
+# Key types we ask for, best first. Restricting the scan keeps the stored value
+# small and avoids pinning a type OpenSSH would not have negotiated anyway.
+SCAN_KEY_TYPES = "ed25519,rsa,ecdsa"
+
+SCAN_TIMEOUT_SECONDS = 10
+
+# How long to leave a connection unscanned after its host key could not be read.
+SCAN_RETRY_COOLDOWN_SECONDS = 60
+
+HOST_KEY_STATUS_TRUSTED = "trusted"
+HOST_KEY_STATUS_UNKNOWN = "unknown"
+HOST_KEY_STATUS_CHANGED = "changed"
+HOST_KEY_STATUS_UNREACHABLE = "unreachable"
+
+
+class HostKeyScanError(Exception):
+    """Raised when the remote host's key could not be read."""
+
+
+def known_hosts_dir() -> Path:
+    """Directory holding the per-connection known_hosts files."""
+    return Path(settings.ssh_home_dir or settings.ssh_keys_dir) / "known_hosts.d"
+
+
+def known_hosts_path(connection) -> Path:
+    """Path of the known_hosts file materialised for one connection.
+
+    A connection that has not been saved yet has no id, so it is addressed by
+    the host and port it points at instead. Both are stable for the lifetime of
+    such an object, and a saved row always wins on id.
+    """
+    connection_id = getattr(connection, "id", None)
+    if connection_id is not None:
+        return known_hosts_dir() / f"connection_{connection_id}"
+
+    host = getattr(connection, "host", "") or ""
+    port = getattr(connection, "port", 22) or 22
+    digest = hashlib.sha256(f"{host}:{port}".encode()).hexdigest()[:16]
+    return known_hosts_dir() / f"host_{digest}"
+
+
+def scan_host_key(host: str, port: int = 22) -> str:
+    """Return the known_hosts lines ``ssh-keyscan`` reports for a host.
+
+    Raises HostKeyScanError when the host cannot be reached or offers no key.
+    """
+    if not host:
+        raise HostKeyScanError("No host to scan")
+
+    try:
+        result = subprocess.run(
+            [
+                "ssh-keyscan",
+                "-T",
+                str(SCAN_TIMEOUT_SECONDS),
+                "-t",
+                SCAN_KEY_TYPES,
+                "-p",
+                str(port or 22),
+                host,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=SCAN_TIMEOUT_SECONDS + 5,
+        )
+    except FileNotFoundError as exc:
+        raise HostKeyScanError("ssh-keyscan is not installed") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise HostKeyScanError(f"Timed out reading the host key of {host}") from exc
+
+    lines = [
+        line.strip()
+        for line in (result.stdout or "").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+    if not lines:
+        detail = (result.stderr or "").strip().splitlines()
+        raise HostKeyScanError(
+            detail[-1] if detail else f"No host key returned by {host}"
+        )
+
+    return "\n".join(lines)
+
+
+async def scan_host_key_async(host: str, port: int = 22) -> str:
+    """Async wrapper around :func:`scan_host_key`, for use in request handlers."""
+    return await asyncio.to_thread(scan_host_key, host, port)
+
+
+def key_fingerprint(host_key: Optional[str]) -> Optional[str]:
+    """Return the ``SHA256:`` fingerprint of the first key in a known_hosts blob.
+
+    Computed here rather than shelled out to ``ssh-keygen``: the connection
+    list renders one of these per row. The format matches what OpenSSH prints,
+    so a user can compare it against ``ssh-keygen -lf`` on the host itself.
+    ``ssh-keyscan`` lists key types in SCAN_KEY_TYPES order, so the first line
+    is the strongest key the host offered.
+    """
+    if not host_key or not host_key.strip():
+        return None
+
+    for line in host_key.splitlines():
+        fields = line.strip().split()
+        if len(fields) < 3:
+            continue
+        try:
+            blob = base64.b64decode(fields[2], validate=True)
+        except (ValueError, binascii.Error):
+            continue
+        digest = base64.b64encode(hashlib.sha256(blob).digest()).decode().rstrip("=")
+        return f"SHA256:{digest}"
+
+    return None
+
+
+def host_keys_match(stored: Optional[str], observed: Optional[str]) -> bool:
+    """Whether an observed scan still contains the key we pinned.
+
+    A host can legitimately gain a key type between scans, so a match means
+    "every key we pinned is still offered", not "the scans are identical".
+    """
+    if not stored or not observed:
+        return False
+
+    observed_lines = {line.strip() for line in observed.splitlines() if line.strip()}
+    stored_lines = [line.strip() for line in stored.splitlines() if line.strip()]
+    if not stored_lines:
+        return False
+
+    return all(line in observed_lines for line in stored_lines)
+
+
+def pinned_host_key(connection) -> Optional[str]:
+    """The key a connection has pinned, or None when it has none.
+
+    Anything that is not a non-empty string counts as unpinned, so a partially
+    built or mocked connection object cannot smuggle a non-key into the
+    known_hosts file.
+    """
+    host_key = getattr(connection, "known_host_key", None)
+    if not isinstance(host_key, str) or not host_key.strip():
+        return None
+    return host_key
+
+
+def write_known_hosts_file(connection) -> Optional[str]:
+    """Materialise a connection's pinned key as a known_hosts file.
+
+    Returns the file path, or None when nothing is pinned yet.
+    """
+    host_key = pinned_host_key(connection)
+    if not host_key:
+        return None
+
+    directory = known_hosts_dir()
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        path = known_hosts_path(connection)
+        # Write via a temporary file in the same directory so a concurrent
+        # command never reads a half-written known_hosts file.
+        fd, temp_path = tempfile.mkstemp(dir=str(directory), prefix=".known_hosts.")
+        with os.fdopen(fd, "w") as handle:
+            handle.write(host_key.rstrip("\n") + "\n")
+        os.chmod(temp_path, 0o600)
+        os.replace(temp_path, path)
+        return str(path)
+    except OSError as exc:
+        logger.warning(
+            "Could not write the known_hosts file for an SSH connection",
+            connection_id=getattr(connection, "id", None),
+            error=str(exc),
+        )
+        return None
+
+
+def forget_known_hosts_file(connection) -> None:
+    """Remove a connection's materialised known_hosts file, if any."""
+    try:
+        known_hosts_path(connection).unlink(missing_ok=True)
+    except OSError:  # pragma: no cover - best effort cleanup
+        pass
+
+
+def _session_for(connection, db):
+    """The session that owns a connection row, when the caller passed none."""
+    if db is not None:
+        return db
+    try:
+        from sqlalchemy.orm import object_session
+
+        return object_session(connection)
+    except Exception:  # pragma: no cover - detached or non-ORM object
+        return None
+
+
+def pin_host_key(connection, db, host_key: str) -> None:
+    """Store a host key on a connection and materialise its known_hosts file."""
+    connection.known_host_key = host_key.strip()
+    session = _session_for(connection, db)
+    if session is not None:
+        try:
+            session.commit()
+        except Exception as exc:  # pragma: no cover - a pin is never worth a 500
+            logger.warning(
+                "Could not persist a pinned host key",
+                connection_id=getattr(connection, "id", None),
+                error=str(exc),
+            )
+            session.rollback()
+    write_known_hosts_file(connection)
+
+
+_FAILED_SCANS: dict[object, float] = {}
+
+
+def _scan_recently_failed(connection) -> bool:
+    """Whether this connection's key was scanned, and failed, a moment ago.
+
+    A scan against an unreachable host costs the full ssh-keyscan timeout. That
+    is fine once, but an unpinned connection is retried on every SSH invocation,
+    and a backup plan makes many. The cooldown keeps a host that is simply down
+    from adding that timeout to every command.
+    """
+    key = getattr(connection, "id", None) or id(connection)
+    failed_at = _FAILED_SCANS.get(key)
+    if failed_at is None:
+        return False
+    if time.monotonic() - failed_at < SCAN_RETRY_COOLDOWN_SECONDS:
+        return True
+    _FAILED_SCANS.pop(key, None)
+    return False
+
+
+def _auto_pin(connection, db) -> bool:
+    """Silently pin the key of a connection that has never had one.
+
+    Returns True when a key was pinned. Only for connections created before
+    host-key verification existed: they were used with no verification at all,
+    so recording the current key can only improve on that.
+    """
+    if _scan_recently_failed(connection):
+        return False
+
+    host = getattr(connection, "host", None)
+    try:
+        host_key = scan_host_key(host, getattr(connection, "port", 22) or 22)
+    except HostKeyScanError as exc:
+        logger.warning(
+            "Could not pin the host key of an SSH connection",
+            connection_id=getattr(connection, "id", None),
+            host=host,
+            error=str(exc),
+        )
+        _FAILED_SCANS[getattr(connection, "id", None) or id(connection)] = (
+            time.monotonic()
+        )
+        return False
+
+    _FAILED_SCANS.pop(getattr(connection, "id", None) or id(connection), None)
+    pin_host_key(connection, db, host_key)
+    logger.info(
+        "Pinned the host key of an existing SSH connection on first use",
+        connection_id=getattr(connection, "id", None),
+        host=host,
+        fingerprint=key_fingerprint(host_key),
+    )
+    return True
+
+
+def host_key_ssh_opts(connection, db=None) -> list[str]:
+    """Return the OpenSSH options that verify one connection's host key.
+
+    Pins the key first when the connection has none. Falls back to
+    ``accept-new`` only when the host key cannot be read at all, which is still
+    stricter than the ``StrictHostKeyChecking=no`` this replaced: a key change
+    on a host we have already talked to is refused either way.
+    """
+    if connection is None:
+        return [
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+            "-o",
+            f"UserKnownHostsFile={_shared_known_hosts_path()}",
+        ]
+
+    if not pinned_host_key(connection):
+        _auto_pin(connection, db)
+
+    path = write_known_hosts_file(connection)
+    if not path:
+        # Nothing pinned and the scan failed: let OpenSSH record the key it
+        # sees in the per-connection file so the next command verifies against
+        # it, rather than reverting to trusting anything.
+        directory = known_hosts_dir()
+        try:
+            directory.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            return [
+                "-o",
+                "StrictHostKeyChecking=accept-new",
+                "-o",
+                f"UserKnownHostsFile={_shared_known_hosts_path()}",
+            ]
+        return [
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+            "-o",
+            f"UserKnownHostsFile={known_hosts_path(connection)}",
+        ]
+
+    return [
+        "-o",
+        "StrictHostKeyChecking=yes",
+        "-o",
+        f"UserKnownHostsFile={path}",
+    ]
+
+
+def host_key_ssh_opts_for_path(path: str) -> list[str]:
+    """Verify a bare ``ssh://`` URL against the pinned key of its connection.
+
+    For the few helpers that are handed a URL rather than a connection row.
+    Falls back to recording the key on first use when the URL matches no stored
+    connection, which is still stricter than trusting whatever answers.
+    """
+    if not path or not path.startswith("ssh://"):
+        return host_key_ssh_opts(None)
+
+    from app.database.database import SessionLocal
+    from app.utils.ssh_utils import find_ssh_connection_for_path
+
+    session = SessionLocal()
+    try:
+        return host_key_ssh_opts(find_ssh_connection_for_path(path, session), session)
+    except Exception as exc:  # pragma: no cover - a lookup failure is not fatal
+        logger.warning(
+            "Could not resolve the SSH connection for a path",
+            path=path,
+            error=str(exc),
+        )
+        return host_key_ssh_opts(None)
+    finally:
+        session.close()
+
+
+def _shared_known_hosts_path() -> Path:
+    """Fallback known_hosts file for invocations with no connection row.
+
+    Creates the directory as a side effect: OpenSSH will not record a key in a
+    file whose directory does not exist, and an invocation with no connection
+    row has nothing else to verify against.
+    """
+    directory = known_hosts_dir()
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:  # pragma: no cover - unwritable data dir
+        logger.warning("Could not create the known_hosts directory", error=str(exc))
+    return directory / "shared"
+
+
+def host_key_verification_failed(output: Optional[str]) -> bool:
+    """Whether SSH output shows the pinned key no longer matches."""
+    if not output:
+        return False
+    lowered = output.lower()
+    return (
+        "host key verification failed" in lowered
+        or "remote host identification has changed" in lowered
+    )
+
+
+def describe_host_key_status(connection, observed: Optional[str]) -> str:
+    """Classify a fresh scan against what the connection has pinned."""
+    stored = pinned_host_key(connection)
+    if not observed:
+        return HOST_KEY_STATUS_UNREACHABLE
+    if not stored:
+        return HOST_KEY_STATUS_UNKNOWN
+    if host_keys_match(stored, observed):
+        return HOST_KEY_STATUS_TRUSTED
+    return HOST_KEY_STATUS_CHANGED
+
+
+def ssh_keyscan_available() -> bool:
+    """Whether ``ssh-keyscan`` exists in this image."""
+    return shutil.which("ssh-keyscan") is not None

--- a/app/utils/ssh_host_keys.py
+++ b/app/utils/ssh_host_keys.py
@@ -191,6 +191,18 @@ def pinned_host_key(connection) -> Optional[str]:
     return host_key
 
 
+def trusts_on_first_use(connection) -> bool:
+    """Whether this connection may pin whatever key answers, without asking.
+
+    True only for connections that existed before host-key verification did.
+    Those were already running with no verification at all, so recording the
+    current key is strictly better than the status quo and does not break an
+    install on upgrade. A connection created since gets the confirm dialog
+    instead, which is the moment verification is actually worth something.
+    """
+    return getattr(connection, "host_key_trust_on_first_use", False) is True
+
+
 def write_known_hosts_file(connection) -> Optional[str]:
     """Materialise a connection's pinned key as a known_hosts file.
 
@@ -242,19 +254,25 @@ def _session_for(connection, db):
 
 
 def pin_host_key(connection, db, host_key: str) -> None:
-    """Store a host key on a connection and materialise its known_hosts file."""
+    """Store a host key on a connection and materialise its known_hosts file.
+
+    Raises whatever the commit raised if the key could not be persisted: a
+    caller that told the user their host is now verified must not say so when
+    the row still has no key.
+    """
     connection.known_host_key = host_key.strip()
     session = _session_for(connection, db)
     if session is not None:
         try:
             session.commit()
-        except Exception as exc:  # pragma: no cover - a pin is never worth a 500
+        except Exception as exc:
             logger.warning(
                 "Could not persist a pinned host key",
                 connection_id=getattr(connection, "id", None),
                 error=str(exc),
             )
             session.rollback()
+            raise
     write_known_hosts_file(connection)
 
 
@@ -305,7 +323,16 @@ def _auto_pin(connection, db) -> bool:
         return False
 
     _FAILED_SCANS.pop(getattr(connection, "id", None) or id(connection), None)
-    pin_host_key(connection, db, host_key)
+    try:
+        pin_host_key(connection, db, host_key)
+    except Exception as exc:  # a failed pin must not fail the SSH command
+        logger.warning(
+            "Could not store the host key pinned on first use",
+            connection_id=getattr(connection, "id", None),
+            host=host,
+            error=str(exc),
+        )
+        return False
     logger.info(
         "Pinned the host key of an existing SSH connection on first use",
         connection_id=getattr(connection, "id", None),
@@ -331,37 +358,80 @@ def host_key_ssh_opts(connection, db=None) -> list[str]:
             f"UserKnownHostsFile={_shared_known_hosts_path()}",
         ]
 
-    if not pinned_host_key(connection):
+    if not pinned_host_key(connection) and trusts_on_first_use(connection):
         _auto_pin(connection, db)
 
-    path = write_known_hosts_file(connection)
-    if not path:
-        # Nothing pinned and the scan failed: let OpenSSH record the key it
-        # sees in the per-connection file so the next command verifies against
-        # it, rather than reverting to trusting anything.
-        directory = known_hosts_dir()
-        try:
-            directory.mkdir(parents=True, exist_ok=True)
-        except OSError:
-            return [
-                "-o",
-                "StrictHostKeyChecking=accept-new",
-                "-o",
-                f"UserKnownHostsFile={_shared_known_hosts_path()}",
-            ]
+    if pinned_host_key(connection):
+        # A pinned connection always verifies strictly. If the file could not
+        # be written, OpenSSH finds no key for the host and refuses to connect,
+        # which is the right way to fail: never downgrade a connection the user
+        # has verified because of a full or read-only disk.
+        path = write_known_hosts_file(connection) or str(known_hosts_path(connection))
+        return [
+            "-o",
+            "StrictHostKeyChecking=yes",
+            "-o",
+            f"UserKnownHostsFile={path}",
+        ]
+
+    # Nothing pinned: either a connection awaiting the user's confirmation, or
+    # one whose host could not be scanned. Let OpenSSH record the key it sees
+    # in the per-connection file so a later change is still refused, rather
+    # than reverting to trusting anything.
+    directory = known_hosts_dir()
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+    except OSError:
         return [
             "-o",
             "StrictHostKeyChecking=accept-new",
             "-o",
-            f"UserKnownHostsFile={known_hosts_path(connection)}",
+            f"UserKnownHostsFile={_shared_known_hosts_path()}",
         ]
-
     return [
         "-o",
-        "StrictHostKeyChecking=yes",
+        "StrictHostKeyChecking=accept-new",
         "-o",
-        f"UserKnownHostsFile={path}",
+        f"UserKnownHostsFile={known_hosts_path(connection)}",
     ]
+
+
+def host_key_ssh_opts_for_host(
+    host: str, port: int = 22, username: Optional[str] = None
+) -> list[str]:
+    """Verify a bare host/port against the pinned key of its stored connection.
+
+    For the helpers that are handed connection details as loose strings rather
+    than a row. An endpoint that matches no single stored connection, or one
+    that matches several, records the key on first use instead: there is no
+    single pin to enforce, and refusing outright would break paths that run
+    before a connection exists at all, such as key deployment.
+    """
+    if not host:
+        return host_key_ssh_opts(None)
+
+    from app.database.database import SessionLocal
+    from app.database.models import SSHConnection
+
+    session = SessionLocal()
+    try:
+        query = session.query(SSHConnection).filter(
+            SSHConnection.host == host, SSHConnection.port == (port or 22)
+        )
+        if username:
+            query = query.filter(SSHConnection.username == username)
+        matches = query.all()
+        connection = matches[0] if len(matches) == 1 else None
+        return host_key_ssh_opts(connection, session)
+    except Exception as exc:  # pragma: no cover - a lookup failure is not fatal
+        logger.warning(
+            "Could not resolve the SSH connection for a host",
+            host=host,
+            error=str(exc),
+        )
+        return host_key_ssh_opts(None)
+    finally:
+        session.close()
 
 
 def host_key_ssh_opts_for_path(path: str) -> list[str]:

--- a/app/utils/ssh_host_keys.py
+++ b/app/utils/ssh_host_keys.py
@@ -49,6 +49,14 @@ logger = structlog.get_logger()
 # small and avoids pinning a type OpenSSH would not have negotiated anyway.
 SCAN_KEY_TYPES = "ed25519,rsa,ecdsa"
 
+# Preference order for the keys a host offers, strongest first. ssh-keyscan
+# queries the types concurrently and prints whichever answers first, so its
+# output order changes from run to run; every scan is sorted by this before it
+# is stored or compared. Without that, two scans of the same unchanged host
+# produce different strings, and the fingerprint shown to the user changes
+# every time the dialog is opened.
+KEY_TYPE_PREFERENCE = ("ssh-ed25519", "ssh-rsa", "ecdsa-sha2")
+
 SCAN_TIMEOUT_SECONDS = 10
 
 # How long to leave a connection unscanned after its host key could not be read.
@@ -127,7 +135,22 @@ def scan_host_key(host: str, port: int = 22) -> str:
             detail[-1] if detail else f"No host key returned by {host}"
         )
 
-    return "\n".join(lines)
+    return "\n".join(sort_host_key_lines(lines))
+
+
+def _key_type_rank(line: str) -> tuple[int, str]:
+    """Sort key: preferred type first, then the line itself for ties."""
+    fields = line.split()
+    key_type = fields[1] if len(fields) > 1 else ""
+    for rank, prefix in enumerate(KEY_TYPE_PREFERENCE):
+        if key_type.startswith(prefix):
+            return (rank, line)
+    return (len(KEY_TYPE_PREFERENCE), line)
+
+
+def sort_host_key_lines(lines) -> list[str]:
+    """Order known_hosts lines so the same host always yields the same blob."""
+    return sorted((line.strip() for line in lines if line.strip()), key=_key_type_rank)
 
 
 async def scan_host_key_async(host: str, port: int = 22) -> str:
@@ -136,18 +159,21 @@ async def scan_host_key_async(host: str, port: int = 22) -> str:
 
 
 def key_fingerprint(host_key: Optional[str]) -> Optional[str]:
-    """Return the ``SHA256:`` fingerprint of the first key in a known_hosts blob.
+    """Return the ``SHA256:`` fingerprint of a blob's strongest key.
 
     Computed here rather than shelled out to ``ssh-keygen``: the connection
     list renders one of these per row. The format matches what OpenSSH prints,
     so a user can compare it against ``ssh-keygen -lf`` on the host itself.
-    ``ssh-keyscan`` lists key types in SCAN_KEY_TYPES order, so the first line
-    is the strongest key the host offered.
+
+    The lines are ordered by KEY_TYPE_PREFERENCE first, so the same host always
+    shows the same fingerprint. Reading whichever line came first would show a
+    different one on each scan, which is useless for the one thing a
+    fingerprint is for: comparing it against the host.
     """
     if not host_key or not host_key.strip():
         return None
 
-    for line in host_key.splitlines():
+    for line in sort_host_key_lines(host_key.splitlines()):
         fields = line.strip().split()
         if len(fields) < 3:
             continue

--- a/app/utils/ssh_host_keys.py
+++ b/app/utils/ssh_host_keys.py
@@ -423,13 +423,49 @@ def host_key_ssh_opts_for_host(
         matches = query.all()
         connection = matches[0] if len(matches) == 1 else None
         return host_key_ssh_opts(connection, session)
-    except Exception as exc:  # pragma: no cover - a lookup failure is not fatal
-        logger.warning(
+    except Exception as exc:
+        # A lookup that failed is not a lookup that found nothing: the host may
+        # well have a pinned key we simply could not read. Falling back to
+        # accept-new here would let a database error downgrade verification,
+        # so the caller fails instead.
+        logger.error(
             "Could not resolve the SSH connection for a host",
             host=host,
             error=str(exc),
         )
+        raise
+    finally:
+        session.close()
+
+
+def host_key_ssh_opts_for_connection_id(connection_id) -> list[str]:
+    """Verify against the pin of a connection we only hold the id of.
+
+    For callers that know a repository is attached to a connection but have no
+    session to resolve it with. Looking it up is what keeps a repository whose
+    connection is pinned from falling back to recording on first use.
+    """
+    if connection_id is None:
         return host_key_ssh_opts(None)
+
+    from app.database.database import SessionLocal
+    from app.database.models import SSHConnection
+
+    session = SessionLocal()
+    try:
+        connection = (
+            session.query(SSHConnection)
+            .filter(SSHConnection.id == connection_id)
+            .first()
+        )
+        return host_key_ssh_opts(connection, session)
+    except Exception as exc:
+        logger.error(
+            "Could not load the SSH connection of a repository",
+            connection_id=connection_id,
+            error=str(exc),
+        )
+        raise
     finally:
         session.close()
 
@@ -450,13 +486,15 @@ def host_key_ssh_opts_for_path(path: str) -> list[str]:
     session = SessionLocal()
     try:
         return host_key_ssh_opts(find_ssh_connection_for_path(path, session), session)
-    except Exception as exc:  # pragma: no cover - a lookup failure is not fatal
-        logger.warning(
+    except Exception as exc:
+        # As in host_key_ssh_opts_for_host: a failed lookup says nothing about
+        # whether a pin exists, so it must not downgrade to accept-new.
+        logger.error(
             "Could not resolve the SSH connection for a path",
             path=path,
             error=str(exc),
         )
-        return host_key_ssh_opts(None)
+        raise
     finally:
         session.close()
 

--- a/app/utils/ssh_utils.py
+++ b/app/utils/ssh_utils.py
@@ -91,6 +91,11 @@ def _find_matching_ssh_connection(path: str, db) -> Optional[SSHConnection]:
     return matches[0] if len(matches) == 1 else None
 
 
+def find_ssh_connection_for_path(path: str, db) -> Optional[SSHConnection]:
+    """Return the stored SSH connection an ``ssh://`` URL points at, if any."""
+    return _find_matching_ssh_connection(path, db)
+
+
 def resolve_repository_ssh_connection(repository, db) -> Optional[SSHConnection]:
     """Resolve a repository's configured or legacy URL-matched SSH connection."""
     connection_id = getattr(repository, "connection_id", None)

--- a/frontend/src/components/RemoteMachineCard.stories.tsx
+++ b/frontend/src/components/RemoteMachineCard.stories.tsx
@@ -69,3 +69,23 @@ export const WithoutRunDiagnostics: Story = {
     ...handlers,
   },
 }
+
+export const HostKeyVerified: Story = {
+  args: {
+    machine: {
+      ...machine,
+      host_key_verified: true,
+      host_key_fingerprint: 'SHA256:Zx9Q3n1sKk2Yy8bV0pRfT4uJ6mE7cD1aS5gH2wN0qLk',
+    },
+    ...handlers,
+    onVerifyHostKey: fn(),
+  },
+}
+
+export const HostKeyNotVerified: Story = {
+  args: {
+    machine: { ...machine, host_key_verified: false },
+    ...handlers,
+    onVerifyHostKey: fn(),
+  },
+}

--- a/frontend/src/components/RemoteMachineCard.tsx
+++ b/frontend/src/components/RemoteMachineCard.tsx
@@ -19,6 +19,8 @@ import {
   HardDrive,
   Network,
   Key,
+  ShieldCheck,
+  ShieldAlert,
 } from 'lucide-react'
 
 interface StorageInfo {
@@ -48,6 +50,8 @@ interface RemoteMachine {
   last_success?: string
   error_message?: string
   storage?: StorageInfo | null
+  host_key_verified?: boolean
+  host_key_fingerprint?: string | null
   created_at: string
 }
 
@@ -59,6 +63,7 @@ interface RemoteMachineCardProps {
   onTestConnection: (machine: RemoteMachine) => void
   onDeployKey: (machine: RemoteMachine) => void
   onRunDiagnostics?: (machine: RemoteMachine) => void
+  onVerifyHostKey?: (machine: RemoteMachine) => void
   canManageConnections?: boolean
 }
 
@@ -96,6 +101,7 @@ export default function RemoteMachineCard({
   onTestConnection,
   onDeployKey,
   onRunDiagnostics,
+  onVerifyHostKey,
   canManageConnections = true,
 }: RemoteMachineCardProps) {
   const { t } = useTranslation()
@@ -226,6 +232,31 @@ export default function RemoteMachineCard({
           >
             {machine.username}@{machine.host}:{machine.port}
           </Typography>
+
+          {/* Host-key trust. The remote host is only authenticated once its key
+              is pinned, so a connection without one says so plainly. */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                color: machine.host_key_verified
+                  ? theme.palette.success.main
+                  : theme.palette.warning.main,
+              }}
+            >
+              {machine.host_key_verified ? <ShieldCheck size={12} /> : <ShieldAlert size={12} />}
+            </Box>
+            <Typography
+              noWrap
+              title={machine.host_key_fingerprint || undefined}
+              sx={{ fontSize: '0.62rem', color: 'text.disabled', minWidth: 0 }}
+            >
+              {machine.host_key_verified
+                ? t('remoteMachineCard.hostKey.verified')
+                : t('remoteMachineCard.hostKey.unverified')}
+            </Typography>
+          </Box>
         </Box>
 
         {/* ── Storage Stats Band ── */}
@@ -498,6 +529,22 @@ export default function RemoteMachineCard({
                 <RefreshCw size={16} />
               </IconButton>
             </Tooltip>
+            {onVerifyHostKey && (
+              <Tooltip title={t('remoteMachineCard.hostKey.action')} arrow>
+                <IconButton
+                  size="small"
+                  aria-label={t('remoteMachineCard.hostKey.action')}
+                  onClick={() => onVerifyHostKey(machine)}
+                  sx={coloredIconBtnSx(machine.host_key_verified ? 'success' : 'warning')}
+                >
+                  {machine.host_key_verified ? (
+                    <ShieldCheck size={16} />
+                  ) : (
+                    <ShieldAlert size={16} />
+                  )}
+                </IconButton>
+              </Tooltip>
+            )}
             {onRunDiagnostics && (
               <Tooltip title={t('remoteMachine.actions.runDiagnostics')} arrow>
                 <IconButton

--- a/frontend/src/components/__tests__/RemoteMachineCard.test.tsx
+++ b/frontend/src/components/__tests__/RemoteMachineCard.test.tsx
@@ -486,4 +486,72 @@ describe('RemoteMachineCard', () => {
       expect(mockOnEdit).toHaveBeenCalledWith(baseMachine)
     })
   })
+
+  describe('Host key', () => {
+    it('says the host key is not verified when nothing is pinned', () => {
+      render(
+        <RemoteMachineCard
+          machine={baseMachine}
+          onEdit={mockOnEdit}
+          onDelete={mockOnDelete}
+          onRefreshStorage={mockOnRefreshStorage}
+          onTestConnection={mockOnTestConnection}
+          onDeployKey={mockOnDeployKey}
+        />
+      )
+
+      expect(screen.getByText('Host key not verified')).toBeInTheDocument()
+    })
+
+    it('says the host key is verified once one is pinned', () => {
+      render(
+        <RemoteMachineCard
+          machine={{ ...baseMachine, host_key_verified: true, host_key_fingerprint: 'SHA256:abc' }}
+          onEdit={mockOnEdit}
+          onDelete={mockOnDelete}
+          onRefreshStorage={mockOnRefreshStorage}
+          onTestConnection={mockOnTestConnection}
+          onDeployKey={mockOnDeployKey}
+        />
+      )
+
+      expect(screen.getByText('Host key verified')).toBeInTheDocument()
+      expect(screen.getByTitle('SHA256:abc')).toBeInTheDocument()
+    })
+
+    it('offers no host key action when the page does not handle one', () => {
+      render(
+        <RemoteMachineCard
+          machine={baseMachine}
+          onEdit={mockOnEdit}
+          onDelete={mockOnDelete}
+          onRefreshStorage={mockOnRefreshStorage}
+          onTestConnection={mockOnTestConnection}
+          onDeployKey={mockOnDeployKey}
+        />
+      )
+
+      expect(screen.queryByRole('button', { name: 'Host key' })).not.toBeInTheDocument()
+    })
+
+    it('hands the machine to the host key handler', async () => {
+      const user = userEvent.setup()
+      const onVerifyHostKey = vi.fn()
+      render(
+        <RemoteMachineCard
+          machine={baseMachine}
+          onEdit={mockOnEdit}
+          onDelete={mockOnDelete}
+          onRefreshStorage={mockOnRefreshStorage}
+          onTestConnection={mockOnTestConnection}
+          onDeployKey={mockOnDeployKey}
+          onVerifyHostKey={onVerifyHostKey}
+        />
+      )
+
+      await user.click(screen.getByRole('button', { name: 'Host key' }))
+
+      expect(onVerifyHostKey).toHaveBeenCalledWith(baseMachine)
+    })
+  })
 })

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -5473,7 +5473,8 @@
         "failedListBackupSources": "Fehler beim Auflisten der Sicherungsquellen: {{error}}",
         "failedVerifyBorgInstallation": "Fehler beim Überprüfen der Borg-Installation: {{error}}",
         "failedReadHostKey": "Hostschlüssel konnte nicht gelesen werden: {{error}}",
-        "hostKeyChangedWhileConfirming": "Der Hostschlüssel hat sich während der Bestätigung geändert. Prüfen Sie ihn erneut, bevor Sie ihm vertrauen."
+        "hostKeyChangedWhileConfirming": "Der Hostschlüssel hat sich während der Bestätigung geändert. Prüfen Sie ihn erneut, bevor Sie ihm vertrauen.",
+        "failedStoreHostKey": "Hostschlüssel konnte nicht gespeichert werden: {{error}}"
       },
       "settings": {
         "adminAccessRequired": "Administratorzugriff erforderlich",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -2472,7 +2472,26 @@
       "keyDeleteFailed": "SSH-Schlüssel konnte nicht gelöscht werden",
       "publicKeyCopied": "Öffentlicher Schlüssel in Zwischenablage kopiert!",
       "diagnosticsComplete": "Diagnose abgeschlossen",
-      "diagnosticsFailed": "Diagnose konnte nicht ausgeführt werden"
+      "diagnosticsFailed": "Diagnose konnte nicht ausgeführt werden",
+      "hostKeyTrusted": "Hostschlüssel wird vertraut",
+      "hostKeyTrustFailed": "Dem Hostschlüssel konnte nicht vertraut werden",
+      "hostKeyForgotten": "Hostschlüssel vergessen. Die nächste Verbindung muss ihn erneut prüfen.",
+      "hostKeyForgetFailed": "Hostschlüssel konnte nicht vergessen werden",
+      "hostKeyReadFailed": "Hostschlüssel konnte nicht gelesen werden"
+    },
+    "hostKeyDialog": {
+      "title": "Hostschlüssel",
+      "subtitle": "Der Schlüssel, den {{host}}:{{port}} beim Verbinden präsentiert.",
+      "trusted": "Diesem Hostschlüssel wird vertraut. Verbindungen zu dieser Maschine werden dagegen geprüft.",
+      "unknown": "Für diese Verbindung wird noch keinem Hostschlüssel vertraut. Die Maschine unter dieser Adresse ist damit nicht authentifiziert.",
+      "changed": "Der präsentierte Schlüssel ist nicht der, dem Borg UI vertraut. Entweder wurde der Schlüssel auf dem Host gewechselt oder jemand antwortet an seiner Stelle. Prüfen Sie ihn auf dem Host, bevor Sie ihm vertrauen.",
+      "unreachable": "Der Hostschlüssel konnte nicht gelesen werden. Die Maschine ist möglicherweise offline oder nicht erreichbar.",
+      "trustedFingerprint": "Vertrauter Fingerabdruck",
+      "observedFingerprint": "Aktuell präsentierter Fingerabdruck",
+      "compareHint": "Vergleichen Sie ihn mit der Ausgabe von ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub auf dem Host selbst.",
+      "trust": "Diesem Schlüssel vertrauen",
+      "trustNewKey": "Dem neuen Schlüssel vertrauen",
+      "forget": "Schlüssel vergessen"
     }
   },
   "scripts": {
@@ -3798,6 +3817,11 @@
       "edit": "Bearbeiten",
       "delete": "Löschen",
       "deploy": "Schlüssel bereitstellen"
+    },
+    "hostKey": {
+      "verified": "Hostschlüssel verifiziert",
+      "unverified": "Hostschlüssel nicht verifiziert",
+      "action": "Hostschlüssel"
     }
   },
   "restoreJobCard": {
@@ -5447,7 +5471,9 @@
         "failedDeleteSshKey": "Fehler beim Löschen des SSH-Schlüssels: {{error}}",
         "failedToggleBackupSource": "Fehler beim Umschalten der Sicherungsquelle: {{error}}",
         "failedListBackupSources": "Fehler beim Auflisten der Sicherungsquellen: {{error}}",
-        "failedVerifyBorgInstallation": "Fehler beim Überprüfen der Borg-Installation: {{error}}"
+        "failedVerifyBorgInstallation": "Fehler beim Überprüfen der Borg-Installation: {{error}}",
+        "failedReadHostKey": "Hostschlüssel konnte nicht gelesen werden: {{error}}",
+        "hostKeyChangedWhileConfirming": "Der Hostschlüssel hat sich während der Bestätigung geändert. Prüfen Sie ihn erneut, bevor Sie ihm vertrauen."
       },
       "settings": {
         "adminAccessRequired": "Administratorzugriff erforderlich",
@@ -5682,7 +5708,9 @@
         "sshKeyUpdated": "SSH-Schlüssel erfolgreich aktualisiert",
         "storageRefreshed": "Speicherinformationen erfolgreich aktualisiert",
         "systemKeyGenerated": "System-SSH-Schlüssel erfolgreich generiert",
-        "systemKeyImported": "System-SSH-Schlüssel erfolgreich importiert"
+        "systemKeyImported": "System-SSH-Schlüssel erfolgreich importiert",
+        "hostKeyTrusted": "Hostschlüssel wird vertraut",
+        "hostKeyForgotten": "Hostschlüssel vergessen"
       },
       "packages": {
         "installationInProgress": "Installation von Paket '{{name}}' ist bereits im Gange",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -2472,7 +2472,26 @@
       "keyDeleteFailed": "Failed to delete SSH key",
       "publicKeyCopied": "Public key copied to clipboard!",
       "diagnosticsComplete": "Diagnostics complete",
-      "diagnosticsFailed": "Failed to run diagnostics"
+      "diagnosticsFailed": "Failed to run diagnostics",
+      "hostKeyTrusted": "Host key trusted",
+      "hostKeyTrustFailed": "Failed to trust the host key",
+      "hostKeyForgotten": "Host key forgotten. The next connection has to verify it again.",
+      "hostKeyForgetFailed": "Failed to forget the host key",
+      "hostKeyReadFailed": "Failed to read the host key"
+    },
+    "hostKeyDialog": {
+      "title": "Host key",
+      "subtitle": "The key {{host}}:{{port}} presents when Borg UI connects.",
+      "trusted": "This host key is trusted. Connections to this machine are verified against it.",
+      "unknown": "No host key is trusted for this connection yet, so the machine answering on this address is not authenticated.",
+      "changed": "The key this host presents is not the one Borg UI trusts. That is either a key rotation on the host or someone answering in its place. Verify it on the host before trusting it.",
+      "unreachable": "The host key could not be read. The machine may be offline or unreachable.",
+      "trustedFingerprint": "Trusted fingerprint",
+      "observedFingerprint": "Fingerprint the host presents now",
+      "compareHint": "Compare this with the output of ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub on the host itself.",
+      "trust": "Trust this key",
+      "trustNewKey": "Trust the new key",
+      "forget": "Forget this key"
     }
   },
   "scripts": {
@@ -3798,6 +3817,11 @@
       "edit": "Edit",
       "delete": "Delete",
       "deploy": "Deploy Key"
+    },
+    "hostKey": {
+      "verified": "Host key verified",
+      "unverified": "Host key not verified",
+      "action": "Host key"
     }
   },
   "restoreJobCard": {
@@ -5447,7 +5471,9 @@
         "failedDeleteSshKey": "Failed to delete SSH key: {{error}}",
         "failedToggleBackupSource": "Failed to toggle backup source: {{error}}",
         "failedListBackupSources": "Failed to list backup sources: {{error}}",
-        "failedVerifyBorgInstallation": "Failed to verify Borg installation: {{error}}"
+        "failedVerifyBorgInstallation": "Failed to verify Borg installation: {{error}}",
+        "failedReadHostKey": "Failed to read the host key: {{error}}",
+        "hostKeyChangedWhileConfirming": "The host key changed while you were confirming it. Check it again before trusting it."
       },
       "settings": {
         "adminAccessRequired": "Admin access required",
@@ -5682,7 +5708,9 @@
         "sshKeyUpdated": "SSH key updated successfully",
         "storageRefreshed": "Storage information refreshed successfully",
         "systemKeyGenerated": "System SSH key generated successfully",
-        "systemKeyImported": "System SSH key imported successfully"
+        "systemKeyImported": "System SSH key imported successfully",
+        "hostKeyTrusted": "Host key trusted",
+        "hostKeyForgotten": "Host key forgotten"
       },
       "packages": {
         "installationInProgress": "Package '{{name}}' installation already in progress",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -5473,7 +5473,8 @@
         "failedListBackupSources": "Failed to list backup sources: {{error}}",
         "failedVerifyBorgInstallation": "Failed to verify Borg installation: {{error}}",
         "failedReadHostKey": "Failed to read the host key: {{error}}",
-        "hostKeyChangedWhileConfirming": "The host key changed while you were confirming it. Check it again before trusting it."
+        "hostKeyChangedWhileConfirming": "The host key changed while you were confirming it. Check it again before trusting it.",
+        "failedStoreHostKey": "Failed to store the host key: {{error}}"
       },
       "settings": {
         "adminAccessRequired": "Admin access required",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -2472,7 +2472,26 @@
       "keyDeleteFailed": "Error al eliminar la clave SSH",
       "publicKeyCopied": "¡Clave pública copiada al portapapeles!",
       "diagnosticsComplete": "Diagnóstico completado",
-      "diagnosticsFailed": "Error al ejecutar el diagnóstico"
+      "diagnosticsFailed": "Error al ejecutar el diagnóstico",
+      "hostKeyTrusted": "Clave de host aceptada",
+      "hostKeyTrustFailed": "No se pudo confiar en la clave de host",
+      "hostKeyForgotten": "Clave de host olvidada. La próxima conexión tendrá que verificarla de nuevo.",
+      "hostKeyForgetFailed": "No se pudo olvidar la clave de host",
+      "hostKeyReadFailed": "No se pudo leer la clave de host"
+    },
+    "hostKeyDialog": {
+      "title": "Clave de host",
+      "subtitle": "La clave que presenta {{host}}:{{port}} al conectarse.",
+      "trusted": "Se confía en esta clave de host. Las conexiones a esta máquina se verifican con ella.",
+      "unknown": "Todavía no se confía en ninguna clave de host para esta conexión, por lo que la máquina que responde en esta dirección no está autenticada.",
+      "changed": "La clave que presenta este host no es la que Borg UI tiene guardada. Puede ser una rotación de clave o alguien respondiendo en su lugar. Verifíquela en el host antes de confiar en ella.",
+      "unreachable": "No se pudo leer la clave de host. La máquina puede estar apagada o inaccesible.",
+      "trustedFingerprint": "Huella de confianza",
+      "observedFingerprint": "Huella que presenta el host ahora",
+      "compareHint": "Compárela con la salida de ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub en el propio host.",
+      "trust": "Confiar en esta clave",
+      "trustNewKey": "Confiar en la nueva clave",
+      "forget": "Olvidar esta clave"
     }
   },
   "scripts": {
@@ -3798,6 +3817,11 @@
       "edit": "Editar",
       "delete": "Eliminar",
       "deploy": "Desplegar clave"
+    },
+    "hostKey": {
+      "verified": "Clave de host verificada",
+      "unverified": "Clave de host sin verificar",
+      "action": "Clave de host"
     }
   },
   "restoreJobCard": {
@@ -5447,7 +5471,9 @@
         "failedDeleteSshKey": "Error al eliminar la clave SSH: {{error}}",
         "failedToggleBackupSource": "Error al alternar la fuente de copia de seguridad: {{error}}",
         "failedListBackupSources": "Error al listar las fuentes de copia de seguridad: {{error}}",
-        "failedVerifyBorgInstallation": "Error al verificar la instalación de Borg: {{error}}"
+        "failedVerifyBorgInstallation": "Error al verificar la instalación de Borg: {{error}}",
+        "failedReadHostKey": "No se pudo leer la clave de host: {{error}}",
+        "hostKeyChangedWhileConfirming": "La clave de host cambió mientras la confirmaba. Vuelva a comprobarla antes de confiar en ella."
       },
       "settings": {
         "adminAccessRequired": "Se requiere acceso de administrador",
@@ -5682,7 +5708,9 @@
         "sshKeyUpdated": "Clave SSH actualizada correctamente",
         "storageRefreshed": "Información de almacenamiento actualizada correctamente",
         "systemKeyGenerated": "Clave SSH del sistema generada correctamente",
-        "systemKeyImported": "Clave SSH del sistema importada correctamente"
+        "systemKeyImported": "Clave SSH del sistema importada correctamente",
+        "hostKeyTrusted": "Clave de host aceptada",
+        "hostKeyForgotten": "Clave de host olvidada"
       },
       "packages": {
         "installationInProgress": "La instalación del paquete '{{name}}' ya está en curso",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -5473,7 +5473,8 @@
         "failedListBackupSources": "Error al listar las fuentes de copia de seguridad: {{error}}",
         "failedVerifyBorgInstallation": "Error al verificar la instalación de Borg: {{error}}",
         "failedReadHostKey": "No se pudo leer la clave de host: {{error}}",
-        "hostKeyChangedWhileConfirming": "La clave de host cambió mientras la confirmaba. Vuelva a comprobarla antes de confiar en ella."
+        "hostKeyChangedWhileConfirming": "La clave de host cambió mientras la confirmaba. Vuelva a comprobarla antes de confiar en ella.",
+        "failedStoreHostKey": "No se pudo guardar la clave de host: {{error}}"
       },
       "settings": {
         "adminAccessRequired": "Se requiere acceso de administrador",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -5473,7 +5473,8 @@
         "failedListBackupSources": "Impossibile elencare le sorgenti di backup: {{error}}",
         "failedVerifyBorgInstallation": "Impossibile verificare l'installazione di Borg: {{error}}",
         "failedReadHostKey": "Impossibile leggere la chiave host: {{error}}",
-        "hostKeyChangedWhileConfirming": "La chiave host è cambiata durante la conferma. Ricontrollatela prima di renderla attendibile."
+        "hostKeyChangedWhileConfirming": "La chiave host è cambiata durante la conferma. Ricontrollatela prima di renderla attendibile.",
+        "failedStoreHostKey": "Impossibile salvare la chiave host: {{error}}"
       },
       "settings": {
         "adminAccessRequired": "Accesso amministratore richiesto",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -2472,7 +2472,26 @@
       "keyDeleteFailed": "Impossibile eliminare la chiave SSH",
       "publicKeyCopied": "Chiave pubblica copiata negli appunti!",
       "diagnosticsComplete": "Diagnostica completata",
-      "diagnosticsFailed": "Impossibile eseguire la diagnostica"
+      "diagnosticsFailed": "Impossibile eseguire la diagnostica",
+      "hostKeyTrusted": "Chiave host resa attendibile",
+      "hostKeyTrustFailed": "Impossibile rendere attendibile la chiave host",
+      "hostKeyForgotten": "Chiave host dimenticata. La prossima connessione dovrà verificarla di nuovo.",
+      "hostKeyForgetFailed": "Impossibile dimenticare la chiave host",
+      "hostKeyReadFailed": "Impossibile leggere la chiave host"
+    },
+    "hostKeyDialog": {
+      "title": "Chiave host",
+      "subtitle": "La chiave che {{host}}:{{port}} presenta durante la connessione.",
+      "trusted": "Questa chiave host è considerata attendibile. Le connessioni a questa macchina vengono verificate con essa.",
+      "unknown": "Nessuna chiave host è ancora attendibile per questa connessione, quindi la macchina che risponde a questo indirizzo non è autenticata.",
+      "changed": "La chiave presentata da questo host non è quella che Borg UI considera attendibile. Può trattarsi di una rotazione della chiave oppure di qualcuno che risponde al suo posto. Verificatela sull'host prima di fidarvi.",
+      "unreachable": "Non è stato possibile leggere la chiave host. La macchina potrebbe essere spenta o irraggiungibile.",
+      "trustedFingerprint": "Impronta attendibile",
+      "observedFingerprint": "Impronta presentata ora dall'host",
+      "compareHint": "Confrontatela con l'output di ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub sull'host stesso.",
+      "trust": "Considera attendibile questa chiave",
+      "trustNewKey": "Considera attendibile la nuova chiave",
+      "forget": "Dimentica questa chiave"
     }
   },
   "scripts": {
@@ -3798,6 +3817,11 @@
       "edit": "Modifica",
       "delete": "Elimina",
       "deploy": "Distribuisci Chiave"
+    },
+    "hostKey": {
+      "verified": "Chiave host verificata",
+      "unverified": "Chiave host non verificata",
+      "action": "Chiave host"
     }
   },
   "restoreJobCard": {
@@ -5447,7 +5471,9 @@
         "failedDeleteSshKey": "Impossibile eliminare la chiave SSH: {{error}}",
         "failedToggleBackupSource": "Impossibile cambiare lo stato della sorgente di backup: {{error}}",
         "failedListBackupSources": "Impossibile elencare le sorgenti di backup: {{error}}",
-        "failedVerifyBorgInstallation": "Impossibile verificare l'installazione di Borg: {{error}}"
+        "failedVerifyBorgInstallation": "Impossibile verificare l'installazione di Borg: {{error}}",
+        "failedReadHostKey": "Impossibile leggere la chiave host: {{error}}",
+        "hostKeyChangedWhileConfirming": "La chiave host è cambiata durante la conferma. Ricontrollatela prima di renderla attendibile."
       },
       "settings": {
         "adminAccessRequired": "Accesso amministratore richiesto",
@@ -5682,7 +5708,9 @@
         "sshKeyUpdated": "Chiave SSH aggiornata con successo",
         "storageRefreshed": "Informazioni archiviazione aggiornate con successo",
         "systemKeyGenerated": "Chiave SSH di sistema generata con successo",
-        "systemKeyImported": "Chiave SSH di sistema importata con successo"
+        "systemKeyImported": "Chiave SSH di sistema importata con successo",
+        "hostKeyTrusted": "Chiave host resa attendibile",
+        "hostKeyForgotten": "Chiave host dimenticata"
       },
       "packages": {
         "installationInProgress": "Installazione del pacchetto '{{name}}' già in corso",

--- a/frontend/src/pages/SSHConnectionsSingleKey.tsx
+++ b/frontend/src/pages/SSHConnectionsSingleKey.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Navigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
@@ -59,6 +59,7 @@ export default function SSHConnectionsSingleKey() {
   const [hostKeyConnection, setHostKeyConnection] = useState<SSHConnection | null>(null)
   const [hostKey, setHostKey] = useState<SSHHostKeyResponse | null>(null)
   const [hostKeyLoading, setHostKeyLoading] = useState(false)
+  const hostKeyRequestRef = useRef<number | null>(null)
   const [diagnosticsResult, setDiagnosticsResult] =
     useState<SSHConnectionDiagnosticsResponse | null>(null)
   const [keyType, setKeyType] = useState('ed25519')
@@ -253,9 +254,11 @@ export default function SSHConnectionsSingleKey() {
   const trustHostKeyMutation = useMutation({
     mutationFn: ({ connectionId, key }: { connectionId: number; key: string }) =>
       sshKeysAPI.trustConnectionHostKey(connectionId, key),
-    onSuccess: (response) => {
+    onSuccess: (response, variables) => {
       toast.success(t('sshConnections.toasts.hostKeyTrusted'))
-      setHostKey(response.data)
+      if (hostKeyRequestRef.current === variables.connectionId) {
+        setHostKey(response.data)
+      }
       queryClient.invalidateQueries({ queryKey: ['ssh-connections'] })
     },
     onError: (error: unknown) => {
@@ -475,26 +478,36 @@ export default function SSHConnectionsSingleKey() {
   }
 
   const handleVerifyHostKey = async (connection: SSHConnection) => {
+    // Scanning a host takes seconds, so the user can close this dialog or open
+    // another machine's before the answer arrives. Every update below is guarded
+    // on the dialog still showing the connection that was asked about, otherwise
+    // one machine's fingerprint could appear under another machine's name.
+    hostKeyRequestRef.current = connection.id
     setHostKeyConnection(connection)
     setHostKey(null)
     setHostKeyDialogOpen(true)
     setHostKeyLoading(true)
     try {
       const response = await sshKeysAPI.getConnectionHostKey(connection.id)
+      if (hostKeyRequestRef.current !== connection.id) return
       setHostKey(response.data)
     } catch (error) {
       console.error('Failed to read host key:', error)
+      if (hostKeyRequestRef.current !== connection.id) return
       toast.error(
         translateBackendKey(getApiErrorDetail(error)) ||
           t('sshConnections.toasts.hostKeyReadFailed')
       )
       setHostKeyDialogOpen(false)
     } finally {
-      setHostKeyLoading(false)
+      if (hostKeyRequestRef.current === connection.id) {
+        setHostKeyLoading(false)
+      }
     }
   }
 
   const closeHostKeyDialog = () => {
+    hostKeyRequestRef.current = null
     setHostKeyDialogOpen(false)
     setHostKeyConnection(null)
     setHostKey(null)

--- a/frontend/src/pages/SSHConnectionsSingleKey.tsx
+++ b/frontend/src/pages/SSHConnectionsSingleKey.tsx
@@ -8,12 +8,14 @@ import { sshKeysAPI } from '../services/api'
 import type {
   SSHConnectionDiagnosticsRequest,
   SSHConnectionDiagnosticsResponse,
+  SSHHostKeyResponse,
 } from '../services/api'
 import { getApiErrorDetail } from '../utils/apiErrors'
 import { translateBackendKey } from '../utils/translateBackendKey'
 import { useAnalytics } from '../hooks/useAnalytics'
 import { useAuth } from '../hooks/useAuth'
 import { SSHConnectionsSingleKeyView } from './ssh-connections-single-key/SSHConnectionsSingleKeyView'
+import { HostKeyDialog } from './ssh-connections-single-key/dialogs/HostKeyDialog'
 import {
   createConnectionForm,
   createEditConnectionForm,
@@ -53,6 +55,10 @@ export default function SSHConnectionsSingleKey() {
   const [diagnosticsDialogOpen, setDiagnosticsDialogOpen] = useState(false)
   const [selectedConnection, setSelectedConnection] = useState<SSHConnection | null>(null)
   const [diagnosticsConnection, setDiagnosticsConnection] = useState<SSHConnection | null>(null)
+  const [hostKeyDialogOpen, setHostKeyDialogOpen] = useState(false)
+  const [hostKeyConnection, setHostKeyConnection] = useState<SSHConnection | null>(null)
+  const [hostKey, setHostKey] = useState<SSHHostKeyResponse | null>(null)
+  const [hostKeyLoading, setHostKeyLoading] = useState(false)
   const [diagnosticsResult, setDiagnosticsResult] =
     useState<SSHConnectionDiagnosticsResponse | null>(null)
   const [keyType, setKeyType] = useState('ed25519')
@@ -240,6 +246,41 @@ export default function SSHConnectionsSingleKey() {
       toast.error(
         translateBackendKey(getApiErrorDetail(error)) ||
           t('sshConnections.toasts.connectionTestFailed')
+      )
+    },
+  })
+
+  const trustHostKeyMutation = useMutation({
+    mutationFn: ({ connectionId, key }: { connectionId: number; key: string }) =>
+      sshKeysAPI.trustConnectionHostKey(connectionId, key),
+    onSuccess: (response) => {
+      toast.success(t('sshConnections.toasts.hostKeyTrusted'))
+      setHostKey(response.data)
+      queryClient.invalidateQueries({ queryKey: ['ssh-connections'] })
+    },
+    onError: (error: unknown) => {
+      console.error('Failed to trust host key:', error)
+      toast.error(
+        translateBackendKey(getApiErrorDetail(error)) ||
+          t('sshConnections.toasts.hostKeyTrustFailed')
+      )
+    },
+  })
+
+  const forgetHostKeyMutation = useMutation({
+    mutationFn: (connectionId: number) => sshKeysAPI.forgetConnectionHostKey(connectionId),
+    onSuccess: () => {
+      toast.success(t('sshConnections.toasts.hostKeyForgotten'))
+      setHostKeyDialogOpen(false)
+      setHostKeyConnection(null)
+      setHostKey(null)
+      queryClient.invalidateQueries({ queryKey: ['ssh-connections'] })
+    },
+    onError: (error: unknown) => {
+      console.error('Failed to forget host key:', error)
+      toast.error(
+        translateBackendKey(getApiErrorDetail(error)) ||
+          t('sshConnections.toasts.hostKeyForgetFailed')
       )
     },
   })
@@ -433,6 +474,45 @@ export default function SSHConnectionsSingleKey() {
     testExistingConnectionMutation.mutate(connection.id)
   }
 
+  const handleVerifyHostKey = async (connection: SSHConnection) => {
+    setHostKeyConnection(connection)
+    setHostKey(null)
+    setHostKeyDialogOpen(true)
+    setHostKeyLoading(true)
+    try {
+      const response = await sshKeysAPI.getConnectionHostKey(connection.id)
+      setHostKey(response.data)
+    } catch (error) {
+      console.error('Failed to read host key:', error)
+      toast.error(
+        translateBackendKey(getApiErrorDetail(error)) ||
+          t('sshConnections.toasts.hostKeyReadFailed')
+      )
+      setHostKeyDialogOpen(false)
+    } finally {
+      setHostKeyLoading(false)
+    }
+  }
+
+  const closeHostKeyDialog = () => {
+    setHostKeyDialogOpen(false)
+    setHostKeyConnection(null)
+    setHostKey(null)
+  }
+
+  const handleTrustHostKey = () => {
+    if (!hostKeyConnection || !hostKey?.observed_key) return
+    trustHostKeyMutation.mutate({
+      connectionId: hostKeyConnection.id,
+      key: hostKey.observed_key,
+    })
+  }
+
+  const handleForgetHostKey = () => {
+    if (!hostKeyConnection) return
+    forgetHostKeyMutation.mutate(hostKeyConnection.id)
+  }
+
   const handleRunDiagnostics = (connection: SSHConnection) => {
     setDiagnosticsConnection(connection)
     setDiagnosticsResult(null)
@@ -540,12 +620,24 @@ export default function SSHConnectionsSingleKey() {
         handleTestConnection={handleTestConnection}
         handleDeployKeyToConnection={handleDeployKeyToConnection}
         handleRunDiagnostics={handleRunDiagnostics}
+        handleVerifyHostKey={handleVerifyHostKey}
         handleConfirmRedeployKey={handleConfirmRedeployKey}
         handleDeleteKey={handleDeleteKey}
         onRefreshConnections={() =>
           queryClient.invalidateQueries({ queryKey: ['ssh-connections'] })
         }
         onRefreshStorage={(connectionId) => refreshStorageMutation.mutate(connectionId)}
+      />
+      <HostKeyDialog
+        t={t}
+        open={hostKeyDialogOpen}
+        onClose={closeHostKeyDialog}
+        connection={hostKeyConnection}
+        hostKey={hostKey}
+        loading={hostKeyLoading}
+        pending={trustHostKeyMutation.isPending || forgetHostKeyMutation.isPending}
+        onTrust={handleTrustHostKey}
+        onForget={handleForgetHostKey}
       />
       <ConnectionDiagnosticsDialog
         open={diagnosticsDialogOpen}

--- a/frontend/src/pages/ssh-connections-single-key/SSHConnectionsSingleKeyView.tsx
+++ b/frontend/src/pages/ssh-connections-single-key/SSHConnectionsSingleKeyView.tsx
@@ -86,6 +86,7 @@ interface SSHConnectionsSingleKeyViewProps {
   handleTestConnection: (connection: SSHConnection) => void
   handleDeployKeyToConnection: (connection: SSHConnection) => void
   handleRunDiagnostics: (connection: SSHConnection) => void
+  handleVerifyHostKey: (connection: SSHConnection) => void
   handleConfirmRedeployKey: () => void
   handleDeleteKey: () => void
   onRefreshConnections: () => void
@@ -162,6 +163,7 @@ export function SSHConnectionsSingleKeyView({
   handleTestConnection,
   handleDeployKeyToConnection,
   handleRunDiagnostics,
+  handleVerifyHostKey,
   handleConfirmRedeployKey,
   handleDeleteKey,
   onRefreshConnections,
@@ -205,6 +207,7 @@ export function SSHConnectionsSingleKeyView({
         onTestConnection={handleTestConnection}
         onDeployKeyToConnection={handleDeployKeyToConnection}
         onRunDiagnostics={handleRunDiagnostics}
+        onVerifyHostKey={handleVerifyHostKey}
       />
       <SSHConnectionDialogs
         t={t}

--- a/frontend/src/pages/ssh-connections-single-key/dialogs/HostKeyDialog.stories.tsx
+++ b/frontend/src/pages/ssh-connections-single-key/dialogs/HostKeyDialog.stories.tsx
@@ -1,0 +1,104 @@
+import type { JSX } from 'react'
+import type { TFunction } from 'i18next'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box } from '@mui/material'
+import i18n from '../../../i18n'
+import type { SSHHostKeyResponse } from '../../../services/api'
+import type { SSHConnection } from '../types'
+import { HostKeyDialog } from './HostKeyDialog'
+
+const t = i18n.t.bind(i18n) as TFunction
+
+const connection: SSHConnection = {
+  id: 1,
+  ssh_key_id: 1,
+  ssh_key_name: 'System key',
+  host: 'storage.example.com',
+  username: 'borg',
+  port: 2222,
+  use_sftp_mode: true,
+  use_sudo: false,
+  status: 'connected',
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+const OBSERVED = 'SHA256:Zx9Q3n1sKk2Yy8bV0pRfT4uJ6mE7cD1aS5gH2wN0qLk'
+const PINNED = 'SHA256:Ab1Cd2Ef3Gh4Ij5Kl6Mn7Op8Qr9St0Uv1Wx2Yz3A4B5'
+
+function HostKeyDialogStory({
+  hostKey,
+  loading = false,
+}: {
+  hostKey: SSHHostKeyResponse | null
+  loading?: boolean
+}): JSX.Element {
+  return (
+    <Box sx={{ p: 3, bgcolor: 'background.default', minHeight: '100vh' }}>
+      <HostKeyDialog
+        t={t}
+        open
+        onClose={() => {}}
+        connection={connection}
+        hostKey={hostKey}
+        loading={loading}
+        pending={false}
+        onTrust={() => {}}
+        onForget={() => {}}
+      />
+    </Box>
+  )
+}
+
+const meta = {
+  title: 'Remote Machines/HostKeyDialog',
+  component: HostKeyDialogStory,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof HostKeyDialogStory>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const base: SSHHostKeyResponse = {
+  connection_id: connection.id,
+  host: connection.host,
+  port: connection.port,
+  status: 'unknown',
+  trusted_fingerprint: null,
+  observed_fingerprint: OBSERVED,
+  observed_key: 'storage.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA',
+}
+
+export const FirstConnect: Story = {
+  args: { hostKey: base },
+}
+
+export const Trusted: Story = {
+  args: {
+    hostKey: { ...base, status: 'trusted', trusted_fingerprint: OBSERVED },
+  },
+}
+
+export const KeyChanged: Story = {
+  args: {
+    hostKey: { ...base, status: 'changed', trusted_fingerprint: PINNED },
+  },
+}
+
+export const HostUnreachable: Story = {
+  args: {
+    hostKey: {
+      ...base,
+      status: 'unreachable',
+      trusted_fingerprint: PINNED,
+      observed_fingerprint: null,
+      observed_key: null,
+    },
+  },
+}
+
+export const Loading: Story = {
+  args: { hostKey: null, loading: true },
+}

--- a/frontend/src/pages/ssh-connections-single-key/dialogs/HostKeyDialog.tsx
+++ b/frontend/src/pages/ssh-connections-single-key/dialogs/HostKeyDialog.tsx
@@ -1,0 +1,136 @@
+import type { TFunction } from 'i18next'
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  Typography,
+} from '@mui/material'
+import type { SSHHostKeyResponse } from '../../../services/api'
+import type { SSHConnection } from '../types'
+
+interface HostKeyDialogProps {
+  t: TFunction
+  open: boolean
+  onClose: () => void
+  connection: SSHConnection | null
+  hostKey?: SSHHostKeyResponse | null
+  loading: boolean
+  pending: boolean
+  onTrust: () => void
+  onForget: () => void
+}
+
+const FINGERPRINT_SX = {
+  fontFamily: '"JetBrains Mono","Fira Code",ui-monospace,monospace',
+  fontSize: '0.78rem',
+  wordBreak: 'break-all' as const,
+}
+
+/**
+ * Shows what host key a connection trusts and what the host offers right now,
+ * so the fingerprint can be compared against the host itself before it is
+ * pinned. This is OpenSSH's first-connect question, asked in the UI.
+ */
+export function HostKeyDialog({
+  t,
+  open,
+  onClose,
+  connection,
+  hostKey,
+  loading,
+  pending,
+  onTrust,
+  onForget,
+}: HostKeyDialogProps) {
+  const status = hostKey?.status
+  const canTrust = status === 'unknown' || status === 'changed'
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{t('sshConnections.hostKeyDialog.title')}</DialogTitle>
+      <DialogContent>
+        {connection && (
+          <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2 }}>
+            {t('sshConnections.hostKeyDialog.subtitle', {
+              host: connection.host,
+              port: connection.port,
+            })}
+          </Typography>
+        )}
+
+        {loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
+            <CircularProgress size={24} />
+          </Box>
+        ) : (
+          <Stack spacing={2}>
+            {status === 'changed' && (
+              <Alert severity="error" data-testid="host-key-changed">
+                {t('sshConnections.hostKeyDialog.changed')}
+              </Alert>
+            )}
+            {status === 'unknown' && (
+              <Alert severity="warning">{t('sshConnections.hostKeyDialog.unknown')}</Alert>
+            )}
+            {status === 'trusted' && (
+              <Alert severity="success">{t('sshConnections.hostKeyDialog.trusted')}</Alert>
+            )}
+            {status === 'unreachable' && (
+              <Alert severity="info">{t('sshConnections.hostKeyDialog.unreachable')}</Alert>
+            )}
+
+            {hostKey?.trusted_fingerprint && (
+              <Box>
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                  {t('sshConnections.hostKeyDialog.trustedFingerprint')}
+                </Typography>
+                <Typography sx={FINGERPRINT_SX}>{hostKey.trusted_fingerprint}</Typography>
+              </Box>
+            )}
+
+            {hostKey?.observed_fingerprint && (
+              <Box>
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                  {t('sshConnections.hostKeyDialog.observedFingerprint')}
+                </Typography>
+                <Typography sx={FINGERPRINT_SX}>{hostKey.observed_fingerprint}</Typography>
+              </Box>
+            )}
+
+            {canTrust && (
+              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                {t('sshConnections.hostKeyDialog.compareHint')}
+              </Typography>
+            )}
+          </Stack>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>{t('common.buttons.cancel')}</Button>
+        {status === 'trusted' && (
+          <Button color="warning" onClick={onForget} disabled={pending}>
+            {t('sshConnections.hostKeyDialog.forget')}
+          </Button>
+        )}
+        {canTrust && (
+          <Button
+            variant="contained"
+            color={status === 'changed' ? 'error' : 'primary'}
+            onClick={onTrust}
+            disabled={pending || !hostKey?.observed_key}
+          >
+            {status === 'changed'
+              ? t('sshConnections.hostKeyDialog.trustNewKey')
+              : t('sshConnections.hostKeyDialog.trust')}
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/ssh-connections-single-key/dialogs/HostKeyDialog.tsx
+++ b/frontend/src/pages/ssh-connections-single-key/dialogs/HostKeyDialog.tsx
@@ -4,13 +4,13 @@ import {
   Box,
   Button,
   CircularProgress,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   Stack,
   Typography,
 } from '@mui/material'
+import ResponsiveDialog from '../../../components/shared/ResponsiveDialog'
 import type { SSHHostKeyResponse } from '../../../services/api'
 import type { SSHConnection } from '../types'
 
@@ -52,7 +52,34 @@ export function HostKeyDialog({
   const canTrust = status === 'unknown' || status === 'changed'
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+    <ResponsiveDialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      footer={
+        <DialogActions>
+          <Button onClick={onClose}>{t('common.buttons.cancel')}</Button>
+          {status === 'trusted' && (
+            <Button color="warning" onClick={onForget} disabled={pending}>
+              {t('sshConnections.hostKeyDialog.forget')}
+            </Button>
+          )}
+          {canTrust && (
+            <Button
+              variant="contained"
+              color={status === 'changed' ? 'error' : 'primary'}
+              onClick={onTrust}
+              disabled={pending || !hostKey?.observed_key}
+            >
+              {status === 'changed'
+                ? t('sshConnections.hostKeyDialog.trustNewKey')
+                : t('sshConnections.hostKeyDialog.trust')}
+            </Button>
+          )}
+        </DialogActions>
+      }
+    >
       <DialogTitle>{t('sshConnections.hostKeyDialog.title')}</DialogTitle>
       <DialogContent>
         {connection && (
@@ -111,26 +138,6 @@ export function HostKeyDialog({
           </Stack>
         )}
       </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>{t('common.buttons.cancel')}</Button>
-        {status === 'trusted' && (
-          <Button color="warning" onClick={onForget} disabled={pending}>
-            {t('sshConnections.hostKeyDialog.forget')}
-          </Button>
-        )}
-        {canTrust && (
-          <Button
-            variant="contained"
-            color={status === 'changed' ? 'error' : 'primary'}
-            onClick={onTrust}
-            disabled={pending || !hostKey?.observed_key}
-          >
-            {status === 'changed'
-              ? t('sshConnections.hostKeyDialog.trustNewKey')
-              : t('sshConnections.hostKeyDialog.trust')}
-          </Button>
-        )}
-      </DialogActions>
-    </Dialog>
+    </ResponsiveDialog>
   )
 }

--- a/frontend/src/pages/ssh-connections-single-key/dialogs/__tests__/HostKeyDialog.test.tsx
+++ b/frontend/src/pages/ssh-connections-single-key/dialogs/__tests__/HostKeyDialog.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useTranslation } from 'react-i18next'
+import { HostKeyDialog } from '../HostKeyDialog'
+import type { SSHHostKeyResponse } from '../../../../services/api'
+import type { SSHConnection } from '../../types'
+
+const connection: SSHConnection = {
+  id: 1,
+  ssh_key_id: 1,
+  ssh_key_name: 'System key',
+  host: 'storage.example.com',
+  username: 'borg',
+  port: 2222,
+  use_sftp_mode: true,
+  use_sudo: false,
+  status: 'connected',
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+const hostKey = (overrides: Partial<SSHHostKeyResponse> = {}): SSHHostKeyResponse => ({
+  connection_id: 1,
+  host: connection.host,
+  port: connection.port,
+  status: 'unknown',
+  trusted_fingerprint: null,
+  observed_fingerprint: 'SHA256:observed',
+  observed_key: 'storage.example.com ssh-ed25519 AAAA',
+  ...overrides,
+})
+
+function Harness(props: {
+  hostKey?: SSHHostKeyResponse | null
+  loading?: boolean
+  pending?: boolean
+  onTrust?: () => void
+  onForget?: () => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <HostKeyDialog
+      t={t}
+      open
+      onClose={vi.fn()}
+      connection={connection}
+      hostKey={props.hostKey}
+      loading={props.loading ?? false}
+      pending={props.pending ?? false}
+      onTrust={props.onTrust ?? vi.fn()}
+      onForget={props.onForget ?? vi.fn()}
+    />
+  )
+}
+
+describe('HostKeyDialog', () => {
+  it('offers to trust a key that is not pinned yet', () => {
+    render(<Harness hostKey={hostKey()} />)
+
+    expect(screen.getByText('SHA256:observed')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Trust this key' })).toBeEnabled()
+  })
+
+  it('warns loudly and asks again when the key changed', () => {
+    render(
+      <Harness hostKey={hostKey({ status: 'changed', trusted_fingerprint: 'SHA256:pinned' })} />
+    )
+
+    expect(screen.getByTestId('host-key-changed')).toBeInTheDocument()
+    expect(screen.getByText('SHA256:pinned')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Trust the new key' })).toBeInTheDocument()
+  })
+
+  it('offers only to forget a key that is already trusted', () => {
+    render(
+      <Harness hostKey={hostKey({ status: 'trusted', trusted_fingerprint: 'SHA256:observed' })} />
+    )
+
+    expect(screen.getByRole('button', { name: 'Forget this key' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Trust this key' })).not.toBeInTheDocument()
+  })
+
+  it('cannot trust a key it could not read', () => {
+    render(
+      <Harness
+        hostKey={hostKey({
+          status: 'unreachable',
+          observed_fingerprint: null,
+          observed_key: null,
+        })}
+      />
+    )
+
+    expect(screen.queryByRole('button', { name: 'Trust this key' })).not.toBeInTheDocument()
+  })
+
+  it('confirms the key through the trust handler', async () => {
+    const user = userEvent.setup()
+    const onTrust = vi.fn()
+    render(<Harness hostKey={hostKey()} onTrust={onTrust} />)
+
+    await user.click(screen.getByRole('button', { name: 'Trust this key' }))
+
+    expect(onTrust).toHaveBeenCalledOnce()
+  })
+
+  it('shows nothing to act on while the host key is being read', () => {
+    render(<Harness hostKey={null} loading />)
+
+    expect(screen.queryByRole('button', { name: 'Trust this key' })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/ssh-connections-single-key/types.ts
+++ b/frontend/src/pages/ssh-connections-single-key/types.ts
@@ -26,6 +26,8 @@ export interface SSHConnection {
   last_success?: string
   error_message?: string
   storage?: StorageInfo | null
+  host_key_verified?: boolean
+  host_key_fingerprint?: string | null
   created_at: string
 }
 

--- a/frontend/src/pages/ssh-connections-single-key/view/RemoteConnectionsSection.tsx
+++ b/frontend/src/pages/ssh-connections-single-key/view/RemoteConnectionsSection.tsx
@@ -19,6 +19,7 @@ interface RemoteConnectionsSectionProps {
   onTestConnection: (connection: SSHConnection) => void
   onDeployKeyToConnection: (connection: SSHConnection) => void
   onRunDiagnostics: (connection: SSHConnection) => void
+  onVerifyHostKey: (connection: SSHConnection) => void
 }
 
 export function RemoteConnectionsSection({
@@ -35,6 +36,7 @@ export function RemoteConnectionsSection({
   onTestConnection,
   onDeployKeyToConnection,
   onRunDiagnostics,
+  onVerifyHostKey,
 }: RemoteConnectionsSectionProps) {
   return (
     <Box>
@@ -173,6 +175,7 @@ export function RemoteConnectionsSection({
                 onTestConnection={onTestConnection}
                 onDeployKey={onDeployKeyToConnection}
                 onRunDiagnostics={onRunDiagnostics}
+                onVerifyHostKey={onVerifyHostKey}
                 canManageConnections={canManageSsh}
               />
             </Box>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1115,7 +1115,27 @@ export const sshKeysAPI = {
     ),
   redeployKeyToConnection: (connectionId: number, password: string) =>
     api.post(`/ssh-keys/connections/${connectionId}/redeploy`, { password }),
+  getConnectionHostKey: (connectionId: number) =>
+    api.get<SSHHostKeyResponse>(`/ssh-keys/connections/${connectionId}/host-key`),
+  trustConnectionHostKey: (connectionId: number, key: string) =>
+    api.post<SSHHostKeyResponse>(`/ssh-keys/connections/${connectionId}/host-key/trust`, {
+      key,
+    }),
+  forgetConnectionHostKey: (connectionId: number) =>
+    api.delete(`/ssh-keys/connections/${connectionId}/host-key`),
   importSSHKey: (data: ApiData) => api.post('/ssh-keys/import', data),
+}
+
+export type SSHHostKeyStatus = 'trusted' | 'unknown' | 'changed' | 'unreachable'
+
+export interface SSHHostKeyResponse {
+  connection_id: number
+  host: string
+  port: number
+  status: SSHHostKeyStatus
+  trusted_fingerprint: string | null
+  observed_fingerprint: string | null
+  observed_key: string | null
 }
 
 export interface AgentMachineResponse {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,28 @@ def pytest_configure(config):
         "markers", "requires_ui: Tests that require Borg UI to be running"
     )
 
+    _create_process_wide_schema()
+
+
+def _create_process_wide_schema():
+    """Give the process-wide engine its tables.
+
+    Most tests get a per-test database through the ``test_db`` fixture, but
+    application code that opens its own session (anything calling
+    ``SessionLocal`` directly, because it is handed a path or an id rather than
+    a session) goes to the engine built from DATABASE_URL at import time. That
+    database had no tables at all, so those lookups raised OperationalError,
+    and code under test saw a database failure that cannot happen in
+    production, where the schema is always present.
+
+    The tables are left empty: a lookup finds nothing, which is a real answer,
+    rather than blowing up.
+    """
+    from app.database.database import Base, engine
+    import app.database.models  # noqa: F401 - registers the tables on Base
+
+    Base.metadata.create_all(bind=engine)
+
 
 @pytest.fixture(scope="session")
 def test_base_url():

--- a/tests/unit/test_api_repositories_helpers.py
+++ b/tests/unit/test_api_repositories_helpers.py
@@ -44,8 +44,9 @@ class TestRepositoryHelperFunctions:
         opts = get_standard_ssh_opts()
 
         assert "-i" not in opts
-        assert "StrictHostKeyChecking=no" in opts
-        assert "UserKnownHostsFile=/dev/null" in opts
+        assert "StrictHostKeyChecking=no" not in opts
+        assert "UserKnownHostsFile=/dev/null" not in opts
+        assert "StrictHostKeyChecking=accept-new" in opts
         assert "BatchMode=yes" in opts
         assert "PreferredAuthentications=publickey" in opts
         assert "PasswordAuthentication=no" in opts
@@ -57,7 +58,7 @@ class TestRepositoryHelperFunctions:
         opts = get_standard_ssh_opts("/tmp/test-key")
 
         assert opts[:2] == ["-i", "/tmp/test-key"]
-        assert "StrictHostKeyChecking=no" in opts
+        assert "StrictHostKeyChecking=no" not in opts
         assert "BatchMode=yes" in opts
         assert "IdentitiesOnly=yes" in opts
         assert "PreferredAuthentications=publickey" in opts

--- a/tests/unit/test_api_ssh_keys.py
+++ b/tests/unit/test_api_ssh_keys.py
@@ -1567,13 +1567,79 @@ class TestSSHConnectionHostKeyEndpoints:
         response = test_client.post(
             f"/api/ssh-keys/connections/{connection.id}/host-key/trust",
             headers=admin_headers,
-            json={},
+            json={"key": self.ED25519},
         )
 
         assert response.status_code == 502
         assert response.json()["detail"]["key"] == (
             "backend.errors.ssh.failedReadHostKey"
         )
+
+    def test_refuses_to_trust_without_a_confirmed_key(
+        self, test_client: TestClient, admin_headers, test_db, monkeypatch
+    ):
+        """An empty body must not mean "pin whatever answers right now"."""
+        connection = self._connection(test_db)
+        scan = AsyncMock(return_value=self.ED25519)
+        monkeypatch.setattr(ssh_keys_api, "scan_host_key_async", scan)
+
+        for body in ({}, {"key": ""}, {"key": None}):
+            response = test_client.post(
+                f"/api/ssh-keys/connections/{connection.id}/host-key/trust",
+                headers=admin_headers,
+                json=body,
+            )
+            assert response.status_code == 422
+
+        scan.assert_not_awaited()
+        test_db.refresh(connection)
+        assert connection.known_host_key is None
+
+    def test_reports_a_key_that_could_not_be_stored(
+        self, test_client: TestClient, admin_headers, test_db, monkeypatch
+    ):
+        """A failed write must not be reported to the user as verified."""
+        connection = self._connection(test_db)
+        monkeypatch.setattr(
+            ssh_keys_api,
+            "scan_host_key_async",
+            AsyncMock(return_value=self.ED25519),
+        )
+
+        def fail(*args, **kwargs):
+            raise RuntimeError("database is locked")
+
+        monkeypatch.setattr(ssh_keys_api, "pin_host_key", fail)
+
+        response = test_client.post(
+            f"/api/ssh-keys/connections/{connection.id}/host-key/trust",
+            headers=admin_headers,
+            json={"key": self.ED25519},
+        )
+
+        assert response.status_code == 500
+        assert response.json()["detail"]["key"] == (
+            "backend.errors.ssh.failedStoreHostKey"
+        )
+
+    def test_forgetting_also_stops_silent_pinning(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """A connection old enough to pin silently must stop doing so."""
+        connection = self._connection(
+            test_db,
+            known_host_key=self.ED25519,
+            host_key_trust_on_first_use=True,
+        )
+
+        test_client.delete(
+            f"/api/ssh-keys/connections/{connection.id}/host-key",
+            headers=admin_headers,
+        )
+
+        test_db.refresh(connection)
+        assert connection.known_host_key is None
+        assert connection.host_key_trust_on_first_use is False
 
     def test_forgetting_clears_the_pin(
         self, test_client: TestClient, admin_headers, test_db

--- a/tests/unit/test_api_ssh_keys.py
+++ b/tests/unit/test_api_ssh_keys.py
@@ -1430,3 +1430,182 @@ class TestSSHKeyStorageAndHelpers:
 
         assert response.status_code == 404
         assert response.json()["detail"]["key"] == "backend.errors.ssh.noSystemKeyFound"
+
+
+@pytest.mark.unit
+class TestSSHConnectionHostKeyEndpoints:
+    """Host-key trust flow: inspect, confirm, forget."""
+
+    ED25519 = (
+        "keys.example.com ssh-ed25519 "
+        "AAAAC3NzaC1lZDI1NTE5AAAAIBERERERERERERERERERERERERERERERERERERERERER"
+    )
+    ROTATED = (
+        "keys.example.com ssh-ed25519 "
+        "AAAAC3NzaC1lZDI1NTE5AAAAIBEREREREREREREREREREREREREREREREREREREREREQ"
+    )
+
+    def _connection(self, test_db, **overrides):
+        connection = SSHConnection(
+            host="keys.example.com",
+            username="borg",
+            port=2222,
+            status="connected",
+            **overrides,
+        )
+        test_db.add(connection)
+        test_db.commit()
+        test_db.refresh(connection)
+        return connection
+
+    def test_reports_an_unpinned_connection_as_unknown(
+        self, test_client: TestClient, admin_headers, test_db, monkeypatch
+    ):
+        connection = self._connection(test_db)
+        monkeypatch.setattr(
+            ssh_keys_api,
+            "scan_host_key_async",
+            AsyncMock(return_value=self.ED25519),
+        )
+
+        response = test_client.get(
+            f"/api/ssh-keys/connections/{connection.id}/host-key",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "unknown"
+        assert body["trusted_fingerprint"] is None
+        assert body["observed_fingerprint"].startswith("SHA256:")
+
+    def test_reports_a_changed_key(
+        self, test_client: TestClient, admin_headers, test_db, monkeypatch
+    ):
+        connection = self._connection(test_db, known_host_key=self.ED25519)
+        monkeypatch.setattr(
+            ssh_keys_api,
+            "scan_host_key_async",
+            AsyncMock(return_value=self.ROTATED),
+        )
+
+        response = test_client.get(
+            f"/api/ssh-keys/connections/{connection.id}/host-key",
+            headers=admin_headers,
+        )
+
+        assert response.json()["status"] == "changed"
+
+    def test_reports_an_unreachable_host(
+        self, test_client: TestClient, admin_headers, test_db, monkeypatch
+    ):
+        connection = self._connection(test_db, known_host_key=self.ED25519)
+        monkeypatch.setattr(
+            ssh_keys_api,
+            "scan_host_key_async",
+            AsyncMock(side_effect=ssh_keys_api.HostKeyScanError("timed out")),
+        )
+
+        response = test_client.get(
+            f"/api/ssh-keys/connections/{connection.id}/host-key",
+            headers=admin_headers,
+        )
+
+        assert response.json()["status"] == "unreachable"
+
+    def test_trusting_pins_the_confirmed_key(
+        self, test_client: TestClient, admin_headers, test_db, monkeypatch
+    ):
+        connection = self._connection(test_db)
+        monkeypatch.setattr(
+            ssh_keys_api,
+            "scan_host_key_async",
+            AsyncMock(return_value=self.ED25519),
+        )
+
+        response = test_client.post(
+            f"/api/ssh-keys/connections/{connection.id}/host-key/trust",
+            headers=admin_headers,
+            json={"key": self.ED25519},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "trusted"
+        test_db.refresh(connection)
+        assert connection.known_host_key == self.ED25519
+
+    def test_refuses_to_pin_a_key_that_changed_while_confirming(
+        self, test_client: TestClient, admin_headers, test_db, monkeypatch
+    ):
+        connection = self._connection(test_db)
+        monkeypatch.setattr(
+            ssh_keys_api,
+            "scan_host_key_async",
+            AsyncMock(return_value=self.ROTATED),
+        )
+
+        response = test_client.post(
+            f"/api/ssh-keys/connections/{connection.id}/host-key/trust",
+            headers=admin_headers,
+            json={"key": self.ED25519},
+        )
+
+        assert response.status_code == 409
+        test_db.refresh(connection)
+        assert connection.known_host_key is None
+
+    def test_reports_a_host_that_cannot_be_read_when_trusting(
+        self, test_client: TestClient, admin_headers, test_db, monkeypatch
+    ):
+        connection = self._connection(test_db)
+        monkeypatch.setattr(
+            ssh_keys_api,
+            "scan_host_key_async",
+            AsyncMock(side_effect=ssh_keys_api.HostKeyScanError("refused")),
+        )
+
+        response = test_client.post(
+            f"/api/ssh-keys/connections/{connection.id}/host-key/trust",
+            headers=admin_headers,
+            json={},
+        )
+
+        assert response.status_code == 502
+        assert response.json()["detail"]["key"] == (
+            "backend.errors.ssh.failedReadHostKey"
+        )
+
+    def test_forgetting_clears_the_pin(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        connection = self._connection(test_db, known_host_key=self.ED25519)
+
+        response = test_client.delete(
+            f"/api/ssh-keys/connections/{connection.id}/host-key",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "unknown"
+        test_db.refresh(connection)
+        assert connection.known_host_key is None
+
+    def test_the_connection_list_reports_host_key_state(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        self._connection(test_db, known_host_key=self.ED25519)
+
+        response = test_client.get("/api/ssh-keys/connections", headers=admin_headers)
+
+        connection = response.json()["connections"][0]
+        assert connection["host_key_verified"] is True
+        assert connection["host_key_fingerprint"].startswith("SHA256:")
+
+    def test_missing_connection_returns_404(
+        self, test_client: TestClient, admin_headers
+    ):
+        response = test_client.get(
+            "/api/ssh-keys/connections/424242/host-key", headers=admin_headers
+        )
+
+        assert response.status_code == 404

--- a/tests/unit/test_api_ssh_keys.py
+++ b/tests/unit/test_api_ssh_keys.py
@@ -1534,6 +1534,36 @@ class TestSSHConnectionHostKeyEndpoints:
         test_db.refresh(connection)
         assert connection.known_host_key == self.ED25519
 
+    def test_trusting_survives_a_rescan_in_a_different_order(
+        self, test_client: TestClient, admin_headers, test_db, monkeypatch
+    ):
+        """A host offering several key types is the normal case.
+
+        ssh-keyscan prints them in whatever order they answer, so the confirmed
+        blob and the fresh scan describe the same keys in a different order.
+        Refusing that made trusting impossible against every real multi-key
+        host, which is nearly all of them.
+        """
+        connection = self._connection(test_db)
+        rsa = "keys.example.com ssh-rsa AAAAB3NzaC1yc2EiIiIiIiIiIiIiIiIiIiIi"
+        monkeypatch.setattr(
+            ssh_keys_api,
+            "scan_host_key_async",
+            AsyncMock(return_value=f"{rsa}\n{self.ED25519}"),
+        )
+
+        response = test_client.post(
+            f"/api/ssh-keys/connections/{connection.id}/host-key/trust",
+            headers=admin_headers,
+            json={"key": f"{self.ED25519}\n{rsa}"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "trusted"
+        test_db.refresh(connection)
+        assert self.ED25519 in connection.known_host_key
+        assert rsa in connection.known_host_key
+
     def test_refuses_to_pin_a_key_that_changed_while_confirming(
         self, test_client: TestClient, admin_headers, test_db, monkeypatch
     ):

--- a/tests/unit/test_source_discovery.py
+++ b/tests/unit/test_source_discovery.py
@@ -15,6 +15,20 @@ from app.database.models import LicensingState, SSHConnection, SSHKey
 from app.utils.script_params import parse_script_parameters
 
 
+def _scan_root(tmp_path):
+    """A directory holding only what the test puts in it.
+
+    The test_db fixture writes the harness's own SQLite database to
+    <tmp_path>/test.db, so a scan rooted at tmp_path detects that as a real
+    SQLite source. It only does so once the file carries the "SQLite format 3"
+    header, which is why scans rooted at tmp_path passed alone and failed in a
+    full-suite run.
+    """
+    root = tmp_path / "scan-root"
+    root.mkdir(exist_ok=True)
+    return root
+
+
 def _set_plan(test_db, plan: str) -> None:
     state = test_db.query(LicensingState).first()
     if state is None:
@@ -895,8 +909,9 @@ class TestSourceDiscovery:
         self, test_client, admin_headers, tmp_path, monkeypatch
     ):
         monkeypatch.setattr(source_discovery, "which", lambda command: None)
-        first_db = tmp_path / "app.sqlite3"
-        second_db = tmp_path / "cache.db"
+        scan_root = _scan_root(tmp_path)
+        first_db = scan_root / "app.sqlite3"
+        second_db = scan_root / "cache.db"
         first_db.write_bytes(b"SQLite format 3\x00")
         second_db.write_bytes(b"SQLite format 3\x00")
 
@@ -905,7 +920,7 @@ class TestSourceDiscovery:
             json={
                 "source_type": "local",
                 "source_ssh_connection_id": None,
-                "paths": [str(tmp_path)],
+                "paths": [str(scan_root)],
             },
             headers=admin_headers,
         )
@@ -1145,7 +1160,8 @@ class TestSourceDiscovery:
         # PG_VERSION lives 3 levels below the scan root. Default depth (6)
         # should discover it.
         monkeypatch.setattr(source_discovery, "which", lambda command: None)
-        nested_pg = tmp_path / "var" / "lib" / "postgresql" / "16" / "main"
+        scan_root = _scan_root(tmp_path)
+        nested_pg = scan_root / "var" / "lib" / "postgresql" / "16" / "main"
         nested_pg.mkdir(parents=True)
         (nested_pg / "PG_VERSION").write_text("16\n")
 
@@ -1154,7 +1170,7 @@ class TestSourceDiscovery:
             json={
                 "source_type": "local",
                 "source_ssh_connection_id": None,
-                "paths": [str(tmp_path)],
+                "paths": [str(scan_root)],
             },
             headers=admin_headers,
         )
@@ -1171,7 +1187,8 @@ class TestSourceDiscovery:
         # PG_VERSION sits 4 levels below the scan root. max_depth=2 means
         # the walk stops before reaching it, so nothing is detected.
         monkeypatch.setattr(source_discovery, "which", lambda command: None)
-        nested_pg = tmp_path / "a" / "b" / "c" / "d"
+        scan_root = _scan_root(tmp_path)
+        nested_pg = scan_root / "a" / "b" / "c" / "d"
         nested_pg.mkdir(parents=True)
         (nested_pg / "PG_VERSION").write_text("16\n")
 
@@ -1180,7 +1197,7 @@ class TestSourceDiscovery:
             json={
                 "source_type": "local",
                 "source_ssh_connection_id": None,
-                "paths": [str(tmp_path)],
+                "paths": [str(scan_root)],
                 "max_depth": 2,
             },
             headers=admin_headers,
@@ -1195,11 +1212,12 @@ class TestSourceDiscovery:
         # A PG signature inside an ignored dir should be missed. The same
         # signature outside it should be picked up.
         monkeypatch.setattr(source_discovery, "which", lambda command: None)
-        ignored_pg = tmp_path / "node_modules" / "fixture-pg"
+        scan_root = _scan_root(tmp_path)
+        ignored_pg = scan_root / "node_modules" / "fixture-pg"
         ignored_pg.mkdir(parents=True)
         (ignored_pg / "PG_VERSION").write_text("16\n")
 
-        kept_mysql = tmp_path / "data" / "mysql"
+        kept_mysql = scan_root / "data" / "mysql"
         kept_mysql.mkdir(parents=True)
 
         response = test_client.post(
@@ -1207,7 +1225,7 @@ class TestSourceDiscovery:
             json={
                 "source_type": "local",
                 "source_ssh_connection_id": None,
-                "paths": [str(tmp_path)],
+                "paths": [str(scan_root)],
                 "ignore_patterns": ["node_modules"],
             },
             headers=admin_headers,
@@ -1222,10 +1240,11 @@ class TestSourceDiscovery:
         self, test_client, admin_headers, tmp_path, monkeypatch
     ):
         monkeypatch.setattr(source_discovery, "which", lambda command: None)
-        noisy_sqlite = tmp_path / "usr" / "bin" / "tool.db"
+        scan_root = _scan_root(tmp_path)
+        noisy_sqlite = scan_root / "usr" / "bin" / "tool.db"
         noisy_sqlite.parent.mkdir(parents=True)
         noisy_sqlite.write_bytes(b"SQLite format 3\x00")
-        app_sqlite = tmp_path / "etc" / "pihole" / "gravity.db"
+        app_sqlite = scan_root / "etc" / "pihole" / "gravity.db"
         app_sqlite.parent.mkdir(parents=True)
         app_sqlite.write_bytes(b"SQLite format 3\x00")
 
@@ -1234,7 +1253,7 @@ class TestSourceDiscovery:
             json={
                 "source_type": "local",
                 "source_ssh_connection_id": None,
-                "paths": [str(tmp_path)],
+                "paths": [str(scan_root)],
             },
             headers=admin_headers,
         )

--- a/tests/unit/test_source_discovery.py
+++ b/tests/unit/test_source_discovery.py
@@ -469,6 +469,7 @@ class TestSourceDiscovery:
             username="backup",
             port=2222,
             is_backup_source=True,
+            known_host_key="docker-host.test ssh-ed25519 AAAATESTHOSTKEY",
         )
         test_db.add(connection)
         test_db.commit()
@@ -500,7 +501,7 @@ class TestSourceDiscovery:
         def fake_run(cmd, **kwargs):
             del kwargs
             assert cmd[0] == "ssh"
-            assert "StrictHostKeyChecking=accept-new" in cmd
+            assert "StrictHostKeyChecking=yes" in cmd
             assert "du -s -B1 /srv/nginx/html" in cmd[-1]
             return SimpleNamespace(
                 returncode=0,
@@ -552,16 +553,18 @@ class TestSourceDiscovery:
 
         source_discovery._run_remote_container_scan(
             connection=SimpleNamespace(
+                id=4242,
                 host="docker-host.test",
                 username="backup",
                 port=2222,
+                known_host_key="docker-host.test ssh-ed25519 AAAATESTHOSTKEY",
             ),
             key_file_path="/tmp/borg-ui-test-key",
             include_stopped=True,
             timeout_seconds=15,
         )
 
-        assert "StrictHostKeyChecking=accept-new" in captured["cmd"]
+        assert "StrictHostKeyChecking=yes" in captured["cmd"]
         assert "StrictHostKeyChecking=no" not in captured["cmd"]
         assert "UserKnownHostsFile=/dev/null" not in captured["cmd"]
 

--- a/tests/unit/test_ssh_host_keys.py
+++ b/tests/unit/test_ssh_host_keys.py
@@ -1,0 +1,302 @@
+"""Tests for SSH host-key pinning (trust on first use)."""
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from app.utils import ssh_host_keys
+
+
+ED25519 = (
+    "example.com ssh-ed25519 "
+    "AAAAC3NzaC1lZDI1NTE5AAAAIBERERERERERERERERERERERERERERERERERERERERER"
+)
+RSA = (
+    "example.com ssh-rsa "
+    "AAAAB3NzaC1yc2EiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIi"
+)
+
+
+@pytest.fixture
+def connection():
+    return SimpleNamespace(id=7, host="example.com", port=2222, known_host_key=None)
+
+
+@pytest.fixture(autouse=True)
+def no_scan_cooldown_leak():
+    ssh_host_keys._FAILED_SCANS.clear()
+    yield
+    ssh_host_keys._FAILED_SCANS.clear()
+
+
+@pytest.fixture(autouse=True)
+def known_hosts_home(tmp_path, monkeypatch):
+    monkeypatch.setattr(ssh_host_keys.settings, "ssh_home_dir", str(tmp_path))
+    monkeypatch.setattr(ssh_host_keys.settings, "ssh_keys_dir", str(tmp_path))
+    return tmp_path
+
+
+class _Db:
+    def __init__(self):
+        self.commits = 0
+
+    def commit(self):
+        self.commits += 1
+
+
+def _fake_run(stdout="", stderr="", returncode=0):
+    def run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0], returncode=returncode, stdout=stdout, stderr=stderr
+        )
+
+    return run
+
+
+class TestScanHostKey:
+    def test_returns_the_offered_keys(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess, "run", _fake_run(stdout=f"# comment\n{ED25519}\n{RSA}\n")
+        )
+
+        assert ssh_host_keys.scan_host_key("example.com", 2222) == f"{ED25519}\n{RSA}"
+
+    def test_passes_the_port_to_ssh_keyscan(self, monkeypatch):
+        captured = {}
+
+        def run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, ED25519, "")
+
+        monkeypatch.setattr(subprocess, "run", run)
+        ssh_host_keys.scan_host_key("example.com", 2222)
+
+        assert "-p" in captured["cmd"]
+        assert captured["cmd"][captured["cmd"].index("-p") + 1] == "2222"
+
+    def test_raises_when_no_key_is_offered(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess, "run", _fake_run(stdout="", stderr="connection refused")
+        )
+
+        with pytest.raises(ssh_host_keys.HostKeyScanError, match="connection refused"):
+            ssh_host_keys.scan_host_key("example.com")
+
+    def test_raises_without_a_host(self):
+        with pytest.raises(ssh_host_keys.HostKeyScanError):
+            ssh_host_keys.scan_host_key("")
+
+    def test_raises_when_ssh_keyscan_is_missing(self, monkeypatch):
+        def run(*args, **kwargs):
+            raise FileNotFoundError()
+
+        monkeypatch.setattr(subprocess, "run", run)
+
+        with pytest.raises(ssh_host_keys.HostKeyScanError, match="not installed"):
+            ssh_host_keys.scan_host_key("example.com")
+
+
+class TestHostKeysMatch:
+    def test_matches_when_every_pinned_key_is_still_offered(self):
+        assert ssh_host_keys.host_keys_match(ED25519, f"{ED25519}\n{RSA}")
+
+    def test_does_not_match_a_different_key(self):
+        assert not ssh_host_keys.host_keys_match(ED25519, RSA)
+
+    def test_does_not_match_when_nothing_is_pinned(self):
+        assert not ssh_host_keys.host_keys_match(None, ED25519)
+        assert not ssh_host_keys.host_keys_match("", ED25519)
+
+
+class TestKnownHostsFile:
+    def test_writes_the_pinned_key_with_owner_only_permissions(self, connection):
+        connection.known_host_key = ED25519
+
+        path = ssh_host_keys.write_known_hosts_file(connection)
+
+        assert path is not None
+        from pathlib import Path
+
+        written = Path(path)
+        assert written.read_text() == ED25519 + "\n"
+        assert written.stat().st_mode & 0o777 == 0o600
+
+    def test_returns_none_when_nothing_is_pinned(self, connection):
+        assert ssh_host_keys.write_known_hosts_file(connection) is None
+
+    def test_leaves_no_temporary_files_behind(self, connection):
+        connection.known_host_key = ED25519
+        ssh_host_keys.write_known_hosts_file(connection)
+        ssh_host_keys.write_known_hosts_file(connection)
+
+        leftovers = list(ssh_host_keys.known_hosts_dir().glob(".known_hosts.*"))
+        assert leftovers == []
+
+    def test_forget_removes_the_file(self, connection):
+        connection.known_host_key = ED25519
+        ssh_host_keys.write_known_hosts_file(connection)
+
+        ssh_host_keys.forget_known_hosts_file(connection)
+
+        assert not ssh_host_keys.known_hosts_path(connection).exists()
+
+
+class TestHostKeySshOpts:
+    def test_verifies_strictly_against_a_pinned_key(self, connection):
+        connection.known_host_key = ED25519
+
+        opts = ssh_host_keys.host_key_ssh_opts(connection)
+
+        assert "StrictHostKeyChecking=yes" in opts
+        assert (
+            f"UserKnownHostsFile={ssh_host_keys.known_hosts_path(connection)}" in opts
+        )
+        assert "StrictHostKeyChecking=no" not in opts
+        assert "UserKnownHostsFile=/dev/null" not in opts
+
+    def test_pins_the_key_of_a_connection_that_has_none(self, connection, monkeypatch):
+        monkeypatch.setattr(
+            ssh_host_keys, "scan_host_key", lambda host, port: f"{ED25519}\n{RSA}"
+        )
+        db = _Db()
+
+        opts = ssh_host_keys.host_key_ssh_opts(connection, db)
+
+        assert connection.known_host_key == f"{ED25519}\n{RSA}"
+        assert db.commits == 1
+        assert "StrictHostKeyChecking=yes" in opts
+
+    def test_never_disables_checking_when_the_host_cannot_be_scanned(
+        self, connection, monkeypatch
+    ):
+        def fail(host, port):
+            raise ssh_host_keys.HostKeyScanError("unreachable")
+
+        monkeypatch.setattr(ssh_host_keys, "scan_host_key", fail)
+
+        opts = ssh_host_keys.host_key_ssh_opts(connection, _Db())
+
+        assert "StrictHostKeyChecking=accept-new" in opts
+        assert "StrictHostKeyChecking=no" not in opts
+        assert "UserKnownHostsFile=/dev/null" not in opts
+
+    def test_does_not_rescan_an_unreachable_host_on_every_command(
+        self, connection, monkeypatch
+    ):
+        scans = {"count": 0}
+
+        def fail(host, port):
+            scans["count"] += 1
+            raise ssh_host_keys.HostKeyScanError("unreachable")
+
+        monkeypatch.setattr(ssh_host_keys, "scan_host_key", fail)
+
+        ssh_host_keys.host_key_ssh_opts(connection, _Db())
+        ssh_host_keys.host_key_ssh_opts(connection, _Db())
+
+        assert scans["count"] == 1
+
+    def test_rescans_once_the_cooldown_has_passed(self, connection, monkeypatch):
+        scans = {"count": 0}
+
+        def fail(host, port):
+            scans["count"] += 1
+            raise ssh_host_keys.HostKeyScanError("unreachable")
+
+        monkeypatch.setattr(ssh_host_keys, "scan_host_key", fail)
+        monkeypatch.setattr(ssh_host_keys, "SCAN_RETRY_COOLDOWN_SECONDS", 0)
+
+        ssh_host_keys.host_key_ssh_opts(connection, _Db())
+        ssh_host_keys.host_key_ssh_opts(connection, _Db())
+
+        assert scans["count"] == 2
+
+    def test_falls_back_to_a_shared_file_without_a_connection(self):
+        opts = ssh_host_keys.host_key_ssh_opts(None)
+
+        assert "StrictHostKeyChecking=accept-new" in opts
+        assert "UserKnownHostsFile=/dev/null" not in opts
+
+    def test_does_not_rescan_a_connection_that_is_already_pinned(
+        self, connection, monkeypatch
+    ):
+        connection.known_host_key = ED25519
+
+        def fail(host, port):  # pragma: no cover - must not run
+            raise AssertionError("scanned an already pinned connection")
+
+        monkeypatch.setattr(ssh_host_keys, "scan_host_key", fail)
+
+        ssh_host_keys.host_key_ssh_opts(connection, _Db())
+
+
+class TestStatus:
+    def test_unknown_without_a_pin(self, connection):
+        assert (
+            ssh_host_keys.describe_host_key_status(connection, ED25519)
+            == ssh_host_keys.HOST_KEY_STATUS_UNKNOWN
+        )
+
+    def test_trusted_when_the_key_still_matches(self, connection):
+        connection.known_host_key = ED25519
+        assert (
+            ssh_host_keys.describe_host_key_status(connection, f"{ED25519}\n{RSA}")
+            == ssh_host_keys.HOST_KEY_STATUS_TRUSTED
+        )
+
+    def test_changed_when_the_key_differs(self, connection):
+        connection.known_host_key = ED25519
+        assert (
+            ssh_host_keys.describe_host_key_status(connection, RSA)
+            == ssh_host_keys.HOST_KEY_STATUS_CHANGED
+        )
+
+    def test_unreachable_without_an_observation(self, connection):
+        connection.known_host_key = ED25519
+        assert (
+            ssh_host_keys.describe_host_key_status(connection, None)
+            == ssh_host_keys.HOST_KEY_STATUS_UNREACHABLE
+        )
+
+
+class TestFingerprint:
+    def test_matches_the_openssh_sha256_format(self):
+        import base64
+        import hashlib
+
+        blob = base64.b64decode(ED25519.split()[2])
+        expected = base64.b64encode(hashlib.sha256(blob).digest()).decode().rstrip("=")
+
+        assert ssh_host_keys.key_fingerprint(ED25519) == f"SHA256:{expected}"
+
+    def test_uses_the_first_key_of_a_multi_key_blob(self):
+        assert ssh_host_keys.key_fingerprint(
+            f"{ED25519}\n{RSA}"
+        ) == ssh_host_keys.key_fingerprint(ED25519)
+
+    def test_returns_none_for_an_empty_key(self):
+        assert ssh_host_keys.key_fingerprint(None) is None
+        assert ssh_host_keys.key_fingerprint("  ") is None
+
+    def test_returns_none_for_an_unparseable_key(self):
+        assert (
+            ssh_host_keys.key_fingerprint("example.com ssh-ed25519 not-base64!!")
+            is None
+        )
+
+
+class TestVerificationFailureDetection:
+    @pytest.mark.parametrize(
+        "output",
+        [
+            "Host key verification failed.",
+            "@@@ WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED! @@@",
+        ],
+    )
+    def test_detects_a_rejected_host_key(self, output):
+        assert ssh_host_keys.host_key_verification_failed(output)
+
+    def test_ignores_other_failures(self):
+        assert not ssh_host_keys.host_key_verification_failed("Permission denied")
+        assert not ssh_host_keys.host_key_verification_failed(None)

--- a/tests/unit/test_ssh_host_keys.py
+++ b/tests/unit/test_ssh_host_keys.py
@@ -20,7 +20,14 @@ RSA = (
 
 @pytest.fixture
 def connection():
-    return SimpleNamespace(id=7, host="example.com", port=2222, known_host_key=None)
+    """A connection that predates host-key verification, so it may pin silently."""
+    return SimpleNamespace(
+        id=7,
+        host="example.com",
+        port=2222,
+        known_host_key=None,
+        host_key_trust_on_first_use=True,
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -229,6 +236,96 @@ class TestHostKeySshOpts:
         monkeypatch.setattr(ssh_host_keys, "scan_host_key", fail)
 
         ssh_host_keys.host_key_ssh_opts(connection, _Db())
+
+
+class TestFirstUseTrust:
+    def test_a_connection_predating_verification_pins_silently(
+        self, connection, monkeypatch
+    ):
+        connection.host_key_trust_on_first_use = True
+        monkeypatch.setattr(ssh_host_keys, "scan_host_key", lambda host, port: ED25519)
+
+        opts = ssh_host_keys.host_key_ssh_opts(connection, _Db())
+
+        assert connection.known_host_key == ED25519
+        assert "StrictHostKeyChecking=yes" in opts
+
+    def test_a_new_connection_waits_for_the_user_to_confirm(
+        self, connection, monkeypatch
+    ):
+        connection.host_key_trust_on_first_use = False
+
+        def fail(host, port):  # pragma: no cover - must not run
+            raise AssertionError("scanned a connection the user has not confirmed")
+
+        monkeypatch.setattr(ssh_host_keys, "scan_host_key", fail)
+
+        opts = ssh_host_keys.host_key_ssh_opts(connection, _Db())
+
+        assert connection.known_host_key is None
+        # Still recorded on first use by OpenSSH itself, so a later change is
+        # refused, but nothing is pinned to the row without confirmation.
+        assert "StrictHostKeyChecking=accept-new" in opts
+        assert (
+            f"UserKnownHostsFile={ssh_host_keys.known_hosts_path(connection)}" in opts
+        )
+
+    def test_a_connection_without_the_column_is_not_pinned_silently(self, monkeypatch):
+        bare = SimpleNamespace(id=9, host="example.com", port=22, known_host_key=None)
+
+        def fail(host, port):  # pragma: no cover - must not run
+            raise AssertionError("scanned a connection with no trust flag")
+
+        monkeypatch.setattr(ssh_host_keys, "scan_host_key", fail)
+
+        ssh_host_keys.host_key_ssh_opts(bare, _Db())
+
+        assert bare.known_host_key is None
+
+
+class TestFailClosed:
+    def test_a_pinned_connection_never_degrades_when_the_file_cannot_be_written(
+        self, connection, monkeypatch
+    ):
+        connection.known_host_key = ED25519
+        monkeypatch.setattr(ssh_host_keys, "write_known_hosts_file", lambda conn: None)
+
+        opts = ssh_host_keys.host_key_ssh_opts(connection)
+
+        assert "StrictHostKeyChecking=yes" in opts
+        assert "StrictHostKeyChecking=accept-new" not in opts
+
+    def test_a_failed_commit_is_reported_to_the_caller(self, connection):
+        class _Failing:
+            def commit(self):
+                raise RuntimeError("database is locked")
+
+            def rollback(self):
+                self.rolled_back = True
+
+        session = _Failing()
+
+        with pytest.raises(RuntimeError, match="database is locked"):
+            ssh_host_keys.pin_host_key(connection, session, ED25519)
+
+        assert session.rolled_back is True
+
+    def test_a_failed_commit_does_not_fail_the_ssh_command(
+        self, connection, monkeypatch
+    ):
+        class _Failing:
+            def commit(self):
+                raise RuntimeError("database is locked")
+
+            def rollback(self):
+                pass
+
+        connection.host_key_trust_on_first_use = True
+        monkeypatch.setattr(ssh_host_keys, "scan_host_key", lambda host, port: ED25519)
+
+        opts = ssh_host_keys.host_key_ssh_opts(connection, _Failing())
+
+        assert "StrictHostKeyChecking" in " ".join(opts)
 
 
 class TestStatus:

--- a/tests/unit/test_ssh_host_keys.py
+++ b/tests/unit/test_ssh_host_keys.py
@@ -104,6 +104,38 @@ class TestScanHostKey:
             ssh_host_keys.scan_host_key("example.com")
 
 
+class TestScanOrderIsStable:
+    """ssh-keyscan queries the key types concurrently and prints whichever
+    answers first, so its output order changes between runs against the same
+    unchanged host. Everything downstream has to be immune to that."""
+
+    ECDSA = (
+        "example.com ecdsa-sha2-nistp256 "
+        "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBERERERERERERE="
+    )
+
+    def _scan_returning(self, monkeypatch, stdout):
+        monkeypatch.setattr(subprocess, "run", _fake_run(stdout=stdout))
+        return ssh_host_keys.scan_host_key("example.com")
+
+    def test_two_scans_of_one_host_agree_whatever_the_order(self, monkeypatch):
+        first = self._scan_returning(monkeypatch, f"{RSA}\n{self.ECDSA}\n{ED25519}\n")
+        second = self._scan_returning(monkeypatch, f"{ED25519}\n{RSA}\n{self.ECDSA}\n")
+
+        assert first == second
+
+    def test_the_strongest_key_comes_first(self, monkeypatch):
+        scanned = self._scan_returning(monkeypatch, f"{RSA}\n{ED25519}\n")
+
+        assert scanned.splitlines()[0] == ED25519
+
+    def test_the_fingerprint_does_not_depend_on_scan_order(self):
+        one = ssh_host_keys.key_fingerprint(f"{RSA}\n{ED25519}")
+        other = ssh_host_keys.key_fingerprint(f"{ED25519}\n{RSA}")
+
+        assert one == other == ssh_host_keys.key_fingerprint(ED25519)
+
+
 class TestHostKeysMatch:
     def test_matches_when_every_pinned_key_is_still_offered(self):
         assert ssh_host_keys.host_keys_match(ED25519, f"{ED25519}\n{RSA}")

--- a/tests/unit/test_ssh_host_keys.py
+++ b/tests/unit/test_ssh_host_keys.py
@@ -328,6 +328,116 @@ class TestFailClosed:
         assert "StrictHostKeyChecking" in " ".join(opts)
 
 
+class TestLookupFailuresFailClosed:
+    """A lookup that failed says nothing about whether a pin exists.
+
+    Falling back to accept-new on a database error would let one downgrade
+    verification for a host that is in fact pinned.
+    """
+
+    def test_a_failed_host_lookup_is_not_silently_downgraded(self, monkeypatch):
+        class _Session:
+            def query(self, *args, **kwargs):
+                raise RuntimeError("database is gone")
+
+            def close(self):
+                self.closed = True
+
+        session = _Session()
+        monkeypatch.setattr(
+            "app.database.database.SessionLocal", lambda: session, raising=False
+        )
+
+        with pytest.raises(RuntimeError, match="database is gone"):
+            ssh_host_keys.host_key_ssh_opts_for_host("example.com", 22, "borg")
+
+        assert session.closed is True
+
+    def test_a_failed_path_lookup_is_not_silently_downgraded(self, monkeypatch):
+        class _Session:
+            def close(self):
+                self.closed = True
+
+        session = _Session()
+        monkeypatch.setattr(
+            "app.database.database.SessionLocal", lambda: session, raising=False
+        )
+
+        def fail(path, db):
+            raise RuntimeError("database is gone")
+
+        monkeypatch.setattr(
+            "app.utils.ssh_utils.find_ssh_connection_for_path", fail, raising=False
+        )
+
+        with pytest.raises(RuntimeError, match="database is gone"):
+            ssh_host_keys.host_key_ssh_opts_for_path("ssh://borg@example.com/repo")
+
+    def test_a_host_with_no_stored_connection_still_records_on_first_use(
+        self, monkeypatch
+    ):
+        """Finding nothing is not the same as failing, and must keep working."""
+
+        class _Query:
+            def filter(self, *args, **kwargs):
+                return self
+
+            def all(self):
+                return []
+
+        class _Session:
+            def query(self, *args, **kwargs):
+                return _Query()
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            "app.database.database.SessionLocal", lambda: _Session(), raising=False
+        )
+
+        opts = ssh_host_keys.host_key_ssh_opts_for_host("example.com", 22, "borg")
+
+        assert "StrictHostKeyChecking=accept-new" in opts
+        assert "StrictHostKeyChecking=no" not in opts
+
+
+class TestOptsForConnectionId:
+    def test_verifies_against_the_pin_of_a_connection_it_only_has_the_id_of(
+        self, monkeypatch
+    ):
+        pinned = SimpleNamespace(
+            id=11, host="example.com", port=22, known_host_key=ED25519
+        )
+
+        class _Query:
+            def filter(self, *args, **kwargs):
+                return self
+
+            def first(self):
+                return pinned
+
+        class _Session:
+            def query(self, *args, **kwargs):
+                return _Query()
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            "app.database.database.SessionLocal", lambda: _Session(), raising=False
+        )
+
+        opts = ssh_host_keys.host_key_ssh_opts_for_connection_id(11)
+
+        assert "StrictHostKeyChecking=yes" in opts
+
+    def test_without_an_id_there_is_nothing_to_verify_against(self):
+        opts = ssh_host_keys.host_key_ssh_opts_for_connection_id(None)
+
+        assert "StrictHostKeyChecking=accept-new" in opts
+
+
 class TestStatus:
     def test_unknown_without_a_pin(self, connection):
         assert (

--- a/tests/unit/test_ssh_key_deployment.py
+++ b/tests/unit/test_ssh_key_deployment.py
@@ -121,8 +121,11 @@ class TestSSHKeyDeployment:
         assert captured_cmd[4] == "-s", "Should include -s flag when use_sftp_mode=True"
         assert "-i" in captured_cmd, "Should include identity file flag"
         assert "-o" in captured_cmd, "Should include SSH options"
-        assert "StrictHostKeyChecking=no" in captured_cmd, (
-            "Should disable strict host key checking"
+        assert "StrictHostKeyChecking=no" not in captured_cmd, (
+            "Should never disable strict host key checking"
+        )
+        assert "StrictHostKeyChecking=accept-new" in captured_cmd, (
+            "Should record the host key on first use"
         )
         assert "testuser@test.example.com" in captured_cmd, "Should include user@host"
 
@@ -236,8 +239,11 @@ class TestSSHKeyDeployment:
             "Should NOT include -s flag when use_sftp_mode=False"
         )
         assert "-o" in captured_cmd, "Should include SSH options"
-        assert "StrictHostKeyChecking=no" in captured_cmd, (
-            "Should disable strict host key checking"
+        assert "StrictHostKeyChecking=no" not in captured_cmd, (
+            "Should never disable strict host key checking"
+        )
+        assert "StrictHostKeyChecking=accept-new" in captured_cmd, (
+            "Should record the host key on first use"
         )
         assert "admin@synology.local" in captured_cmd, "Should include user@host"
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -164,11 +164,12 @@ class TestProcessUtils:
             "-o PreferredAuthentications=publickey",
             "-o PasswordAuthentication=no",
             "-o NumberOfPasswordPrompts=0",
-            "-o StrictHostKeyChecking=no",
-            "-o UserKnownHostsFile=/dev/null",
+            "-o StrictHostKeyChecking=accept-new",
             "-o LogLevel=ERROR",
         ]:
             assert option in borg_rsh
+        assert "-o StrictHostKeyChecking=no" not in borg_rsh
+        assert "-o UserKnownHostsFile=/dev/null" not in borg_rsh
 
     def test_cleanup_orphaned_jobs(self):
         """Test cleanup of orphaned jobs"""

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -171,6 +171,44 @@ class TestProcessUtils:
         assert "-o StrictHostKeyChecking=no" not in borg_rsh
         assert "-o UserKnownHostsFile=/dev/null" not in borg_rsh
 
+    @patch("subprocess.run")
+    def test_break_repository_lock_ssh_verifies_a_pinned_host_key(self, mock_run):
+        """A repository whose connection has a pinned key verifies against it."""
+        from app.database.models import SSHConnection
+        from app.utils import process_utils
+
+        connection = SSHConnection(
+            id=1,
+            host="host",
+            username="user",
+            port=22,
+            known_host_key="host ssh-ed25519 AAAA",
+        )
+        repo = Repository(
+            id=1,
+            path="ssh://user@host/repo",
+            connection_id=1,
+            remote_path="/usr/bin/borg",
+        )
+
+        mock_run.return_value.returncode = 0
+
+        with (
+            patch.object(process_utils, "object_session", return_value=MagicMock()),
+            patch.object(
+                process_utils,
+                "resolve_repository_ssh_connection",
+                return_value=connection,
+            ),
+            patch.object(process_utils, "resolve_repo_ssh_key_file", return_value=None),
+        ):
+            assert break_repository_lock(repo) is True
+
+        borg_rsh = mock_run.call_args[1]["env"]["BORG_RSH"]
+        assert "-o StrictHostKeyChecking=yes" in borg_rsh
+        assert "-o StrictHostKeyChecking=accept-new" not in borg_rsh
+        assert "-o UserKnownHostsFile=/dev/null" not in borg_rsh
+
     def test_cleanup_orphaned_jobs(self):
         """Test cleanup of orphaned jobs"""
         # Create mock session

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -138,6 +138,8 @@ class TestProcessUtils:
     @patch("subprocess.run")
     def test_break_repository_lock_ssh_success(self, mock_run):
         """Test breaking lock for SSH repo"""
+        from app.utils import borg_env
+
         repo = Repository(
             id=1,
             path="ssh://user@host/repo",
@@ -147,7 +149,14 @@ class TestProcessUtils:
 
         mock_run.return_value.returncode = 0
 
-        assert break_repository_lock(repo) is True
+        # The repository carries no session here, so its connection is looked
+        # up by id; this test is about the command shape, not that lookup.
+        with patch.object(
+            borg_env,
+            "host_key_ssh_opts_for_connection_id",
+            return_value=["-o", "StrictHostKeyChecking=accept-new"],
+        ):
+            assert break_repository_lock(repo) is True
 
         # Verify command includes remote-path
         args = mock_run.call_args[0][0]
@@ -170,6 +179,34 @@ class TestProcessUtils:
             assert option in borg_rsh
         assert "-o StrictHostKeyChecking=no" not in borg_rsh
         assert "-o UserKnownHostsFile=/dev/null" not in borg_rsh
+
+    @patch("subprocess.run")
+    def test_break_repository_lock_fails_rather_than_skipping_verification(
+        self, mock_run
+    ):
+        """A connection that cannot be loaded must not mean "connect anyway".
+
+        The repository is attached to a connection, so a pinned host key may
+        well exist. Running borg against that host without checking it is worse
+        than failing the lock recovery and saying so.
+        """
+        from app.utils import borg_env
+
+        repo = Repository(
+            id=1,
+            path="ssh://user@host/repo",
+            connection_id=1,
+            remote_path="/usr/bin/borg",
+        )
+
+        with patch.object(
+            borg_env,
+            "host_key_ssh_opts_for_connection_id",
+            side_effect=RuntimeError("database is gone"),
+        ):
+            assert break_repository_lock(repo) is False
+
+        mock_run.assert_not_called()
 
     @patch("subprocess.run")
     def test_break_repository_lock_ssh_verifies_a_pinned_host_key(self, mock_run):


### PR DESCRIPTION
Second half of the security hardening spec, after #918 encrypted repository passphrases at rest. This is the last thing blocking the public `/security` page.

## The problem

Every SSH invocation passed `StrictHostKeyChecking=no` together with `UserKnownHostsFile=/dev/null`. The remote host was never authenticated: anything that could answer on the address was trusted, on every connection, forever. There was no defence against a MITM, on first connect or any later one.

## The model

OpenSSH's own, pinned per connection. The first time we talk to a host, its public key is recorded on the connection row (new `known_host_key` column, Alembic revision `a1c9f4d27b60`). From then on the key must match or the connection fails.

A key gets pinned two ways:

- **Explicitly**, from the new host-key dialog: the fingerprint is shown and confirmed before it is stored. Every newly created connection takes this path, and it is the moment verification is actually worth something.
- **Silently**, on first use of a connection that predates this feature. Those connections were already running with zero verification, so pinning whatever answers now is strictly better than the status quo, and it avoids breaking every existing install on upgrade. This was the decision recorded in the spec.

Once a key is pinned, a change is never absorbed silently either way: the connection fails and the user has to re-verify.

## Scope note (a departure from the spec)

The spec scoped this to the 8 call sites bound to an `SSHConnection`. I removed the bypass from **all 20**. A `/security` page cannot claim host-key verification while `app/core/borg.py`, `app/api/filesystem.py` and the key-deployment paths still pass `StrictHostKeyChecking=no`.

- Invocations holding a connection verify strictly against its pinned key.
- The handful with only a URL or a bare host (`ssh-copy-id` deployment, first-contact tests, the generic Borg env builders) record the key on first use in a shared `known_hosts` file. That is `accept-new`, not `no`: a key that changes afterwards is still refused.
- `app/utils/fs.py` resolves its connection through the new `find_ssh_connection_for_path` rather than staying an unpinned exception, as the spec asked.

A failed scan is remembered for 60s, so a host that is simply down does not add the `ssh-keyscan` timeout to every command a backup plan runs.

## API

- `GET /api/ssh-keys/connections/{id}/host-key` — what is trusted, what the host offers now, and the status (`trusted` / `unknown` / `changed` / `unreachable`).
- `POST /api/ssh-keys/connections/{id}/host-key/trust` — the key is re-read and re-compared before pinning, so one that changed while the dialog was open is refused with a 409 rather than trusted.
- `DELETE /api/ssh-keys/connections/{id}/host-key` — forget a pin, forcing the next connection to verify again.

The connection list now returns `host_key_verified` and `host_key_fingerprint` (computed in Python, not shelled out to `ssh-keygen`, since it renders once per row).

## UI

Each remote machine card shows whether its host key is verified, with the fingerprint on hover, and a shield action opening the dialog. The dialog shows both fingerprints, tells the user to compare against `ssh-keygen -lf` on the host itself, and turns red with a distinct message when the key changed. Strings in all four locales.

## Testing

- 30 new unit tests for the pinning module, 9 for the endpoints, 4 for the card, 6 for the dialog.
- Full backend unit suite: 3184 passed. Three `test_source_discovery.py::test_database_scan_*` failures appear only in full-suite order and pass in isolation; a baseline run on `main` was in flight to confirm they are pre-existing, and I will confirm in a comment.
- Full frontend suite: 2378 passed. Typecheck, oxlint, prettier, ruff and locale parity all clean.
- Storybook stories added for both the dialog (5 states) and the card's two host-key states.

## Not verified here

The pinning path has not been exercised against a real remote host in a Docker image yet. `ssh-keyscan` ships with `openssh-client`, which the runtime base image already installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 4 changed, 36 added, 0 removed, 506 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-919/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/34049839804
<details>
<summary>Changed files</summary>
- `remote-machines-remotemachinecard--with-run-diagnostics--mobile.png` (9.27%)
- `remote-machines-remotemachinecard--with-run-diagnostics.png` (2.97%)
- `remote-machines-remotemachinecard--without-run-diagnostics--mobile.png` (9.22%)
- `remote-machines-remotemachinecard--without-run-diagnostics.png` (2.96%)
</details>
<details>
<summary>New screenshots</summary>
- `components-licensingtab--enterprise-no-upgrade-link--mobile.png`
- `components-licensingtab--enterprise-no-upgrade-link.png`
- `components-licensingtab--pro-with-upgrade-link--mobile.png`
- `components-licensingtab--pro-with-upgrade-link.png`
- `components-planbadge--all-states--mobile.png`
- `components-planbadge--all-states.png`
- `components-planbadge--community--mobile.png`
- `components-planbadge--community.png`
- `components-planbadge--full-access-countdown--mobile.png`
- `components-planbadge--full-access-countdown.png`
- `components-planbadge--full-access-early--mobile.png`
- `components-planbadge--full-access-early.png`
- `components-planbadge--pro--mobile.png`
- `components-planbadge--pro.png`
- `components-planinfodrawer--enterprise-plan-drawer--mobile.png`
- `components-planinfodrawer--enterprise-plan-drawer.png`
- `components-planinfodrawer--full-access-ending-soon-drawer--mobile.png`
- `components-planinfodrawer--full-access-ending-soon-drawer.png`
- `components-planinfodrawer--full-access-expired-drawer--mobile.png`
- `components-planinfodrawer--full-access-expired-drawer.png`
- `components-planinfodrawer--pro-plan-drawer--mobile.png`
- `components-planinfodrawer--pro-plan-drawer.png`
- `remote-machines-hostkeydialog--first-connect--mobile.png`
- `remote-machines-hostkeydialog--first-connect.png`
- `remote-machines-hostkeydialog--host-unreachable--mobile.png`
- `remote-machines-hostkeydialog--host-unreachable.png`
- `remote-machines-hostkeydialog--key-changed--mobile.png`
- `remote-machines-hostkeydialog--key-changed.png`
- `remote-machines-hostkeydialog--loading--mobile.png`
- `remote-machines-hostkeydialog--loading.png`
- `remote-machines-hostkeydialog--trusted--mobile.png`
- `remote-machines-hostkeydialog--trusted.png`
- `remote-machines-remotemachinecard--host-key-not-verified--mobile.png`
- `remote-machines-remotemachinecard--host-key-not-verified.png`
- `remote-machines-remotemachinecard--host-key-verified--mobile.png`
- `remote-machines-remotemachinecard--host-key-verified.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->