### PR TITLE
fix: restore delete-job cancel endpoint and fail smoke test on 500

### DIFF
--- a/app/api/archives.py
+++ b/app/api/archives.py
@@ -28,6 +28,7 @@ from app.database.database import get_db
 from app.database.models import AgentMachine, DeleteArchiveJob, Repository, User
 from app.services.agent_artifact_relay import agent_artifact_relay
 from app.services.agent_job_dispatcher import dispatch_agent_job_best_effort
+from app.services.delete_archive_service import delete_archive_service
 from app.services.log_policy import get_log_save_policy, job_has_logs_by_policy
 from app.services.repository_executor import (
     is_agent_executor,
@@ -689,6 +690,8 @@ async def cancel_delete_job(
             check_repo_access(db, current_user, repo, "operator")
         await delete_archive_service.cancel_delete(job_id, db)
         return {"message": "backend.success.archives.deletionCancelled"}
+    except HTTPException:
+        raise
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:

--- a/tests/smoke/test_delete_cancel_smoke.py
+++ b/tests/smoke/test_delete_cancel_smoke.py
@@ -100,12 +100,10 @@ def main() -> int:
                     flush=True,
                 )
                 return 0
-            print(
-                f"Delete cancel smoke skipped: cancel endpoint returned {cancel_response.status_code} "
-                f"while delete state was {payload.get('status')}",
-                flush=True,
+            raise SmokeFailure(
+                f"Cancel endpoint returned {cancel_response.status_code} "
+                f"while delete state was {payload.get('status')}: {cancel_response.text}"
             )
-            return 0
         if "cancel" not in str(cancel_response.json()).lower():
             raise SmokeFailure(
                 f"Unexpected delete cancel response: {cancel_response.text}"

--- a/tests/unit/test_api_archives.py
+++ b/tests/unit/test_api_archives.py
@@ -754,3 +754,74 @@ def test_archives_list_route_sends_deprecation_headers(
     assert r.status_code == 200
     assert r.headers["deprecation"] == "true"
     assert "/archives" in r.headers["link"]
+
+
+@pytest.mark.unit
+class TestDeleteJobCancel:
+    @staticmethod
+    def _create_delete_job(test_db, status: str) -> DeleteArchiveJob:
+        repo = Repository(
+            name="Cancel Repo",
+            path="/tmp/cancel-repo",
+            encryption="none",
+            repository_type="local",
+        )
+        test_db.add(repo)
+        test_db.flush()
+        job = DeleteArchiveJob(
+            repository_id=repo.id,
+            repository_path=repo.path,
+            archive_name="archive-1",
+            status=status,
+            started_at=datetime(2026, 4, 27, 3, 0, 6),
+        )
+        test_db.add(job)
+        test_db.commit()
+        return job
+
+    def test_cancel_running_delete_job_marks_it_cancelled(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        job = self._create_delete_job(test_db, "running")
+
+        response = test_client.post(
+            f"/api/archives/delete-jobs/{job.id}/cancel", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "message": "backend.success.archives.deletionCancelled"
+        }
+        test_db.expire_all()
+        assert (
+            test_db.query(DeleteArchiveJob).filter_by(id=job.id).one().status
+            == "cancelled"
+        )
+
+    def test_cancel_finished_delete_job_returns_400(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        job = self._create_delete_job(test_db, "completed")
+
+        response = test_client.post(
+            f"/api/archives/delete-jobs/{job.id}/cancel", headers=admin_headers
+        )
+
+        assert response.status_code == 400
+        test_db.expire_all()
+        assert (
+            test_db.query(DeleteArchiveJob).filter_by(id=job.id).one().status
+            == "completed"
+        )
+
+    def test_cancel_unknown_delete_job_returns_404(
+        self, test_client: TestClient, admin_headers
+    ):
+        response = test_client.post(
+            "/api/archives/delete-jobs/999999/cancel", headers=admin_headers
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == {
+            "key": "backend.errors.archives.deleteJobNotFound"
+        }


### PR DESCRIPTION
## Description

`POST /api/archives/delete-jobs/{job_id}/cancel` has returned HTTP 500 on every call since `a4bc1c43` (2026-04-10) replaced the `delete_archive_service` import in `app/api/archives.py` with `BorgRouter` but left `cancel_delete_job` calling the removed name. The handler raised `NameError`, which the generic `except Exception` turned into `500 Failed to cancel delete job: name 'delete_archive_service' is not defined`.

Three changes:

1. **Restore the import.** `cancel_delete` (`app/services/delete_archive_service.py:322`) only flips the job row to `cancelled`; it does not touch a process or a service instance, so it needs no version routing and the pre-refactor call is the right one.
2. **Let `HTTPException` pass through the handler.** The 404 raised for an unknown job id sat inside the same `try` and was converted to 500 by the generic `except Exception`. An explicit `except HTTPException: raise` restores the intended status.
3. **Make the smoke test fail on this.** `tests/smoke/test_delete_cancel_smoke.py` treated a non-200 cancel while the job was still `running` as "skipped" with exit code 0. That is why this went unnoticed for five months: the latest green `Tests` run on `main` (run 33964565961) prints `Delete cancel smoke skipped: cancel endpoint returned 500 while delete state was running`. The skip now remains only for the genuine race where the job reached a terminal state before the cancel; a non-200 while still running raises `SmokeFailure`.

Plus three unit tests for the route (running → 200 and row `cancelled`, finished → 400 and row unchanged, unknown → 404 with the i18n key). All three fail on `main` (all with 500) and pass with the fix.

Out of scope, noted for a separate issue: only the Borg 1 delete service polls the `cancelled` flag and kills the process; `app/services/v2/delete_archive_service.py` never reads it, so on a Borg 2 repository a cancel marks the row but the delete keeps running. That predates the refactor.

## Related Issue

Fixes #922

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

Clean venv from `requirements.txt`, macOS, borg 1.4.5 on PATH, base `main` at `c7f32d1`.

The new tests against `main` (fix stashed):

```
$ python -m pytest tests/unit/test_api_archives.py -q -o addopts='' -k TestDeleteJobCancel
FAILED tests/unit/test_api_archives.py::TestDeleteJobCancel::test_cancel_running_delete_job_marks_it_cancelled
FAILED tests/unit/test_api_archives.py::TestDeleteJobCancel::test_cancel_finished_delete_job_returns_400
FAILED tests/unit/test_api_archives.py::TestDeleteJobCancel::test_cancel_unknown_delete_job_returns_404
3 failed, 25 deselected, 41 warnings in 1.66s
```

(all three requests logged as `status_code: 500` by the request middleware)

With the fix:

```
$ python -m pytest tests/unit/test_api_archives.py -q -o addopts=''
28 passed, 82 warnings in 6.95s

$ ruff check app/api/archives.py tests/unit/test_api_archives.py tests/smoke/test_delete_cancel_smoke.py
All checks passed!
$ ruff format --check app/api/archives.py tests/unit/test_api_archives.py tests/smoke/test_delete_cancel_smoke.py
3 files already formatted
```

The smoke test change was not run end to end locally; the `smoke-borg-extended` CI job exercises it. Frontend untouched.

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass (the touched unit module in full; the CI matrix is the authoritative full run)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (n/a, no new logic beyond the re-raise)
- [x] I have made corresponding changes to the documentation (n/a)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Context

`ruff --select F821` reports this line on `main`; `ruff.toml` currently selects only `F401`. #921 tracks enabling `F811`/`F821`.
