### PR TITLE
fix(operations): index chain gives agent repositories stats and per-archive info

### DIFF
--- a/app/services/operations/executors/index.py
+++ b/app/services/operations/executors/index.py
@@ -3,9 +3,11 @@ Series inference follows spec 6.6 through `app.services.operations.series`.
 """
 
 import json
+import re
 from typing import Iterable, Optional, Sequence
 
 import structlog
+from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.api.repositories import (
@@ -21,7 +23,7 @@ from app.config import settings
 from app.core.borg_router import BorgRouter
 from app.database.models import Archive, Repository, SystemSettings, utc_now
 from app.services.operations import executors
-from app.services.operations.runner import Outcome
+from app.services.operations.runner import Outcome, repository_busy
 from app.services.operations.series import infer_series, series_prefixes_for_repository
 from app.services.repository_command_lock import run_serialized_repository_command
 from app.services.repository_executor import is_agent_executor
@@ -119,6 +121,11 @@ def apply_listing(
         else:
             for key, value in fields.items():
                 if key == "borg_id":
+                    continue
+                if key == "end" and value is None:
+                    # listings carry no end (`borg info` does): keep the
+                    # value fill_archive_info stored instead of wiping it
+                    # on every sync
                     continue
                 if key == "series" and value != row.series:
                     row.history_state = "pending"
@@ -229,26 +236,147 @@ def _info_stats(payload: str) -> Optional[dict]:
     }
 
 
+_UTC_OFFSET_SUFFIX = re.compile(r"(Z|[+-]\d{2}:?\d{2})$")
+
+
+def _carries_utc_offset(value: object) -> bool:
+    """True for ISO timestamps with an explicit offset (Borg 2 output)."""
+    return isinstance(value, str) and _UTC_OFFSET_SUFFIX.search(value) is not None
+
+
+def archive_end_resolvable(db: Session, repository: Repository) -> bool:
+    """False while a naive Borg 1 time from this repository has no zone to
+    be read in: an agent repository whose agent never reported one. Server
+    listings run under TZ=UTC and Borg 2 renders an offset, so only that
+    case is unresolvable."""
+    if not is_agent_executor(repository):
+        return True
+    return bool(agent_timezone_for_repository(db, repository))
+
+
 def archives_needing_info(
-    db: Session, repository: Repository, *, limit: int
+    db: Session,
+    repository: Repository,
+    *,
+    limit: int,
+    include_missing_end: bool = False,
 ) -> list[Archive]:
     """Archives still missing their `borg info` stats, oldest first.
 
     Not just the rows this run created: a repository imported with more
     archives than `INDEX_ARCHIVE_INFO_PER_RUN` fills the oldest few now and
     the rest on later runs, which is what the per-run cap is for (spec 6.4).
+
+    `include_missing_end` also picks rows whose sizes are set but whose
+    `end` is not (fill_archive_info withheld a naive end while the agent's
+    zone was unknown), but only into the slots the rows without sizes leave
+    free: a row whose end can never be parsed costs at most a spare slot per
+    run and never displaces an archive that has no stats at all.
     """
     if limit <= 0:
         return []
-    return (
-        db.query(Archive)
-        .filter(
-            Archive.repository_id == repository.id,
-            Archive.original_size.is_(None),
+
+    def _select(predicate, exclude_ids: set[int], n: int) -> list[Archive]:
+        q = db.query(Archive).filter(Archive.repository_id == repository.id, predicate)
+        if exclude_ids:
+            q = q.filter(Archive.id.notin_(exclude_ids))
+        return q.order_by(Archive.start.asc()).limit(n).all()
+
+    rows = _select(Archive.original_size.is_(None), set(), limit)
+    spare = limit - len(rows)
+    if include_missing_end and spare > 0:
+        rows += _select(Archive.end.is_(None), {a.id for a in rows}, spare)
+    return rows
+
+
+class AgentUnavailable(RuntimeError):
+    """The agent did not answer a per-archive job within the timeout."""
+
+
+async def _agent_archive_info(
+    db: Session, repository: Repository, archive: Archive, *, timeout_seconds: int
+) -> Optional[dict]:
+    """Run `repository.archive_info` on the agent for one archive.
+
+    Borg 2 archives are addressed by `aid:<id>` so a series name never
+    resolves to a different archive; Borg 1 has no id selector.
+    """
+    from app.services.agent_job_dispatcher import (
+        dispatch_agent_cancel_if_connected,
+        dispatch_agent_job_best_effort,
+    )
+    from app.services.repository_executor import (
+        abandon_agent_repository_operation_job,
+        queue_agent_repository_operation_job,
+        wait_for_agent_repository_operation_job,
+    )
+
+    ref = (
+        f"aid:{archive.borg_id}"
+        if (repository.borg_version or 1) == 2
+        else archive.name
+    )
+    job = queue_agent_repository_operation_job(
+        db, repository, job_kind="repository.archive_info", operation={"archive": ref}
+    )
+    await dispatch_agent_job_best_effort(
+        db, job, repository_id=repository.id, archive_name=ref
+    )
+    try:
+        result = await wait_for_agent_repository_operation_job(
+            db, job.id, timeout_seconds=timeout_seconds
         )
-        .order_by(Archive.start.asc())
-        .limit(limit)
-        .all()
+    except HTTPException as exc:
+        if exc.status_code != status.HTTP_504_GATEWAY_TIMEOUT:
+            raise
+        # Left behind, the job counts as active repository work for every
+        # later archive_info and stats request (the reaper never reaps a
+        # queued job). Cancel it, and tell the caller the agent is gone.
+        abandoned = abandon_agent_repository_operation_job(db, job.id)
+        if abandoned is not None and abandoned.status == "cancel_requested":
+            await dispatch_agent_cancel_if_connected(abandoned)
+        raise AgentUnavailable(
+            f"no answer from the agent within {timeout_seconds}s"
+        ) from exc
+    if not _agent_listing_ok(result):
+        return None
+    return {"success": True, "stdout": result.get("stdout") or ""}
+
+
+async def _server_archive_info(
+    repository: Repository, archive: Archive, env: dict
+) -> Optional[dict]:
+    remote_path = effective_repository_remote_path(repository)
+    # TZ=UTC so borg renders the archive end time in UTC (see stats env).
+    info_env = _repository_stats_borg_env(env or {})
+    if (repository.borg_version or 1) == 2:
+        from app.core.borg2 import borg2
+
+        return await run_serialized_repository_command(
+            repository.id,
+            lambda: borg2.info_archive(
+                repository.path,
+                f"aid:{archive.borg_id}",
+                passphrase=repository.passphrase,
+                remote_path=remote_path,
+                bypass_lock=repository.bypass_lock,
+                env=info_env,
+            ),
+            scope="metadata",
+        )
+    from app.core.borg import borg
+
+    return await run_serialized_repository_command(
+        repository.id,
+        lambda: borg.info_archive(
+            repository.path,
+            archive.name,
+            passphrase=repository.passphrase,
+            remote_path=remote_path,
+            bypass_lock=repository.bypass_lock,
+            env=info_env,
+        ),
+        scope="metadata",
     )
 
 
@@ -260,46 +388,39 @@ async def fill_archive_info(
     *,
     limit: int,
 ) -> int:
-    """Run per-archive `borg info` for up to `limit` archives, oldest first."""
-    if is_agent_executor(repository) or limit <= 0:
+    """Run per-archive `borg info` for up to `limit` archives, oldest first.
+
+    Agent repositories go through the agent's `repository.archive_info` job;
+    the agent renders naive Borg 1 timestamps in its reported zone.
+    """
+    if limit <= 0:
         return 0
+    agent = is_agent_executor(repository)
+    timezone_name = agent_timezone_for_repository(db, repository) if agent else "UTC"
+    timeout_seconds = get_operation_timeouts(db)["info_timeout"] if agent else None
     filled = 0
-    remote_path = effective_repository_remote_path(repository)
-    # TZ=UTC so borg renders the archive end time in UTC (see stats env).
-    info_env = _repository_stats_borg_env(env or {})
     for archive in sorted(archives, key=lambda a: a.start)[:limit]:
         try:
-            if (repository.borg_version or 1) == 2:
-                from app.core.borg2 import borg2
-
-                result = await run_serialized_repository_command(
-                    repository.id,
-                    lambda archive=archive: borg2.info_archive(
-                        repository.path,
-                        f"aid:{archive.borg_id}",
-                        passphrase=repository.passphrase,
-                        remote_path=remote_path,
-                        bypass_lock=repository.bypass_lock,
-                        env=info_env,
-                    ),
-                    scope="metadata",
+            if agent:
+                result = await _agent_archive_info(
+                    db, repository, archive, timeout_seconds=timeout_seconds
                 )
             else:
-                from app.core.borg import borg
-
-                result = await run_serialized_repository_command(
-                    repository.id,
-                    lambda archive=archive: borg.info_archive(
-                        repository.path,
-                        archive.name,
-                        passphrase=repository.passphrase,
-                        remote_path=remote_path,
-                        bypass_lock=repository.bypass_lock,
-                        env=info_env,
-                    ),
-                    scope="metadata",
-                )
+                result = await _server_archive_info(repository, archive, env)
+        except AgentUnavailable as exc:
+            # every further archive would wait out the same timeout
+            logger.warning(
+                "archive info abandoned, agent not answering",
+                archive=archive.name,
+                error=str(exc),
+            )
+            break
         except Exception as exc:
+            if repository_busy(exc):
+                # another job took the repository between two archives: the
+                # runner defers the whole operation and retries later, which
+                # beats one refused job per remaining archive
+                raise
             logger.warning("archive info failed", archive=archive.name, error=str(exc))
             continue
         if not result or not result.get("success"):
@@ -311,9 +432,13 @@ async def fill_archive_info(
         archive.original_size = info["original_size"]
         archive.compressed_size = info["compressed_size"]
         archive.deduplicated_size = info["deduplicated_size"]
-        if info["end"]:
+        if info["end"] and (timezone_name or _carries_utc_offset(info["end"])):
+            # A naive end time from an agent that never reported its zone
+            # would be read in the server's zone; leave it unset instead.
             try:
-                archive.end = _parse_borg_archive_time(info["end"], timezone_name="UTC")
+                archive.end = _parse_borg_archive_time(
+                    info["end"], timezone_name=timezone_name
+                )
             except ValueError:
                 pass
         if info["duration"] is not None:
@@ -419,6 +544,21 @@ async def run_archive_sync(ctx) -> Outcome:
     if repository is None:
         return Outcome(status="skipped", skip_reason="repository_missing")
     db = ctx.db
+    if (repository.borg_version or 1) != 2 and not archive_end_resolvable(
+        db, repository
+    ):
+        # A Borg 1 listing is naive wall clock in the zone the agent ran it
+        # in. Without that zone the times would be stored in the server's
+        # zone, and `start` is NOT NULL, so there is no row to withhold it
+        # from. The agent reports its zone on hello; the next reconcile
+        # retries.
+        return Outcome(
+            status="failed",
+            error_message=(
+                "agent has not reported its timezone; Borg 1 archive times "
+                "cannot be placed until it does"
+            ),
+        )
     env, temp_key_file = _prepare_repository_borg_env(repository, db)
     try:
         ok, entries, timezone_name = await list_archives_for_repository(
@@ -437,7 +577,10 @@ async def run_archive_sync(ctx) -> Outcome:
             db,
             repository,
             archives_needing_info(
-                db, repository, limit=settings.index_archive_info_per_run
+                db,
+                repository,
+                limit=settings.index_archive_info_per_run,
+                include_missing_end=True,
             ),
             env,
             limit=settings.index_archive_info_per_run,

--- a/app/services/operations/runner.py
+++ b/app/services/operations/runner.py
@@ -2,6 +2,7 @@
 cancellation, and crash recovery. One instance per process."""
 
 import asyncio
