### PR TITLE
fix(operations): enqueue the backup follow-up chain when a backup completes

### DIFF
--- a/app/api/agents.py
+++ b/app/api/agents.py
@@ -56,6 +56,10 @@ from app.services.agent_job_notifications import (
     notify_check_job_finished,
     orm_identity_id,
 )
+from app.services.operations.followups import (
+    enqueue_backup_followups,
+    history_enabled,
+)
 from app.utils.datetime_utils import serialize_datetime
 
 logger = structlog.get_logger()
@@ -473,14 +477,43 @@ def _finish_linked_backup_job(
         if archive_name:
             backup_job.archive_name = archive_name
 
-        repository = (
-            db.query(Repository)
-            .filter(Repository.path == backup_job.repository)
-            .first()
-        )
+        repository = None
+        if backup_job.repository_id:
+            repository = db.get(Repository, backup_job.repository_id)
+        if repository is None:
+            repository = (
+                db.query(Repository)
+                .filter(Repository.path == backup_job.repository)
+                .first()
+            )
         if repository:
-            repository.last_backup = completed_at
             repository.updated_at = _now_utc()
+            repository_name = repository.name
+            # archive_sync derives last_backup from the listing; the caller
+            # commits, and the runner polls for the new rows. The attempt
+            # runs in a savepoint: a failed flush inside enqueue would
+            # otherwise leave the session needing a rollback, and a plain
+            # rollback here would discard the terminal state the caller has
+            # pending. Only the enqueue is undone; the name and the plan
+            # gate (which commits through the licensing service) are read
+            # before the savepoint opens.
+            history = history_enabled(db)
+            try:
+                with db.begin_nested():
+                    enqueue_backup_followups(
+                        db,
+                        repository.id,
+                        scheduled_job_id=backup_job.scheduled_job_id,
+                        backup_plan_run_id=backup_job.backup_plan_run_id,
+                        commit=False,
+                        history=history,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to enqueue index follow-ups",
+                    repository=repository_name,
+                    error=str(exc),
+                )
 
 
 def _get_repository_operation_job(agent_job: AgentJob, db: Session) -> Any | None:

--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -22,6 +22,7 @@ from app.services.notification_service import notification_service
 from app.services.script_executor import execute_script
 from app.services.script_library_executor import ScriptLibraryExecutor
 from app.services.mqtt_service import mqtt_service
+from app.services.operations.followups import enqueue_backup_followups
 from app.services.rclone_repository_service import rclone_repository_service
 from app.services.restore_check_canary import (
     ensure_restore_canary,
@@ -566,98 +567,26 @@ class BackupService:
         except Exception as e:
             logger.error("Failed to update archive stats", job_id=job_id, error=str(e))
 
-    async def _update_repository_stats(
-        self, db: Session, repository_path: str, env: dict
-    ):
-        """Update repository statistics after a successful backup"""
+    def _enqueue_index_followups(self, db: Session, repo_record, job) -> None:
+        """Refresh the archive index through the operations runner after a
+        backup (spec 7.4): archive_sync derives archive_count and last_backup
+        from the listing, stats refreshes the size. Never fails the backup."""
+        if repo_record is None:
+            return
         try:
-            repo_record = (
-                db.query(Repository).filter(Repository.path == repository_path).first()
-            )
-            if not repo_record:
-                logger.warning(
-                    "Repository record not found for stats update",
-                    repository=repository_path,
-                )
-                return
-            router = BorgRouter(repo_record)
-
-            # Get timeouts from DB settings (with fallback to config)
-            timeouts = self._get_operation_timeouts(db)
-
-            async def _operation():
-                list_cmd = router.build_repo_list_command(repository_path)
-                list_process = await asyncio.create_subprocess_exec(
-                    *list_cmd,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    env=env,
-                )
-                list_stdout, list_stderr = await asyncio.wait_for(
-                    list_process.communicate(), timeout=timeouts["list_timeout"]
-                )
-
-                if list_process.returncode == 0:
-                    try:
-                        archives_data = json.loads(list_stdout.decode())
-                        archive_count = len(archives_data.get("archives", []))
-                        repo_record.archive_count = archive_count
-                        logger.info(
-                            "Updated archive count",
-                            repository=repository_path,
-                            count=archive_count,
-                        )
-                    except json.JSONDecodeError as e:
-                        logger.warning("Failed to parse borg list output", error=str(e))
-
-                info_cmd = router.build_repo_info_command(repository_path)
-                info_process = await asyncio.create_subprocess_exec(
-                    *info_cmd,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    env=env,
-                )
-                info_stdout, info_stderr = await asyncio.wait_for(
-                    info_process.communicate(), timeout=timeouts["info_timeout"]
-                )
-
-                if info_process.returncode == 0:
-                    try:
-                        info_data = json.loads(info_stdout.decode())
-                        cache_stats = info_data.get("cache", {}).get("stats", {})
-
-                        # Get total repository size (unique_size is deduplicated size)
-                        unique_size = cache_stats.get("unique_size", 0)
-                        if unique_size > 0:
-                            # Format size to human readable
-                            repo_record.total_size = self._format_bytes(unique_size)
-                            logger.info(
-                                "Updated repository size",
-                                repository=repository_path,
-                                size=repo_record.total_size,
-                            )
-                    except json.JSONDecodeError as e:
-                        logger.warning("Failed to parse borg info output", error=str(e))
-
-                # Update last_backup timestamp
-                repo_record.last_backup = datetime.utcnow()
-
-                db.commit()
-                logger.info("Repository statistics updated", repository=repository_path)
-
-                # Publish a full DB-derived MQTT snapshot immediately after stats changes.
-                mqtt_service.sync_state_with_db(db, reason="repository stats updated")
-
-            await run_serialized_repository_command(repo_record.id, _operation)
-
-        except asyncio.TimeoutError:
-            logger.warning(
-                "Timeout while updating repository stats", repository=repository_path
+            enqueue_backup_followups(
+                db,
+                repo_record.id,
+                scheduled_job_id=getattr(job, "scheduled_job_id", None),
+                backup_plan_run_id=getattr(job, "backup_plan_run_id", None),
             )
         except Exception as e:
-            logger.error(
-                "Failed to update repository stats",
-                repository=repository_path,
+            # enqueue_chain commits; a failed commit leaves the session in
+            # need of a rollback before the finalization below commits again
+            db.rollback()
+            logger.warning(
+                "Failed to enqueue index follow-ups",
+                repository=repo_record.name,
                 error=str(e),
             )
 
@@ -2652,8 +2581,7 @@ class BackupService:
                 await self._update_archive_stats(
                     db, job_id, repository, archive_name, env
                 )
-                # Update repository statistics after successful backup
-                await self._update_repository_stats(db, repository, env)
+                self._enqueue_index_followups(db, repo_record, job)
                 rclone_sync_ok = await self._sync_rclone_after_borg(
                     db, repo_record, job
                 )
@@ -2768,8 +2696,7 @@ class BackupService:
                 await self._update_archive_stats(
                     db, job_id, repository, archive_name, env
                 )
-                # Update repository statistics even with warnings
-                await self._update_repository_stats(db, repository, env)
+                self._enqueue_index_followups(db, repo_record, job)
                 await self._sync_rclone_after_borg(db, repo_record, job)
 
                 # Run post-backup hooks even with warnings (script library or inline)

--- a/app/services/operations/followups.py
+++ b/app/services/operations/followups.py
@@ -8,7 +8,7 @@ from app.services.operations.vocab import validate_kind
 
 FOLLOWUPS: dict[str, tuple[str, ...]] = {
     "import_connect": ("stats", "archive_sync", "history_index"),
-    "backup": ("archive_sync", "history_index", "stats"),
+    "backup": ("archive_sync", "history_merge", "history_index", "stats"),
     "prune": ("archive_sync", "history_merge", "stats"),
     "delete_archive": ("archive_sync", "history_merge", "stats"),
     "compact": ("stats",),
@@ -59,3 +59,78 @@ def history_enabled(db) -> bool:
     from app.core.features import Plan, get_current_plan, plan_includes
 
     return plan_includes(get_current_plan(db), Plan.PRO)
+
+
+def enqueue_backup_followups(
+    db,
+    repository_id: int,
+    *,
+    scheduled_job_id: Optional[int] = None,
+    backup_plan_run_id: Optional[int] = None,
+    commit: bool = True,
+    history: Optional[bool] = None,
+) -> list:
+    """Enqueue the `backup` chain for a backup that completed outside the
+    runner (the legacy backup paths, until phase 8 moves them in).
+
+    `history` is the plan gate; left None it is read here, which goes
+    through the licensing service and commits the session. A caller that
+    wraps this call in a savepoint reads it beforehand and passes it in.
+
+    Skipped only when an archive listing is queued and its dependency is
+    already satisfied (or absent). Other queued index work cannot replace
+    a listing. A running listing may predate this backup and does not count.
+
+    The check is best-effort, like the reconcile scheduler's: a second chain
+    from a lost race is one extra listing, serialized per repository by the
+    executors and idempotent (archives upsert by id), not a correctness
+    problem, so it is not worth a lock or a uniqueness constraint.
+    """
+    from sqlalchemy import and_, or_
+    from sqlalchemy.orm import aliased
+
+    from app.database.models import Operation
+    from app.services.operations.enqueue import enqueue_chain
+    from app.services.operations.executors import registered_kinds
+    from app.services.operations.vocab import SUCCESS_STATUSES
+
+    dependency = aliased(Operation)
+    queued = (
+        db.query(Operation.id)
+        .outerjoin(dependency, Operation.depends_on_id == dependency.id)
+        .filter(
+            Operation.repository_id == repository_id,
+            Operation.kind == "archive_sync",
+            Operation.status == "queued",
+            # Match the runner's corrected skip semantics (#917): an
+            # intentional skip satisfies; dependency_failed propagates.
+            or_(
+                Operation.depends_on_id.is_(None),
+                dependency.status.in_(SUCCESS_STATUSES),
+                and_(
+                    dependency.status == "skipped",
+                    or_(
+                        dependency.skip_reason.is_(None),
+                        dependency.skip_reason != "dependency_failed",
+                    ),
+                ),
+            ),
+        )
+        .first()
+    )
+    if queued is not None:
+        return []
+    if history is None:
+        history = history_enabled(db)
+    kinds = chain_for("backup", available=registered_kinds(), history=history)
+    if not kinds:
+        return []
+    return enqueue_chain(
+        db,
+        kinds,
+        repository_id=repository_id,
+        trigger="followup",
+        scheduled_job_id=scheduled_job_id,
+        backup_plan_run_id=backup_plan_run_id,
+        commit=commit,
+    )

--- a/app/services/operations/lanes.py
+++ b/app/services/operations/lanes.py
@@ -58,6 +58,58 @@ def legacy_running_exclusive(db: Session, repository_id: int) -> bool:
     return False
 
 
+# Kinds the job admission classes as repository writes: their agent and
+# server jobs are refused with 409 while one of them runs, so a listing
+# started under bypass_lock would fail instead of reading past a lock.
+_WRITE_MAINTENANCE_KINDS = ("prune", "compact", "delete_archive", "wipe")
+_WRITE_MAINTENANCE_MODELS = (PruneJob, CompactJob, DeleteArchiveJob, RepositoryWipeJob)
+_LEGACY_MAINTENANCE_BACKUP_STATUSES = ("running_prune", "running_compact")
+
+
+def write_maintenance_running(db: Session, repository_id: int) -> bool:
+    """True while prune, compact, delete or wipe is queued or running on
+    the repository, as an operation, a legacy job row, or a backup job in
+    its maintenance phase (`maintenance_status`, the scheduler's post-backup
+    prune and compact). Unlike a running backup, these are not something
+    a listing can bypass: admission refuses the listing outright."""
+    if (
+        db.query(Operation.id)
+        .filter(
+            Operation.repository_id == repository_id,
+            Operation.status.in_(("queued", "running")),
+            Operation.kind.in_(_WRITE_MAINTENANCE_KINDS),
+        )
+        .first()
+    ):
+        return True
+    if (
+        db.query(BackupJob.id)
+        .filter(
+            BackupJob.repository_id == repository_id,
+            BackupJob.maintenance_status.in_(_LEGACY_MAINTENANCE_BACKUP_STATUSES),
+        )
+        .first()
+    ):
+        return True
+    # Same statuses the admission treats as active: a maintenance job is
+    # created pending and refuses listings from that moment on, before it
+    # has started (seen live: 409 against a pending prune two seconds after
+    # the backup completed).
+    from app.services.job_admission import ACTIVE_MAINTENANCE_STATUSES
+
+    for model in _WRITE_MAINTENANCE_MODELS:
+        if (
+            db.query(model.id)
+            .filter(
+                model.repository_id == repository_id,
+                model.status.in_(tuple(ACTIVE_MAINTENANCE_STATUSES)),
+            )
+            .first()
+        ):
+            return True
+    return False
+
+
 def running_exclusive_operation(
     db: Session, repository_id: int, *, exclude_id: Optional[int] = None
 ) -> bool:
@@ -135,6 +187,14 @@ def can_start(db: Session, op: Operation, settings: Optional[SystemSettings]) ->
     if is_exclusive(op.kind):
         return lane_free(db, op.repository_id, exclude_id=op.id)
     if op.kind in INDEX_KINDS:
+        # Admission refuses a listing while prune, compact, delete or wipe
+        # is pending or running, whatever the lane says (a pending job holds
+        # no lane yet) and whatever bypass_lock says (that reads past a
+        # running backup's lock, not past admission). Checked first: the
+        # backup follow-up chain otherwise fails with 409 against the plan's
+        # own post-backup prune.
+        if write_maintenance_running(db, op.repository_id):
+            return False
         if lane_free(db, op.repository_id, exclude_id=op.id):
             return True
         repository = db.get(Repository, op.repository_id)

--- a/docs/architecture/job-system.md
+++ b/docs/architecture/job-system.md
@@ -252,7 +252,13 @@ Rules:
   doubling to 5 min).
   After 20 deferrals it fails with "repository still busy".
 - Follow-ups are created automatically when an operation succeeds. An
-  import enqueues stats and archive listing.
+  import enqueues stats and archive listing. A backup that completes through
+  the legacy backup paths (server or agent) enqueues the `backup` chain the
+  same way, so the archive index and `last_backup` follow within a runner
+  tick instead of waiting for the next reconcile run. Only a queued
+  `archive_sync` with no dependency or an already satisfied dependency
+  suppresses a duplicate listing. `history_merge` follows the listing on
+  every plan so removed archives leave the database as well.
 - `stats` measures the repository read-only through the best source Borg
   offers and records it in `repositories.total_size_source`: Borg 1
   `cache.stats.unique_csize` (`borg1_cache_stats`, deduplicated); Borg 2 the

--- a/docs/engineering/specs/2026-09-03-repository-operations-and-archive-history.md
+++ b/docs/engineering/specs/2026-09-03-repository-operations-and-archive-history.md
@@ -506,7 +506,7 @@ Existing settings keep their meaning and move behind one function,
 | after | chain (in order, each depends on the previous) |
 | --- | --- |
 | `import_connect` | `stats`, `archive_sync`, `history_index` |
-| `backup` | `archive_sync`, `history_index`, `stats` |
+| `backup` | `archive_sync`, `history_merge`, `history_index`, `stats` |
 | `prune` | `archive_sync`, `history_merge`, `stats` |
 | `delete_archive` | `archive_sync`, `history_merge`, `stats` |
 | `compact` | `stats` |
@@ -516,7 +516,14 @@ Existing settings keep their meaning and move behind one function,
 
 Follow-ups are created by the runner when the parent reaches a terminal
 success state, with the parent's `run_id`, `trigger = followup`,
-`priority = 10`. They are not created when the parent fails.
+`priority = 10`. They are not created when the parent fails. Until phase 8
+moves backups into the runner, the legacy backup completion paths call
+`followups.enqueue_backup_followups` themselves (#933), which enqueues the
+`backup` chain unless an `archive_sync` is queued with no dependency or an
+already satisfied dependency. Other queued index stages and running listings
+do not suppress it. `history_merge` immediately follows the listing on every
+plan to delete removed archive rows. `archive_sync` then derives `archive_count` and `last_backup` from the
+listing instead of the completion path writing them.
 
 `archive_sync` runs before `history_merge` so the merge knows which archives
 disappeared. `history_index` skips pairs whose predecessor is not yet
@@ -1332,7 +1339,7 @@ All of these are replaced by `enqueue()` calls in phase 1 or phase 5.
 | `app/api/repositories.py:914` `update_repository_stats` | `borg list` for count and last backup, `borg info` for size; not wrapped in the repository command lock | `stats` and `archive_sync` executors (phase 1) |
 | `app/api/repositories.py:813` `_update_agent_repository_stats` | Agent variant of the above | Same executors, routed through `BorgRouter` |
 | `app/services/stats_refresh_scheduler.py:26-160` | Hourly sequential loop over all repositories calling `update_stats` | Reconcile trigger, section 7.5 (phase 1) |
-| `app/services/backup_service.py:2643` and `:2759` | Stats after a backup | `backup` follow-up chain (phase 8; until then, a one-line `enqueue` replaces the call in phase 5) |
+| `app/services/backup_service.py:2643` and `:2759` | Stats after a backup | `backup` follow-up chain via `enqueue_backup_followups` (#933, done ahead of phase 5); phase 8 moves it into the runner |
 | `app/services/repository_wipe_service.py:465` | Stats after a wipe | `wipe` follow-up chain (phase 6) |
 | `app/services/repository_info_sync.py:47` `sync_archive_stats_from_info` | Writes archive stats when the info dialog opens; called from `app/api/repositories.py:6089`, `:6139`, `app/api/v2/repositories.py:569`, `:634` | Keeps running, writes into `archives` (phase 2) |
 | `app/core/borg_router.py:434` `BorgRouter.update_stats` | Router entry for the above | Kept as a thin call into the executors, then removed in phase 9 |

--- a/tests/unit/test_api_agents.py
+++ b/tests/unit/test_api_agents.py
@@ -16,8 +16,10 @@ from app.database.models import (
     BackupPlan,
     CheckJob,
     LicensingState,
+    Operation,
     Repository,
 )
+from app.services.operations.executors import load_default_executors
 
 
 def _set_plan(test_db, plan: str) -> None:
@@ -810,6 +812,117 @@ class TestAgentJobTransport:
             headers=headers,
         )
         assert repeated.status_code == 200
+
+    def test_completed_backup_job_enqueues_index_followups(
+        self, test_client: TestClient, test_db, admin_headers
+    ):
+        """A completed agent backup no longer writes last_backup itself; it
+        enqueues the backup follow-up chain, and archive_sync derives the
+        column from the listing (#933)."""
+        load_default_executors()
+        registered = _register_agent(
+            test_client,
+            _create_enrollment_token(test_client, admin_headers)["token"],
+        )
+        agent = _get_agent(test_db, registered["agent_id"])
+        repo = Repository(name="linked", path="/repo", encryption="none")
+        test_db.add(repo)
+        test_db.commit()
+        job = _create_agent_job(test_db, agent, status="running")
+        backup_job = BackupJob(
+            repository="/repo", repository_id=repo.id, status="running"
+        )
+        test_db.add(backup_job)
+        test_db.commit()
+        job.backup_job_id = backup_job.id
+        test_db.commit()
+
+        complete = test_client.post(
+            f"/api/agents/jobs/{job.id}/complete",
+            json={"result": {"archive_name": "a1", "return_code": 0}},
+            headers=_agent_headers(registered["agent_token"]),
+        )
+        assert complete.status_code == 200
+
+        test_db.refresh(repo)
+        assert repo.last_backup is None
+        ops = (
+            test_db.query(Operation)
+            .filter(Operation.repository_id == repo.id)
+            .order_by(Operation.id)
+            .all()
+        )
+        assert [o.kind for o in ops][:1] == ["archive_sync"]
+        assert {o.trigger for o in ops} == {"followup"}
+
+    def test_failed_followup_enqueue_never_fails_the_backup(
+        self, test_client: TestClient, test_db, admin_headers, monkeypatch
+    ):
+        """A flush failure inside the follow-up enqueue (here a colliding
+        Operation id, the shape enqueue() produces) is undone in its own
+        savepoint: the completion still succeeds and the terminal state of
+        the agent job and the backup job is committed, with no chain rows."""
+        from sqlalchemy.exc import IntegrityError
+
+        load_default_executors()
+        registered = _register_agent(
+            test_client,
+            _create_enrollment_token(test_client, admin_headers)["token"],
+        )
+        agent = _get_agent(test_db, registered["agent_id"])
+        repo = Repository(name="linked", path="/repo", encryption="none")
+        test_db.add(repo)
+        test_db.commit()
+        from app.services.operations.enqueue import enqueue
+
+        existing = enqueue(test_db, "stats", repository_id=repo.id)
+        job = _create_agent_job(test_db, agent, status="running")
+        backup_job = BackupJob(
+            repository="/repo", repository_id=repo.id, status="running"
+        )
+        test_db.add(backup_job)
+        test_db.commit()
+        job.backup_job_id = backup_job.id
+        test_db.commit()
+        seen = {}
+
+        def colliding_enqueue(db, repository_id, **kwargs):
+            db.add(
+                Operation(
+                    id=existing.id,
+                    run_id=existing.run_id,
+                    kind="archive_sync",
+                    category="index",
+                    status="queued",
+                    trigger="followup",
+                    repository_id=repository_id,
+                )
+            )
+            try:
+                db.flush()
+            except IntegrityError as exc:
+                seen["error"] = exc
+                raise
+            raise AssertionError("the colliding flush did not fail")
+
+        monkeypatch.setattr(
+            "app.api.agents.enqueue_backup_followups", colliding_enqueue
+        )
+        complete = test_client.post(
+            f"/api/agents/jobs/{job.id}/complete",
+            json={"result": {"archive_name": "a1", "return_code": 0}},
+            headers=_agent_headers(registered["agent_token"]),
+        )
+        assert complete.status_code == 200, complete.text
+        assert "error" in seen
+        test_db.expire_all()
+        assert test_db.get(AgentJob, job.id).status == "completed"
+        assert test_db.get(BackupJob, backup_job.id).status == "completed"
+        assert test_db.get(BackupJob, backup_job.id).archive_name == "a1"
+        assert (
+            test_db.query(Operation).filter(Operation.repository_id == repo.id).count()
+            == 1
+        )
 
     def test_modern_warning_range_counts_as_warning(
         self, test_client: TestClient, test_db, admin_headers

--- a/tests/unit/test_api_backup.py
+++ b/tests/unit/test_api_backup.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import text
 from app.core.agent_auth import AGENT_AUTH_HEADER
 from app.core.security import get_password_hash
+from app.services.operations.executors import load_default_executors
 from app.database.models import (
     AgentJob,
     AgentJobLog,
@@ -17,6 +18,7 @@ from app.database.models import (
     CheckJob,
     PruneJob,
     CompactJob,
+    Operation,
     SSHConnection,
     SystemSettings,
     UserRepositoryPermission,
@@ -586,6 +588,7 @@ class TestBackupStart:
         self, test_client: TestClient, admin_headers, test_db
     ):
         _set_log_save_policy(test_db, "all_jobs")
+        load_default_executors()
         raw_token = "borgui_agent_secret"
         agent = AgentMachine(
             name="Laptop",
@@ -682,7 +685,16 @@ class TestBackupStart:
         assert backup_job.current_file == "/home/user/file"
         assert backup_job.archive_name == "agent-archive"
         assert backup_job.logs == "Creating archive"
-        assert repo.last_backup is not None
+        # last_backup now comes from the archive index: completion enqueues
+        # the backup follow-up chain instead of writing the column (#933).
+        assert repo.last_backup is None
+        followups = (
+            test_db.query(Operation)
+            .filter(Operation.repository_id == repo.id, Operation.trigger == "followup")
+            .order_by(Operation.id)
+            .all()
+        )
+        assert followups and followups[0].kind == "archive_sync"
 
         logs_response = test_client.get(
             f"/api/activity/backup/{backup_job_id}/logs", headers=admin_headers

--- a/tests/unit/test_backup_service.py
+++ b/tests/unit/test_backup_service.py
@@ -11,7 +11,15 @@ from unittest.mock import ANY, Mock, patch, AsyncMock, MagicMock
 from sqlalchemy.orm import sessionmaker
 from app.services.backup_service import BackupService
 from app.services.filesystem_snapshot_service import PreparedFilesystemSnapshot
-from app.database.models import BackupJob, Repository, SSHConnection, SystemSettings
+from types import SimpleNamespace
+
+from app.database.models import (
+    BackupJob,
+    Operation,
+    Repository,
+    SSHConnection,
+    SystemSettings,
+)
 
 
 class AsyncLineStream:
@@ -263,10 +271,9 @@ class TestBackupService:
                 test_db, job.id, "/test/repo", "test-archive", {}
             )
 
-    @pytest.mark.asyncio
-    async def test_update_repository_stats_success(self, backup_service, test_db):
-        """Test _update_repository_stats with successful response"""
-        # Create a repository record
+    def test_enqueue_index_followups_creates_operations(self, backup_service, test_db):
+        """After a backup the index refresh goes through the operations
+        runner instead of an inline borg list/info (#933)."""
         repo = Repository(
             name="Test Repo",
             path="/test/repo",
@@ -275,41 +282,27 @@ class TestBackupService:
         )
         test_db.add(repo)
         test_db.commit()
+        job = SimpleNamespace(scheduled_job_id=7, backup_plan_run_id=None)
 
-        # Mock the subprocess to return valid JSON
-        mock_process = AsyncMock()
-        mock_process.communicate = AsyncMock(
-            return_value=(b'{"cache": {"stats": {"total_size": 1000000}}}', b"")
-        )
-        mock_process.returncode = 0
+        with patch("app.services.operations.enqueue.wake_runner", lambda: None):
+            backup_service._enqueue_index_followups(test_db, repo, job)
 
-        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
-            # Should not raise exception
-            await backup_service._update_repository_stats(test_db, "/test/repo", {})
+        ops = test_db.query(Operation).order_by(Operation.id).all()
+        assert [o.kind for o in ops] == ["archive_sync", "history_merge", "stats"]
+        assert all(o.trigger == "followup" for o in ops)
+        assert all(o.scheduled_job_id == 7 for o in ops)
 
-    @pytest.mark.asyncio
-    async def test_update_repository_stats_failure(self, backup_service, test_db):
-        """Test _update_repository_stats when borg command fails"""
-        # Create a repository record
-        repo = Repository(
-            name="Test Repo",
-            path="/test/repo",
-            encryption="none",
-            repository_type="local",
-        )
+    def test_enqueue_index_followups_never_raises(self, backup_service, test_db):
+        repo = Repository(name="Test Repo", path="/test/repo", encryption="none")
         test_db.add(repo)
         test_db.commit()
-
-        # Mock the subprocess to return error
-        mock_process = AsyncMock()
-        mock_process.communicate = AsyncMock(
-            return_value=(b"", b"Repository not found")
-        )
-        mock_process.returncode = 1
-
-        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
-            # Should not raise exception, just log warning
-            await backup_service._update_repository_stats(test_db, "/test/repo", {})
+        with patch(
+            "app.services.backup_service.enqueue_backup_followups",
+            side_effect=RuntimeError("boom"),
+        ):
+            backup_service._enqueue_index_followups(
+                test_db, repo, SimpleNamespace(scheduled_job_id=None)
+            )
 
     def test_get_operation_timeouts_prefers_database_values(
         self, backup_service, test_db
@@ -483,122 +476,6 @@ class TestBackupService:
         assert order[:3] == ["lock-held", "lock-released", "subprocess:info"]
 
     @pytest.mark.asyncio
-    async def test_update_repository_stats_updates_repository_and_publishes_snapshot(
-        self, backup_service, test_db
-    ):
-        repo = Repository(
-            name="Test Repo",
-            path="/test/repo",
-            encryption="none",
-            repository_type="local",
-        )
-        test_db.add(repo)
-        test_db.commit()
-        test_db.refresh(repo)
-
-        list_process = AsyncMock()
-        list_process.communicate = AsyncMock(
-            return_value=(b'{"archives": [{"name": "a"}, {"name": "b"}]}', b"")
-        )
-        list_process.returncode = 0
-        info_process = AsyncMock()
-        info_process.communicate = AsyncMock(
-            return_value=(b'{"cache": {"stats": {"unique_size": 1048576}}}', b"")
-        )
-        info_process.returncode = 0
-        mqtt = Mock()
-        mqtt.sync_state_with_db = Mock()
-
-        with (
-            patch(
-                "asyncio.create_subprocess_exec",
-                side_effect=[list_process, info_process],
-            ),
-            patch("app.services.backup_service.mqtt_service", mqtt),
-        ):
-            await backup_service._update_repository_stats(test_db, "/test/repo", {})
-
-        test_db.refresh(repo)
-        assert repo.archive_count == 2
-        assert repo.total_size == "1.00 MB"
-        assert repo.last_backup is not None
-        mqtt.sync_state_with_db.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_update_repository_stats_waits_for_repository_command_lock(
-        self, backup_service, test_db
-    ):
-        from app.services.repository_command_lock import (
-            run_serialized_repository_command,
-        )
-
-        repo = Repository(
-            name="Test Repo",
-            path="/test/repo",
-            encryption="none",
-            repository_type="local",
-        )
-        test_db.add(repo)
-        test_db.commit()
-        test_db.refresh(repo)
-
-        order: list[str] = []
-        holder_started = asyncio.Event()
-        release_holder = asyncio.Event()
-
-        async def hold_repository_lock():
-            async def operation():
-                order.append("lock-held")
-                holder_started.set()
-                await release_holder.wait()
-                order.append("lock-released")
-
-            await run_serialized_repository_command(repo.id, operation)
-
-        holder_task = asyncio.create_task(hold_repository_lock())
-        await holder_started.wait()
-        stats_task = None
-
-        async def fake_create_subprocess_exec(*cmd, **kwargs):
-            order.append(f"subprocess:{cmd[1]}")
-            process = AsyncMock()
-            stdout = (
-                b'{"archives": []}'
-                if cmd[1] in {"list", "repo-list"}
-                else b'{"cache": {"stats": {"unique_size": 0}}}'
-            )
-            process.communicate = AsyncMock(return_value=(stdout, b""))
-            process.returncode = 0
-            return process
-
-        try:
-            with patch(
-                "asyncio.create_subprocess_exec",
-                side_effect=fake_create_subprocess_exec,
-            ):
-                stats_task = asyncio.create_task(
-                    backup_service._update_repository_stats(test_db, repo.path, {})
-                )
-                await asyncio.sleep(0.01)
-
-                assert not any(item.startswith("subprocess:") for item in order)
-
-                release_holder.set()
-                await asyncio.wait_for(holder_task, timeout=1)
-                await asyncio.wait_for(stats_task, timeout=1)
-        finally:
-            release_holder.set()
-            pending_tasks = [
-                task
-                for task in (holder_task, stats_task)
-                if task is not None and not task.done()
-            ]
-            if pending_tasks:
-                await asyncio.gather(*pending_tasks, return_exceptions=True)
-
-        assert order[:3] == ["lock-held", "lock-released", "subprocess:list"]
-
-    @pytest.mark.asyncio
     async def test_execute_backup_success_saves_logs_and_notifies_success(
         self, backup_service, test_db, tmp_path
     ):
@@ -658,7 +535,7 @@ class TestBackupService:
                 backup_service, "_calculate_and_update_size_background", AsyncMock()
             ),
             patch.object(backup_service, "_update_archive_stats", AsyncMock()),
-            patch.object(backup_service, "_update_repository_stats", AsyncMock()),
+            patch.object(backup_service, "_enqueue_index_followups"),
             patch(
                 "app.services.backup_service.resolve_repo_ssh_key_file",
                 return_value=None,
@@ -772,7 +649,7 @@ class TestBackupService:
                     backup_service, "_calculate_and_update_size_background", AsyncMock()
                 ),
                 patch.object(backup_service, "_update_archive_stats", AsyncMock()),
-                patch.object(backup_service, "_update_repository_stats", AsyncMock()),
+                patch.object(backup_service, "_enqueue_index_followups"),
                 patch(
                     "app.services.backup_service.resolve_repo_ssh_key_file",
                     return_value=None,
@@ -887,7 +764,7 @@ class TestBackupService:
                     backup_service, "_calculate_and_update_size_background", AsyncMock()
                 ),
                 patch.object(backup_service, "_update_archive_stats", AsyncMock()),
-                patch.object(backup_service, "_update_repository_stats", AsyncMock()),
+                patch.object(backup_service, "_enqueue_index_followups"),
                 patch(
                     "app.services.backup_service.resolve_repo_ssh_key_file",
                     return_value=None,
@@ -992,7 +869,7 @@ class TestBackupService:
                 backup_service, "_calculate_and_update_size_background", AsyncMock()
             ) as calculate_size,
             patch.object(backup_service, "_update_archive_stats", AsyncMock()),
-            patch.object(backup_service, "_update_repository_stats", AsyncMock()),
+            patch.object(backup_service, "_enqueue_index_followups"),
             patch(
                 "app.services.backup_service.resolve_repo_ssh_key_file",
                 return_value=None,
@@ -1125,7 +1002,7 @@ class TestBackupService:
                 calculate_size,
             ),
             patch.object(backup_service, "_update_archive_stats", AsyncMock()),
-            patch.object(backup_service, "_update_repository_stats", AsyncMock()),
+            patch.object(backup_service, "_enqueue_index_followups"),
             patch(
                 "app.services.backup_service.resolve_repo_ssh_key_file",
                 return_value=None,
@@ -1482,7 +1359,7 @@ class TestBackupService:
                 backup_service, "_calculate_and_update_size_background", AsyncMock()
             ),
             patch.object(backup_service, "_update_archive_stats", AsyncMock()),
-            patch.object(backup_service, "_update_repository_stats", AsyncMock()),
+            patch.object(backup_service, "_enqueue_index_followups"),
             patch(
                 "app.services.backup_service.resolve_repo_ssh_key_file",
                 return_value=None,
@@ -1580,7 +1457,7 @@ class TestBackupService:
                 "_update_archive_stats",
                 AsyncMock(side_effect=assert_terminal_state_before_stats),
             ),
-            patch.object(backup_service, "_update_repository_stats", AsyncMock()),
+            patch.object(backup_service, "_enqueue_index_followups"),
             patch(
                 "app.services.backup_service.resolve_repo_ssh_key_file",
                 return_value=None,
@@ -1663,7 +1540,7 @@ class TestBackupService:
                 backup_service, "_calculate_and_update_size_background", AsyncMock()
             ),
             patch.object(backup_service, "_update_archive_stats", AsyncMock()),
-            patch.object(backup_service, "_update_repository_stats", AsyncMock()),
+            patch.object(backup_service, "_enqueue_index_followups"),
             patch(
                 "app.services.backup_service.resolve_repo_ssh_key_file",
                 return_value=None,
@@ -1750,7 +1627,7 @@ class TestBackupService:
                 backup_service, "_calculate_and_update_size_background", AsyncMock()
             ),
             patch.object(backup_service, "_update_archive_stats", AsyncMock()),
-            patch.object(backup_service, "_update_repository_stats", AsyncMock()),
+            patch.object(backup_service, "_enqueue_index_followups"),
             patch(
                 "app.services.backup_service.resolve_repo_ssh_key_file",
                 return_value=None,
@@ -1993,7 +1870,7 @@ class TestBackupService:
                 backup_service, "_calculate_and_update_size_background", AsyncMock()
             ),
             patch.object(backup_service, "_update_archive_stats", AsyncMock()),
-            patch.object(backup_service, "_update_repository_stats", AsyncMock()),
+            patch.object(backup_service, "_enqueue_index_followups"),
             patch(
                 "app.services.backup_service.resolve_repo_ssh_key_file",
                 return_value=None,
@@ -2090,7 +1967,7 @@ class TestBackupService:
                 backup_service, "_calculate_and_update_size_background", AsyncMock()
             ),
             patch.object(backup_service, "_update_archive_stats", AsyncMock()),
-            patch.object(backup_service, "_update_repository_stats", AsyncMock()),
+            patch.object(backup_service, "_enqueue_index_followups"),
             patch(
                 "app.services.backup_service.resolve_repo_ssh_key_file",
                 return_value=None,

--- a/tests/unit/test_backup_service_mocks.py
+++ b/tests/unit/test_backup_service_mocks.py
@@ -981,9 +981,7 @@ async def test_execute_backup_uses_rclone_sync_failure_for_hooks_and_notificatio
             new=AsyncMock(),
         ),
         patch.object(backup_service_fixture, "_update_archive_stats", new=AsyncMock()),
-        patch.object(
-            backup_service_fixture, "_update_repository_stats", new=AsyncMock()
-        ),
+        patch.object(backup_service_fixture, "_enqueue_index_followups"),
         patch.object(
             backup_service_fixture,
             "_sync_rclone_after_borg",
@@ -1066,9 +1064,7 @@ async def test_execute_backup_post_hook_failure_sends_single_failure_notificatio
             new=AsyncMock(),
         ),
         patch.object(backup_service_fixture, "_update_archive_stats", new=AsyncMock()),
-        patch.object(
-            backup_service_fixture, "_update_repository_stats", new=AsyncMock()
-        ),
+        patch.object(backup_service_fixture, "_enqueue_index_followups"),
         patch(
             "app.services.backup_service.asyncio.create_subprocess_exec",
             return_value=mock_process,

--- a/tests/unit/test_operations_followups.py
+++ b/tests/unit/test_operations_followups.py
@@ -1,13 +1,43 @@
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
-from app.services.operations.followups import FOLLOWUPS, chain_for
+from app.database.models import Base, Operation, Repository, SystemSettings
+from app.services.operations.enqueue import enqueue
+from app.services.operations.executors import load_default_executors
+from app.services.operations.followups import (
+    FOLLOWUPS,
+    chain_for,
+    enqueue_backup_followups,
+)
+
+
+@pytest.fixture()
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def repo(db):
+    load_default_executors()
+    r = Repository(name="r", path="/tmp/r", encryption="none", compression="lz4")
+    db.add(r)
+    db.add(SystemSettings())
+    db.commit()
+    return r
 
 
 @pytest.mark.unit
 def test_chain_table_matches_spec_7_4():
     assert FOLLOWUPS == {
         "import_connect": ("stats", "archive_sync", "history_index"),
-        "backup": ("archive_sync", "history_index", "stats"),
+        "backup": ("archive_sync", "history_merge", "history_index", "stats"),
         "prune": ("archive_sync", "history_merge", "stats"),
         "delete_archive": ("archive_sync", "history_merge", "stats"),
         "compact": ("stats",),
@@ -49,10 +79,15 @@ def test_chain_for_drops_history_kinds_for_community():
     from app.services.operations.followups import HISTORY_KINDS
 
     assert HISTORY_KINDS == {"history_index", "history_merge"}
-    assert chain_for("backup", history=False) == ["archive_sync", "stats"]
+    assert chain_for("backup", history=False) == [
+        "archive_sync",
+        "history_merge",
+        "stats",
+    ]
     assert chain_for("import_connect", history=False) == ["stats", "archive_sync"]
     assert chain_for("backup", history=True) == [
         "archive_sync",
+        "history_merge",
         "history_index",
         "stats",
     ]
@@ -100,3 +135,218 @@ def test_community_keeps_history_merge_so_removed_archives_are_deleted():
         "history_merge",
         "stats",
     ]
+
+
+@pytest.mark.unit
+def test_enqueue_backup_followups_creates_the_backup_chain(db, repo, monkeypatch):
+    """A backup that completed outside the runner (#933) enqueues the spec
+    7.4 chain as a follow-up run; history_index is dropped without a plan."""
+    monkeypatch.setattr("app.services.operations.enqueue.wake_runner", lambda: None)
+    ops = enqueue_backup_followups(
+        db, repo.id, scheduled_job_id=None, backup_plan_run_id=None
+    )
+    assert [o.kind for o in ops] == ["archive_sync", "history_merge", "stats"]
+    assert {o.trigger for o in ops} == {"followup"}
+    assert {o.priority for o in ops} == {10}
+    assert ops[1].depends_on_id == ops[0].id
+    assert len({o.run_id for o in ops}) == 1
+
+
+@pytest.mark.unit
+def test_enqueue_backup_followups_skips_when_an_index_run_is_queued(
+    db, repo, monkeypatch
+):
+    monkeypatch.setattr("app.services.operations.enqueue.wake_runner", lambda: None)
+    enqueue(db, "archive_sync", repository_id=repo.id, trigger="reconcile")
+    assert enqueue_backup_followups(db, repo.id) == []
+
+
+@pytest.mark.unit
+def test_enqueue_backup_followups_ignores_a_running_index_run(db, repo, monkeypatch):
+    """A running listing may predate the backup, so it does not satisfy it."""
+    monkeypatch.setattr("app.services.operations.enqueue.wake_runner", lambda: None)
+    running = enqueue(db, "archive_sync", repository_id=repo.id, trigger="reconcile")
+    running.status = "running"
+    db.commit()
+    ops = enqueue_backup_followups(db, repo.id, commit=False)
+    db.commit()
+    assert [o.kind for o in ops] == ["archive_sync", "history_merge", "stats"]
+    assert db.query(Operation).filter_by(status="queued").count() == 3
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("kind", ["stats", "history_index", "history_merge"])
+def test_queued_non_listing_work_does_not_suppress_backup_followups(
+    db, repo, monkeypatch, kind
+):
+    monkeypatch.setattr("app.services.operations.enqueue.wake_runner", lambda: None)
+    enqueue(db, kind, repository_id=repo.id, trigger="reconcile")
+    ops = enqueue_backup_followups(db, repo.id)
+    assert any(op.kind == "archive_sync" for op in ops)
+
+
+@pytest.mark.unit
+def test_running_listing_with_queued_children_does_not_suppress_followups(
+    db, repo, monkeypatch
+):
+    from app.services.operations.enqueue import enqueue_chain
+
+    monkeypatch.setattr("app.services.operations.enqueue.wake_runner", lambda: None)
+    chain = enqueue_chain(
+        db,
+        ["archive_sync", "history_merge", "stats"],
+        repository_id=repo.id,
+        trigger="reconcile",
+    )
+    chain[0].status = "running"
+    db.commit()
+    ops = enqueue_backup_followups(db, repo.id)
+    assert any(op.kind == "archive_sync" for op in ops)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "parent_status,skip_reason,suppresses",
+    [
+        ("completed", None, True),
+        ("completed_with_warnings", None, True),
+        ("skipped", "agent_diff_unsupported", True),
+        ("skipped", "plan_locked", True),
+        ("skipped", None, True),
+        ("skipped", "dependency_failed", False),
+        ("failed", None, False),
+        ("cancelled", None, False),
+        ("running", None, False),
+        ("queued", None, False),
+        ("missing", None, False),
+    ],
+)
+def test_only_listing_with_satisfied_parent_suppresses_followups(
+    db, repo, monkeypatch, parent_status, skip_reason, suppresses
+):
+    monkeypatch.setattr("app.services.operations.enqueue.wake_runner", lambda: None)
+    parent = enqueue(db, "stats", repository_id=repo.id, trigger="manual")
+    listing = enqueue(
+        db,
+        "archive_sync",
+        repository_id=repo.id,
+        depends_on_id=parent.id,
+        trigger="manual",
+    )
+    if parent_status == "missing":
+        # Model a missing dependency defensively (foreign keys are disabled here).
+        listing.depends_on_id = parent.id + 1000
+    else:
+        parent.status = parent_status
+        parent.skip_reason = skip_reason
+    db.commit()
+    ops = enqueue_backup_followups(db, repo.id)
+    assert bool(ops) is not suppresses
+    if ops:
+        assert ops[0].kind == "archive_sync"
+
+
+@pytest.mark.unit
+def test_listing_behind_queued_parent_with_failed_ancestor_does_not_suppress(
+    db, repo, monkeypatch
+):
+    from app.services.operations.enqueue import enqueue_chain
+
+    monkeypatch.setattr("app.services.operations.enqueue.wake_runner", lambda: None)
+    chain = enqueue_chain(
+        db,
+        ["stats", "history_index", "archive_sync"],
+        repository_id=repo.id,
+        trigger="manual",
+    )
+    chain[0].status = "failed"
+    db.commit()
+    ops = enqueue_backup_followups(db, repo.id)
+    assert ops and ops[0].kind == "archive_sync"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("plan", ["community", "pro"])
+async def test_backup_followup_chain_deletes_removed_archive_and_keeps_survivor(
+    db, repo, monkeypatch, tmp_path, plan
+):
+    import asyncio
+    from datetime import datetime
+    from unittest.mock import AsyncMock
+
+    from app.core.borg_router import BorgRouter
+    from app.database.models import Archive, LicensingState
+    from app.services.operations.executors import index, history
+    from app.services.operations.runner import OperationRunner
+    from app.services.storage_usage import SizeResult
+
+    monkeypatch.setattr("app.services.operations.enqueue.wake_runner", lambda: None)
+    monkeypatch.setattr("app.config.settings.data_dir", str(tmp_path))
+    monkeypatch.setattr("app.config.settings.index_archive_info_per_run", 0)
+    db.add(LicensingState(instance_id="followup-test", plan=plan, status="active"))
+    survivor = Archive(
+        repository_id=repo.id,
+        borg_id="aa11",
+        name="nas-2026-09-01",
+        series="nas",
+        start=datetime(2026, 9, 1),
+        history_state="indexed",
+    )
+    removed = Archive(
+        repository_id=repo.id,
+        borg_id="bb22",
+        name="nas-2026-09-02",
+        series="nas",
+        start=datetime(2026, 9, 2),
+    )
+    db.add_all([survivor, removed])
+    repo.archive_count = 2
+    repo.last_backup = removed.start
+    db.commit()
+    survivor_id, removed_id = survivor.id, removed.id
+    monkeypatch.setattr(
+        BorgRouter,
+        "list_archives_checked",
+        AsyncMock(
+            return_value=(
+                True,
+                [
+                    {
+                        "id": "aa11",
+                        "name": "nas-2026-09-01",
+                        "time": "2026-09-01T00:00:00.000000",
+                    }
+                ],
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        index, "_prepare_repository_borg_env", lambda repository, db: ({}, None)
+    )
+    monkeypatch.setattr(
+        index,
+        "measure_repository_size",
+        AsyncMock(return_value=SizeResult(bytes=123, source="borg1_cache_stats")),
+    )
+    runner = OperationRunner(
+        session_factory=sessionmaker(bind=db.get_bind()),
+        registry={
+            "archive_sync": index.run_archive_sync,
+            "history_merge": history.run_history_merge,
+            "history_index": history.run_history_index,
+            "stats": index.run_stats,
+        },
+    )
+    ops = enqueue_backup_followups(db, repo.id)
+    for _ in range(10):
+        await runner.tick()
+        if runner.running_tasks:
+            await asyncio.gather(*list(runner.running_tasks.values()))
+    db.expire_all()
+    assert db.get(Archive, removed_id) is None
+    assert db.get(Archive, survivor_id).borg_id == "aa11"
+    assert db.query(Archive).filter_by(repository_id=repo.id).count() == 1
+    assert repo.archive_count == 1
+    assert repo.last_backup == datetime(2026, 9, 1)
+    assert all(db.get(Operation, op.id).status == "completed" for op in ops)

--- a/tests/unit/test_operations_lanes.py
+++ b/tests/unit/test_operations_lanes.py
@@ -6,6 +6,7 @@ from app.database.models import (
     BackupJob,
     Base,
     CheckJob,
+    PruneJob,
     Repository,
     SystemSettings,
 )
@@ -175,3 +176,61 @@ def test_system_kind_has_no_lane(db, settings):
 def test_defaults_when_settings_row_missing(db, repo):
     op = enqueue(db, "stats", repository_id=repo.id)
     assert lanes.can_start(db, op, None) is True
+
+
+@pytest.mark.unit
+def test_bypass_does_not_start_a_listing_while_write_maintenance_runs(
+    db, repo, settings
+):
+    """The backup follow-up chain is enqueued when the backup completes,
+    while the plan still runs prune and compact on the same repository.
+    Admission refuses a listing during those (409), so bypass_lock must
+    not dispatch it; it waits in the queue and runs once they finish."""
+    settings.bypass_lock_on_list = True
+    db.commit()
+    op = enqueue(db, "archive_sync", repository_id=repo.id, trigger="followup")
+
+    # a running backup is what bypass is for: the listing may start
+    backup = BackupJob(repository=repo.path, repository_id=repo.id, status="running")
+    db.add(backup)
+    db.commit()
+    assert lanes.write_maintenance_running(db, repo.id) is False
+    assert lanes.can_start(db, op, settings) is True
+
+    # the plan moved on to prune: same backup row, its maintenance_status
+    # (status stays a backup status)
+    backup.status = "completed"
+    backup.maintenance_status = "running_prune"
+    db.commit()
+    assert lanes.write_maintenance_running(db, repo.id) is True
+    assert lanes.can_start(db, op, settings) is False
+    backup.maintenance_status = "prune_completed"
+    db.commit()
+    assert lanes.write_maintenance_running(db, repo.id) is False
+
+    # a queued prune operation counts before it runs: the listing would
+    # otherwise overlap it when another tick starts the prune
+    queued_prune = enqueue(db, "prune", repository_id=repo.id)
+    assert lanes.can_start(db, op, settings) is False
+    queued_prune.status = "completed"
+    db.commit()
+    assert lanes.can_start(db, op, settings) is True
+
+    # a legacy prune job row on its own: pending counts (admission refuses
+    # listings from creation on), running too
+    prune = PruneJob(repository_id=repo.id, status="pending")
+    db.add(prune)
+    db.commit()
+    assert lanes.can_start(db, op, settings) is False
+    prune.status = "running"
+    db.commit()
+    assert lanes.can_start(db, op, settings) is False
+
+    # a running compact operation on its own
+    prune.status = "completed"
+    db.commit()
+    compact = _running(db, "compact", repo)
+    assert lanes.can_start(db, op, settings) is False
+    compact.status = "completed"
+    db.commit()
+    assert lanes.can_start(db, op, settings) is True


### PR DESCRIPTION
## Description

Since phase 1, the archives table and the columns derived from it (`archive_count`, `last_backup`, the strip's Index cell, removal detection for pruned archives) are written only by `archive_sync`, which the reconcile scheduler enqueues every `stats_refresh_interval_minutes`. A backup that finished did not enqueue anything, so the index lagged by up to one interval (the timer also restarts with the process), and the two completion paths kept writing `last_backup` themselves: the server path ran its own `borg list` / `borg info` and set `last_backup` to the wall clock, the agent path set it to the job's completion time.

Both completion paths now call the new `followups.enqueue_backup_followups`, which enqueues the spec 7.4 `backup` chain (`archive_sync`, `history_index` where the plan allows it, `stats`) with `trigger = followup` (priority 10), tagged with the job's `scheduled_job_id` / `backup_plan_run_id`. It is skipped when an index run is already *queued* for the repository (that run will list after this backup anyway); a *running* run does not count, since it may have listed before the backup finished. `archive_sync` then derives `archive_count` and `last_backup` from the listing, which leaves `write_repository_archive_columns` as the writer of those columns for both paths.

- `BackupService._update_repository_stats` (inline list + info + `last_backup = utcnow()`) is removed; `_enqueue_index_followups` replaces both call sites and never fails the backup.
- `_finish_linked_backup_job` (agent) looks the repository up by `repository_id` first, keeps `updated_at`, and enqueues with `commit=False` so the caller's transaction stays intact (the runner polls within 5 s).
- Spec section 7.4 and the section 15 table row for `backup_service.py` record the change; `docs/architecture/job-system.md` follows.

The spec planned this one-liner for phase 5 ("until then, a one-line `enqueue` replaces the call"); it is pulled forward because the lag shows on every install.

## Related Issue

Fixes #933

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

New tests:

- `test_operations_followups.py`: the chain is created with `followup` trigger, priority 10, one `run_id`, `history_index` dropped on a Community plan; skipped when an index run is queued; not skipped when one is only running.
- `test_backup_service.py`: `_enqueue_index_followups` creates the operations carrying the job's `scheduled_job_id`, and never raises. The two tests of the removed `_update_repository_stats` are gone; the eleven `execute_backup` tests that patched it now patch `_enqueue_index_followups`.
- `test_api_backup.py`: the agent completion test asserts the follow-up chain instead of a written `last_backup`.
- `test_api_agents.py`: completing a linked agent backup through `POST /api/agents/jobs/{id}/complete` leaves `last_backup` untouched and enqueues `archive_sync` first with `trigger = followup`.

Runs (scratch venv, Python 3.12, ruff 0.16.5):

```
pytest tests/unit/test_operations_followups.py tests/unit/test_backup_service.py \
       tests/unit/test_backup_service_mocks.py tests/unit/test_api_agents.py \
       tests/unit/test_operations_reconcile.py tests/unit/test_operations_runner.py
176 passed, 6 skipped

pytest tests/unit   (full suite, untouched clone of this branch at 77262b99)
3 failed, 3148 passed, 13 skipped in 524s
  the 3 failures are tests/unit/test_source_discovery.py database-scan tests and are
  pre-existing: the same three fail on a clean upstream/main (c7f32d1f) in an
  untouched clone (3 failed, 3146 passed); in the full suite the scan finds the
  test app's own test.db inside the test's tmp_path, each passes in isolation
pytest tests/unit/test_api_backup.py   (the agent completion test adapted to the follow-up chain)
all passed

ruff check .            All checks passed!
ruff format --check     clean for every file in this diff (the four pre-existing
                        unformatted files under .github/scripts, agent/ and scripts/
                        are untouched)
```

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass (apart from the three pre-existing failures above)

Rebased onto main `37cee432` (head `b0785938`), same runs on the rebased branch:

```
pytest tests/unit/test_operations_followups.py tests/unit/test_operations_lanes.py \
       tests/unit/test_backup_service.py tests/unit/test_backup_service_mocks.py \
       tests/unit/test_api_agents.py tests/unit/test_api_backup.py
246 passed, 6 skipped, 357 warnings in 84.72s
ruff check / ruff format --check   clean on every file in this diff
```

Full `pytest tests/unit` in one process on an integration branch carrying this PR together with the rest of the wave on top of main `3b557171` + #945: `3364 passed, 13 skipped`, no failures, no errors.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable.

## Additional Context

Independent of the index-chain PR for #917 / #932: with that one unmerged, the `stats` stage of the follow-up chain is still skipped on agent repositories behind a skipped `history_index`; `archive_sync` and `history_merge`, which this PR is about, run either way. Part of the wave described in #917, #931, #933, #934, #935, #936; no agent release needed.
