### PR TITLE
docs: add a trust page for what Borg UI stores and sends

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -291,8 +291,13 @@ async def startup_event():
             except Exception as e:
                 logger.warning("Background licensing refresh failed", error=str(e))
 
+    # The same setting has to gate this loop, not just the startup call above.
+    # Spawning it unconditionally meant ENABLE_STARTUP_LICENSE_SYNC=false only
+    # delayed contact with the activation service by an hour instead of
+    # preventing it, so an instance could never actually be kept offline.
     global licensing_refresh_task
-    licensing_refresh_task = _spawn_background_task(licensing_refresh_loop())
+    if settings.enable_startup_license_sync:
+        licensing_refresh_task = _spawn_background_task(licensing_refresh_loop())
 
     # Create first user if no users exist
     await create_first_user()

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -75,6 +75,7 @@ export default defineConfig({
       {
         text: 'Security',
         items: [
+          { text: 'What We Do With Your Data', link: '/trust' },
           { text: 'Authentication and SSO', link: '/authentication' },
           { text: 'Access Control', link: '/access-control' },
           { text: 'Security', link: '/security' },

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -4,7 +4,7 @@ Borg UI has optional product analytics.
 
 It is used to understand broad product usage and error patterns. It should not include backup contents, Borg repository contents, passphrases, SSH keys, private hostnames, private IP addresses, or raw repository paths.
 
-Analytics is controlled by the consent banner after login. Users can change the setting later in Settings > Preferences.
+Analytics starts on. A banner after first login asks whether to keep it, and declining stops it from that point, though page views from before the answer are counted. Users can change the setting later in Settings > Preferences.
 
 ## Disable
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -319,7 +319,7 @@ requirements.
 | `ACTIVATION_TIMEOUT_SECONDS` | `10` | Activation request timeout |
 | `ENABLE_STARTUP_LICENSE_SYNC` | `true` in production | Sync license/full-access state at startup and hourly |
 
-Set `ENABLE_STARTUP_LICENSE_SYNC=false` to prevent all contact with the activation service, both at startup and on the hourly refresh.
+Set `ENABLE_STARTUP_LICENSE_SYNC=false` to stop all automatic contact with the activation service, both at startup and on the hourly refresh. Admin-initiated activation, deactivation, and refresh from Settings still contact it.
 
 ## Reverse Proxy Sub-Path
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -317,9 +317,9 @@ requirements.
 | --- | --- | --- |
 | `ACTIVATION_SERVICE_URL` | `https://license.borgui.com` | License activation endpoint |
 | `ACTIVATION_TIMEOUT_SECONDS` | `10` | Activation request timeout |
-| `ENABLE_STARTUP_LICENSE_SYNC` | `true` in production | Sync license/full-access state at startup |
+| `ENABLE_STARTUP_LICENSE_SYNC` | `true` in production | Sync license/full-access state at startup and hourly |
 
-Set `ENABLE_STARTUP_LICENSE_SYNC=false` to prevent startup contact with the activation service.
+Set `ENABLE_STARTUP_LICENSE_SYNC=false` to prevent all contact with the activation service, both at startup and on the hourly refresh.
 
 ## Reverse Proxy Sub-Path
 

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -34,7 +34,7 @@ disable both:
 ENABLE_STARTUP_LICENSE_SYNC=false
 ```
 
-With it set, the instance never reaches the activation service.
+With it set, the instance makes no automatic contact. Entering, refreshing, or removing a license key from Settings still reaches the service, since those actions cannot work otherwise.
 
 ## Enter a License
 

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -27,11 +27,14 @@ Startup license sync contacts:
 https://license.borgui.com
 ```
 
-To disable startup sync:
+Contact happens at startup and then on a background refresh every hour. To
+disable both:
 
 ```bash
 ENABLE_STARTUP_LICENSE_SYNC=false
 ```
+
+With it set, the instance never reaches the activation service.
 
 ## Enter a License
 
@@ -44,3 +47,5 @@ The app stores the effective plan locally and refreshes activation state when li
 The Community feature set does not require a license key.
 
 If you disable activation sync, plan upgrades and full-access activation cannot refresh automatically.
+
+What the instance sends when sync is enabled is listed in [What Borg UI Does With Your Data](trust).

--- a/docs/security.md
+++ b/docs/security.md
@@ -8,6 +8,10 @@ description: "Security practices for Borg UI deployments"
 
 Borg UI controls backup and restore operations. Treat it as sensitive infrastructure.
 
+This page is about hardening your deployment. For what the software itself stores,
+encrypts, and sends anywhere else, see
+[What Borg UI Does With Your Data](trust).
+
 ## First Steps
 
 After installation:

--- a/docs/trust.md
+++ b/docs/trust.md
@@ -75,30 +75,41 @@ Two things, both of which you can see and control.
 
 ### The license service
 
-Your instance talks to `https://license.borgui.com` to activate the 30-day full
-access period, to check a license key you entered, and to refresh entitlement
-state afterwards. Each request sends:
+Your instance talks to a license service to activate the 30-day full access
+period, to check a license key you entered, and to refresh entitlement state
+afterward. The endpoint defaults to `https://license.borgui.com` and is
+overridable with `ACTIVATION_SERVICE_URL`, so if you want to see the traffic or
+block it, point that at your own host or firewall the one you configured.
 
-| Field | Value |
+Four requests exist, and this is every field each one sends
+(`app/services/licensing_service.py`):
+
+| Request | Fields |
 | --- | --- |
-| `instance_id` | A random id generated on your instance |
-| `app` | The literal string `borg-ui` |
-| `app_version` | The version you are running |
-| `hostname` | The container's `HOSTNAME` environment variable |
-| `requested_plan` | The plan being asked for |
+| Full access activation (`/v1/trials/activate`) | `instance_id`, `app`, `app_version`, `hostname`, `fingerprint`, `requested_plan` |
+| Entitlement refresh (`/v1/entitlements/refresh`) | `instance_id`, `current_entitlement_id`, `app_version` |
+| License activation (`/v1/licenses/activate`) | `instance_id`, `license_key`, `app_version` |
+| License deactivation (`/v1/licenses/deactivate`) | `instance_id`, `license_id` |
 
-That is the whole payload (`app/services/licensing_service.py`). No repository
-names, no paths, no archive contents, no file names, no user accounts, no email
-addresses, and no authentication headers.
+`instance_id` is a random id generated on your instance. `hostname` is the
+container's `HOSTNAME` environment variable, and it is sent only by the first
+request. No authentication headers are attached to any of them.
+
+Nothing else is in these requests: no repository names, no paths, no archive
+contents, no file names, no user accounts, and no email addresses.
 
 Community does not need a license key and no feature is gated behind reaching
-this service. If the service is unreachable, Borg UI keeps working.
+this service. If it is unreachable, Borg UI keeps working.
 
-Contact happens at startup and then on a background refresh roughly every hour.
-`ENABLE_STARTUP_LICENSE_SYNC=false` currently suppresses only the startup call,
-not the background refresh, so it does not yet make an instance fully offline.
-If you need an instance that never reaches the network, block the host at your
-firewall until that setting covers both.
+To stop the contact entirely, set:
+
+```bash
+ENABLE_STARTUP_LICENSE_SYNC=false
+```
+
+That covers both the call at startup and the hourly refresh, so an instance
+with it set never reaches the license service. Plan upgrades and full-access
+activation then cannot refresh on their own.
 
 ### Usage analytics
 
@@ -107,9 +118,10 @@ usage. It is on by default and you can turn it off in Settings > Preferences.
 
 Before anything is sent, your real hostname and URL are replaced with
 `app.borgui`, so your private DNS names and IP addresses do not leave the
-browser. The identifier attached to a session is a hash of your install id and
-username, not the username itself. See `frontend/src/utils/analytics.ts` and
-[Analytics](analytics).
+browser. The script tag is loaded with `referrerpolicy="no-referrer"` so the
+request that fetches it cannot carry the origin either. The identifier attached
+to a session is a hash of your install id and username, not the username
+itself. See `frontend/src/utils/analytics.ts` and [Analytics](analytics).
 
 Nothing else phones home. No crash reporting, no error telemetry, no update
 beacon.

--- a/docs/trust.md
+++ b/docs/trust.md
@@ -119,7 +119,10 @@ service at all, block it at your firewall.
 ### Usage analytics
 
 The web UI loads [Umami](https://umami.is) to count page views and feature
-usage. It is on by default and you can turn it off in Settings > Preferences.
+usage. It starts on, and a banner on first login asks whether to keep it.
+Declining stops it from that point, and you can change the answer whenever you
+like in Settings > Preferences. Page views from that first session, before you
+answer the banner, are counted.
 
 Before anything is sent, your real hostname and URL are replaced with
 `app.borgui`, so your private DNS names and IP addresses do not leave the

--- a/docs/trust.md
+++ b/docs/trust.md
@@ -1,0 +1,136 @@
+---
+title: What Borg UI Does With Your Data
+nav_order: 8
+description: "What Borg UI stores, what it encrypts, and what leaves your machine"
+---
+
+# What Borg UI Does With Your Data
+
+Borg UI holds the keys to your backups. Before you install it, you should know
+what it keeps, what it protects, and what it sends anywhere else.
+
+Everything on this page is checkable. Borg UI is AGPL-3.0 and the whole source
+tree is public, so every claim below names the file that implements it. If a
+claim and the code disagree, the code is right and this page is a bug.
+
+For hardening a deployment (TLS, the Docker socket, reverse proxies, `/metrics`),
+see [Security](security). This page is about the software itself.
+
+## Secrets Are Encrypted At Rest
+
+Your Borg repository passphrase is encrypted in the database, not stored in
+plain text. So are the other secrets the app holds:
+
+| Secret | Where |
+| --- | --- |
+| Borg repository passphrase | `repositories.passphrase` |
+| SSH private keys | SSH key storage |
+| Two-factor (TOTP) secrets | `users.totp_secret_encrypted` |
+| OIDC client secret and cached ID tokens | OIDC settings, session rows |
+| Cloud provider OAuth client secrets | Google Drive, OneDrive settings |
+| Password-type script parameters | Script parameter values |
+
+Encryption is Fernet (AES-128-CBC with an HMAC), keyed from the instance's
+`SECRET_KEY`. See `EncryptedString` in `app/database/models.py` and
+`encrypt_secret` in `app/core/security.py`.
+
+**What this protects against:** someone who reads a copy of the database, such
+as a stolen backup of `/data`, a leaked volume snapshot, or an SQL injection
+that dumps a table.
+
+**What it does not protect against:** someone who has your whole `/data`
+directory. The key is derived from `SECRET_KEY`, which is generated into `/data`
+on first boot, so an attacker holding all of `/data` holds the key as well.
+Treat `/data` as being exactly as sensitive as the backups it can restore, and
+set `SECRET_KEY` yourself if you want the key to live somewhere else.
+
+## SSH Hosts Are Verified
+
+Every SSH connection Borg UI makes verifies the remote host's key. Connecting
+to a machine whose key does not match the one on record fails; it is never
+accepted silently.
+
+The model is OpenSSH's own trust on first use:
+
+- **New connections.** When you add a remote machine, Borg UI shows you the
+  host's fingerprint and asks you to confirm it before storing it. The
+  fingerprint shown matches `ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub`
+  on the host exactly, so you can compare the two.
+- **Connections that predate this feature.** Those were already running with no
+  verification at all. Rather than break every existing install on upgrade, the
+  key in use is recorded on first contact after the upgrade.
+- **Either way, a key that changes later is refused** and you have to
+  re-verify before the connection works again.
+
+The recorded key is stored on the connection row and is visible in the UI, so
+you can see what your instance trusts. See `app/utils/ssh_host_keys.py`.
+
+Before this shipped, every SSH invocation passed `StrictHostKeyChecking=no`
+with `UserKnownHostsFile=/dev/null`, meaning anything that answered on the
+address was trusted. If you are running an older version, upgrade.
+
+## What Leaves Your Machine
+
+Two things, both of which you can see and control.
+
+### The license service
+
+Your instance talks to `https://license.borgui.com` to activate the 30-day full
+access period, to check a license key you entered, and to refresh entitlement
+state afterwards. Each request sends:
+
+| Field | Value |
+| --- | --- |
+| `instance_id` | A random id generated on your instance |
+| `app` | The literal string `borg-ui` |
+| `app_version` | The version you are running |
+| `hostname` | The container's `HOSTNAME` environment variable |
+| `requested_plan` | The plan being asked for |
+
+That is the whole payload (`app/services/licensing_service.py`). No repository
+names, no paths, no archive contents, no file names, no user accounts, no email
+addresses, and no authentication headers.
+
+Community does not need a license key and no feature is gated behind reaching
+this service. If the service is unreachable, Borg UI keeps working.
+
+Contact happens at startup and then on a background refresh roughly every hour.
+`ENABLE_STARTUP_LICENSE_SYNC=false` currently suppresses only the startup call,
+not the background refresh, so it does not yet make an instance fully offline.
+If you need an instance that never reaches the network, block the host at your
+firewall until that setting covers both.
+
+### Usage analytics
+
+The web UI loads [Umami](https://umami.is) to count page views and feature
+usage. It is on by default and you can turn it off in Settings > Preferences.
+
+Before anything is sent, your real hostname and URL are replaced with
+`app.borgui`, so your private DNS names and IP addresses do not leave the
+browser. The identifier attached to a session is a hash of your install id and
+username, not the username itself. See `frontend/src/utils/analytics.ts` and
+[Analytics](analytics).
+
+Nothing else phones home. No crash reporting, no error telemetry, no update
+beacon.
+
+### What never leaves
+
+Your backup data. Borg UI runs `borg` against your repositories on your
+infrastructure. Archive contents, file names, and repository paths are never
+transmitted anywhere. There is no cloud component in the backup path.
+
+## Your Keys Keep Working
+
+- Borg UI is AGPL-3.0. You can read it, fork it, patch it, and run your fork.
+- Repositories are ordinary Borg repositories. If Borg UI disappears tomorrow,
+  `borg list`, `borg extract`, and `borg mount` still work against them from
+  the command line. There is no proprietary format and no lock-in.
+- A license key is a signed document validated on your instance. It is not a
+  runtime permission slip fetched from us on every action.
+
+## Reporting a Vulnerability
+
+Report security issues privately through
+[GitHub security advisories](https://github.com/karanhudia/borg-ui/security/advisories/new)
+rather than a public issue.

--- a/docs/trust.md
+++ b/docs/trust.md
@@ -107,9 +107,14 @@ To stop the contact entirely, set:
 ENABLE_STARTUP_LICENSE_SYNC=false
 ```
 
-That covers both the call at startup and the hourly refresh, so an instance
-with it set never reaches the license service. Plan upgrades and full-access
-activation then cannot refresh on their own.
+That covers both the call at startup and the hourly refresh, so the instance
+stops contacting the service on its own. Plan upgrades and full-access
+activation then cannot refresh automatically.
+
+What remains is only contact you start yourself: entering a license key,
+refreshing it, or removing it from Settings, all admin-only actions that do
+nothing until you take them. If you want an instance that cannot reach the
+service at all, block it at your firewall.
 
 ### Usage analytics
 

--- a/frontend/src/utils/__tests__/analytics.test.ts
+++ b/frontend/src/utils/__tests__/analytics.test.ts
@@ -15,6 +15,7 @@ import {
   trackConsentResponse,
   trackLanguageChange,
   getOrCreateInstallId,
+  initAnalyticsIfEnabled,
   resetOptOutCache,
   anonymizeEntityName,
   EventCategory,
@@ -159,6 +160,32 @@ describe('analytics (umami)', () => {
       )
       expect(arePreferencesLoaded()).toBe(true)
       expect(hasConsentBeenGiven()).toBe(true)
+    })
+  })
+
+  describe('initAnalyticsIfEnabled', () => {
+    it('loads the Umami script with no referrer so the origin never leaves', async () => {
+      Storage.prototype.getItem = vi.fn().mockReturnValue(null)
+      getAuthConfigMock.mockResolvedValueOnce({
+        data: { proxy_auth_enabled: false, insecure_no_auth_enabled: true },
+      })
+      fetchJsonForAuthModeMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          preferences: { analytics_enabled: true, analytics_consent_given: true },
+        }),
+      } as Response)
+
+      await loadUserPreference()
+      initAnalyticsIfEnabled()
+
+      const script = document.head.querySelector<HTMLScriptElement>(
+        'script[src="https://cloud.umami.is/script.js"]'
+      )
+      expect(script).not.toBeNull()
+      // Without this the browser attaches the instance's own origin to the
+      // request, which is exactly what the payload masking exists to prevent.
+      expect(script?.referrerPolicy).toBe('no-referrer')
     })
   })
 

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -68,6 +68,10 @@ const initUmamiScript = (): void => {
 
   const script = document.createElement('script')
   script.defer = true
+  // Without this the browser attaches the instance's own origin to the script
+  // request, which hands Umami the private hostname the payload masking exists
+  // to keep from it.
+  script.referrerPolicy = 'no-referrer'
   script.src = UMAMI_SCRIPT_URL
   script.setAttribute('data-website-id', UMAMI_WEBSITE_ID)
   // Disable auto page tracking — we handle it via trackPageView so it respects opt-out

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -117,9 +117,7 @@ class TestStartupEvent:
             cache_max_size_mb=128,
         )
 
-    async def test_background_license_refresh_uses_runtime_version_when_startup_sync_disabled(
-        self, mock_db
-    ):
+    async def test_background_license_refresh_uses_runtime_version(self, mock_db):
         """The refresh loop should not close over an undefined app_version."""
         mock_settings = Mock()
         mock_settings.redis_url = None
@@ -142,7 +140,8 @@ class TestStartupEvent:
         with (
             patch("app.core.security.create_first_user", new_callable=AsyncMock),
             patch("app.database.db_upgrade.ensure_schema"),
-            patch("app.main.settings.enable_startup_license_sync", False),
+            patch("app.main.settings.enable_startup_license_sync", True),
+            patch("app.main.sync_licensing_state", new_callable=AsyncMock),
             patch("app.database.database.SessionLocal", return_value=mock_db),
             patch("app.main.get_runtime_app_version", return_value="9.9.9"),
             patch(
@@ -172,6 +171,65 @@ class TestStartupEvent:
             assert captured_refresh_coro.cr_frame is not None
             assert captured_refresh_coro.cr_frame.f_locals["app_version"] == "9.9.9"
             captured_refresh_coro.close()
+
+    async def test_no_background_license_refresh_when_startup_sync_disabled(
+        self, mock_db
+    ):
+        """ENABLE_STARTUP_LICENSE_SYNC=false has to keep the instance offline.
+
+        The loop used to be spawned unconditionally, so the setting only
+        delayed the first call to the activation service by an hour.
+        """
+        mock_settings = Mock()
+        mock_settings.redis_url = None
+        mock_settings.log_cleanup_on_startup = False
+        mock_settings.mqtt_enabled = False
+        mock_settings.mqtt_beta_enabled = False
+        mock_db.query.return_value.first.return_value = mock_settings
+
+        spawned_coro_names = []
+
+        def fake_spawn_background_task(coro):
+            spawned_coro_names.append(
+                getattr(getattr(coro, "cr_code", None), "co_name", "")
+            )
+            coro.close()
+            return Mock()
+
+        sync = AsyncMock()
+
+        with (
+            patch("app.core.security.create_first_user", new_callable=AsyncMock),
+            patch("app.database.db_upgrade.ensure_schema"),
+            patch("app.main.settings.enable_startup_license_sync", False),
+            patch("app.main.sync_licensing_state", sync),
+            patch("app.database.database.SessionLocal", return_value=mock_db),
+            patch("app.main.get_runtime_app_version", return_value="9.9.9"),
+            patch(
+                "app.main._spawn_background_task",
+                side_effect=fake_spawn_background_task,
+            ),
+            patch("app.services.cache_service.archive_cache"),
+            patch("app.core.borg.borg.get_system_info", new_callable=AsyncMock),
+            patch("app.services.backup_service.backup_service"),
+            patch("app.utils.process_utils.cleanup_orphaned_jobs"),
+            patch("app.utils.process_utils.cleanup_orphaned_mounts"),
+            patch("app.api.schedule.check_scheduled_jobs", return_value=AsyncMock()),
+            patch("app.services.operations.runner.operation_runner"),
+            patch("app.services.operations.reconcile.reconcile_scheduler"),
+            patch(
+                "app.services.mqtt_sync_scheduler.start_mqtt_sync_scheduler",
+                return_value=AsyncMock(),
+            ),
+            patch("asyncio.create_task"),
+        ):
+            from app.main import startup_event, app
+
+            app.state.background_tasks = []
+            await startup_event()
+
+        assert "licensing_refresh_loop" not in spawned_coro_names
+        sync.assert_not_awaited()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Why

`docs/security.md` is an operator hardening guide: TLS, the Docker socket, `/metrics`, reverse proxies. It answers "how do I run this safely". It does not answer "what does this software do with my repository passphrase", which is the question someone asks *before* they install it, and the one the growth plan needs a page for.

Both code gaps found while verifying the planned claims are now closed (#918 passphrase at rest, #919 SSH host-key verification), so the page can finally make them.

## The page

`docs/trust.md`, linked first in the Security sidebar section, with `docs/security.md` pointing at it. Every claim names the file that implements it so a reader can check it instead of trusting us:

- **Secrets encrypted at rest**, with the limit stated: the Fernet key is derived from `SECRET_KEY`, which is generated into `/data`, so whoever has all of `/data` has the key. Saying "encrypted at rest" without that would be the misleading half of a true sentence.
- **SSH host keys verified** on every connection, how new connections differ from ones that predate #919, and that a changed key is always refused.
- **The license service**: the default endpoint and its `ACTIVATION_SERVICE_URL` override, then a row per request listing every field it sends.
- **Analytics**: opt-out, where the toggle is, the hostname masking, and the referrer policy.
- **Backup data never leaves.** Repositories stay plain Borg repositories, so `borg extract` works without this app.

## Two code fixes the page forced

Writing a page that says "check us against the code" is a good way to find out where the code does not deserve the claim. Two places did not, and both moved rather than being written around.

**`ENABLE_STARTUP_LICENSE_SYNC=false` did not stop license traffic.** `licensing_refresh_loop` was spawned outside the flag's branch in `app/main.py`, so the setting delayed the first call to the activation service by an hour instead of preventing it, and no instance could actually be kept offline. The loop is now gated on the same setting.

The existing regression test for the loop's `app_version` closure ran on the sync-disabled path, which no longer spawns a loop, so it moves to the enabled path; a new test covers the disabled one. Verified it fails without the fix.

**The Umami script tag leaked the origin.** `trackPageView` masks the hostname to `app.borgui` in the payload, but the `script.js` request itself carried the real origin under the browser default `strict-origin-when-cross-origin`. A self-hosted instance therefore handed Umami exactly the private hostname the masking exists to hide. Now loaded with `referrerpolicy="no-referrer"`, with a test that fails when the line is removed.

`docs/configuration.md` and `docs/licensing.md` are updated to match the new behaviour of the flag.

## Verification

- `pytest tests/unit/test_main.py` — 14 passed. Both new assertions confirmed non-vacuous by reverting each fix and watching them fail.
- `vitest run src/utils/__tests__/analytics.test.ts` — 37 passed, same check done on the referrer test.
- `tsc --noEmit`, `oxlint --deny-warnings`, `prettier --check`, `ruff check`, `ruff format --check` all clean.
- `npx vitepress build .` passes; VitePress fails the build on dead links, so the internal links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 24 changed, 0 added, 0 removed, 666 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-938/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/34055775830
<details>
<summary>Changed files</summary>
- `components-repositorycard--default--mobile.png` (0.20%)
- `components-repositorycard--default.png` (0.21%)
- `components-repositorycard--enable-cloud-mirror--mobile.png` (0.20%)
- `components-repositorycard--enable-cloud-mirror-for-ssh--mobile.png` (0.20%)
- `components-repositorycard--enable-cloud-mirror-for-ssh.png` (0.21%)
- `components-repositorycard--enable-cloud-mirror.png` (0.21%)
- `components-repositorycard--managed-agent-mirror-pending--mobile.png` (0.20%)
- `components-repositorycard--managed-agent-mirror-pending.png` (0.21%)
- `components-repositorycard--rclone-failed--mobile.png` (0.20%)
- `components-repositorycard--rclone-failed.png` (0.21%)
- `components-repositorycard--rclone-hydration-required--mobile.png` (0.20%)
- `components-repositorycard--rclone-hydration-required.png` (0.21%)
- `components-repositorycard--rclone-scheduled--mobile.png` (0.20%)
- `components-repositorycard--rclone-scheduled-failed--mobile.png` (0.20%)
- `components-repositorycard--rclone-scheduled-failed.png` (0.21%)
- `components-repositorycard--rclone-scheduled.png` (0.21%)
- `components-repositorycard--rclone-synced--mobile.png` (0.20%)
- `components-repositorycard--rclone-synced.png` (0.21%)
- `components-repositorycard--remote-repository-without-permanent-delete--mobile.png` (0.20%)
- `components-repositorycard--remote-repository-without-permanent-delete.png` (0.21%)
- `components-repositorycard--with-upload-limit--mobile.png` (0.20%)
- `components-repositorycard--with-upload-limit.png` (0.21%)
- `components-repositorycard--without-break-lock-access--mobile.png` (0.20%)
- `components-repositorycard--without-break-lock-access.png` (0.21%)
</details>
<details>
<summary>New screenshots</summary>
- None
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->