+import math
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -10,7 +11,7 @@ from typing import Optional
 import structlog
 from sqlalchemy.orm import Session
 
-from app.config import settings as app_settings
+import app.config as app_config
 from app.database.models import Operation, Repository, SystemSettings, utc_now
 from app.services.operations import executors as executor_registry
 from app.services.operations.enqueue import enqueue_chain
@@ -25,8 +26,67 @@ from app.utils.process_utils import is_process_alive
 
 logger = structlog.get_logger()
 
-_FAILED_DEPENDENCY_STATUSES = ("failed", "cancelled", "skipped")
-_OUTCOME_STATUSES = ("completed", "completed_with_warnings", "skipped", "failed")
+# An intentional skip lets dependants run, but a skip caused by a failed
+# dependency must propagate the failure through the remaining chain.
+# Executors that need a predecessor's result read it defensively.
+_FAILED_DEPENDENCY_STATUSES = ("failed", "cancelled")
+_SATISFIED_DEPENDENCY_STATUSES = SUCCESS_STATUSES | {"skipped"}
+# What an executor may return. A deferral is not among them: it is the
+# runner's own reaction to the admission's 409 and never an executor's
+# choice, so an executor cannot requeue itself by accident.
+_OUTCOME_STATUSES = (
+    "completed",
+    "completed_with_warnings",
+    "skipped",
+    "failed",
+)
+# An operation refused by the repository admission (another job holds the
+# repository) goes back to the queue instead of failing: the backup
+# follow-up listing is enqueued the instant the backup completes, while the
+# plan is still creating its prune job, so the lane check can run before the
+# prune row exists and admission then refuses the listing. Bounded, so a
+# repository that never frees up still ends in a visible failure.
+MAX_DEFERRALS = 20
+# Each deferral waits before the next attempt, doubling from 5 s to 5 min.
+# The runner is woken by every completion anywhere in the system, so without
+# the delay a busy install would spend the whole deferral budget in seconds
+# while a pending prune sits on the repository. 20 attempts give a
+# repository about 75 minutes to free up.
+DEFERRAL_DELAY_SECONDS = 5.0
+DEFERRAL_MAX_DELAY_SECONDS = 300.0
+REPOSITORY_BUSY_KEY = "backend.errors.jobs.repositoryOperationActive"
+
+
+def deferred_until(op: Operation) -> Optional[float]:
+    """The not-before time (epoch seconds) of a deferred operation, if any."""
+    raw = (op.params or {}).get("deferred_until")
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    # inf would park the operation forever, nan would skip the backoff
+    return value if math.isfinite(value) else None
+
+
+def deferral_count(op: Operation) -> int:
+    """How often the operation has been deferred; unreadable bookkeeping
+    counts as none rather than crashing the runner."""
+    try:
+        count = int((op.params or {}).get("deferrals", 0))
+    except (TypeError, ValueError, OverflowError):
+        # inf overflows int(), nan and text are ValueErrors
+        return 0
+    return max(count, 0)
+
+
+def repository_busy(exc: BaseException) -> bool:
+    """True for the admission's 409 (repositoryOperationActive)."""
+    if getattr(exc, "status_code", None) != 409:
+        return False
+    detail = getattr(exc, "detail", None)
+    return isinstance(detail, dict) and detail.get("key") == REPOSITORY_BUSY_KEY
 
 
 @dataclass
@@ -42,7 +102,7 @@ class Outcome:
 
 
 def operation_log_path(operation_id: int) -> Path:
-    return Path(app_settings.data_dir) / "logs" / f"operation_{operation_id}.log"
+    return Path(app_config.settings.data_dir) / "logs" / f"operation_{operation_id}.log"
 
 
 class OperationContext:
@@ -107,13 +167,19 @@ class OperationContext:
 
 class OperationRunner:
     def __init__(
-        self, *, session_factory=None, registry=None, poll_interval: float = 5.0
+        self,
+        *,
+        session_factory=None,
+        registry=None,
+        poll_interval: float = 5.0,
+        deferral_delay: float = DEFERRAL_DELAY_SECONDS,
     ):
         self._session_factory = session_factory
         self._registry = (
             registry if registry is not None else executor_registry.REGISTRY
         )
         self._poll_interval = poll_interval
+        self._deferral_delay = deferral_delay
         self._wake: Optional[asyncio.Event] = None
         self._stopped = False
         self.running_tasks: dict[int, asyncio.Task] = {}
@@ -135,6 +201,13 @@ class OperationRunner:
 
     def _registered_kinds(self) -> set[str]:
         return set(self._registry)
+
+    def deferral_delay_for(self, deferrals: int) -> float:
+        """Seconds to wait before the attempt after the n-th deferral."""
+        return min(
+            self._deferral_delay * 2 ** max(deferrals - 1, 0),
+            DEFERRAL_MAX_DELAY_SECONDS,
+        )
 
     # -- loop ------------------------------------------------------------------
 
@@ -237,18 +310,26 @@ class OperationRunner:
                 )
                 .all()
             )
+            now = time.time()
             for op in queued:
                 if op.id in self.running_tasks:
+                    continue
+                not_before = deferred_until(op)
+                if not_before is not None and not_before > now:
                     continue
                 if op.depends_on_id is not None:
                     dependency = db.get(Operation, op.depends_on_id)
                     if (
                         dependency is None
                         or dependency.status in _FAILED_DEPENDENCY_STATUSES
+                        or (
+                            dependency.status == "skipped"
+                            and dependency.skip_reason == "dependency_failed"
+                        )
                     ):
                         await self._skip(db, op, "dependency_failed")
                         continue
-                    if dependency.status not in SUCCESS_STATUSES:
+                    if dependency.status not in _SATISFIED_DEPENDENCY_STATUSES:
                         continue
                 if self._get_executor(op.kind) is None:
                     await self._skip(db, op, "executor_unavailable")
@@ -279,6 +360,7 @@ class OperationRunner:
     async def run_operation(self, operation_id: int) -> None:
         db: Session = self._session()
         ctx: Optional[OperationContext] = None
+        deferred = False
         try:
             op = db.get(Operation, operation_id)
             if op is None or op.status != "running":
@@ -286,6 +368,7 @@ class OperationRunner:
             executor = self._get_executor(op.kind)
             ctx = OperationContext(self, db, op)
             outcome: Optional[Outcome]
+            busy_error: Optional[str] = None
             try:
                 outcome = await executor(ctx)
             except asyncio.CancelledError:
@@ -295,13 +378,73 @@ class OperationRunner:
                 await broadcast_operation_updated(op, db)
                 raise
             except Exception as exc:
