### PR TITLE
test: restore shadowed prune test and drop duplicate archive-failure test

### DIFF
--- a/tests/unit/test_api_v2_repositories.py
+++ b/tests/unit/test_api_v2_repositories.py
@@ -1258,25 +1258,6 @@ class TestV2RepositoryRoutes:
         assert response.status_code == 500
         assert response.json()["detail"]["key"] == "backend.errors.repo.listFailed"
 
-    def test_list_archives_returns_500_on_borg_failure(
-        self, test_client: TestClient, admin_headers, test_db
-    ):
-        _enable_borg_v2(test_db)
-        repo = _create_v2_repo(test_db)
-
-        with patch(
-            "app.api.v2.repositories.borg2.list_archives",
-            new=AsyncMock(
-                return_value={"success": False, "stdout": "", "stderr": "boom"}
-            ),
-        ):
-            response = test_client.get(
-                f"/api/v2/repositories/{repo.id}/archives", headers=admin_headers
-            )
-
-        assert response.status_code == 500
-        assert response.json()["detail"]["key"] == "backend.errors.repo.listFailed"
-
     def test_get_repository_stats_success(
         self, test_client: TestClient, admin_headers, test_db
     ):

--- a/tests/unit/test_borg_router.py
+++ b/tests/unit/test_borg_router.py
@@ -365,7 +365,7 @@ async def test_compact_delegates_to_v1_service():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_prune_delegates_to_v2_service():
+async def test_prune_delegates_to_v2_service_positional_args():
     repo = SimpleNamespace(borg_version=2, id=41)
 
     with patch(


### PR DESCRIPTION
## Description

Two test functions are each defined twice in the same scope. Python rebinds the name on the
second `def`, so pytest only ever collects the second definition and the first one has never
run. The two cases need opposite remedies, which is the point of this PR.

**1. `tests/unit/test_borg_router.py` — real coverage loss, so restore the shadowed test.**

`test_prune_delegates_to_v2_service` is defined at module scope twice, at line 368 and again at
line 1142, and the bodies are **not** equivalent:

```python
# line 368  (shadowed - never collected)
await BorgRouter(repo).prune(7, 1, 2, 3, 4, 5, 6, dry_run=True)

# line 1142 (the one that actually runs)
await BorgRouter(repo).prune(
    job_id=7, keep_hourly=1, keep_daily=2, keep_weekly=3,
    keep_monthly=4, keep_quarterly=5, keep_yearly=6, dry_run=True,
)
```

So the **positional** calling convention of `BorgRouter.prune` has had zero coverage since the
duplicate was added — and that is the convention production actually uses, at both call sites:

- `app/api/repositories.py:179-190` — `args = (job.id, keep_hourly, ..., False)` then
  `BorgRouter(router_repo).prune(*args, **kwargs)`
- `app/api/repositories.py:5710-5720` — eight positional arguments

The surviving keyword-only test would not catch a reordering of `prune`'s parameters; the
shadowed one would. This PR renames only the line-368 definition to
`test_prune_delegates_to_v2_service_positional_args` so both conventions are collected and run.
Its body and assertions are untouched, and it passes as written.

**2. `tests/unit/test_api_v2_repositories.py` — genuinely redundant, so drop the copy.**

`TestV2RepositoryRoutes.test_list_archives_returns_500_on_borg_failure` is defined at line 1242
and again at line 1261 with identical assertions. The only difference is the mocked stderr
string (`"list failed"` vs `"boom"`), and it cannot change the code path:
`_borg2_failure_detail` (`app/api/v2/repositories.py:146`) only branches through
`_is_borg2_remote_protocol_mismatch` (`:139`), which requires `InvalidRPCMethod` or
`RPC method ... is not valid` in stderr — neither string matches, so both take the fallback
branch. The string only reaches `detail.params.error`, which neither test asserts on; both
assert exactly `response.status_code == 500` and
`response.json()["detail"]["key"] == "backend.errors.repo.listFailed"`. The second copy is
removed and the original (line 1242) is kept, so zero coverage is lost.

**Why CI never flagged this:** `ruff.toml` has `select = ["F401"]`, so `F811` (redefinition of
unused name) is not enabled. Adding `"F811"` would catch this class of shadowing automatically.
I deliberately left that out of this PR to keep the diff to tests only — happy to open a
follow-up if you want it. (For reference it would not flag the legitimate
`Settings.cors_origins` property/setter pair at `app/config.py:149/158`, since pyflakes
special-cases decorated redefinitions. An AST scan over `app/` and `tests/` confirms those three
were the only same-scope duplicates in the repo, and after this PR only the property/setter pair
remains.)

Net diff: 1 line changed, 19 lines removed. Tests only, no application code.

## Related Issue

N/A — no existing issue covers this.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

All commands run from the repo root against `main` (`c7f32d1`) in a clean venv built from
`requirements.txt` (pytest 9.1.1). Real output, trimmed to the summary lines.

**Collection count proves the shadowing — 51 → 52:**

```
# before
$ python -m pytest tests/unit/test_borg_router.py --collect-only -q | tail -1
========================= 51 tests collected in 1.56s =========================
$ python -m pytest tests/unit/test_borg_router.py --collect-only -q \
    | grep -c test_prune_delegates_to_v2_service
1

# after
$ python -m pytest tests/unit/test_borg_router.py --collect-only -q | tail -1
========================= 52 tests collected in 0.23s =========================
$ python -m pytest tests/unit/test_borg_router.py --collect-only -q \
    | grep -c test_prune_delegates_to_v2_service
2
```

**The restored test runs and passes — 5 → 6:**

```
# before
$ python -m pytest tests/unit/test_borg_router.py -k prune -q | tail -1
================ 5 passed, 46 deselected, 8 warnings in 1.44s =================

# after
$ python -m pytest tests/unit/test_borg_router.py -k prune -q | tail -1
================ 6 passed, 46 deselected, 8 warnings in 0.62s =================
```

**The deleted copy was never collected — count is 1 before and after, total unchanged at 40:**

```
$ python -m pytest tests/unit/test_api_v2_repositories.py --collect-only -q \
    | grep -c test_list_archives_returns_500_on_borg_failure
1
$ python -m pytest tests/unit/test_api_v2_repositories.py --collect-only -q | tail -1
========================= 40 tests collected in 5.08s =========================
```

**Both touched files, full run:**

```
$ python -m pytest tests/unit/test_borg_router.py tests/unit/test_api_v2_repositories.py -q | tail -1
====================== 92 passed, 214 warnings in 46.55s ======================
```

**Lint, per the repo's `ruff.toml`:**

```
$ python -m ruff check tests/unit/test_borg_router.py tests/unit/test_api_v2_repositories.py
All checks passed!
$ python -m ruff format --check tests/unit/test_borg_router.py tests/unit/test_api_v2_repositories.py
2 files already formatted
```

**Full backend suite (`python3 -m pytest tests/`) — honest caveat:** I could only run this on a
Windows workstation, where a large number of tests fail for platform reasons that predate this
PR. `tests/unit/agent/test_service_setup.py` and `tests/unit/test_deploy_ssh_key_script.py` do
not even import (`ModuleNotFoundError: No module named 'grp'` / `'pwd'`); excluding those two,
the run is:

```
$ python -m pytest tests/ -q \
    --ignore=tests/unit/agent/test_service_setup.py \
    --ignore=tests/unit/test_deploy_ssh_key_script.py
= 111 failed, 2782 passed, 114 skipped, 3190 warnings, 289 errors in 1491.18s (0:24:51) =
```

Those are POSIX assumptions (e.g. `assert mode == oct(0o600)` yields `'0o666'` on NTFS, `/bin/sh`
script execution, POSIX path discovery), not regressions from this PR. I confirmed that by
running a sample of the failing modules on unmodified `main` in the same venv and getting an
identical result:

```
$ git switch --detach origin/main    # c7f32d1
$ python -m pytest tests/unit/test_ssh_utils.py tests/unit/test_script_executor.py -q | tail -1
================== 11 failed, 8 passed, 4 warnings in 0.44s ===================

$ git switch test/restore-shadowed-duplicate-tests
$ python -m pytest tests/unit/test_ssh_utils.py tests/unit/test_script_executor.py -q | tail -1
================== 11 failed, 8 passed, 4 warnings in 0.41s ===================
```

This PR touches only two test files and both pass in full (92/92 above); the Linux CI job on
this PR is the authoritative full-suite run.

Frontend was not built or tested — no frontend files are touched by this PR.

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works — the restored
  test is the proof; it is collected and passes where it previously never ran
- [x] All existing tests pass — both touched modules pass in full; the full-suite caveat above is
  a pre-existing Windows/POSIX issue, not a regression from this PR

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas — n/a, no new code
- [x] I have made corresponding changes to the documentation — n/a, no docs affected
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Context

Both duplicates read like copy/paste while adding an adjacent case. Neither is user-facing, but
the router one is a silently missing regression guard rather than cosmetic dedup, which is why
the two are treated asymmetrically here. If you would rather delete the shadowed positional test
than restore it, say the word and I will amend — but given that both production call sites pass
positionally, keeping it seems like the more useful outcome.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
