### PR TITLE
fix(storybook): give every story a router so components render

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -2,10 +2,15 @@ import type { Preview } from '@storybook/react-vite'
 import CssBaseline from '@mui/material/CssBaseline'
 import { ThemeProvider } from '@mui/material/styles'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
 import '../src/i18n'
 import '../src/index.css'
 import { getTheme } from '../src/theme'
 import type { SystemInfo } from '../src/hooks/useSystemInfo'
+
+type RouterParameters = {
+  initialEntries?: string[]
+}
 
 function createStoryQueryClient(systemInfo?: SystemInfo) {
   const queryClient = new QueryClient({
@@ -28,12 +33,19 @@ const preview: Preview = {
   decorators: [
     (Story, context) => {
       const systemInfo = context.parameters.systemInfo as SystemInfo | undefined
+      // Every story gets a router: components reach useNavigate/useLocation
+      // through children (RepositoryCard does), and without one they render
+      // Storybook's error page instead of the component. Stories that need a
+      // specific location set parameters.router.initialEntries.
+      const router = context.parameters.router as RouterParameters | undefined
 
       return (
         <ThemeProvider theme={getTheme('light')}>
           <CssBaseline />
           <QueryClientProvider client={createStoryQueryClient(systemInfo)}>
-            <Story />
+            <MemoryRouter initialEntries={router?.initialEntries ?? ['/']}>
+              <Story />
+            </MemoryRouter>
           </QueryClientProvider>
         </ThemeProvider>
       )

--- a/frontend/src/components/AppSidebar.stories.tsx
+++ b/frontend/src/components/AppSidebar.stories.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState, type ReactNode } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import MockAdapter from 'axios-mock-adapter'
 import { Box } from '@mui/material'
-import { BrowserRouter } from 'react-router-dom'
 import AppSidebar from './AppSidebar'
 import { AppProvider } from '../context/AppContext'
 import { AuthProvider } from '../hooks/useAuth'
@@ -76,13 +75,11 @@ function SidebarStoryProviders({
   if (!isReady) return null
 
   return (
-    <BrowserRouter>
-      <RemoteBackendProvider>
-        <AuthProvider>
-          <AppProvider>{children}</AppProvider>
-        </AuthProvider>
-      </RemoteBackendProvider>
-    </BrowserRouter>
+    <RemoteBackendProvider>
+      <AuthProvider>
+        <AppProvider>{children}</AppProvider>
+      </AuthProvider>
+    </RemoteBackendProvider>
   )
 }
 
@@ -106,6 +103,9 @@ const meta = {
   parameters: {
     layout: 'fullscreen',
     systemInfo: proSystemInfo,
+    // The sidebar highlights the active nav item from useLocation, so pin the
+    // story to a real route instead of the router's default '/'.
+    router: { initialEntries: ['/dashboard'] },
   },
 } satisfies Meta<typeof AppSidebar>
 

--- a/frontend/src/components/ArchiveContentsDialog.stories.tsx
+++ b/frontend/src/components/ArchiveContentsDialog.stories.tsx
@@ -2,7 +2,6 @@ import { useEffect, type ComponentProps } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import MockAdapter from 'axios-mock-adapter'
 import ArchiveContentsDialog from './ArchiveContentsDialog'
-import { MemoryRouter } from 'react-router-dom'
 import { httpClient, type Repository } from '../services/borgApi/client'
 import type { Archive } from '../types'
 import type { ArchiveRow } from '../types/archives'
@@ -95,9 +94,5 @@ export const WithFullPageLink: Story = {
     storedArchives: [storedArchive],
     onClose: () => {},
   },
-  render: (args) => (
-    <MemoryRouter>
-      <AwaitingAgentStory {...args} />
-    </MemoryRouter>
-  ),
+  render: (args) => <AwaitingAgentStory {...args} />,
 }

--- a/frontend/src/components/BackendTargetSwitcher.stories.tsx
+++ b/frontend/src/components/BackendTargetSwitcher.stories.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState, type ReactNode } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import MockAdapter from 'axios-mock-adapter'
 import { Box } from '@mui/material'
-import { BrowserRouter } from 'react-router-dom'
 import BackendTargetSwitcher from './BackendTargetSwitcher'
 import { AuthProvider } from '../hooks/useAuth'
 import api from '../services/api'
@@ -70,11 +69,9 @@ function SwitcherStoryProviders({
   if (!isReady) return null
 
   return (
-    <BrowserRouter>
-      <RemoteBackendStoryProvider state={state}>
-        <AuthProvider>{children}</AuthProvider>
-      </RemoteBackendStoryProvider>
-    </BrowserRouter>
+    <RemoteBackendStoryProvider state={state}>
+      <AuthProvider>{children}</AuthProvider>
+    </RemoteBackendStoryProvider>
   )
 }
 

--- a/frontend/src/components/BackgroundWorkTab.stories.tsx
+++ b/frontend/src/components/BackgroundWorkTab.stories.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState, type ReactNode } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import MockAdapter from 'axios-mock-adapter'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { MemoryRouter } from 'react-router-dom'
 import { Box } from '@mui/material'
 import BackgroundWorkTab from './BackgroundWorkTab'
 import { AuthProvider } from '../hooks/useAuth'
@@ -104,11 +103,9 @@ function StoryProviders({
     <QueryClientProvider
       client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
     >
-      <MemoryRouter>
-        <RemoteBackendProvider>
-          <AuthProvider>{children}</AuthProvider>
-        </RemoteBackendProvider>
-      </MemoryRouter>
+      <RemoteBackendProvider>
+        <AuthProvider>{children}</AuthProvider>
+      </RemoteBackendProvider>
     </QueryClientProvider>
   )
 }

--- a/frontend/src/components/activity/RepositoryScopeSelect.stories.tsx
+++ b/frontend/src/components/activity/RepositoryScopeSelect.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { MemoryRouter } from 'react-router-dom'
 import { Box } from '@mui/material'
 import RepositoryScopeSelect from './RepositoryScopeSelect'
 
@@ -14,11 +13,9 @@ const meta: Meta<typeof RepositoryScopeSelect> = {
       <QueryClientProvider
         client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
       >
-        <MemoryRouter>
-          <Box sx={{ width: 320 }}>
-            <Story />
-          </Box>
-        </MemoryRouter>
+        <Box sx={{ width: 320 }}>
+          <Story />
+        </Box>
       </QueryClientProvider>
     ),
   ],

--- a/frontend/src/components/background-work/PipelineBoard.stories.tsx
+++ b/frontend/src/components/background-work/PipelineBoard.stories.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState, type ReactNode } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import MockAdapter from 'axios-mock-adapter'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { MemoryRouter } from 'react-router-dom'
 import { Box } from '@mui/material'
 import PipelineBoard from './PipelineBoard'
 import api from '../../services/api'
@@ -44,9 +43,7 @@ function StoryProviders({
     <QueryClientProvider
       client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
     >
-      <MemoryRouter>
-        <Box sx={{ p: 3 }}>{children}</Box>
-      </MemoryRouter>
+      <Box sx={{ p: 3 }}>{children}</Box>
     </QueryClientProvider>
   )
 }

--- a/frontend/src/components/background-work/RepositoryHubRow.stories.tsx
+++ b/frontend/src/components/background-work/RepositoryHubRow.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { MemoryRouter } from 'react-router-dom'
 import { Box } from '@mui/material'
 import RepositoryHubRow from './RepositoryHubRow'
 import { deriveTrack } from './repositoryTrack'
@@ -16,11 +15,9 @@ const meta = {
   parameters: { layout: 'fullscreen' },
   decorators: [
     (Story) => (
-      <MemoryRouter>
-        <Box sx={{ p: 3, maxWidth: 1100 }}>
-          <Story />
-        </Box>
-      </MemoryRouter>
+      <Box sx={{ p: 3, maxWidth: 1100 }}>
+        <Story />
+      </Box>
     ),
   ],
   args: {

--- a/frontend/src/components/background-work/RepositoryTrackDialog.stories.tsx
+++ b/frontend/src/components/background-work/RepositoryTrackDialog.stories.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import MockAdapter from 'axios-mock-adapter'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { MemoryRouter } from 'react-router-dom'
 import { Button } from '@mui/material'
 import RepositoryTrackDialog from './RepositoryTrackDialog'
 import api from '../../services/api'
@@ -24,19 +23,17 @@ function Wrapper({ detail }: { detail: HubRepositoryDetail }) {
     <QueryClientProvider
       client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
     >
-      <MemoryRouter>
-        <Button onClick={() => setOpen(true)}>Open</Button>
-        <RepositoryTrackDialog
-          open={open}
-          onClose={() => setOpen(false)}
-          repositoryId={4}
-          repositoryName="laptop"
-          operations={[
-            op({ kind: 'stats', status: 'completed' }),
-            op({ id: 2, kind: 'archive_sync', status: 'running' }),
-          ]}
-        />
-      </MemoryRouter>
+      <Button onClick={() => setOpen(true)}>Open</Button>
+      <RepositoryTrackDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        repositoryId={4}
+        repositoryName="laptop"
+        operations={[
+          op({ kind: 'stats', status: 'completed' }),
+          op({ id: 2, kind: 'archive_sync', status: 'running' }),
+        ]}
+      />
     </QueryClientProvider>
   )
 }

--- a/frontend/src/pages/activity/RepositoryOperationsView.stories.tsx
+++ b/frontend/src/pages/activity/RepositoryOperationsView.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { MemoryRouter } from 'react-router-dom'
 import { Box } from '@mui/material'
 import RepositoryOperationsView from './RepositoryOperationsView'
 
@@ -20,11 +19,9 @@ export const Default: Story = {
     <QueryClientProvider
       client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
     >
-      <MemoryRouter>
-        <Box sx={{ p: 3 }}>
-          <RepositoryOperationsView repositoryId={1} />
-        </Box>
-      </MemoryRouter>
+      <Box sx={{ p: 3 }}>
+        <RepositoryOperationsView repositoryId={1} />
+      </Box>
     </QueryClientProvider>
   ),
 }


### PR DESCRIPTION
## Problem

`frontend/.storybook/preview.tsx` wrapped every story in `ThemeProvider` + `CssBaseline` + `QueryClientProvider`, but no router. Any story whose tree calls a react-router hook rendered Storybook's error page instead of the component:

> useNavigate() may be used only in the context of a `<Router>` component.

This is not a new regression. The visual-regression baseline on `main` already contains that error page, so those snapshots are baselines of an error, and real visual changes in those components have been passing silently.

## Fix

- `MemoryRouter` (react-router-dom 7.18, the version the app already uses) added inside the existing global decorator, so every story gets one.
- Opt-in `parameters.router.initialEntries` for stories that need a specific location. `AppSidebar` uses it to pin to `/dashboard`, since it highlights the active nav item from `useLocation`; on the router default `/` nothing would be active.
- Nine stories that supplied their own `MemoryRouter` / `BrowserRouter` drop it. react-router throws `You cannot render a <Router> inside another <Router>`, so the local wrappers had to go rather than stay alongside the global one.

## Verification

All 345 stories were rendered from a Storybook build and scanned for the router error, before and after:

| | stories showing the error page |
|---|---|
| before | 12 |
| after | 0 |

The 12 were all `Components/RepositoryCard` (`--default`, `--rclone-synced`, `--enable-cloud-mirror`, and 9 more), which is 24 snapshots across the two viewports. `RepositoryCard` calls `useNavigate` directly at `frontend/src/components/RepositoryCard.tsx:111`.

`components-repositorycard--default` before the fix rendered the error text above; after the fix it renders the card ("Production Archive", "ARCHIVES 128", "TOTAL SIZE 842.6 GB", "Enable cloud mirror", ...).

`npm run lint`, `npm run typecheck` and `npx vitest run` (223 files, 2573 tests) all pass.

## Expected visual diff (this is the point, not a regression)

Expect a large visual diff on this PR across roughly 24 snapshots: the Storybook error page turning into the actual `RepositoryCard`. That diff is the evidence the fix worked. `AppSidebar` also changes, gaining an active-state highlight on Dashboard.

No baselines were regenerated or committed here. `.github/workflows/visual-regression.yml` runs in baseline mode on pushes to `main` and replaces `visual-state/visual/baseline` from its own run, so the baseline re-cuts itself once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 26 changed, 0 added, 0 removed, 664 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-942/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/34056819887
<details>
<summary>Changed files</summary>
- `components-appsidebar--community-plan.png` (0.89%)
- `components-appsidebar--with-remote-clients.png` (0.89%)
- `components-repositorycard--default--mobile.png` (79.59%)
- `components-repositorycard--default.png` (96.50%)
- `components-repositorycard--enable-cloud-mirror--mobile.png` (79.61%)
- `components-repositorycard--enable-cloud-mirror-for-ssh--mobile.png` (79.83%)
- `components-repositorycard--enable-cloud-mirror-for-ssh.png` (96.55%)
- `components-repositorycard--enable-cloud-mirror.png` (96.55%)
- `components-repositorycard--managed-agent-mirror-pending--mobile.png` (77.94%)
- `components-repositorycard--managed-agent-mirror-pending.png` (95.97%)
- `components-repositorycard--rclone-failed--mobile.png` (79.99%)
- `components-repositorycard--rclone-failed.png` (96.52%)
- `components-repositorycard--rclone-hydration-required--mobile.png` (80.24%)
- `components-repositorycard--rclone-hydration-required.png` (96.61%)
- `components-repositorycard--rclone-scheduled--mobile.png` (78.92%)
- `components-repositorycard--rclone-scheduled-failed--mobile.png` (78.65%)
- `components-repositorycard--rclone-scheduled-failed.png` (96.72%)
- `components-repositorycard--rclone-scheduled.png` (95.83%)
- `components-repositorycard--rclone-synced--mobile.png` (79.90%)
- `components-repositorycard--rclone-synced.png` (96.51%)
- `components-repositorycard--remote-repository-without-permanent-delete--mobile.png` (79.80%)
- `components-repositorycard--remote-repository-without-permanent-delete.png` (96.56%)
- `components-repositorycard--with-upload-limit--mobile.png` (79.40%)
- `components-repositorycard--with-upload-limit.png` (96.57%)
- `components-repositorycard--without-break-lock-access--mobile.png` (79.56%)
- `components-repositorycard--without-break-lock-access.png` (96.50%)
</details>
<details>
<summary>New screenshots</summary>
- None
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->