-                logger.exception("Operation failed", operation_id=op.id, kind=op.kind)
-                outcome = Outcome(
-                    status="failed",
-                    error_message=str(exc) or exc.__class__.__name__,
-                )
+                if repository_busy(exc):
+                    busy_error = str(exc)
+                    # a cancel that arrived while the operation was being
+                    # refused wins: requeueing would drop the request in
+                    # `finally`, so the refusal falls through to the
+                    # cancelled path below with the admission's message
+                    outcome = Outcome(error_message=busy_error)
+                else:
+                    logger.exception(
+                        "Operation failed", operation_id=op.id, kind=op.kind
+                    )
+                    outcome = Outcome(
+                        status="failed",
+                        error_message=str(exc) or exc.__class__.__name__,
+                    )
             if outcome is None:
                 outcome = Outcome()
+            if busy_error is not None and operation_id not in self.cancel_requested:
+                deferrals = deferral_count(op) + 1
+                if deferrals > MAX_DEFERRALS:
+                    outcome = Outcome(
+                        status="failed",
+                        error_message=(
+                            f"repository still busy after {MAX_DEFERRALS} attempts: "
+                            f"{busy_error}"
+                        ),
+                    )
+                else:
+                    logger.info(
+                        "Operation deferred, repository busy",
+                        operation_id=op.id,
+                        kind=op.kind,
+                        deferrals=deferrals,
+                    )
+                    delay = self.deferral_delay_for(deferrals)
+                    op.status = "queued"
+                    op.started_at = None
+                    op.error_message = None
+                    op.params = {
+                        **(op.params or {}),
+                        "deferrals": deferrals,
+                        "deferred_until": time.time() + delay,
+                    }
+                    try:
+                        db.commit()
+                    except Exception as exc:
+                        # the row would otherwise stay `running` with no task
+                        # behind it until the next restart: fail it instead
+                        db.rollback()
+                        logger.exception(
+                            "Operation requeue failed",
+                            operation_id=op.id,
+                            kind=op.kind,
+                        )
+                        outcome = Outcome(
+                            status="failed",
+                            error_message=(
+                                f"could not requeue the deferred operation: {exc}"
+                            ),
+                        )
+                    else:
+                        await broadcast_operation_updated(op, db)
+                        # no wake, and the tick skips the operation until
+                        # deferred_until: wakes from other completions must
+                        # not burn the deferrals
+                        deferred = True
+                        return
             if op.status == "cancelled" or (
                 operation_id in self.cancel_requested and outcome.status != "failed"
             ):
@@ -338,7 +481,8 @@ class OperationRunner:
             db.close()
             self.running_tasks.pop(operation_id, None)
             self.cancel_requested.discard(operation_id)
-            self.wake()
+            if not deferred:
+                self.wake()
 
     # -- cancellation ----------------------------------------------------------
 

--- a/app/services/repository_executor.py
+++ b/app/services/repository_executor.py
@@ -625,6 +625,61 @@ def get_agent_job_for_backup(db: Session, backup_job_id: int) -> Optional[AgentJ
     )
 
 
+# A job moves queued -> claimed -> running -> terminal, so two lost races are
+# the most a live job can cost; the bound only guards against a pathological
+# writer flipping the row back and forth.
+ABANDON_ATTEMPTS = 4
+
+
+def abandon_agent_repository_operation_job(
+    db: Session, agent_job_id: int, *, now: Optional[datetime] = None
+) -> Optional[AgentJob]:
+    """Take a repository job the caller stopped waiting for out of the
+    admission's way.
+
+    A job nobody claimed is cancelled outright: the reaper only reaps
+    in-flight jobs, so a queued job of an unresponsive agent would count as
+    active work for every later request on the repository until the agent
+    reconnects and runs the stale job. A claimed or running job gets
+    cancel_requested and the agent ends it. Terminal jobs are left alone.
+    Returns the job, or None when it no longer exists.
+    """
+    agent_job = db.query(AgentJob).filter(AgentJob.id == agent_job_id).first()
+    if agent_job is None:
+        return None
+    now = now or datetime.utcnow()
+    # Conditional on the status just read, and retried while the job is
+    # still live: the agent's reports land concurrently. A completion must
+    # not turn back into cancel_requested (admission counts that as
+    # active); a claim or start between read and write must still get the
+    # cancel, so a lost race re-reads and writes for the new state.
+    for _ in range(ABANDON_ATTEMPTS):
+        observed = agent_job.status
+        if observed == "queued":
+            values = {
+                "status": "canceled",
+                "completed_at": now,
+                "error_message": (
+                    "Abandoned by server: the agent did not pick the job up in time"
+                ),
+                "updated_at": now,
+            }
+        elif observed in ("claimed", "running"):
+            values = {"status": "cancel_requested", "updated_at": now}
+        else:
+            return agent_job
+        changed = (
+            db.query(AgentJob)
+            .filter(AgentJob.id == agent_job.id, AgentJob.status == observed)
+            .update(values, synchronize_session=False)
+        )
+        db.commit()
+        db.refresh(agent_job)
+        if changed:
+            return agent_job
+    return agent_job
+
+
 def cancel_agent_backup_job(
     db: Session, backup_job: BackupJob, *, now: Optional[datetime] = None
 ) -> tuple[AgentJob, bool]:

--- a/docs/architecture/job-system.md
+++ b/docs/architecture/job-system.md
@@ -188,8 +188,16 @@ Rules:
   run alongside.
 - Lower priority number runs first: manual and plan work at 0, scheduled at
   5, follow-ups at 10, reconcile at 20.
-- A failed, cancelled, or skipped operation skips everything that depends on
-  it with `skip_reason = dependency_failed`.
+- A failed or cancelled operation skips everything that depends on it with
+  `skip_reason = dependency_failed`, including every subsequent dependant
+  of that skip. An intentional skip means the stage had nothing to do, so
+  dependants (`stats` after an unsupported `history_index`) still run.
+- An operation the repository admission refuses (409, another job holds
+  the repository) goes back to the queue instead of failing, with
+  `params.deferrals` counting the attempts and `params.deferred_until`
+  holding the next attempt's not-before time as epoch seconds (5 s,
+  doubling to 5 min).
+  After 20 deferrals it fails with "repository still busy".
 - Follow-ups are created automatically when an operation succeeds. An
   import enqueues stats and archive listing.
 - `stats` measures the repository read-only through the best source Borg

--- a/docs/engineering/specs/2026-09-03-repository-operations-and-archive-history.md
+++ b/docs/engineering/specs/2026-09-03-repository-operations-and-archive-history.md
@@ -218,6 +218,12 @@ Stored as strings, validated in Python. Defined once in
 **status:** `queued`, `running`, `completed`, `completed_with_warnings`,
 `failed`, `cancelled`, `skipped`.
 
+A deferral is not a status. An operation the repository admission refuses
+(409 `repositoryOperationActive`) goes back to `queued`; the runner keeps
+its bookkeeping in `params.deferrals` (attempts so far) and
+`params.deferred_until` (epoch seconds before which the tick will not
+dispatch it again), see 7.1. Executors cannot return a deferral.
+
 Mapping from existing vocabularies during migration:
 
 | old | new |
@@ -429,15 +435,34 @@ schedulers. It waits on an `asyncio.Event` that `enqueue()` sets, with a
 fallback poll every 5 seconds. Each tick:
 
 1. Load `queued` operations whose `depends_on_id` is null or points at a
