### PR TITLE
fix: log repository.id in inline script error handler

### DIFF
--- a/app/services/script_library_executor.py
+++ b/app/services/script_library_executor.py
@@ -652,7 +652,7 @@ class ScriptLibraryExecutor:
         except Exception as e:
             logger.error(
                 "Inline script execution exception",
-                repository_id=repository_id,
+                repository_id=repository.id,
                 error=str(e),
             )
 

--- a/tests/unit/test_script_library_executor.py
+++ b/tests/unit/test_script_library_executor.py
@@ -202,3 +202,32 @@ async def test_execute_inline_script_injects_repository_parameter_values(db_sess
     assert captured["env"]["TARGET_DIR"] == "/srv/data"
     assert captured["env"]["RETRIES"] == "3"
     assert "RESULT_PATH" not in captured["env"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_inline_script_returns_failure_result_when_runner_raises(
+    db_session,
+):
+    repository = Repository(id=7, name="Repo", path="/backups/repo")
+    executor = ScriptLibraryExecutor(db_session)
+
+    async def failing_execute_script(script, timeout, env, context):
+        raise RuntimeError("interpreter missing")
+
+    with patch(
+        "app.services.script_library_executor.execute_script",
+        new=failing_execute_script,
+    ):
+        result = await executor.execute_inline_script(
+            script_content="echo test",
+            script_type="post-backup",
+            timeout=30,
+            repository=repository,
+        )
+
+    assert result["success"] is False
+    assert result["exit_code"] is None
+    assert result["stderr"] == "interpreter missing"
+    assert "STATUS: FAILED (Exception)" in result["logs"]
+    assert "ERROR: interpreter missing" in result["logs"]


### PR DESCRIPTION
## Description

The `except Exception` handler in `ScriptLibraryExecutor.execute_inline_script` (`app/services/script_library_executor.py:655`) logged `repository_id=repository_id`, but the method has no `repository_id` in scope; its parameter is `repository`, and the success path already uses `repository.id`. Whenever `execute_script` raised (timeout, missing interpreter, OS error), the handler itself raised `NameError`, the original exception was lost, and the callers in `app/api/schedule.py` (2222, 2329) and `app/services/backup_service.py:289` received a `NameError` instead of the structured `{"success": False, ...}` result. The `STATUS: FAILED (Exception)` log block the handler exists to produce was never written.

Introduced in `efd6fc37` (2026-04-13) when the log call was reformatted. One-token fix: `repository.id`.

Adds a unit test that patches `execute_script` to raise and asserts the failure result, `stderr`, and both log lines. It fails on `main` with the `NameError` and passes with the fix.

## Related Issue

Fixes #923

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

Clean venv from `requirements.txt`, base `main` at `c7f32d1`.

New test against `main` (fix stashed):

```
$ python -m pytest tests/unit/test_script_library_executor.py -q -o addopts='' -k runner_raises
E           NameError: name 'repository_id' is not defined
app/services/script_library_executor.py:655: NameError
```

With the fix:

```
$ python -m pytest tests/unit/test_script_library_executor.py -q -o addopts=''
8 passed, 4 warnings in 0.17s

$ ruff check app/services/script_library_executor.py tests/unit/test_script_library_executor.py
All checks passed!
$ ruff format --check app/services/script_library_executor.py tests/unit/test_script_library_executor.py
2 files already formatted
```

Frontend untouched.

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass (the touched unit module in full; the CI matrix is the authoritative full run)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (n/a)
- [x] I have made corresponding changes to the documentation (n/a)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Context

`ruff --select F821` reports this line on `main`; `ruff.toml` currently selects only `F401`. #921 tracks enabling `F811`/`F821`.
