### PR TITLE
chore(runtime-base): adopt Borg 2.0.0b24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG BASE_IMAGE=docker.io/ainullcode/borg-ui-runtime-base:runtime-borg1-1.4.5-borg2-2.0.0b23-r1
+ARG BASE_IMAGE=docker.io/ainullcode/borg-ui-runtime-base:runtime-borg1-1.4.5-borg2-2.0.0b24-r1
 # The Python the builder stages use — kept in step with runtime-base.env by a
 # guard test; the site-packages COPY paths derive from it.
 ARG PYTHON_VERSION=3.12

--- a/Dockerfile.runtime-base
+++ b/Dockerfile.runtime-base
@@ -18,7 +18,7 @@ ARG PYTHON_VERSION=3.12
 FROM python:${PYTHON_VERSION}-slim AS builder
 
 ARG BORG1_VERSION=1.4.5
-ARG BORG2_VERSION=2.0.0b23
+ARG BORG2_VERSION=2.0.0b24
 ARG BORGSTORE_VERSION=0.6.1
 
 # Build-time only. OS packages track the base image's Debian release rather than
@@ -52,7 +52,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # share deps (rclone+rest both only need requests), so it is obvious at a glance
 # that no scheme is missing. NB: posixfs is NOT a pip extra — it is always
 # available — so it must not appear in the brackets. blake3 is not a backend
-# but Borg 2.0.0b23's id-hash dependency, required by its pyproject.
+# but Borg 2's id-hash dependency (since 2.0.0b23), required by its pyproject.
 # hadolint ignore=DL3013,DL3059
 RUN pip install --no-cache-dir pyfuse3 "borgbackup==${BORG1_VERSION}" && \
     python3 -m venv /opt/borg2-venv && \
@@ -94,7 +94,7 @@ FROM python:${PYTHON_VERSION}-slim AS runtime-base
 
 ARG PYTHON_VERSION
 ARG BORG1_VERSION=1.4.5
-ARG BORG2_VERSION=2.0.0b23
+ARG BORG2_VERSION=2.0.0b24
 ENV BORG1_VERSION=${BORG1_VERSION}
 ENV BORG2_VERSION=${BORG2_VERSION}
 

--- a/app/api/agent_installer.py
+++ b/app/api/agent_installer.py
@@ -91,7 +91,8 @@ Borg install options:
   --borg-source distro  Use distribution packages instead. The version is then
                         whatever the distribution ships, which may differ from
                         the server's. Required on platforms with no published
-                        static binary, such as 32-bit ARM.
+                        static binary, such as 32-bit ARM. Borg 1 only: no
+                        distribution ships Borg 2 yet.
 
 Agent install options:
   --agent-source server Install the agent package the enrolling server offers
@@ -418,6 +419,54 @@ select_borg_binary() {
   [[ -n "${BINARY_URL}" ]]
 }
 