-   `completed` or `completed_with_warnings` operation. If the dependency is
-   `failed`, `cancelled`, or `skipped`, mark the dependant `skipped` with
-   `skip_reason = "dependency_failed"` and continue down the chain.
-2. Order by `priority`, then `created_at`.
+   `completed`, `completed_with_warnings`, or `skipped` operation. If the
+   dependency is `failed` or `cancelled`, mark the dependant `skipped` with
+   `skip_reason = "dependency_failed"` and continue down the chain. A
+   skip with `skip_reason = "dependency_failed"` propagates the same skip
+   to its dependants, preserving failure and cancellation through the whole
+   chain. Other skipped dependencies satisfy their dependants: skipping
+   means the stage had
+   nothing to do (agent without diff support, plan without history), not
+   that it broke, and `stats` must not wait behind a `history_index` it
+   does not use (#917).
+2. Order by `priority`, then `created_at`. Skip rows whose
+   `params.deferred_until` is still in the future.
 3. For each candidate, check the lane and the global limits (7.3). Dispatch
    the first that fits, then re-evaluate. Stop when nothing fits.
 4. Dispatch means: set `running`, `started_at`, spawn
    `asyncio.create_task(executor(operation))`, keep the task handle in
    memory for cancellation.
+5. If the executor is refused by the repository admission (409
+   `repositoryOperationActive`: a legacy job or an agent job holds the
+   repository in a state the lane check does not see, such as a prune row
+   still `pending`), the runner returns the row to `queued` instead of
+   failing it, with `params.deferrals` incremented and
+   `params.deferred_until` set to now plus a delay that doubles from 5 s
+   to 5 min. The runner does not wake itself for a deferral, and the
+   not-before time keeps wakes from other completions from burning the
+   attempts. After `MAX_DEFERRALS` (20, about 75 minutes) the operation
+   fails with "repository still busy". A requeue whose commit fails marks
+   the operation `failed` rather than leaving it `running` with no task.
 
 Executors receive an `OperationContext` with the row, a `progress()`
 callback that throttles writes to at most one per second and broadcasts an
@@ -532,7 +557,9 @@ This replaces the per-table startup cleanup for each kind as it migrates.
 `POST /api/operations/{id}/cancel` sets `cancelled` on a `queued` row
 directly. For a `running` row it sets a cancel flag the executor observes
 via `ctx.cancelled()`; Borg executors also terminate the child process, as
-the existing cancel paths do. Dependants become `skipped`.
+the existing cancel paths do. Dependants become `skipped`. A cancel that
+arrives while the admission is refusing the operation wins over the
+deferral (7.1 step 5): the row ends `cancelled` instead of being requeued.
 
 ### 7.8 Retention
 
@@ -557,8 +584,15 @@ as today. Replaces the size half of `update_repository_stats`.
 3. Rows in `archives` not present in the list are collected as
    `result["removed_archive_ids"]` and left in place; `history_merge`
    consumes and deletes them.
-4. For up to `INDEX_ARCHIVE_INFO_PER_RUN` never-seen archives, run
-   per-archive `borg info` and fill sizes.
+4. For up to `INDEX_ARCHIVE_INFO_PER_RUN` archives, oldest first, run
+   per-archive `borg info` and fill sizes, `end`, and duration: archives
+   without stats first, archives missing only `end` into the slots left
+   over. Agent repositories go through the agent's `repository.archive_info`
+   job; a job the agent does not answer within the info timeout is
+   cancelled and the run stops asking. A Borg 1 agent listing needs the
+   agent's reported zone to place its naive times; without one the stage
+   fails and the next reconcile retries. The listing never carries `end`,
+   so a resync leaves a filled `end` alone.
 5. Write `repository.archive_count` and `repository.last_backup`.
 
 ### 8.3 `history_index`

--- a/tests/unit/test_agent_job_abandon.py
+++ b/tests/unit/test_agent_job_abandon.py
@@ -1,0 +1,147 @@
+"""abandon_agent_repository_operation_job: a repository job the server
+stopped waiting for must not stay queued, where the reaper never reaches it
+and the admission counts it as active work."""
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy import create_engine, update
+from sqlalchemy.orm import sessionmaker
+
+from app.core.security import get_password_hash
+from app.database.models import AgentJob, AgentMachine, Base
+from app.services.repository_executor import abandon_agent_repository_operation_job
+
+
+@pytest.fixture()
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def agent(db):
+    machine = AgentMachine(
+        name="agent",
+        agent_id="agt_abandon",
+        token_hash=get_password_hash("secret"),
+        token_prefix="secret",
+        status="active",
+        capabilities=["repository.archive_info"],
+    )
+    db.add(machine)
+    db.commit()
+    return machine
+
+
+def _job(db, agent, status):
+    job = AgentJob(
+        agent_machine_id=agent.id,
+        job_type="repository",
+        status=status,
+        payload={"job_kind": "repository.archive_info", "repository": {"id": 1}},
+        created_at=datetime(2026, 9, 7, 10, 0),
+        updated_at=datetime(2026, 9, 7, 10, 0),
+    )
+    db.add(job)
+    db.commit()
+    return job
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("before", "after"),
+    [
+        ("queued", "canceled"),
+        ("claimed", "cancel_requested"),
+        ("running", "cancel_requested"),
+        ("cancel_requested", "cancel_requested"),
+        ("completed", "completed"),
+        ("failed", "failed"),
+        ("canceled", "canceled"),
+    ],
+)
+def test_abandon_moves_only_live_jobs(db, agent, before, after):
+    job = _job(db, agent, before)
+    now = datetime(2026, 9, 7, 10, 30)
+    returned = abandon_agent_repository_operation_job(db, job.id, now=now)
+    db.expire_all()
+    row = db.get(AgentJob, job.id)
+    assert returned is not None and returned.id == row.id
+    assert row.status == after
+    if before == "queued":
+        assert row.completed_at == now and "Abandoned" in row.error_message
+        assert row.updated_at == now
+    elif before in ("claimed", "running"):
+        assert row.completed_at is None and row.updated_at == now
+    else:
+        assert row.updated_at == datetime(2026, 9, 7, 10, 0)
+
+
+@pytest.mark.unit
+def test_abandon_unknown_job_is_a_noop(db):
+    assert abandon_agent_repository_operation_job(db, 4242) is None
+
+
+@pytest.mark.unit
+def test_abandon_loses_to_a_completion_that_landed_first(db, agent):
+    """The agent's completion report can commit between the read and the
+    write; the write is conditional on the status read, so a terminal job
+    stays terminal instead of turning into cancel_requested."""
+    job = _job(db, agent, "running")
+    # completed by the report handler behind this session's back: the row
+    # says completed, the identity map still holds "running" (no commit
+    # here, a commit would expire it and hide the race)
+    db.execute(
+        update(AgentJob)
+        .where(AgentJob.id == job.id)
+        .values(
+            status="completed",
+            completed_at=datetime(2026, 9, 7, 10, 29),
+            updated_at=datetime(2026, 9, 7, 10, 29),
+        ),
+        execution_options={"synchronize_session": False},
+    )
+    assert job.status == "running"
+    returned = abandon_agent_repository_operation_job(
+        db, job.id, now=datetime(2026, 9, 7, 10, 30)
+    )
+    assert returned is not None and returned.status == "completed"
+    db.expire_all()
+    row = db.get(AgentJob, job.id)
+    assert row.status == "completed"
+    assert row.completed_at == datetime(2026, 9, 7, 10, 29)
+    # untouched by the abandonment: the report's timestamp stands
+    assert row.updated_at == datetime(2026, 9, 7, 10, 29)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("read", "meanwhile", "after"),
+    [
+        ("queued", "claimed", "cancel_requested"),
+        ("claimed", "running", "cancel_requested"),
+    ],
+)
+def test_abandon_retries_after_a_live_transition(db, agent, read, meanwhile, after):
+    """The agent claims or starts the job between the read and the write:
+    the first conditional write matches nothing, the retry reads the new
+    live state and still requests the cancel."""
+    job = _job(db, agent, read)
+    db.execute(
+        update(AgentJob).where(AgentJob.id == job.id).values(status=meanwhile),
+        execution_options={"synchronize_session": False},
+    )
+    assert job.status == read
+    now = datetime(2026, 9, 7, 10, 30)
+    returned = abandon_agent_repository_operation_job(db, job.id, now=now)
+    assert returned is not None and returned.status == after
+    db.expire_all()
+    row = db.get(AgentJob, job.id)
+    assert row.status == after and row.completed_at is None
+    assert row.updated_at == now

--- a/tests/unit/test_operations_index_executors.py
+++ b/tests/unit/test_operations_index_executors.py
@@ -133,6 +133,21 @@ def test_apply_listing_upserts_and_reports_removed(db, repo):
 
 
 @pytest.mark.unit
+def test_apply_listing_keeps_the_info_filled_end(db, repo):
+    """`borg list --json` has no end (only `borg info` does): a resync must
+    not wipe the end fill_archive_info stored, or every run refills it."""
+    index_exec.apply_listing(db, repo, [BORG1_ENTRY], timezone_name="UTC")
+    row = db.query(Archive).filter_by(borg_id="aa11").one()
+    row.end = datetime(2026, 9, 2, 2, 10)
+    db.commit()
+    index_exec.apply_listing(db, repo, [BORG1_ENTRY], timezone_name="UTC")
+    db.expire_all()
+    assert db.query(Archive).filter_by(borg_id="aa11").one().end == datetime(
+        2026, 9, 2, 2, 10
+    )
+
+
+@pytest.mark.unit
 def test_apply_listing_series_change_resets_history_state(db, repo):
     repo.borg_version = 2
     db.commit()
@@ -379,6 +394,418 @@ async def test_fill_archive_info_limits_and_orders_oldest_first(db, repo, monkey
     assert newest.nfiles is None
 
 
+def _agent_info_payload(end="2026-09-01T02:10:00.000000"):
+    return json.dumps(
+        {
+            "archives": [
+                {
+                    "stats": {"nfiles": 7, "original_size": 20},
+                    "end": end,
+                    "duration": 30.0,
+                }
+            ]
+        }
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fill_archive_info_dispatches_agent_job(db, repo, monkeypatch):
+    """Agent repositories fill per-archive info through the agent's
+    `repository.archive_info` job (#932): Borg 2 archives by `aid:<id>`, the
+    agent's reported zone resolves naive end times, a failed job is skipped."""
+    repo.borg_version = 2
+    db.commit()
+    rows = []
+    for i in range(3):
+        a = Archive(
+            repository_id=repo.id,
+            borg_id=f"id{i}",
+            name="series",
+            series="series",
+            start=datetime(2026, 9, i + 1),
+        )
+        db.add(a)
+        rows.append(a)
+    db.commit()
+    queued = []
+
+    def fake_queue(db_, repository, *, job_kind, operation=None):
+        queued.append((job_kind, operation["archive"]))
+        return SimpleNamespace(id=len(queued))
+
+    async def fake_wait(db_, job_id, *, timeout_seconds):
+        assert timeout_seconds == 42
+        if job_id == 2:
+            return {"return_code": 2, "stdout": "", "stderr": "borg: lock"}
+        return {"return_code": 0, "stdout": _agent_info_payload()}
+
+    monkeypatch.setattr(index_exec, "is_agent_executor", lambda repository: True)
+    monkeypatch.setattr(
+        index_exec, "agent_timezone_for_repository", lambda db_, r: "Europe/Berlin"
+    )
+    monkeypatch.setattr(
+        index_exec, "get_operation_timeouts", lambda db_: {"info_timeout": 42}
+    )
+    monkeypatch.setattr(
+        "app.services.repository_executor.queue_agent_repository_operation_job",
+        fake_queue,
+    )
+    monkeypatch.setattr(
+        "app.services.repository_executor.wait_for_agent_repository_operation_job",
+        fake_wait,
+    )
+    monkeypatch.setattr(
+        "app.services.agent_job_dispatcher.dispatch_agent_job_best_effort",
+        AsyncMock(return_value=True),
+    )
+    filled = await index_exec.fill_archive_info(db, repo, rows, {}, limit=3)
+    assert filled == 2
+    assert queued == [
+        ("repository.archive_info", "aid:id0"),
+        ("repository.archive_info", "aid:id1"),
+        ("repository.archive_info", "aid:id2"),
+    ]
+    db.expire_all()
+    first = db.query(Archive).filter_by(borg_id="id0").one()
+    assert first.nfiles == 7 and first.original_size == 20
+    assert first.compressed_size is None and first.deduplicated_size is None
+    assert first.duration_seconds == 30.0
+    # 02:10 Berlin summer time is 00:10 UTC
+    assert first.end == datetime(2026, 9, 1, 0, 10)
+    failed = db.query(Archive).filter_by(borg_id="id1").one()
+    assert failed.nfiles is None and failed.end is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fill_archive_info_agent_without_zone_leaves_naive_end_unset(
+    db, repo, monkeypatch
+):
+    """An agent that never reported its zone renders Borg 1 end times in an
+    unknown wall clock; storing them in the server's zone would shift them.
+    Offset-carrying (Borg 2) values are still stored."""
+    rows = []
+    for i, end in enumerate(
+        ("2026-09-01T02:10:00.000000", "2026-09-02T02:10:00.000000+02:00")
+    ):
+        a = Archive(
+            repository_id=repo.id,
+            borg_id=f"id{i}",
+            name=f"n{i}",
+            series="n",
+            start=datetime(2026, 9, i + 1),
+        )
+        db.add(a)
+        rows.append((a, end))
+    db.commit()
+    ends = {f"n{i}": end for i, (_, end) in enumerate(rows)}
+
+    def fake_queue(db_, repository, *, job_kind, operation=None):
+        return SimpleNamespace(id=operation["archive"])
+
+    async def fake_wait(db_, job_id, *, timeout_seconds):
+        return {"return_code": 0, "stdout": _agent_info_payload(end=ends[job_id])}
+
+    monkeypatch.setattr(index_exec, "is_agent_executor", lambda repository: True)
+    monkeypatch.setattr(
+        index_exec, "agent_timezone_for_repository", lambda db_, r: None
+    )
+    monkeypatch.setattr(
+        index_exec, "get_operation_timeouts", lambda db_: {"info_timeout": 5}
+    )
+    monkeypatch.setattr(
+        "app.services.repository_executor.queue_agent_repository_operation_job",
+        fake_queue,
+    )
+    monkeypatch.setattr(
+        "app.services.repository_executor.wait_for_agent_repository_operation_job",
+        fake_wait,
+    )
+    monkeypatch.setattr(
+        "app.services.agent_job_dispatcher.dispatch_agent_job_best_effort",
+        AsyncMock(return_value=True),
+    )
+    assert (
+        await index_exec.fill_archive_info(db, repo, [a for a, _ in rows], {}, limit=2)
+        == 2
+    )
+    db.expire_all()
+    naive = db.query(Archive).filter_by(borg_id="id0").one()
+    assert naive.nfiles == 7 and naive.duration_seconds == 30.0
+    assert naive.end is None
+    aware = db.query(Archive).filter_by(borg_id="id1").one()
+    assert aware.end == datetime(2026, 9, 2, 0, 10)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fill_archive_info_agent_timeout_abandons_job_and_stops(
+    db, repo, monkeypatch
+):
+    """A job the agent never answers is cancelled instead of left queued:
+    queued jobs are never reaped and would count as active repository work
+    for every later archive_info and stats request (a 409 per archive). The
+    remaining archives are not attempted, each would wait out the timeout."""
+    from fastapi import HTTPException
+
+    rows = []
+    for i in range(3):
+        a = Archive(
+            repository_id=repo.id,
+            borg_id=f"id{i}",
+            name=f"n{i}",
+            series="n",
+            start=datetime(2026, 9, i + 1),
+        )
+        db.add(a)
+        rows.append(a)
+    db.commit()
+    queued, abandoned, cancels = [], [], []
+
+    def fake_queue(db_, repository, *, job_kind, operation=None):
+        queued.append(operation["archive"])
+        return SimpleNamespace(id=len(queued))
+
+    async def fake_wait(db_, job_id, *, timeout_seconds):
+        raise HTTPException(
+            status_code=504,
+            detail={"key": "backend.errors.agents.repositoryOperationTimeout"},
+        )
+
+    def fake_abandon(db_, job_id):
+        abandoned.append(job_id)
+        return SimpleNamespace(id=job_id, status="cancel_requested")
+
+    async def fake_cancel(job):
+        cancels.append(job.id)
+        return True
+
+    monkeypatch.setattr(index_exec, "is_agent_executor", lambda repository: True)
+    monkeypatch.setattr(
+        index_exec, "agent_timezone_for_repository", lambda db_, r: "UTC"
+    )
+    monkeypatch.setattr(
+        index_exec, "get_operation_timeouts", lambda db_: {"info_timeout": 5}
+    )
+    monkeypatch.setattr(
+        "app.services.repository_executor.queue_agent_repository_operation_job",
+        fake_queue,
+    )
+    monkeypatch.setattr(
+        "app.services.repository_executor.wait_for_agent_repository_operation_job",
+        fake_wait,
+    )
+    monkeypatch.setattr(
+        "app.services.repository_executor.abandon_agent_repository_operation_job",
+        fake_abandon,
+    )
+    monkeypatch.setattr(
+        "app.services.agent_job_dispatcher.dispatch_agent_job_best_effort",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "app.services.agent_job_dispatcher.dispatch_agent_cancel_if_connected",
+        fake_cancel,
+    )
+    assert await index_exec.fill_archive_info(db, repo, rows, {}, limit=3) == 0
+    assert queued == ["n0"]
+    assert abandoned == [1] and cancels == [1]
+    db.expire_all()
+    assert all(a.nfiles is None for a in db.query(Archive).all())
+
+
+def _three_archives(db, repo):
+    rows = []
+    for i in range(3):
+        a = Archive(
+            repository_id=repo.id,
+            borg_id=f"id{i}",
+            name=f"n{i}",
+            series="n",
+            start=datetime(2026, 9, i + 1),
+        )
+        db.add(a)
+        rows.append(a)
+    db.commit()
+    return rows
+
+
+def _patch_agent_info(monkeypatch, *, queue, wait, zone="UTC"):
+    monkeypatch.setattr(index_exec, "is_agent_executor", lambda repository: True)
+    monkeypatch.setattr(
+        index_exec, "agent_timezone_for_repository", lambda db_, r: zone
+    )
+    monkeypatch.setattr(
+        index_exec, "get_operation_timeouts", lambda db_: {"info_timeout": 5}
+    )
+    monkeypatch.setattr(
+        "app.services.repository_executor.queue_agent_repository_operation_job",
+        queue,
+    )
+    monkeypatch.setattr(
+        "app.services.repository_executor.wait_for_agent_repository_operation_job",
+        wait,
+    )
+    monkeypatch.setattr(
+        "app.services.agent_job_dispatcher.dispatch_agent_job_best_effort",
+        AsyncMock(return_value=True),
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fill_archive_info_agent_admission_refusal_skips_one_archive(
+    db, repo, monkeypatch
+):
+    """The admission refuses the job for one archive (another job took the
+    repository between two archives): the refusal reaches the runner, which
+    defers the whole operation, instead of one refused job per remaining
+    archive. What the earlier archives wrote stays in the session for the
+    runner's requeue commit. Any other failure still skips just that archive."""
+    from fastapi import HTTPException
+
+    rows = _three_archives(db, repo)
+    queued = []
+
+    def fake_queue(db_, repository, *, job_kind, operation=None):
+        queued.append(operation["archive"])
+        if len(queued) == 2:
+            raise HTTPException(
+                status_code=409,
+                detail={"key": "backend.errors.jobs.repositoryOperationActive"},
+            )
+        if len(queued) == 3:
+            raise HTTPException(status_code=502, detail="agent gone")
+        return SimpleNamespace(id=len(queued))
+
+    async def fake_wait(db_, job_id, *, timeout_seconds):
+        return {"return_code": 0, "stdout": _agent_info_payload()}
+
+    _patch_agent_info(monkeypatch, queue=fake_queue, wait=fake_wait)
+    with pytest.raises(HTTPException) as info:
+        await index_exec.fill_archive_info(db, repo, rows, {}, limit=3)
+    assert info.value.status_code == 409
+    assert queued == ["n0", "n1"]
+    db.commit()
+    db.expire_all()
+    by_id = {a.borg_id: a for a in db.query(Archive).all()}
+    assert by_id["id0"].nfiles == 7
+    assert by_id["id1"].nfiles is None and by_id["id2"].nfiles is None
+
+    # a non-busy failure on one archive still leaves the loop running
+    queued[:] = ["pad", "pad"]  # n1 becomes the third call: the 502
+    assert await index_exec.fill_archive_info(db, repo, rows[1:], {}, limit=2) == 1
+    assert queued == ["pad", "pad", "n1", "n2"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fill_archive_info_agent_writes_survive_the_next_wait(
+    db, repo, monkeypatch
+):
+    """The real queue commits the session and the real wait expires it on
+    every poll. The previous archive's columns are only safe because that
+    commit happens between the two; a fake that behaves the same way pins it."""
+    rows = _three_archives(db, repo)
+    n = {"queued": 0}
+
+    def fake_queue(db_, repository, *, job_kind, operation=None):
+        n["queued"] += 1
+        db_.commit()
+        return SimpleNamespace(id=n["queued"])
+
+    async def fake_wait(db_, job_id, *, timeout_seconds):
+        db_.expire_all()
+        return {"return_code": 0, "stdout": _agent_info_payload()}
+
+    _patch_agent_info(monkeypatch, queue=fake_queue, wait=fake_wait)
+    assert await index_exec.fill_archive_info(db, repo, rows, {}, limit=3) == 3
+    db.expire_all()
+    assert [a.nfiles for a in db.query(Archive).order_by(Archive.start).all()] == [
+        7,
+        7,
+        7,
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fill_archive_info_agent_borg1_uses_archive_name(db, repo, monkeypatch):
+    a = Archive(
+        repository_id=repo.id,
+        borg_id="id0",
+        name="nas-2026-09-01",
+        series="nas",
+        start=datetime(2026, 9, 1),
+    )
+    db.add(a)
+    db.commit()
+    seen = []
+
+    def fake_queue(db_, repository, *, job_kind, operation=None):
+        seen.append(operation["archive"])
+        return SimpleNamespace(id=1)
+
+    async def fake_wait(db_, job_id, *, timeout_seconds):
+        return {"return_code": 0, "stdout": _agent_info_payload()}
+
+    monkeypatch.setattr(index_exec, "is_agent_executor", lambda repository: True)
+    monkeypatch.setattr(
+        index_exec, "agent_timezone_for_repository", lambda db_, r: "UTC"
+    )
+    monkeypatch.setattr(
+        index_exec, "get_operation_timeouts", lambda db_: {"info_timeout": 5}
+    )
+    monkeypatch.setattr(
+        "app.services.repository_executor.queue_agent_repository_operation_job",
+        fake_queue,
+    )
+    monkeypatch.setattr(
+        "app.services.repository_executor.wait_for_agent_repository_operation_job",
+        fake_wait,
+    )
+    monkeypatch.setattr(
+        "app.services.agent_job_dispatcher.dispatch_agent_job_best_effort",
+        AsyncMock(return_value=True),
+    )
+    assert await index_exec.fill_archive_info(db, repo, [a], {}, limit=1) == 1
+    assert seen == ["nas-2026-09-01"]
+    db.expire_all()
+    assert db.query(Archive).filter_by(borg_id="id0").one().end == datetime(
+        2026, 9, 1, 2, 10
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_archive_sync_refuses_borg1_agent_listing_without_zone(
+    db, repo, monkeypatch
+):
+    """A Borg 1 listing from an agent that never reported its zone would be
+    stored in the server's zone, and `start` is NOT NULL so nothing can be
+    withheld. The stage fails visibly before any listing runs; Borg 2 renders
+    an offset and is unaffected."""
+    listing = AsyncMock(return_value=(True, [], "UTC"))
+    monkeypatch.setattr(index_exec, "list_archives_for_repository", listing)
+    monkeypatch.setattr(
+        index_exec, "_prepare_repository_borg_env", lambda repository, db: ({}, None)
+    )
+    monkeypatch.setattr(index_exec, "is_agent_executor", lambda repository: True)
+    monkeypatch.setattr(
+        index_exec, "agent_timezone_for_repository", lambda db_, r: None
+    )
+    outcome = await index_exec.run_archive_sync(_ctx(db, repo))
+    assert outcome.status == "failed" and "timezone" in outcome.error_message
+    listing.assert_not_called()
+
+    repo.borg_version = 2
+    db.commit()
+    outcome = await index_exec.run_archive_sync(_ctx(db, repo))
+    assert outcome.status == "completed"
+    listing.assert_called_once()
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_run_archive_sync_fails_instead_of_wiping_on_failed_listing(
@@ -464,6 +891,68 @@ def test_archives_needing_info_backfills_across_runs(db, repo):
     assert [a.borg_id for a in candidates] == ["id1", "id2"]
     assert index_exec.archives_needing_info(db, repo, limit=1)[0].borg_id == "id1"
     assert index_exec.archives_needing_info(db, repo, limit=0) == []
+
+
+@pytest.mark.unit
+def test_archives_needing_info_revisits_withheld_end(db, repo, monkeypatch):
+    """fill_archive_info sets the sizes but withholds a naive end while the
+    agent's zone is unknown. Once the zone is known those rows must come
+    back, or their end stays NULL forever; while it is unknown they must
+    not, or the same archives are fetched every run for nothing."""
+    db.add(
+        Archive(
+            repository_id=repo.id,
+            borg_id="sized",
+            name="a",
+            series="default",
+            start=datetime(2026, 9, 1),
+            original_size=10,
+            end=None,
+        )
+    )
+    db.add(
+        Archive(
+            repository_id=repo.id,
+            borg_id="done",
+            name="b",
+            series="default",
+            start=datetime(2026, 9, 2),
+            original_size=10,
+            end=datetime(2026, 9, 2, 1),
+        )
+    )
+    db.add(
+        Archive(
+            repository_id=repo.id,
+            borg_id="fresh",
+            name="c",
+            series="default",
+            start=datetime(2026, 9, 3),
+        )
+    )
+    db.commit()
+    ids = lambda rows: [a.borg_id for a in rows]  # noqa: E731
+    assert ids(index_exec.archives_needing_info(db, repo, limit=5)) == ["fresh"]
+    # rows without stats come first, end-only rows take the spare slots: a
+    # row whose end never parses cannot starve an archive without stats
+    assert ids(
+        index_exec.archives_needing_info(db, repo, limit=5, include_missing_end=True)
+    ) == ["fresh", "sized"]
+    assert ids(
+        index_exec.archives_needing_info(db, repo, limit=1, include_missing_end=True)
+    ) == ["fresh"]
+
+    # server repositories always resolve; agent repositories only with a zone
+    assert index_exec.archive_end_resolvable(db, repo) is True
+    monkeypatch.setattr(index_exec, "is_agent_executor", lambda repository: True)
+    monkeypatch.setattr(
+        index_exec, "agent_timezone_for_repository", lambda db_, r: None
+    )
+    assert index_exec.archive_end_resolvable(db, repo) is False
+    monkeypatch.setattr(
+        index_exec, "agent_timezone_for_repository", lambda db_, r: "Europe/Berlin"
+    )
+    assert index_exec.archive_end_resolvable(db, repo) is True
 
 
 @pytest.mark.unit

--- a/tests/unit/test_operations_runner.py
+++ b/tests/unit/test_operations_runner.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from datetime import datetime
 
 import pytest
@@ -58,7 +59,10 @@ def registry():
 def runner(session_factory, registry, monkeypatch, tmp_path):
     monkeypatch.setattr("app.config.settings.data_dir", str(tmp_path))
     return OperationRunner(
-        session_factory=session_factory, registry=registry, poll_interval=0.01
+        session_factory=session_factory,
+        registry=registry,
+        poll_interval=0.01,
+        deferral_delay=0.0,
     )
 
 
@@ -134,6 +138,32 @@ async def test_dependency_waits_for_success(db, repo, runner, registry):
     await runner.tick()
     await asyncio.gather(*runner.running_tasks.values())
     assert seen == ["stats", "archive_sync"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_skipped_dependency_satisfies_dependants(db, repo, runner, registry):
+    """A skipped stage is not a failed one: `stats` behind a `history_index`
+    that had nothing to do still runs (#917)."""
+
+    async def skip(ctx):
+        return Outcome(status="skipped", skip_reason="agent_diff_unsupported")
+
+    async def ok(ctx):
+        return Outcome(result={"unique_csize": 1})
+
+    registry["history_index"] = skip
+    registry["stats"] = ok
+    chain = enqueue_chain(
+        db, ["history_index", "stats"], repository_id=repo.id, trigger="reconcile"
+    )
+    await _drain(runner)
+    db.expire_all()
+    first, second = (db.get(Operation, c.id) for c in chain)
+    assert first.status == "skipped"
+    assert first.skip_reason == "agent_diff_unsupported"
+    assert second.status == "completed"
+    assert second.result == {"unique_csize": 1}
 
 
 @pytest.mark.unit
@@ -357,6 +387,42 @@ async def test_progress_and_log(db, repo, runner, registry, tmp_path):
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_log_path_resolves_settings_at_call_time(
+    db, repo, runner, registry, tmp_path, monkeypatch
+):
+    """A test elsewhere reloads app.config and leaves a new settings object
+    behind (#914). The runner must read app.config.settings when it opens a
+    log, not the object it imported at start. Pinned by swapping the object,
+    not by reloading the module: a real reload re-runs the module's side
+    effects (secret key generation, directory derivation) for every later
+    test in the session."""
+    import app.config as config
+
+    current_dir = tmp_path / "current"
+    monkeypatch.setattr(
+        config,
+        "settings",
+        config.settings.model_copy(update={"data_dir": str(current_dir)}),
+    )
+
+    async def work(ctx):
+        ctx.log("after swap")
+        return Outcome()
+
+    registry["stats"] = work
+    op = enqueue(db, "stats", repository_id=repo.id)
+    await _drain(runner)
+    db.expire_all()
+    op = db.get(Operation, op.id)
+    expected_path = current_dir / "logs" / f"operation_{op.id}.log"
+    assert op.status == "completed"
+    assert op.log_file_path == str(expected_path)
+    assert expected_path.read_text() == "after swap\n"
+    assert not (tmp_path / "logs" / f"operation_{op.id}.log").exists()
+
+
+@pytest.mark.unit
 def test_recover_on_startup(db, repo, runner, monkeypatch):
     idx = enqueue(db, "stats", repository_id=repo.id)
     idx.status = "running"
@@ -517,3 +583,346 @@ def test_start_clears_stale_tasks_from_a_previous_loop(session_factory, registry
     asyncio.run(start_and_stop())
 
     assert 999 not in runner.running_tasks
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("root_status", ["failed", "cancelled"])
+@pytest.mark.parametrize("length", [3, 4])
+async def test_dependency_failure_propagates_through_skipped_children(
+    db, repo, runner, registry, root_status, length
+):
+    executed = []
+
+    async def record(ctx):
+        executed.append(ctx.kind)
+        return Outcome()
+
+    kinds = ["archive_sync", "history_merge", "history_index", "stats"][:length]
+    registry.update({kind: record for kind in kinds})
+    chain = enqueue_chain(db, kinds, repository_id=repo.id, trigger="reconcile")
+    chain[0].status = root_status
+    db.commit()
+    await _drain(runner)
+    db.expire_all()
+    assert executed == []
+    for op in chain[1:]:
+        persisted = db.get(Operation, op.id)
+        assert persisted.status == "skipped"
+        assert persisted.skip_reason == "dependency_failed"
+        assert persisted.completed_at is not None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reason", ["agent_diff_unsupported", "plan_locked"])
+async def test_intentional_skip_in_chain_keeps_stats_runnable(
+    db, repo, runner, registry, reason
+):
+    async def ok(ctx):
+        return Outcome()
+
+    async def optional_stage(ctx):
+        return Outcome(status="skipped", skip_reason=reason)
+
+    registry.update(archive_sync=ok, history_index=optional_stage, stats=ok)
+    chain = enqueue_chain(
+        db,
+        ["archive_sync", "history_index", "stats"],
+        repository_id=repo.id,
+        trigger="reconcile",
+    )
+    await _drain(runner)
+    db.expire_all()
+    rows = [db.get(Operation, op.id) for op in chain]
+    assert [op.status for op in rows] == ["completed", "skipped", "completed"]
+    assert rows[1].skip_reason == reason
+    assert rows[2].skip_reason is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_repository_busy_defers_instead_of_failing(db, repo, runner, registry):
+    """Seen live: the follow-up listing is dispatched 45 ms before the plan
+    creates its prune job and admission refuses it with 409. The operation
+    goes back to the queue with a deferral count and runs on a later tick;
+    its dependants are untouched meanwhile."""
+    from fastapi import HTTPException
+
+    attempts = []
+
+    async def busy_then_done(ctx):
+        attempts.append(ctx.operation_id)
+        if len(attempts) == 1:
+            raise HTTPException(
+                status_code=409,
+                detail={"key": "backend.errors.jobs.repositoryOperationActive"},
+            )
+        return Outcome(result={"listed": 1})
+
+    registry["archive_sync"] = busy_then_done
+    registry["stats"] = lambda ctx: _done()
+    first = enqueue(db, "archive_sync", repository_id=repo.id)
+    child = enqueue(db, "stats", repository_id=repo.id, depends_on_id=first.id)
+    await runner.tick()
+    await asyncio.gather(*list(runner.running_tasks.values()), return_exceptions=True)
+    db.expire_all()
+    first = db.get(Operation, first.id)
+    assert first.status == "queued" and first.started_at is None
+    assert first.params["deferrals"] == 1 and first.error_message is None
+    assert db.get(Operation, child.id).status == "queued"
+    # a deferral does not wake the runner: no tight retry loop
+    assert not runner._event().is_set()
+
+    await _drain(runner)
+    db.expire_all()
+    assert db.get(Operation, first.id).status == "completed"
+    assert db.get(Operation, first.id).result == {"listed": 1}
+    assert db.get(Operation, child.id).status == "completed"
+    assert len(attempts) == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cancel_during_repository_busy_wins_over_the_deferral(
+    db, repo, runner, registry
+):
+    """A cancel that lands while admission is refusing the operation ends it
+    as cancelled; requeueing would drop the request in the runner's cleanup
+    and the operation would run again on the next tick."""
+    from fastapi import HTTPException
+
+    attempts = []
+
+    async def busy(ctx):
+        attempts.append(ctx.operation_id)
+        runner.cancel_requested.add(ctx.operation_id)
+        raise HTTPException(
+            status_code=409,
+            detail={"key": "backend.errors.jobs.repositoryOperationActive"},
+        )
+
+    registry["archive_sync"] = busy
+    first = enqueue(db, "archive_sync", repository_id=repo.id)
+    await runner.tick()
+    await asyncio.gather(*list(runner.running_tasks.values()), return_exceptions=True)
+    db.expire_all()
+    first = db.get(Operation, first.id)
+    assert first.status == "cancelled"
+    assert "deferrals" not in (first.params or {})
+    assert first.id not in runner.cancel_requested
+
+    await _drain(runner)
+    db.expire_all()
+    assert db.get(Operation, first.id).status == "cancelled"
+    assert len(attempts) == 1
+
+
+async def _done():
+    return Outcome()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_deferral_waits_out_its_delay_despite_wakes(
+    db, repo, session_factory, registry, monkeypatch, tmp_path
+):
+    """Every completion anywhere wakes the runner, and each wake ticks. A
+    deferred operation must not be re-dispatched by those ticks until its
+    delay has passed, or a busy install burns MAX_DEFERRALS in seconds while
+    a pending prune holds the repository."""
+    from fastapi import HTTPException
+
+    from app.services.operations import runner as runner_module
+
+    monkeypatch.setattr("app.config.settings.data_dir", str(tmp_path))
+    runner = OperationRunner(
+        session_factory=session_factory,
+        registry=registry,
+        poll_interval=0.01,
+        deferral_delay=0.2,
+    )
+    attempts = []
+
+    async def always_busy(ctx):
+        attempts.append(ctx.operation_id)
+        raise HTTPException(
+            status_code=409,
+            detail={"key": "backend.errors.jobs.repositoryOperationActive"},
+        )
+
+    registry["archive_sync"] = always_busy
+    op = enqueue(db, "archive_sync", repository_id=repo.id)
+    await _drain(runner, rounds=1)
+    db.expire_all()
+    row = db.get(Operation, op.id)
+    assert row.status == "queued" and row.params["deferrals"] == 1
+    not_before = runner_module.deferred_until(row)
+    assert not_before is not None and not_before > time.time()
+
+    # ten wakes in a row change nothing
+    await _drain(runner, rounds=10)
+    db.expire_all()
+    assert db.get(Operation, op.id).params["deferrals"] == 1
+    assert len(attempts) == 1
+
+    await asyncio.sleep(0.25)
+    await _drain(runner, rounds=1)
+    db.expire_all()
+    row = db.get(Operation, op.id)
+    assert row.params["deferrals"] == 2 and len(attempts) == 2
+    # the second wait is longer than the first
+    assert runner_module.deferred_until(row) - not_before > 0.3
+
+    # the delay doubles and is capped
+    assert runner.deferral_delay_for(1) == 0.2
+    assert runner.deferral_delay_for(3) == 0.8
+    assert (
+        runner.deferral_delay_for(runner_module.MAX_DEFERRALS)
+        == runner_module.DEFERRAL_MAX_DELAY_SECONDS
+    )
+    # an unreadable or non-finite not-before never blocks the operation:
+    # inf would park it forever, nan would skip the backoff
+    for bad in ("not a date", float("inf"), float("nan"), None):
+        row.params = {**row.params, "deferred_until": bad}
+        assert runner_module.deferred_until(row) is None
+
+
+@pytest.mark.unit
+def test_deferral_count_normalizes_bad_bookkeeping(db, repo):
+    """inf overflows int() and a negative count would allow more than
+    MAX_DEFERRALS attempts; both read as none, never as a crash that leaves
+    the row running."""
+    from app.services.operations import runner as runner_module
+
+    op = enqueue(db, "archive_sync", repository_id=repo.id)
+    for bad, expected in (
+        (float("inf"), 0),
+        (float("nan"), 0),
+        (-5, 0),
+        ("x", 0),
+        (None, 0),
+        ("3", 3),
+        (2.9, 2),
+    ):
+        op.params = {"deferrals": bad}
+        assert runner_module.deferral_count(op) == expected
+    op.params = None
+    assert runner_module.deferral_count(op) == 0
+
+
+@pytest.mark.unit
+def test_deferred_is_not_an_executor_outcome():
+    """Deferral is the runner's reaction to the admission's 409, never an
+    executor's choice: an executor cannot requeue itself by returning it."""
+    with pytest.raises(ValueError):
+        Outcome(status="deferred")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_requeue_commit_failure_fails_the_operation(
+    db, repo, runner, registry, monkeypatch
+):
+    """The requeue commit can fail like any other (locked database). The row
+    must not stay `running` with no task behind it until the next restart."""
+    from fastapi import HTTPException
+    from sqlalchemy.exc import OperationalError
+    from sqlalchemy.orm import Session
+
+    real_commit = Session.commit
+    fail_next = {"commit": False}
+
+    def flaky_commit(self):
+        if fail_next["commit"]:
+            fail_next["commit"] = False
+            raise OperationalError("UPDATE operations", {}, Exception("locked"))
+        return real_commit(self)
+
+    monkeypatch.setattr(Session, "commit", flaky_commit)
+
+    async def busy(ctx):
+        fail_next["commit"] = True
+        raise HTTPException(
+            status_code=409,
+            detail={"key": "backend.errors.jobs.repositoryOperationActive"},
+        )
+
+    registry["archive_sync"] = busy
+    op = enqueue(db, "archive_sync", repository_id=repo.id)
+    await _drain(runner, rounds=1)
+    db.expire_all()
+    op = db.get(Operation, op.id)
+    assert op.status == "failed"
+    assert "could not requeue" in op.error_message
+    assert op.completed_at is not None
+    assert (op.params or {}).get("deferrals") is None
+    assert not runner.running_tasks
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_malformed_persisted_deferrals_do_not_stall_the_operation(
+    db, repo, runner, registry
+):
+    """Unreadable bookkeeping in params counts as no deferrals: the busy
+    operation is requeued as a first deferral instead of raising before the
+    requeue and leaving the row running."""
+    from fastapi import HTTPException
+
+    attempts = []
+
+    async def busy_then_done(ctx):
+        attempts.append(ctx.operation_id)
+        if len(attempts) == 1:
+            raise HTTPException(
+                status_code=409,
+                detail={"key": "backend.errors.jobs.repositoryOperationActive"},
+            )
+        return Outcome()
+
+    registry["archive_sync"] = busy_then_done
+    op = enqueue(
+        db, "archive_sync", repository_id=repo.id, params={"deferrals": "garbage"}
+    )
+    await _drain(runner, rounds=1)
+    db.expire_all()
+    row = db.get(Operation, op.id)
+    assert row.status == "queued" and row.params["deferrals"] == 1
+    await _drain(runner)
+    db.expire_all()
+    assert db.get(Operation, op.id).status == "completed"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_repository_busy_fails_after_the_deferral_cap(db, repo, runner, registry):
+    from fastapi import HTTPException
+
+    from app.services.operations import runner as runner_module
+
+    async def always_busy(ctx):
+        raise HTTPException(
+            status_code=409,
+            detail={"key": "backend.errors.jobs.repositoryOperationActive"},
+        )
+
+    registry["archive_sync"] = always_busy
+    op = enqueue(db, "archive_sync", repository_id=repo.id)
+    await _drain(runner, rounds=runner_module.MAX_DEFERRALS + 5)
+    db.expire_all()
+    op = db.get(Operation, op.id)
+    assert op.status == "failed"
+    assert op.params["deferrals"] == runner_module.MAX_DEFERRALS
+    assert "still busy" in op.error_message
+
+    # any other exception, and a 409 without the admission key, still fail
+    # at once
+    async def other(ctx):
+        raise HTTPException(status_code=409, detail="something else")
+
+    registry["archive_sync"] = other
+    other_op = enqueue(db, "archive_sync", repository_id=repo.id)
+    await _drain(runner)
+    db.expire_all()
+    assert db.get(Operation, other_op.id).status == "failed"
+    assert (db.get(Operation, other_op.id).params or {}).get("deferrals") is None


### PR DESCRIPTION
## Description

Two gaps left every managed-agent repository second-class in the index chain (spec 6.4 / 7.2):

1. **A skipped dependency was treated like a failed one.** `history_index` is skipped by design on agents without diff support (`agent_diff_unsupported`) and on plans without history (`plan_locked`). `stats` sits behind it in the reconcile and `backup` chains, so it was skipped with `dependency_failed` on every run and `total_size` / `encryption` never refreshed for those repositories. The runner now lets a `skipped` dependency satisfy its dependants; `failed` and `cancelled` still skip them. Spec section 7.2 step 1 and `docs/architecture/job-system.md` say so.

2. **`fill_archive_info` returned 0 for agent repositories**, so `end`, `duration_seconds`, `nfiles` and the sizes stayed NULL there and the heatmap anomalies (`size_outlier`, `duration_outlier`) could never fire. It now dispatches the agent's existing `repository.archive_info` job per archive under the same `INDEX_ARCHIVE_INFO_PER_RUN` cap (`aid:<id>` on Borg 2, the archive name on Borg 1, same selectors the v2 archives route uses), feeds the result to the existing `_info_stats` parser, and resolves naive Borg 1 end times in the agent's reported zone (agents since #889 report `UTC`, older ones their machine zone; with no reported zone a naive `end` is left unset instead of being read in the server's zone). A failed job skips that archive and the rest continue.

3. **A follow-up refused by the repository admission failed instead of waiting** (integration test, round 3). The backup follow-up chain is enqueued the instant a backup completes, while the plan is still creating its prune job, so the listing could be dispatched a few milliseconds before the prune row existed and the admission then answered 409 (`repositoryOperationActive`) once it did. The runner now treats that 409 as a `deferred` outcome: the operation goes back to `queued` (`started_at` cleared, `params.deferrals` incremented) and is retried on the next poll or wake, without waking the loop itself so the retries are not burnt in a tight loop. `MAX_DEFERRALS` (20) bounds it; after that the operation fails with `repository still busy after 20 attempts`. Any other exception still fails the operation as before.

The server path of `fill_archive_info` is unchanged apart from being split into `_server_archive_info`; the existing tests cover it.

## Related Issue

Fixes #917
Fixes #932

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

New tests:

- `test_skipped_dependency_satisfies_dependants`: `history_index` returning `Outcome(status="skipped")` followed by `stats`, which now completes; the existing `test_dependency_gating_and_failure_skips_chain` (failed -> `dependency_failed`) is unchanged.
- `test_fill_archive_info_dispatches_agent_job`: Borg 2 agent repository, three archives, one job failing: `aid:<id>` selectors, cap honoured, sizes and duration filled, `end` converted from the agent zone (Europe/Berlin) to UTC, Borg 2's missing `compressed_size` / `deduplicated_size` stay NULL, the failed archive is skipped.
- `test_fill_archive_info_agent_borg1_uses_archive_name`: Borg 1 agent repository addressed by name, `end` parsed as UTC.
- `test_fill_archive_info_agent_without_zone_leaves_naive_end_unset` (review round 1): an agent that never reported its zone gets stats and duration, but a naive Borg 1 `end` stays unset rather than being read in the server's zone; an offset-carrying Borg 2 `end` is still stored.

- `test_repository_busy_defers_instead_of_failing` / `test_repository_busy_fails_after_the_deferral_cap` (round 3): the executor raising the admission's 409 puts the operation back to `queued` with `deferrals == 1`, leaves its dependant untouched and does not set the runner's wake event; the next run completes it. With `params.deferrals` already at the cap the operation fails with the bounded message.

Runs (scratch venv, Python 3.12, ruff 0.16.5):

```
pytest tests/unit/test_operations_runner.py tests/unit/test_operations_index_executors.py \
       tests/unit/test_operations_followups.py tests/unit/test_operations_reconcile.py \
       tests/unit/test_api_archive_index.py tests/unit/test_api_repositories_import_operations.py
91 passed

pytest tests/unit   (full suite, untouched clone of this branch at 3ae3963f)
3 failed, 3150 passed, 13 skipped in 537s
  the 3 failures are tests/unit/test_source_discovery.py database-scan tests and are
  pre-existing: the same three fail on a clean upstream/main (c7f32d1f) in an
  untouched clone (3 failed, 3146 passed); in the full suite the scan finds the
  test app's own test.db inside the test's tmp_path, each passes in isolation

ruff check .            All checks passed!
ruff format --check .   clean
```

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass (apart from the three pre-existing failures above)

Round 3 (head `ca0d0d85`, on `96adc69d`):

```
pytest tests/unit/test_operations_runner.py tests/unit/test_operations_followups.py
51 passed, 7 warnings in 1.72s
```

Full `pytest tests/unit` on io/integration `058c7a0a` (main `3b557171` + upstream #945 + PRs 54-59): `3364 passed, 13 skipped`.

Rebased onto main `37cee432` (head `f6aff641`), same runs on the rebased branch:

```
pytest tests/unit/test_operations_runner.py tests/unit/test_operations_index_executors.py
50 passed, 7 warnings in 1.32s
ruff check / ruff format --check   clean on every file in this diff
```

Full `pytest tests/unit` in one process on an integration branch carrying this PR together with the rest of the wave on top of main `3b557171` + #945: `3364 passed, 13 skipped`, no failures, no errors.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable.

## Additional Context

Observed before the change on agent repositories (Borg 1 over `ssh://` and Borg 2 over `rest://` alike): every reconcile run ends in `history_index | skipped | agent_diff_unsupported` followed by `stats | skipped | dependency_failed`, and the archives table carries no per-archive statistics. This PR is the first of the wave described in #917, #931, #933, #934, #935, #936; it needs no agent release (the `repository.archive_info` capability exists on every enrolled agent).


<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 0 changed, 4 added, 0 removed, 690 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-948/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/34096586052
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- `components-archives-archiveinfotab--no-unique-data--mobile.png`
- `components-archives-archiveinfotab--no-unique-data.png`
- `components-archives-archiveinfotab--unique-share-below-one-percent--mobile.png`
- `components-archives-archiveinfotab--unique-share-below-one-percent.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->