+# The lowest glibc the pinned Borg $1 asks of this architecture — the floor a
+# machine has to clear — or nothing when no binary exists for the architecture
+# at all. Borg raises the floor whenever it moves its build runner, so the
+# number comes from the manifest, never from this script.
+lowest_glibc_offered() {
+  local major="$1"
+  local row_major row_arch row_glibc row_sha row_url lowest=""
+
+  while read -r row_major row_arch row_glibc row_sha row_url; do
+    [[ -n "${row_major:-}" ]] || continue
+    [[ "${row_major}" == "${major}" ]] || continue
+    [[ "${row_arch}" == "${MACHINE_ARCH}" ]] || continue
+    if [[ -z "${lowest}" ]] ||
+      printf '%s\n%s\n' "${row_glibc}" "${lowest}" | sort -V -C; then
+      lowest="${row_glibc}"
+    fi
+  done <<<"${PINNED_BORG_BINARIES}"
+
+  printf '%s' "${lowest}"
+}
+
+# What to do when the pinned Borg $1 (version $2) cannot come from the server.
+# Borg 1 has distribution packages; Borg 2 has none, so the only way past is a
+# self-managed install exposed under the name the agent resolves: 'borg2' at
+# the link $3, the same contract the forwarder written by
+# install_borg_from_server fulfils. A pip install alone provides only 'borg'.
+# The suggested commands are pinned to the server's version, so agent and
+# server keep speaking the same Borg; without a reported version there is
+# nothing to pin and no command is printed.
+borg_fallback_advice() {
+  local major="$1" version="$2" link="$3"
+
+  if [[ "${major}" == "1" ]]; then
+    echo "Re-run with --borg-source distro to use the distribution package," >&2
+    echo "or with --skip-borg-install to manage Borg yourself." >&2
+    return
+  fi
+
+  echo "No distribution ships Borg 2 yet. Install the version this server runs" >&2
+  echo "yourself and expose it as 'borg2' on PATH, then re-run with --skip-borg-install." >&2
+  if [[ -n "${version}" ]]; then
+    echo "For example (needs a C toolchain, Borg's build dependencies and OpenSSL 3.2 or newer):" >&2
+    echo "  python3 -m venv /opt/borg2" >&2
+    printf '  /opt/borg2/bin/pip install --pre "borgbackup==%s" "borgstore[rclone,sftp,rest,s3,blake3]"\n' "${version}" >&2
+    echo "  ln -sfn /opt/borg2/bin/borg ${link}" >&2
+  fi
+}
+
 install_borg_binary() {
   local major="$1" version="$2" dest_dir dest tmp
 
@@ -482,15 +531,20 @@ install_borg_from_server() {
 
   if [[ -z "${version}" ]]; then
     echo "This Borg UI server did not report a Borg ${major} version." >&2
-    echo "Re-run with --borg-source distro to use the distribution package." >&2
+    borg_fallback_advice "${major}" "" "${link}"
     exit 1
   fi
 
   if ! select_borg_binary "${major}"; then
-    echo "No published Borg ${version} binary for ${MACHINE_ARCH} with glibc ${MACHINE_GLIBC:-unknown}." >&2
-    echo "Borg publishes no static binary for 32-bit ARM or musl systems." >&2
-    echo "Re-run with --borg-source distro to use the distribution package," >&2
-    echo "or with --skip-borg-install to manage Borg yourself." >&2
+    local floor
+    floor="$(lowest_glibc_offered "${major}")"
+    if [[ -n "${floor}" ]]; then
+      echo "Borg ${version} for ${MACHINE_ARCH} needs glibc ${floor} or newer; this machine has glibc ${MACHINE_GLIBC:-unknown}." >&2
+    else
+      echo "No published Borg ${version} binary for ${MACHINE_ARCH}." >&2
+      echo "Borg publishes no static binary for 32-bit ARM or musl systems." >&2
+    fi
+    borg_fallback_advice "${major}" "${version}" "${link}"
     exit 1
   fi
 

--- a/app/api/borg_binaries.json
+++ b/app/api/borg_binaries.json
@@ -1,7 +1,7 @@
 {
   "current": {
     "1": "1.4.5",
-    "2": "2.0.0b23"
+    "2": "2.0.0b24"
   },
   "release_url": "https://github.com/borgbackup/borg/releases/download/{version}/{asset}",
   "binaries": {
@@ -25,18 +25,18 @@
         "sha256": "1410e28609be3080d0e3ab27a78f5c586a29fd0c75c2aa6415fcde1293bcd923"
       }
     ],
-    "2.0.0b23": [
+    "2.0.0b24": [
       {
         "arch": "aarch64",
-        "min_glibc": "2.39",
-        "asset": "borg-linux-glibc239-arm64-gh",
-        "sha256": "a81efdd7bd5652a57b3f3535930f424bf6bb721438854b82846a0e277916a4c3"
+        "min_glibc": "2.43",
+        "asset": "borg-linux-glibc243-arm64-gh",
+        "sha256": "c9474a30e30c5e810ae51c2c88075a631fc1753b37513fc45cc5de2915838b3a"
       },
       {
         "arch": "x86_64",
-        "min_glibc": "2.39",
-        "asset": "borg-linux-glibc239-x86_64-gh",
-        "sha256": "1b9fdf74ff177459dbb42b4eea4464712b361f35f144e9fb7018e44dd4b64907"
+        "min_glibc": "2.43",
+        "asset": "borg-linux-glibc243-x86_64-gh",
+        "sha256": "5fa90f4eac2b6ea4847848c24f3f812926cae117a7a444ee10a2301b9ec6aba7"
       }
     ]
   }

--- a/docker/runtime-base.env
+++ b/docker/runtime-base.env
@@ -10,10 +10,11 @@ BORG1_VERSION=1.4.5
 # support as a whole, not to this bump.
 #
 # b22 was the packs release: it needed NEW repositories and cannot read repos
-# written by earlier betas. b23 keeps that repository format — repositories
-# created with b22 stay readable — and requires borgstore 0.6.x with the
-# blake3 extra.
-BORG2_VERSION=2.0.0b23
+# written by earlier betas. b23 and b24 keep that repository format —
+# repositories created with b22 stay readable — and require borgstore 0.6.x
+# with the blake3 extra. b24 additionally needs OpenSSL >= 3.2 at build time
+# (argon2 now comes from OpenSSL); python:3.12-slim (trixie) provides 3.5.
+BORG2_VERSION=2.0.0b24
 BORGSTORE_VERSION=0.6.1
 PYTHON_VERSION=3.12
 # rclone is fetched as the official static binary (downloads.rclone.org), not the

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -407,8 +407,8 @@ This does not include Redis. Use Compose for normal deployments.
 > 2.0.0b22 changed the repository format (packs) and cannot read a repository
 > written by any earlier Borg 2 beta — opening one fails with
 > `repository version 3 is not supported by this borg version`. There is no
-> in-place conversion. 2.0.0b23 kept that format, so repositories created
-> with 2.0.0b22 or later stay readable. Coming from a pre-b22 image:
+> in-place conversion. 2.0.0b23 and 2.0.0b24 kept that format, so repositories
+> created with 2.0.0b22 or later stay readable. Coming from a pre-b22 image:
 >
 > 1. Keep the image you are upgrading from available — it is the only thing
 >    that can still read the old repositories.

--- a/docs/managed-agents.md
+++ b/docs/managed-agents.md
@@ -36,6 +36,20 @@ installer requires root or sudo, installs system dependencies, registers
 `/etc/borg-ui-agent/config.toml`, runs `service-check`, and enables the systemd
 service with `systemctl enable --now borg-ui-agent`.
 
+By default the installer fetches the exact Borg versions the server runs, as
+the static Linux binaries borgbackup publishes for x86_64 and aarch64. Those
+binaries need a minimum glibc; when the machine's glibc is too old, the
+installer says which version it needs and stops. Borg 1 can then be taken from
+the distribution instead (`--borg-source distro`). No distribution ships
+Borg 2 yet: install the server's version yourself and expose it as `borg2` on
+PATH, then re-run the installer with `--skip-borg-install`. The installer's
+message prints the commands for that, pinned to the server's version — a
+virtualenv with `borgbackup` and `borgstore`, and a `borg2` symlink in
+`/usr/local/bin` (a plain pip install provides only `borg`, which the agent
+does not use for Borg 2). That install builds Borg from source, so the machine
+needs a C toolchain, Borg's build dependencies and, from 2.0.0b24 on, OpenSSL
+3.2 or newer.
+
 By default, the service runs as the user who invoked `sudo`. That means the
 agent can read and write the same paths that user can access, matching the
 permission model used by SSH remote machines. Repository paths must be writable

--- a/tests/unit/test_agent_installer_api.py
+++ b/tests/unit/test_agent_installer_api.py
@@ -1,3 +1,4 @@
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -193,6 +194,137 @@ def test_agent_installer_script_names_the_fallback_for_unsupported_platforms(
         response.text
     )
     assert "Re-run with --borg-source distro" in response.text
+
+
+_INSTALLER_FUNCTIONS = (
+    "glibc_at_least",
+    "select_borg_binary",
+    "lowest_glibc_offered",
+    "borg_fallback_advice",
+    "install_borg_from_server",
+)
+
+
+def _run_install_borg_from_server(
+    script: str, *, major: str, version: str, glibc: str, binaries: str
+) -> subprocess.CompletedProcess:
+    """Run the installer's server-source path in isolation: only the functions
+    it needs, with the machine facts and the pinned manifest table injected."""
+    functions = "\n".join(
+        re.search(rf"^{name}\(\) \{{\n.*?^\}}\n", script, re.M | re.S).group(0)
+        for name in _INSTALLER_FUNCTIONS
+    )
+    link = "/usr/local/bin/borg2" if major == "2" else "/usr/local/bin/borg"
+    harness = "\n".join(
+        [
+            functions,
+            'MACHINE_ARCH="x86_64"',
+            f'MACHINE_GLIBC="{glibc}"',
+            f'PINNED_BORG_BINARIES="{binaries}"',
+            f'install_borg_from_server "{major}" "{version}" {link}',
+        ]
+    )
+    return subprocess.run(
+        ["bash", "-c", harness], capture_output=True, text=True, check=False
+    )
+
+
+_MANIFEST_TABLE = "\n".join(
+    [
+        "1 x86_64 2.31 aa https://example.invalid/borg1-glibc231",
+        "1 x86_64 2.35 bb https://example.invalid/borg1-glibc235",
+        "2 x86_64 2.43 cc https://example.invalid/borg2-glibc243",
+    ]
+)
+
+
+def test_agent_installer_names_the_glibc_floor_for_borg2(test_client: TestClient):
+    """A machine below the floor learns the number it misses, and is not sent to
+    --borg-source distro, which install_borg2 rejects: Borg 2 has no
+    distribution package, so the only way past is a self-managed install."""
+    script = test_client.get("/agent/install.sh").text
+
+    result = _run_install_borg_from_server(
+        script, major="2", version="2.0.0b24", glibc="2.39", binaries=_MANIFEST_TABLE
+    )
+
+    assert result.returncode == 1
+    assert (
+        "Borg 2.0.0b24 for x86_64 needs glibc 2.43 or newer; "
+        "this machine has glibc 2.39."
+    ) in result.stderr
+    # The agent resolves Borg 2 as `borg2`; a bare pip install provides only
+    # `borg`, so the suggested commands pin the server's version and expose it
+    # under the name the installer's own forwarder would have used.
+    assert "expose it as 'borg2' on PATH" in result.stderr
+    # The pip route builds from source: say what the build needs.
+    assert "OpenSSL 3.2 or newer" in result.stderr
+    assert (
+        '/opt/borg2/bin/pip install --pre "borgbackup==2.0.0b24" '
+        '"borgstore[rclone,sftp,rest,s3,blake3]"'
+    ) in result.stderr
+    assert "ln -sfn /opt/borg2/bin/borg /usr/local/bin/borg2" in result.stderr
+    assert "--skip-borg-install" in result.stderr
+    assert "--borg-source distro" not in result.stderr
+    assert "32-bit ARM" not in result.stderr
+
+
+def test_agent_installer_prints_no_unpinned_borg2_install(test_client: TestClient):
+    """Without a version reported by the server there is nothing to pin, and an
+    unpinned `pip install borgbackup` would install whatever is newest — a
+    different Borg than the server. Say what to do, print no command."""
+    script = test_client.get("/agent/install.sh").text
+
+    result = _run_install_borg_from_server(
+        script, major="2", version="", glibc="2.39", binaries=_MANIFEST_TABLE
+    )
+
+    assert result.returncode == 1
+    assert "This Borg UI server did not report a Borg 2 version." in result.stderr
+    assert "expose it as 'borg2' on PATH" in result.stderr
+    assert "--skip-borg-install" in result.stderr
+    assert "pip install" not in result.stderr
+    assert "--borg-source distro" not in result.stderr
+
+
+def test_agent_installer_keeps_the_distro_fallback_for_borg1(
+    test_client: TestClient,
+):
+    """Borg 1 below its floor is pointed at the distribution package."""
+    script = test_client.get("/agent/install.sh").text
+
+    result = _run_install_borg_from_server(
+        script, major="1", version="1.4.5", glibc="2.28", binaries=_MANIFEST_TABLE
+    )
+
+    assert result.returncode == 1
+    assert "needs glibc 2.31 or newer; this machine has glibc 2.28." in result.stderr
+    assert "Re-run with --borg-source distro" in result.stderr
+    assert "pip install" not in result.stderr
+
+
+def test_agent_installer_explains_an_architecture_without_binaries(
+    test_client: TestClient,
+):
+    """No row for the architecture at all: the reason is the platform, not the
+    glibc version, so no floor is quoted."""
+    script = test_client.get("/agent/install.sh").text
+
+    result = _run_install_borg_from_server(
+        script,
+        major="2",
+        version="2.0.0b24",
+        glibc="2.43",
+        binaries="2 aarch64 2.43 cc https://example.invalid/borg2-arm64",
+    )
+
+    assert result.returncode == 1
+    assert "No published Borg 2.0.0b24 binary for x86_64." in result.stderr
+    assert "Borg publishes no static binary for 32-bit ARM or musl systems." in (
+        result.stderr
+    )
+    assert "needs glibc" not in result.stderr
+    assert "--skip-borg-install" in result.stderr
 
 
 def test_agent_installer_installs_rclone_with_borg2(test_client: TestClient):


### PR DESCRIPTION
## Description

Follow-up to #881: the delta from 2.0.0b23 to 2.0.0b24 (released 2026-09-02). Two commits. The first, produced by `refresh_borg_binary_manifest.py --latest` plus the two things the script cannot know: the recomputed base-image tag and the upgrade wording.

**What b24 changes for borg-ui**

- **Repository format unchanged.** Verified live against a real 2.0.0b23 repository: b24 reads it (`repo-info`, `repo-list --json`, `list`, `extract`), writes into it (`create`), `check` passes, and b23 in turn reads the archive b24 wrote. `repo-info`/`repo-list`/`info` `--json` keep their shape.
- **Command surface borg-ui relies on:** `delete -a 'sh:*'` (contents wipe) and its no-filter guard behave as before; `repo-delete --force` still accepts the single flag (b24 made it a plain boolean). The removed prune date filters (`--oldest/--newest/--older/--newer`) are not used here.
- **Build requirement:** OpenSSL >= 3.2 (argon2 now comes from OpenSSL, argon2-cffi dropped). `python:3.12-slim` is trixie with OpenSSL 3.5, so `Dockerfile.runtime-base` needs no change beyond the ARG bump. borgstore stays `~= 0.6.1` with the `blake3` extra.
- **Our upstream report is fixed in this release.** The whole-pack loads on remote repositories that we measured and reported as borgbackup/borg#10204 (a 27-archive `repo-list --json` moving >1 GB per run) are gone at the source: borgbackup/borg#10207 makes the archive item-metadata chunk ids resolve lazily, merged 2026-08-25 (`336a862d`) and contained in the `2.0.0b24` tag. Our workaround was #854: the agent lists Borg 2 archives with `repo-list --json --format "{name}{id}{time}"`, which restricts the keys to what the server reads and keeps borg at the archives directory entries instead of every archive's metadata; the bounded pack cache from #881 (`BORG_STORE_CACHE=1`, `BORG_PACK_CACHE_SIZE`) was the second layer underneath it. With b24 a bare `repo-list --json` no longer loads packs, so neither is required for the listing any more. Both stay: the `--format` call is still the cheaper request, and the pack cache remains a deliberate default because it pays off on every repeated read (browse, info, check) over slow links, not only on the listing. The server-side `list_archives` in `app/core/borg2.py` never had the `--format` restriction, so that path is where b24 removes the remaining cost.

**Coverage regression (installer)**

> [!WARNING]
> borgbackup now builds its Linux binaries on Ubuntu 26.04: the glibc floor for a server-source agent install rises **2.39 -> 2.43** on x86_64 and aarch64. Ubuntu 24.04 (2.39) and Debian 13 (2.41) machines no longer get a server-source binary and fall back to `--borg-source distro`. The installer already reports this and names the fallback.

**Runtime-base image**

The base-image guard is red until the runtime-base image `runtime-borg1-1.4.5-borg2-2.0.0b24-r1` is built and pushed (same as #881).

**Second commit — `fix(agent-installer): name the glibc floor and a fallback that exists`** (CodeRabbit finding on this PR)

The installer's no-binary error suggested `--borg-source distro` for both majors, but `install_borg2` rejects that source because no distribution ships Borg 2 — so a machine below the floor had no way forward, and the message blamed "32-bit ARM or musl" when the real reason is glibc. Now:

- the message quotes the floor from the manifest (`Borg 2.0.0b24 for x86_64 needs glibc 2.43 or newer; this machine has glibc 2.39.`) — the number comes from the served manifest, never from the script;
- Borg 1 keeps the distribution fallback; Borg 2 is pointed at a self-managed install exposed as `borg2` — the name the agent resolves and the installer's forwarder would have provided (a bare pip install yields only `borg`). The printed commands (venv, `borgbackup` + `borgstore`, `borg2` symlink) are pinned to the server's version; when the server reports no version, no install command is printed at all;
- the "32-bit ARM or musl" line is reserved for architectures the manifest has no row for at all.

Four functional tests run the extracted shell functions under bash with an injected manifest table (Borg 2 below the floor, Borg 2 without a reported version, Borg 1 below the floor, architecture without binaries). `docs/managed-agents.md` gains a paragraph on the glibc requirement and the two fallbacks.

## Related Issue

None. Note on the watcher: `borg-binary-update.yml` detected the release path correctly, but its 2026-08-31 run failed with "GitHub Actions is not permitted to create or approve pull requests". Enabling *Allow GitHub Actions to create and approve pull requests* in the repository's Actions settings (or setting `BORG_BINARY_BOT_TOKEN`) lets future bumps arrive as PRs automatically.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

Version-derived unit tests, all green:

```
pytest tests/unit/test_borg_binaries.py tests/unit/test_agent_installer_api.py \
  tests/unit/test_borg_binary_manifest.py tests/unit/test_dockerfile_borg2_fuse.py \
  tests/unit/test_dockerfile_database_url.py tests/unit/test_container_runtime_docs.py \
  tests/unit/test_rclone_binary_version.py tests/unit/test_borg_cache_runtime.py \
  tests/unit/test_docker_port_runtime.py tests/unit/test_borg2.py \
  tests/unit/test_borg_env.py tests/unit/test_agent_runtime.py
======================= 194 passed, 60 warnings in 5.95s =======================
```

Installer tests after the second commit (29 passed, four of them run the shell functions under bash); the rendered script passes `bash -n` and `shellcheck -S warning`.

Live round trip with 2.0.0b23 and 2.0.0b24 installed side by side (from sdist):

```
### b23 repo-create + create            rc=0
### b24 repo-info                        {'encryption': 'aes256-ocb', 'id_hash': 'sha256'}  rc=0
### b24 repo-list --json                 [('arch1', '0bda745d'), ('arch2', 'fa7ea393')]     rc=0
### b24 list / extract --dry-run         rc=0
### b24 create arch3 (into b23 repo)     rc=0
### b23 reads b24-written archive        rc=0
### b24 check                            rc=0
### b24 delete --dry-run -a 'sh:*'       Would delete: arch1, arch2, arch3 (3/3)             rc=0
### b24 delete without filters (guard)   Command error: Aborting: if you really want to delete all archives ...  rc=4
### b24 repo-delete --force              rc=0
### b24 repo-create + b23 repo-list      rc=0
```

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

n/a

## Additional Context

The base-image check is expected to be red until the runtime-base image for b24 exists; everything else derives from `runtime-base.env` and stays green.

**Release recommendation.** When this lands, cut a new pre-release tag, `v2.3.0-alpha.2`, on the merge commit. The current `v2.3.0-alpha.1` (2026-08-16) predates both base-image changes: #881 moved the runtime to `runtime-borg1-1.4.5-borg2-2.0.0b23-r1`, this PR moves it to `runtime-borg1-1.4.5-borg2-2.0.0b24-r1`. A tag on this merge gives operators an unambiguous boundary: images at or after `v2.3.0-alpha.2` run on the b24 base image with its OpenSSL >= 3.2 build and the raised glibc floor for server-source agent installs (2.43); anything tagged `alpha.1` or `2.2.x` does not. It also makes the installer's manifest-derived messages traceable to a release instead of to a commit on `main`.

**Try it before merging (optional).** A public image built from this branch plus the other open PRs is available:

```
ghcr.io/ioanalytica/k8s-borg-ui@sha256:3a2ecd21166891dd14cfb7c9ff1d860868b6a6f778fd7a51eae5a91ca106435b
```

(also tagged `2.3.0-alpha.1`, but that tag has been moved before, so pin the digest). What is in it, precisely: borg-ui `b053fbd0` = `main` at `c7f32d1` + #906 + #910 + #916 + the two commits of this PR, built with this repo's own `Dockerfile` (`context: borg-ui`), multi-arch `linux/amd64` + `linux/arm64`. Three caveats so it is not mistaken for a test of this PR alone: it is the integration bundle, so a problem there cannot be attributed to #928 by itself; the base layer is our build of `Dockerfile.runtime-base` from the same `runtime-base.env` (`ghcr.io/ioanalytica/k8s-borg-ui-runtime-base:runtime-borg1-1.4.5-borg2-2.0.0b24-r1`), not the `ainullcode` artifact, so it exercises b24 at runtime but does not validate your base-image build; and the image carries our chart version in its OCI labels. It has been serving two RKE2 installations since 2026-09-05, one on x86-64 and one on aarch64, with Borg 1 and Borg 2 repositories, agents included.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU Affero General Public License v3.0 (AGPL-3.0), the same license as this project.


