### PR TITLE
feat(operations): read-only repository size by source order, persist Borg's last_modified

### DIFF
--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -93,6 +93,12 @@ from app.services.job_admission import (
 )
 from app.services.log_policy import get_log_save_policy, job_has_logs_by_policy
 from app.services.repository_info_sync import sync_archive_stats_from_info
+from app.services.storage_usage import (
+    SOURCE_BORG1_CACHE_STATS,
+    SOURCE_STORAGE_USED,
+    SizeResult,
+    measure_repository_size,
+)
 from app.services.repository_command_lock import run_serialized_repository_command
 from app.services.rclone_repository_service import (
     SYNC_DIRECTION_AGENT_TO_REMOTE,
@@ -898,6 +904,8 @@ async def _update_agent_repository_stats(repository: Repository, db: Session) ->
 
         encryption_mode = None
         total_size = None
+        total_size_source = None
+        borg_last_modified = None
         try:
             rinfo_job = queue_agent_repository_operation_job(
                 db, repository, job_kind="repository.rinfo"
@@ -924,6 +932,13 @@ async def _update_agent_repository_stats(repository: Repository, db: Session) ->
             size_bytes = stats.get("unique_csize") or stats.get("unique_size")
             if isinstance(size_bytes, (int, float)) and size_bytes > 0:
                 total_size = format_bytes(int(size_bytes))
+                total_size_source = SOURCE_BORG1_CACHE_STATS
+            # Both versions report the last manifest write; the agent renders
+            # it in its reported zone (UTC since #889).
+            borg_last_modified = _parse_borg_archive_time(
+                (rinfo.get("repository") or {}).get("last_modified"),
+                timezone_name=agent_zone,
+            )
         except Exception as e:
             logger.warning(
                 "agent repo-info for stats refresh failed",
@@ -953,6 +968,7 @@ async def _update_agent_repository_stats(repository: Repository, db: Session) ->
                     fields = first.split()
                     if fields and fields[0].isdigit() and int(fields[0]) > 0:
                         total_size = format_bytes(int(fields[0]))
+                        total_size_source = SOURCE_STORAGE_USED
             except Exception as e:
                 logger.warning(
                     "agent disk-usage for stats refresh failed",
@@ -968,6 +984,9 @@ async def _update_agent_repository_stats(repository: Repository, db: Session) ->
             repository.encryption = encryption_mode
         if total_size:
             repository.total_size = total_size
+            repository.total_size_source = total_size_source
+        if borg_last_modified:
+            repository.borg_last_modified = borg_last_modified
         db.commit()
         logger.info(
             "Updated agent repository stats",
@@ -1064,21 +1083,25 @@ async def update_repository_stats(repository: Repository, db: Session) -> bool:
         # Get timeouts from DB settings (with fallback to config)
         timeouts = get_operation_timeouts(db)
 
+        # The same source order as the `stats` operation, so the two writers
+        # of total_size agree on the quantity and label it the same way.
         try:
-            total_size_bytes = await router.calculate_total_size_bytes(
+            measured = await measure_repository_size(
+                repository,
                 env=env,
-                info_timeout=timeouts["info_timeout"],
-                use_bypass_lock=use_bypass_lock,
                 temp_key_file=temp_key_file,
+                info_timeout=timeouts["info_timeout"],
+                use_bypass_lock=bool(use_bypass_lock),
             )
-            if total_size_bytes > 0:
-                total_size = format_bytes(total_size_bytes)
         except Exception as e:
             logger.warning(
                 "Failed to get repository size",
                 repository=repository.name,
                 error=str(e),
             )
+            measured = SizeResult()
+        if measured.bytes:
+            total_size = format_bytes(measured.bytes)
 
         # Update repository
         old_count = repository.archive_count
@@ -1087,6 +1110,9 @@ async def update_repository_stats(repository: Repository, db: Session) -> bool:
         repository.archive_count = archive_count
         if total_size:
             repository.total_size = total_size
+            repository.total_size_source = measured.source
+        if measured.last_modified:
+            repository.borg_last_modified = measured.last_modified
         if last_backup_time:
             repository.last_backup = last_backup_time
 
@@ -6377,7 +6403,8 @@ async def get_repository_stats(
             "compressed_size": "Unknown",
             "deduplicated_size": "Unknown",
             "archive_count": repository.archive_count or 0,
-            "last_modified": format_datetime(repository.updated_at),
+            "last_modified": format_datetime(repository.borg_last_modified),
+            "total_size_source": repository.total_size_source,
             "encryption": repository.encryption or "Unknown",
             "executor": "agent",
         }
@@ -6392,13 +6419,31 @@ async def get_repository_stats(
             cmd.append("--bypass-lock")
         if remote_path := effective_repository_remote_path(repository):
             cmd.extend(["--remote-path", remote_path])
-        info_result = await borg._execute_command(cmd, env=env)
+        # machine-parsed: render timestamps in UTC (Borg 1 prints them naive)
+        info_env = dict(env or {})
+        info_env["TZ"] = "UTC"
+        info_result = await borg._execute_command(cmd, env=info_env)
 
         if not info_result["success"]:
             return {
                 "error": "Failed to get repository info",
                 "details": info_result["stderr"],
             }
+
+        # The info call just made carries Borg's own last_modified; the stored
+        # column is the fallback for a payload without one.
+        last_modified = repository.borg_last_modified
+        try:
+            payload = json.loads(info_result.get("stdout") or "{}")
+            last_modified = (
+                _parse_borg_archive_time(
+                    (payload.get("repository") or {}).get("last_modified"),
+                    timezone_name="UTC",
+                )
+                or last_modified
+            )
+        except (json.JSONDecodeError, ValueError, AttributeError):
+            pass
 
         # Parse repository info (basic implementation)
         # In a real implementation, you would parse the borg info output
@@ -6407,7 +6452,8 @@ async def get_repository_stats(
             "compressed_size": "Unknown",
             "deduplicated_size": "Unknown",
             "archive_count": 0,
-            "last_modified": None,
+            "last_modified": format_datetime(last_modified),
+            "total_size_source": repository.total_size_source,
             "encryption": "Unknown",
         }
 

--- a/app/core/borg_router.py
+++ b/app/core/borg_router.py
@@ -499,41 +499,6 @@ class BorgRouter:
 
         return await update_repository_stats(self.repo, db)
 
-    async def calculate_total_size_bytes(
-        self,
-        *,
-        env: dict = None,
-        info_timeout: int = 60,
-        use_bypass_lock: bool = False,
-        temp_key_file: str = None,
-    ) -> int:
-        """Return repository total size in bytes using the versioned implementation."""
-        if self.is_v2:
-            from app.services.v2.repository_service import repository_v2_service
-
-            return await repository_v2_service.calculate_total_size_bytes(
-                self.repo,
-                temp_key_file=temp_key_file,
-                timeout=30,
-            )
-
-        import json
-        from app.core.borg import borg
-
-        cmd = self.build_repo_info_command(self.repo.path)
-        if remote_path := effective_repository_remote_path(self.repo):
-            cmd.extend(["--remote-path", remote_path])
-        if use_bypass_lock:
-            cmd.append("--bypass-lock")
-
-        info_result = await borg._execute_command(cmd, timeout=info_timeout, env=env)
-        if not info_result["success"]:
-            return 0
-
-        info_data = json.loads(info_result["stdout"])
-        cache = info_data.get("cache", {}).get("stats", {})
-        return cache.get("unique_csize", 0) or 0
-
     def _is_agent(self) -> bool:
         """Whether this repository is executed by a managed agent.
 

--- a/app/database/alembic/versions/8f2a4c6e1d3b_add_repository_size_source_and_last_modified.py
+++ b/app/database/alembic/versions/8f2a4c6e1d3b_add_repository_size_source_and_last_modified.py
@@ -1,0 +1,26 @@
+"""add repository size source and borg last_modified
+
+Revision ID: 8f2a4c6e1d3b
+Revises: 7de0064b0d99
+Create Date: 2026-09-06
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "8f2a4c6e1d3b"
+down_revision = "7de0064b0d99"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("repositories") as batch:
+        batch.add_column(sa.Column("total_size_source", sa.String(), nullable=True))
+        batch.add_column(sa.Column("borg_last_modified", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("repositories") as batch:
+        batch.drop_column("borg_last_modified")
+        batch.drop_column("total_size_source")

--- a/app/database/alembic/versions/c3d5e7f9a1b2_merge_size_source_and_ssh_host_keys.py
+++ b/app/database/alembic/versions/c3d5e7f9a1b2_merge_size_source_and_ssh_host_keys.py
@@ -1,0 +1,27 @@
+"""merge repository size source with SSH host keys
+
+Revision ID: c3d5e7f9a1b2
+Revises: 8f2a4c6e1d3b, b7e1a3c95d84
+Create Date: 2026-09-06
+
+8f2a4c6e1d3b and the SSH host-key revisions (a1c9f4d27b60, b7e1a3c95d84)
+were written against the same parent. 8f2a4c6e1d3b keeps that parent
+because installs have applied it under it: moving an applied revision's
+parent makes Alembic treat such an install as up to date and silently
+skip the other branch's DDL. This merge revision joins the two heads
+instead, so an install at 8f2a4c6e1d3b upgrades through the host-key
+revisions and a fresh install applies both branches in order.
+"""
+
+revision = "c3d5e7f9a1b2"
+down_revision = ("8f2a4c6e1d3b", "b7e1a3c95d84")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -284,6 +284,11 @@ class Repository(Base):
     last_check = Column(DateTime, nullable=True)  # Last successful check completion
     last_compact = Column(DateTime, nullable=True)  # Last successful compact completion
     total_size = Column(String, nullable=True)
+    # Which measurement total_size holds: borg1_cache_stats (deduplicated),
+    # borg2_index (repository object size), storage_used (store file bytes).
+    total_size_source = Column(String, nullable=True)
+    # repository.last_modified as Borg reports it: the last manifest write.
+    borg_last_modified = Column(DateTime, nullable=True)
     archive_count = Column(Integer, default=0)
     created_at = Column(DateTime, default=utc_now)
     updated_at = Column(DateTime, default=utc_now, onupdate=utc_now)

--- a/app/services/operations/executors/index.py
+++ b/app/services/operations/executors/index.py
@@ -25,6 +25,7 @@ from app.services.operations.runner import Outcome
 from app.services.operations.series import infer_series, series_prefixes_for_repository
 from app.services.repository_command_lock import run_serialized_repository_command
 from app.services.repository_executor import is_agent_executor
+from app.services.storage_usage import measure_repository_size
 from app.utils.borg_env import cleanup_temp_key_file, effective_repository_remote_path
 
 logger = structlog.get_logger()
@@ -364,7 +365,9 @@ async def run_stats(ctx) -> Outcome:
             )
         _publish_mqtt_state(db, "operations stats")
         ctx.log(f"agent repository size {repository.total_size}")
-        return Outcome(result={"total_size": repository.total_size, "source": "agent"})
+        return Outcome(
+            result={"total_size": repository.total_size, "executor": "agent"}
+        )
     env, temp_key_file = _prepare_repository_borg_env(repository, db)
     try:
         system_settings = db.query(SystemSettings).first()
@@ -373,26 +376,40 @@ async def run_stats(ctx) -> Outcome:
             or (system_settings and system_settings.bypass_lock_on_list)
         )
         timeouts = get_operation_timeouts(db)
-        router = BorgRouter(repository)
-        total = await run_serialized_repository_command(
+        measured = await run_serialized_repository_command(
             repository.id,
-            lambda: router.calculate_total_size_bytes(
+            lambda: measure_repository_size(
+                repository,
                 env=env,
+                temp_key_file=temp_key_file,
                 info_timeout=timeouts["info_timeout"],
                 use_bypass_lock=use_bypass_lock,
-                temp_key_file=temp_key_file,
             ),
             scope="metadata",
         )
-        if total and total > 0:
-            repository.total_size = format_bytes(total)
+        if measured.bytes:
+            repository.total_size = format_bytes(measured.bytes)
+            repository.total_size_source = measured.source
+        if measured.last_modified:
+            repository.borg_last_modified = measured.last_modified
         if system_settings is not None:
             system_settings.last_stats_refresh = utc_now()
         db.commit()
-        if total and total > 0:
+        if measured.bytes:
             _publish_mqtt_state(db, "operations stats")
-        ctx.log(f"repository size {total} bytes")
-        return Outcome(result={"unique_csize": total})
+        ctx.log(
+            f"repository size {measured.bytes} bytes ({measured.source or 'unknown'})"
+        )
+        return Outcome(
+            result={
+                "bytes": measured.bytes,
+                "objects": measured.objects,
+                "source": measured.source,
+                "last_modified": measured.last_modified.isoformat()
+                if measured.last_modified
+                else None,
+            }
+        )
     finally:
         cleanup_temp_key_file(temp_key_file)
 

--- a/app/services/storage_usage.py
+++ b/app/services/storage_usage.py
@@ -1,0 +1,572 @@
+"""Repository size, read-only, from the best source Borg offers (#934).
+
+Order for Borg 2, which reports no size through any command:
+
+1. the chunk-index sum through Borg's own Python API, run with the
+   interpreter next to the configured Borg 2 binary (a venv install): the
+   bytes of every indexed object, no lock, no pack access, works while a
+   backup holds the lock;
+2. a store-level measurement per URL scheme, which counts file bytes
+   including pack headers and the index ("storage used");
+3. nothing: the caller leaves the stored size alone.
+
+These are different quantities, which is why the caller records the source
+next to the value. `compact --stats` reports pack file bytes, which include
+data no index entry covers (an interrupted write, before compact); on a
+repository whose packs are fully indexed the index sum matched it byte for
+byte in every measurement taken (b23, b24), but the two are not identical
+by definition. Storage used adds the index and other store files on top.
+
+Borg 1 keeps `info --json` `cache.stats.unique_csize`. Both versions also
+report `repository.last_modified` (the last manifest write), which the
+caller persists alongside.
+"""
+
+import asyncio
+import json
+import os
+import shutil
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+from urllib.parse import unquote, urlsplit
+
+import structlog
+
+from app.utils.datetime_utils import parse_borg_archive_time
+
+logger = structlog.get_logger()
+
+SOURCE_BORG1_CACHE_STATS = "borg1_cache_stats"
+SOURCE_BORG2_INDEX = "borg2_index"
+SOURCE_STORAGE_USED = "storage_used"
+
+
+def _port(parts) -> Optional[int]:
+    """The URL port, or None when there is none. Raises ValueError for a
+    port that is not a number in 0..65535 (`urlsplit` defers that check to
+    the `.port` property)."""
+    return parts.port
+
+
+def valid_target(url: str) -> bool:
+    """False when the URL carries a port Borg could never connect to. Such
+    a URL is rejected as unmeasurable rather than measured against some
+    other endpoint."""
+    try:
+        _port(urlsplit(url))
+    except ValueError:
+        return False
+    return True
+
+
+def _host_port(parts) -> str:
+    """host[:port] for a netloc, IPv6 literals back in brackets."""
+    host = parts.hostname or ""
+    if ":" in host:
+        host = f"[{host}]"
+    port = _port(parts)
+    return f"{host}:{port}" if port is not None else host
+
+
+def safe_url(url: str) -> str:
+    """A repository URL for logs: the credentials replaced by `***`.
+
+    `user:secret@host` becomes `user:***@host`. A userinfo without a
+    password is masked whole (`token@host` becomes `***@host`): a REST
+    store takes it as the Basic-auth credential, so it is the secret.
+
+    Never raises and never keeps a credential fragment: this runs while a
+    failure is being logged. The userinfo is cut at the last `@` (a
+    password may contain `@`), the host:port text is kept as written
+    without validating the port, and a URL that does not even parse
+    becomes a fixed placeholder rather than its own text."""
+    try:
+        parts = urlsplit(url)
+        if parts.username is None and not parts.password:
+            return url
+        userinfo, _, hostport = parts.netloc.rpartition("@")
+        if parts.password:
+            redacted = f"{userinfo.split(':', 1)[0]}:***"
+        else:
+            redacted = "***"
+        return parts._replace(netloc=f"{redacted}@{hostport}").geturl()
+    except ValueError:
+        return "<unparseable repository url>"
+
+
+# Sums Repository.list() storage sizes; lock=False reads while another borg
+# holds the exclusive lock (like --bypass-lock). Needs no key: the index is
+# not encrypted. Prints one JSON object. The URL arrives in the environment
+# (REPOSITORY_URL_ENV), never on the command line: it may carry credentials
+# and a process list shows arguments.
+REPOSITORY_URL_ENV = "BORG_UI_REPOSITORY_URL"
+INDEX_SUM_SCRIPT = """
+import json, os
+from borg.logger import setup_logging
+setup_logging()
+from borg.repository import Repository
+from borg.helpers import Location
+total = objects = 0
+marker = None
+with Repository(Location(os.environ["BORG_UI_REPOSITORY_URL"]), exclusive=False, lock=False) as repo:
+    while True:
+        batch = repo.list(limit=100000, marker=marker)
+        if not batch:
+            break
+        for chunk_id, size in batch:
+            total += size
+            objects += 1
+        marker = batch[-1][0]
+print(json.dumps({"objects": objects, "bytes": total}))
+"""
+
+
+@dataclass
+class SizeResult:
+    bytes: Optional[int] = None
+    objects: Optional[int] = None
+    source: Optional[str] = None
+    last_modified: Optional[datetime] = None
+
+
+async def _communicate(process, timeout: int) -> tuple[bytes, bytes]:
+    """communicate() with a deadline that also ends the child: wait_for only
+    cancels the wait, a timed-out (or cancelled) borg or rclone would keep
+    running."""
+    try:
+        return await asyncio.wait_for(process.communicate(), timeout)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        try:
+            process.kill()
+        except ProcessLookupError:
+            # already gone; kill() would otherwise replace the cancellation
+            # with an OSError that the callers treat as "failed to start"
+            pass
+        await process.wait()
+        raise
+
+
+# -- Borg 2 chunk index --------------------------------------------------------
+
+
+def _venv_python(binary: str) -> Optional[str]:
+    """The python of the venv that `binary` lives in, or None. The binary is
+    resolved through symlinks, the python is not (a venv's python is a
+    symlink to the base interpreter; running it by its venv path is what
+    selects the venv's site-packages). A python without a `pyvenv.cfg`
+    next to its bin directory is a system interpreter, where `borg` is not
+    importable, so it does not count."""
+    path = shutil.which(binary) or binary
+    real = os.path.realpath(path)
+    bindir = os.path.dirname(real)
+    candidate = os.path.join(bindir, "python")
+    if not os.access(candidate, os.X_OK):
+        return None
+    if not os.path.isfile(os.path.join(os.path.dirname(bindir), "pyvenv.cfg")):
+        return None
+    return candidate
+
+
+def borg2_interpreter(borg2_binary: str, env: Optional[dict] = None) -> Optional[str]:
+    """The python of the Borg 2 venv, or None for a standalone binary.
+
+    `BORG2_BINARY` in the prepared environment (the deployment's own
+    pointer at the real binary) is tried first: the command on PATH is
+    often a wrapper script whose directory holds the system python."""
+    candidates = []
+    pointed = (env if env is not None else os.environ).get("BORG2_BINARY")
+    if pointed:
+        candidates.append(pointed)
+    candidates.append(borg2_binary)
+    for binary in candidates:
+        python = _venv_python(binary)
+        if python is not None:
+            return python
+    return None
+
+
+async def borg2_index_size(
+    repository_url: str,
+    *,
+    borg2_binary: str,
+    env: Optional[dict] = None,
+    timeout: int = 60,
+) -> Optional[tuple[int, int]]:
+    """(bytes, objects) from the chunk index, or None when Borg is not
+    importable next to the binary or the read failed."""
+    python = borg2_interpreter(borg2_binary, env)
+    if python is None:
+        return None
+    child_env = dict(env if env is not None else os.environ)
+    child_env[REPOSITORY_URL_ENV] = repository_url
+    try:
+        process = await asyncio.create_subprocess_exec(
+            python,
+            "-c",
+            INDEX_SUM_SCRIPT,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=child_env,
+        )
+        stdout, stderr = await _communicate(process, timeout)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "borg2 index size timed out", repository=safe_url(repository_url)
+        )
+        return None
+    except OSError as exc:
+        logger.warning("borg2 index size failed to start", error=str(exc))
+        return None
+    if process.returncode != 0:
+        logger.warning(
+            "borg2 index size failed",
+            repository=safe_url(repository_url),
+            stderr=stderr.decode(errors="replace")[-300:],
+        )
+        return None
+    try:
+        data = json.loads(stdout.decode() or "{}")
+        return int(data["bytes"]), int(data["objects"])
+    except (ValueError, KeyError, TypeError):
+        return None
+
+
+# -- store-level fallbacks --------------------------------------------------------
+
+
+def _rclone_value(value: str) -> str:
+    """Quote a connection-string parameter value when rclone's syntax needs
+    it (commas, colons, quotes); quotes inside are doubled."""
+    if any(ch in value for ch in ',:"'):
+        return '"' + value.replace('"', '""') + '"'
+    return value
+
+
+def rclone_remote_for(url: str, *, key_file: Optional[str] = None) -> Optional[str]:
+    """An rclone on-the-fly remote for a Borg store URL, or None.
+
+    `sftp://user@host:port/./rel` addresses a path relative to the login
+    directory, `sftp://user@host:port/abs` an absolute one; `rclone:remote:path`
+    is passed through.
+    """
+    # the scheme is case-insensitive, the remote name after it is not
+    if url[: len("rclone:")].lower() == "rclone:":
+        return url[len("rclone:") :] or None
+    parts = urlsplit(url)
+    if parts.scheme != "sftp" or not parts.hostname:
+        return None
+    try:
+        port = _port(parts)
+    except ValueError:
+        return None  # an impossible port: nothing rclone could connect to
+    options = [f"host={_rclone_value(parts.hostname)}"]
+    if parts.username:
+        options.append(f"user={_rclone_value(unquote(parts.username))}")
+    if port is not None:
+        options.append(f"port={port}")
+    if key_file:
+        options.append(f"key_file={_rclone_value(key_file)}")
+    path = unquote(parts.path)
+    if path.startswith("/./"):
+        path = path[3:]
+    elif path.startswith("/~/"):
+        path = path[3:]
+    return f":sftp,{','.join(options)}:{path}"
+
+
+async def rclone_storage_used(
+    url: str,
+    *,
+    key_file: Optional[str] = None,
+    env: Optional[dict] = None,
+    timeout: int = 600,
+) -> Optional[int]:
+    """`rclone size --json`. `env` is the prepared Borg environment: it
+    carries `RCLONE_CONFIG` for the managed remotes, which an inherited
+    process environment does not."""
+    remote = rclone_remote_for(url, key_file=key_file)
+    rclone = shutil.which("rclone")
+    if remote is None or rclone is None:
+        return None
+    try:
+        process = await asyncio.create_subprocess_exec(
+            rclone,
+            "size",
+            "--json",
+            remote,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        stdout, stderr = await _communicate(process, timeout)
+    except (asyncio.TimeoutError, OSError) as exc:
+        logger.warning("rclone size failed", repository=safe_url(url), error=str(exc))
+        return None
+    if process.returncode != 0:
+        logger.warning(
+            "rclone size failed",
+            repository=safe_url(url),
+            stderr=stderr.decode(errors="replace")[-300:],
+        )
+        return None
+    try:
+        value = int(json.loads(stdout.decode() or "{}")["bytes"])
+    except (ValueError, KeyError, TypeError):
+        return None
+    return value if value > 0 else None
+
+
+# A borgstore layout nests a few levels (data/xx/yy); a listing deeper than
+# this is a loop or not a store.
+HTTP_WALK_MAX_DEPTH = 16
+# One directory listing is bounded too: a server that keeps sending must
+# neither fill memory nor outlive the walk.
+HTTP_LISTING_MAX_BYTES = 64 * 1024 * 1024
+HTTP_CHUNK_BYTES = 64 * 1024
+
+
+def _http_walk(base_url: str, timeout: int, budget: int = 600) -> Optional[int]:
+    """Sum the sizes a borgstore REST server lists (`GET <dir>/`).
+
+    `timeout` bounds one request, `budget` the whole walk: a listing that
+    points back at an ancestor, or one large enough, must not keep the
+    worker thread past the caller's time."""
+    import requests
+
+    parts = urlsplit(base_url)
+    # urlsplit keeps credentials percent-encoded; requests wants the values.
+    auth = (
+        (unquote(parts.username), unquote(parts.password or ""))
+        if parts.username
+        else None
+    )
+    root = f"{parts.scheme}://{_host_port(parts)}{parts.path.rstrip('/')}"
+    headers = {"Accept": "application/vnd.x.borgstore.rest.v1"}
+    total = 0
+    deadline = time.monotonic() + budget
+
+    def fetch(url: str) -> list:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("REST store walk exceeded its time budget")
+        # requests' timeout bounds each socket operation, not the request:
+        # cap it at what is left of the budget and check the clock between
+        # chunks, so a server that keeps sending cannot outlive the walk.
+        # Never follow a redirect: the store could send the credentials and
+        # the walk to another origin.
+        response = requests.get(
+            url,
+            auth=auth,
+            headers=headers,
+            timeout=min(timeout, remaining),
+            allow_redirects=False,
+            stream=True,
+        )
+        try:
+            response.raise_for_status()
+            body = bytearray()
+            for chunk in response.iter_content(chunk_size=HTTP_CHUNK_BYTES):
+                body += chunk
+                if len(body) > HTTP_LISTING_MAX_BYTES:
+                    raise RuntimeError("REST listing larger than a borgstore directory")
+                if time.monotonic() > deadline:
+                    raise TimeoutError("REST store walk exceeded its time budget")
+        finally:
+            response.close()
+        return json.loads(bytes(body))
+
+    def walk(name: str, depth: int = 0) -> None:
+        nonlocal total
+        if depth > HTTP_WALK_MAX_DEPTH:
+            raise RuntimeError("REST listing nested deeper than a borgstore layout")
+        for item in fetch(f"{root}/{name}/" if name else f"{root}/"):
+            child = f"{name}/{item['name']}" if name else item["name"]
+            if item.get("directory"):
+                walk(child, depth + 1)
+            else:
+                total += int(item.get("size") or 0)
+
+    walk("")
+    return total
+
+
+async def http_storage_used(
+    url: str, *, timeout: int = 60, budget: int = 600
+) -> Optional[int]:
+    """`http(s)://` borgstore REST servers list directories with sizes."""
+    try:
+        value = await asyncio.to_thread(_http_walk, url, timeout, budget)
+    except Exception as exc:
+        logger.warning(
+            "REST store walk failed", repository=safe_url(url), error=str(exc)
+        )
+        return None
+    return value if value and value > 0 else None
+
+
+async def du_storage_used(
+    url_or_path: str, *, key_file: Optional[str] = None, timeout: int = 600
+) -> Optional[int]:
+    """`du -sb` locally or over ssh (`ssh://user@host:port/path`)."""
+    from app.utils.fs import calculate_path_size_bytes
+
+    value = await calculate_path_size_bytes(
+        [url_or_path], timeout=timeout, key_file=key_file
+    )
+    return value if value and value > 0 else None
+
+
+def store_target(repository_path: str) -> tuple[str, Optional[str]]:
+    """(tool, target) for the store-level fallback, or ("", None).
+
+    `rest://user@host:port/path` is borgstore's "ssh to host and run the REST
+    server on stdio" form. The key on such a host is normally bound to that
+    server (`command="...",restrict` in authorized_keys), so a shell command
+    over ssh does not run: no store-level measurement, only the chunk index
+    through Borg itself. `rest:///path` is local. `http(s)://` is a REST
+    server listing.
+    """
+    # URI schemes are case-insensitive; the target keeps the text as given.
+    lowered = repository_path.lower()
+    if lowered.startswith(("http://", "https://")):
+        return "http", repository_path
+    if lowered.startswith(("sftp://", "rclone:")):
+        return "rclone", repository_path
+    if lowered.startswith("rest://"):
+        parts = urlsplit(repository_path)
+        if parts.hostname:
+            return "", None
+        return "du", parts.path
+    if lowered.startswith("ssh://"):
+        return "du", repository_path
+    if "://" not in repository_path and not lowered.startswith(("s3:", "b2:")):
+        return "du", repository_path
+    return "", None
+
+
+async def storage_used(
+    repository_path: str,
+    *,
+    key_file: Optional[str] = None,
+    env: Optional[dict] = None,
+    timeout: int = 600,
+) -> Optional[int]:
+    """Store-level bytes by scheme. `env` reaches rclone; du takes the key
+    file only (ssh reads no Borg variables) and the REST walk needs neither.
+    A URL with an impossible port is unknown, not measured elsewhere."""
+    if not valid_target(repository_path):
+        logger.warning(
+            "repository URL has an invalid port", repository=safe_url(repository_path)
+        )
+        return None
+    tool, target = store_target(repository_path)
+    if tool == "http":
+        return await http_storage_used(target, timeout=min(timeout, 60), budget=timeout)
+    if tool == "rclone":
+        return await rclone_storage_used(
+            target, key_file=key_file, env=env, timeout=timeout
+        )
+    if tool == "du":
+        return await du_storage_used(target, key_file=key_file, timeout=timeout)
+    return None
+
+
+# -- the source order -------------------------------------------------------------
+
+
+def _last_modified(payload: dict, *, timezone_name: str = "UTC") -> Optional[datetime]:
+    value = (payload.get("repository") or {}).get("last_modified")
+    return parse_borg_archive_time(value, timezone_name=timezone_name)
+
+
+async def measure_repository_size(
+    repository,
+    *,
+    env: Optional[dict] = None,
+    temp_key_file: Optional[str] = None,
+    info_timeout: int = 60,
+    use_bypass_lock: bool = False,
+) -> SizeResult:
+    """Best available size and `last_modified` for a server-executed
+    repository. Never returns 0 bytes: unknown is `None`."""
+    from app.utils.borg_env import effective_repository_remote_path
+
+    remote_path = effective_repository_remote_path(repository)
+    if (repository.borg_version or 1) != 2:
+        from app.core.borg import borg
+        from app.core.borg_router import BorgRouter
+
+        cmd = BorgRouter(repository).build_repo_info_command(repository.path)
+        if remote_path:
+            cmd.extend(["--remote-path", remote_path])
+        if use_bypass_lock:
+            cmd.append("--bypass-lock")
+        info_env = dict(env or {})
+        info_env["TZ"] = "UTC"
+        result = await borg._execute_command(cmd, timeout=info_timeout, env=info_env)
+        if not result.get("success"):
+            return SizeResult()
+        try:
+            payload = json.loads(result.get("stdout") or "{}")
+        except json.JSONDecodeError:
+            return SizeResult()
+        raw = ((payload.get("cache") or {}).get("stats") or {}).get("unique_csize")
+        # one normalized value feeds both fields: a source without bytes
+        # would label a size this measurement did not produce
+        size = (
+            int(raw)
+            if isinstance(raw, (int, float)) and not isinstance(raw, bool) and raw > 0
+            else None
+        )
+        return SizeResult(
+            bytes=size,
+            source=SOURCE_BORG1_CACHE_STATS if size else None,
+            last_modified=_last_modified(payload),
+        )
+
+    from app.core.borg2 import _get_borg2_binary, borg2
+
+    last_modified = None
+    rinfo = await borg2.rinfo(
+        repository.path,
+        passphrase=repository.passphrase,
+        remote_path=remote_path,
+        env=env,
+    )
+    if rinfo.get("success"):
+        try:
+            last_modified = _last_modified(json.loads(rinfo.get("stdout") or "{}"))
+        except json.JSONDecodeError:
+            pass
+
+    index_env = dict(env or {})
+    if repository.passphrase:
+        index_env.setdefault("BORG_PASSPHRASE", repository.passphrase)
+    if remote_path:
+        index_env.setdefault("BORG_REMOTE_PATH", remote_path)
+    indexed = await borg2_index_size(
+        repository.path,
+        borg2_binary=_get_borg2_binary(),
+        env=index_env,
+        timeout=info_timeout,
+    )
+    if indexed is not None:
+        return SizeResult(
+            bytes=indexed[0] or None,
+            objects=indexed[1],
+            source=SOURCE_BORG2_INDEX if indexed[0] else None,
+            last_modified=last_modified,
+        )
+
+    # the whole measurement runs under the repository's metadata lock, so
+    # the store-level fallback gets the same budget as the index read
+    used = await storage_used(
+        repository.path, key_file=temp_key_file, env=env, timeout=info_timeout
+    )
+    return SizeResult(
+        bytes=used,
+        source=SOURCE_STORAGE_USED if used else None,
+        last_modified=last_modified,
+    )

--- a/docs/architecture/job-system.md
+++ b/docs/architecture/job-system.md
@@ -165,6 +165,21 @@ Rules:
   it with `skip_reason = dependency_failed`.
 - Follow-ups are created automatically when an operation succeeds. An
   import enqueues stats and archive listing.
+- `stats` measures the repository read-only through the best source Borg
+  offers and records it in `repositories.total_size_source`: Borg 1
+  `cache.stats.unique_csize` (`borg1_cache_stats`, deduplicated); Borg 2 the
+  chunk-index sum through Borg's Python API next to the configured binary
+  (`borg2_index`, the bytes of every indexed object), else a store-level
+  measurement per URL scheme (`storage_used`, file bytes including index and
+  pack headers: rclone for `sftp://` and `rclone:` paths with the prepared
+  environment, du for local
+  paths and `ssh://`, a REST listing for http; none for `rest://user@host`,
+  whose key is bound to the REST server). The labels name different
+  quantities: `compact --stats` counts pack file bytes, which include data
+  no index entry covers, so it and `borg2_index` agree only on a fully
+  indexed repository. An unknown size leaves the stored value alone,
+  never `0`. Both versions' `repository.last_modified` (the last manifest
+  write) lands in `repositories.borg_last_modified`.
 - The reconcile scheduler replaces the old stats refresh loop. Every
   `stats_refresh_interval_minutes` it enqueues an index run for each
   repository that has none queued or running. `0` disables it.

--- a/tests/unit/test_api_repositories.py
+++ b/tests/unit/test_api_repositories.py
@@ -3067,6 +3067,62 @@ class TestRepositoriesStatistics:
         mock_list.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_get_repository_stats_reports_last_modified_from_the_info_call(
+        self, test_db
+    ):
+        """The endpoint runs `info` anyway; Borg's own last_modified from
+        that payload wins over the stored column, which serves as the
+        fallback for a payload without one."""
+        from datetime import datetime
+
+        from app.api.repositories import get_repository_stats
+
+        repo = Repository(
+            name="Stats Repo",
+            path="/tmp/stats-repo",
+            encryption="none",
+            compression="lz4",
+            repository_type="local",
+            borg_last_modified=datetime(2026, 9, 1, 6, 0),
+        )
+        test_db.add(repo)
+        test_db.commit()
+
+        async def stats_for(stdout):
+            with (
+                patch(
+                    "app.api.repositories.resolve_repo_ssh_key_file", return_value=None
+                ),
+                patch(
+                    "app.api.repositories.borg._execute_command",
+                    new=AsyncMock(
+                        return_value={
+                            "success": True,
+                            "stdout": stdout,
+                            "stderr": "",
+                            "return_code": 0,
+                        }
+                    ),
+                ) as mock_exec,
+                patch(
+                    "app.api.repositories.BorgRouter.list_archives",
+                    new=AsyncMock(return_value=[]),
+                ),
+            ):
+                stats = await get_repository_stats(repo, test_db)
+            assert mock_exec.call_args.kwargs["env"]["TZ"] == "UTC"
+            return stats
+
+        live = await stats_for(
+            '{"repository": {"last_modified": "2026-09-07T08:00:00.000000"}}'
+        )
+        assert live["last_modified"] == "2026-09-07T08:00:00+00:00"
+        stored = await stats_for('{"repository": {}}')
+        assert stored["last_modified"] == "2026-09-01T06:00:00+00:00"
+        unparsable = await stats_for("ok")
+        assert unparsable["last_modified"] == "2026-09-01T06:00:00+00:00"
+
+    @pytest.mark.asyncio
     async def test_get_repository_stats_omits_passphrase_for_unencrypted_local_repo(
         self, test_db
     ):

--- a/tests/unit/test_api_repositories_routes.py
+++ b/tests/unit/test_api_repositories_routes.py
@@ -9,6 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.api import repositories as repositories_api
+from app.services.storage_usage import SOURCE_BORG1_CACHE_STATS, SizeResult
 from app.database.models import (
     BackupJob,
     BackupPlan,
@@ -513,9 +514,15 @@ class TestRepositoryHelperContracts:
                 AsyncMock(return_value=list_payload["stdout"]),
             ) as mock_list,
             patch.object(
-                repositories_api.BorgRouter,
-                "calculate_total_size_bytes",
-                AsyncMock(return_value=2097152),
+                repositories_api,
+                "measure_repository_size",
+                AsyncMock(
+                    return_value=SizeResult(
+                        bytes=2097152,
+                        source=SOURCE_BORG1_CACHE_STATS,
+                        last_modified=datetime(2024, 2, 1, 12, 30),
+                    )
+                ),
             ) as mock_size,
         ):
             success = await repositories_api.update_repository_stats(repo, test_db)
@@ -523,6 +530,8 @@ class TestRepositoryHelperContracts:
         assert success is True
         assert repo.archive_count == 2
         assert repo.total_size == "2.00 MB"
+        assert repo.total_size_source == SOURCE_BORG1_CACHE_STATS
+        assert repo.borg_last_modified == datetime(2024, 2, 1, 12, 30)
         assert repo.last_backup == datetime(2024, 2, 1, 12, 0)
         mock_list.assert_awaited_once()
         # TZ=UTC is pinned inside the wrapper methods (mocked away here);
@@ -545,7 +554,8 @@ class TestRepositoryHelperContracts:
         # Borg 1 repo-info carries repo-level dedup size in cache.stats.
         rinfo_stdout = (
             '{"encryption":{"mode":"repokey-aes-ocb"},'
-            '"cache":{"stats":{"unique_csize":2097152}}}'
+            '"cache":{"stats":{"unique_csize":2097152}},'
+            '"repository":{"last_modified":"2024-02-01T12:30:00+00:00"}}'
         )
         wait_returns = [
             {"success": True, "stdout": list_stdout},
@@ -576,6 +586,8 @@ class TestRepositoryHelperContracts:
         assert repo.archive_count == 2
         assert repo.encryption == "repokey-aes-ocb"
         assert repo.total_size == "2.00 MB"
+        assert repo.total_size_source == "borg1_cache_stats"
+        assert repo.borg_last_modified == datetime(2024, 2, 1, 12, 30)
         assert repo.last_backup == datetime(2024, 2, 1, 12, 0)
         job_kinds = [c.kwargs["job_kind"] for c in mock_queue.call_args_list]
         assert job_kinds == ["repository.list_archives", "repository.rinfo"]
@@ -635,9 +647,9 @@ class TestRepositoryHelperContracts:
                 AsyncMock(return_value=archives),
             ),
             patch.object(
-                repositories_api.BorgRouter,
-                "calculate_total_size_bytes",
-                AsyncMock(return_value=0),
+                repositories_api,
+                "measure_repository_size",
+                AsyncMock(return_value=SizeResult()),
             ),
         ):
             success = await repositories_api.update_repository_stats(repo, test_db)
@@ -687,9 +699,11 @@ class TestRepositoryHelperContracts:
                 AsyncMock(return_value='{"archives": []}'),
             ) as mock_list,
             patch.object(
-                repositories_api.BorgRouter,
-                "calculate_total_size_bytes",
-                AsyncMock(return_value=1024),
+                repositories_api,
+                "measure_repository_size",
+                AsyncMock(
+                    return_value=SizeResult(bytes=1024, source=SOURCE_BORG1_CACHE_STATS)
+                ),
             ) as mock_size,
             patch("app.api.repositories.os.path.exists", return_value=False),
         ):
@@ -701,7 +715,7 @@ class TestRepositoryHelperContracts:
         assert not mock_size.await_args.kwargs["use_bypass_lock"]
 
     @pytest.mark.asyncio
-    async def test_update_repository_stats_formats_v2_total_size_from_router(
+    async def test_update_repository_stats_formats_v2_total_size_from_the_measurement(
         self, test_db
     ):
         repo = _create_repo(test_db, "Repo V2", "/repos/v2-main", borg_version=2)
@@ -719,9 +733,9 @@ class TestRepositoryHelperContracts:
                 ),
             ) as mock_list,
             patch.object(
-                repositories_api.BorgRouter,
-                "calculate_total_size_bytes",
-                AsyncMock(return_value=4096),
+                repositories_api,
+                "measure_repository_size",
+                AsyncMock(return_value=SizeResult(bytes=4096, source="borg2_index")),
             ) as mock_size,
             patch("app.api.repositories.os.path.exists", return_value=False),
         ):
@@ -730,9 +744,11 @@ class TestRepositoryHelperContracts:
         assert success is True
         assert repo.archive_count == 1
         assert repo.total_size == "4.00 KB"
+        assert repo.total_size_source == "borg2_index"
         assert repo.last_backup == datetime(2024, 2, 1, 12, 0)
         mock_list.assert_awaited_once()
         mock_size.assert_awaited_once()
+        assert mock_size.await_args.args[0] is repo
 
     @pytest.mark.asyncio
     async def test_repo_metadata_routes_serialize_borg_commands_per_repository(

--- a/tests/unit/test_archive_change_path_index_migration.py
+++ b/tests/unit/test_archive_change_path_index_migration.py
@@ -62,11 +62,14 @@ def _insert_long_path(url):
     engine = _engine(url)
     session = sessionmaker(bind=engine)()
     try:
-        repo = Repository(name="r", path="/srv/r")
-        session.add(repo)
-        session.flush()
+        # Core insert with explicit columns: the schema at this revision
+        # predates columns later revisions add to repositories, which an
+        # ORM insert would include.
+        repo_id = session.execute(
+            Repository.__table__.insert().values(name="r", path="/srv/r")
+        ).inserted_primary_key[0]
         archive = Archive(
-            repository_id=repo.id,
+            repository_id=repo_id,
             borg_id="b",
             name="a",
             series="s",

--- a/tests/unit/test_borg_router.py
+++ b/tests/unit/test_borg_router.py
@@ -39,64 +39,6 @@ async def test_update_stats_delegates_to_v1_repository_helper(db_session):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_calculate_total_size_bytes_delegates_to_v2_repository_service():
-    repo = SimpleNamespace(
-        borg_version=2,
-        path="/tmp/repo",
-        remote_path="/usr/bin/borg2",
-    )
-
-    with patch(
-        "app.services.v2.repository_service.repository_v2_service.calculate_total_size_bytes",
-        new=AsyncMock(return_value=4096),
-    ) as mock_size:
-        size = await BorgRouter(repo).calculate_total_size_bytes(
-            env={"BORG_PASSPHRASE": "secret"},
-            info_timeout=99,
-            use_bypass_lock=True,
-            temp_key_file="/tmp/key",
-        )
-
-    assert size == 4096
-    mock_size.assert_awaited_once_with(
-        repo,
-        temp_key_file="/tmp/key",
-        timeout=30,
-    )
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_calculate_total_size_bytes_uses_v1_info_command():
-    repo = SimpleNamespace(
-        borg_version=1,
-        path="/tmp/repo",
-        remote_path="/usr/bin/borg",
-    )
-
-    with patch(
-        "app.core.borg.borg._execute_command",
-        new=AsyncMock(
-            return_value={
-                "success": True,
-                "stdout": '{"cache":{"stats":{"unique_csize": 2048}}}',
-            }
-        ),
-    ) as mock_exec:
-        size = await BorgRouter(repo).calculate_total_size_bytes(
-            env={"BORG_PASSPHRASE": "secret"},
-            info_timeout=55,
-            use_bypass_lock=True,
-        )
-
-    assert size == 2048
-    cmd = mock_exec.await_args.args[0]
-    assert "--remote-path" in cmd
-    assert "--bypass-lock" in cmd
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
 async def test_check_delegates_to_agent_when_managed():
     repo = SimpleNamespace(borg_version=2, id=41, executor_type="agent")
 

--- a/tests/unit/test_operations_index_executors.py
+++ b/tests/unit/test_operations_index_executors.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import sessionmaker
 from app.database.models import Archive, Base, Repository, SystemSettings
 from app.services.operations.executors import index as index_exec
 from app.services.operations.runner import Outcome
+from app.services.storage_usage import SizeResult
 
 
 @pytest.fixture()
@@ -222,17 +223,81 @@ async def test_run_archive_sync_skips_missing_repository(db, repo):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_run_stats_writes_total_size(db, repo, monkeypatch):
+    """stats persists the measured size with its source and Borg's
+    last_modified (#934)."""
     monkeypatch.setattr(
         index_exec, "_prepare_repository_borg_env", lambda repository, db: ({}, None)
     )
-    with patch(
-        "app.core.borg_router.BorgRouter.calculate_total_size_bytes",
-        new=AsyncMock(return_value=2048),
-    ):
-        outcome = await index_exec.run_stats(_ctx(db, repo, kind="stats"))
-    assert outcome.result == {"unique_csize": 2048}
+    monkeypatch.setattr(
+        index_exec,
+        "measure_repository_size",
+        AsyncMock(
+            return_value=SizeResult(
+                bytes=2048,
+                objects=3,
+                source="borg2_index",
+                last_modified=datetime(2026, 9, 6, 8, 57, 17),
+            )
+        ),
+    )
+    outcome = await index_exec.run_stats(_ctx(db, repo, kind="stats"))
+    assert outcome.result == {
+        "bytes": 2048,
+        "objects": 3,
+        "source": "borg2_index",
+        "last_modified": "2026-09-06T08:57:17",
+    }
     db.refresh(repo)
     assert repo.total_size == "2.00 KB"
+    assert repo.total_size_source == "borg2_index"
+    assert repo.borg_last_modified == datetime(2026, 9, 6, 8, 57, 17)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_stats_leaves_size_alone_when_unknown(db, repo, monkeypatch):
+    repo.total_size = "keep"
+    repo.total_size_source = "borg1_cache_stats"
+    db.commit()
+    monkeypatch.setattr(
+        index_exec, "_prepare_repository_borg_env", lambda repository, db: ({}, None)
+    )
+    monkeypatch.setattr(
+        index_exec, "measure_repository_size", AsyncMock(return_value=SizeResult())
+    )
+    outcome = await index_exec.run_stats(_ctx(db, repo, kind="stats"))
+    assert outcome.status == "completed" and outcome.result["bytes"] is None
+    db.refresh(repo)
+    assert repo.total_size == "keep" and repo.total_size_source == "borg1_cache_stats"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_stats_persists_last_modified_when_the_size_is_unknown(
+    db, repo, monkeypatch
+):
+    """Borg 2 with `repo-info` working but no index and no store measurement:
+    the size stays as it was, `last_modified` is still written."""
+    from datetime import datetime
+
+    repo.total_size = "keep"
+    repo.total_size_source = "borg1_cache_stats"
+    db.commit()
+    monkeypatch.setattr(
+        index_exec, "_prepare_repository_borg_env", lambda repository, db: ({}, None)
+    )
+    monkeypatch.setattr(
+        index_exec,
+        "measure_repository_size",
+        AsyncMock(return_value=SizeResult(last_modified=datetime(2026, 9, 7, 8, 0))),
+    )
+    outcome = await index_exec.run_stats(_ctx(db, repo, kind="stats"))
+    assert outcome.status == "completed"
+    assert outcome.result["bytes"] is None
+    assert outcome.result["last_modified"] == "2026-09-07T08:00:00"
+    db.refresh(repo)
+    assert repo.total_size == "keep" and repo.total_size_source == "borg1_cache_stats"
+    assert repo.borg_last_modified == datetime(2026, 9, 7, 8, 0)
 
 
 @pytest.mark.unit
@@ -257,7 +322,7 @@ async def test_run_stats_agent_repository_leaves_size_alone_when_unmeasurable(
     )
     with patch.object(index_exec, "_publish_mqtt_state"):
         outcome = await index_exec.run_stats(_ctx(db, repo, kind="stats"))
-    assert outcome.result == {"total_size": "keep", "source": "agent"}
+    assert outcome.result == {"total_size": "keep", "executor": "agent"}
     db.refresh(repo)
     assert repo.total_size == "keep"
 
@@ -510,11 +575,12 @@ async def test_index_executors_publish_mqtt_state_after_writing_stats(
         side_effect=lambda session, reason="manual": reasons.append(reason),
     ):
         await index_exec.run_archive_sync(_ctx(db, repo))
-        with patch(
-            "app.core.borg_router.BorgRouter.calculate_total_size_bytes",
-            new=AsyncMock(return_value=2048),
-        ):
-            await index_exec.run_stats(_ctx(db, repo, kind="stats"))
+        monkeypatch.setattr(
+            index_exec,
+            "measure_repository_size",
+            AsyncMock(return_value=SizeResult(bytes=2048, source="borg1_cache_stats")),
+        )
+        await index_exec.run_stats(_ctx(db, repo, kind="stats"))
     assert len(reasons) == 2
 
 

--- a/tests/unit/test_repository_size_source_migration.py
+++ b/tests/unit/test_repository_size_source_migration.py
@@ -1,0 +1,75 @@
+"""Tests for revision 8f2a4c6e1d3b (repository size source, borg last_modified)."""
+
+from alembic import command
+import pytest
+from sqlalchemy import inspect
+
+from app.database.db_upgrade import _alembic_config, _engine
+
+REVISION = "8f2a4c6e1d3b"
+PREVIOUS = "7de0064b0d99"
+
+
+def _migrate(url, target, *, down=False):
+    engine = _engine(url)
+    config = _alembic_config(url)
+    with engine.connect() as connection:
+        config.attributes["connection"] = connection
+        (command.downgrade if down else command.upgrade)(config, target)
+        connection.commit()
+    engine.dispose()
+
+
+def _columns(url):
+    engine = _engine(url)
+    try:
+        return {c["name"] for c in inspect(engine).get_columns("repositories")}
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.unit
+def test_upgrade_adds_and_downgrade_drops_the_columns(tmp_path):
+    url = f"sqlite:///{tmp_path / 'borg.db'}"
+    _migrate(url, PREVIOUS)
+    assert not {"total_size_source", "borg_last_modified"} & _columns(url)
+
+    _migrate(url, REVISION)
+    assert {"total_size_source", "borg_last_modified"} <= _columns(url)
+
+    _migrate(url, PREVIOUS, down=True)
+    assert not {"total_size_source", "borg_last_modified"} & _columns(url)
+
+
+@pytest.mark.unit
+def test_merge_revision_joins_the_ssh_host_key_branch():
+    """8f2a4c6e1d3b keeps its original parent (installs applied it there);
+    c3d5e7f9a1b2 joins it with the SSH host-key branch so the graph has one
+    head and an install at 8f2a4c6e1d3b still receives the host-key columns."""
+    from alembic.script import ScriptDirectory
+
+    script = ScriptDirectory.from_config(_alembic_config("sqlite://"))
+    assert script.get_revision(REVISION).down_revision == "7de0064b0d99"
+    merge = script.get_revision("c3d5e7f9a1b2")
+    assert set(merge.down_revision) == {REVISION, "b7e1a3c95d84"}
+
+
+def _table_columns(url, table):
+    engine = _engine(url)
+    try:
+        return {c["name"] for c in inspect(engine).get_columns(table)}
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.unit
+def test_upgrade_to_head_keeps_both_branches_columns(tmp_path):
+    """Base to head on a fresh database: the size branch and the SSH
+    host-key branch both land, whichever order alembic picks for the
+    parallel revisions, and neither recreates a table under the other."""
+    url = f"sqlite:///{tmp_path / 'borg.db'}"
+    _migrate(url, "head")
+    assert {"total_size_source", "borg_last_modified"} <= _columns(url)
+    assert {"known_host_key", "host_key_trust_on_first_use"} <= _table_columns(
+        url, "ssh_connections"
+    )

--- a/tests/unit/test_storage_usage.py
+++ b/tests/unit/test_storage_usage.py
@@ -1,0 +1,693 @@
+import asyncio
+import json
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services import storage_usage
+from app.services.storage_usage import (
+    SOURCE_BORG1_CACHE_STATS,
+    SOURCE_BORG2_INDEX,
+    SOURCE_STORAGE_USED,
+    SizeResult,
+    borg2_index_size,
+    borg2_interpreter,
+    measure_repository_size,
+    rclone_remote_for,
+    safe_url,
+    store_target,
+)
+
+
+class FakeProcess:
+    def __init__(
+        self, returncode=0, stdout=b"", stderr=b"", hang=False, kill_raises=None
+    ):
+        self.returncode = returncode
+        self._out = (stdout, stderr)
+        self._hang = hang
+        self._kill_raises = kill_raises
+        self.killed = False
+        self.waited = False
+
+    async def communicate(self):
+        if self._hang:
+            await asyncio.sleep(60)
+        return self._out
+
+    def kill(self):
+        self.killed = True
+        if self._kill_raises:
+            raise self._kill_raises
+
+    async def wait(self):
+        self.waited = True
+        return self.returncode
+
+
+def _listing(payload, *, chunks=None):
+    """A streamed `requests` response: the JSON body in one chunk, or the
+    given chunks; records how many were read and whether it was closed."""
+    pieces = [json.dumps(payload).encode()] if chunks is None else chunks
+    state = {"read": 0, "closed": False}
+
+    def iter_content(chunk_size=None):
+        for piece in pieces:
+            state["read"] += 1
+            yield piece
+
+    return SimpleNamespace(
+        raise_for_status=lambda: None,
+        iter_content=iter_content,
+        close=lambda: state.__setitem__("closed", True),
+        state=state,
+    )
+
+
+def _repo(borg_version=2, path="rest://borg@host/repos/repo", passphrase="x"):
+    return SimpleNamespace(
+        borg_version=borg_version,
+        path=path,
+        passphrase=passphrase,
+        bypass_lock=False,
+        ssh_key_id=None,
+        remote_path=None,
+    )
+
+
+@pytest.mark.unit
+def test_borg2_interpreter_is_the_python_next_to_a_venv_borg(tmp_path):
+    bindir = tmp_path / "venv" / "bin"
+    bindir.mkdir(parents=True)
+    borg = bindir / "borg"
+    borg.write_text("#!/bin/sh\n")
+    borg.chmod(0o755)
+    link = tmp_path / "borg2"
+    link.symlink_to(borg)
+    assert borg2_interpreter(str(link), {}) is None  # standalone: no python next to it
+    python = bindir / "python"
+    python.write_text("#!/bin/sh\n")
+    python.chmod(0o755)
+    # a python without pyvenv.cfg is a system interpreter: borg not importable
+    assert borg2_interpreter(str(link), {}) is None
+    (tmp_path / "venv" / "pyvenv.cfg").write_text("home = /usr/bin\n")
+    assert borg2_interpreter(str(link), {}) == str(python)
+
+    # the command on PATH may be a wrapper next to the system python (the
+    # agent image); BORG2_BINARY in the environment points at the real one
+    wrapper_dir = tmp_path / "usr" / "local" / "bin"
+    wrapper_dir.mkdir(parents=True)
+    for name in ("borg2", "python"):
+        (wrapper_dir / name).write_text("#!/bin/sh\n")
+        (wrapper_dir / name).chmod(0o755)
+    assert borg2_interpreter(str(wrapper_dir / "borg2"), {}) is None
+    assert borg2_interpreter(
+        str(wrapper_dir / "borg2"), {"BORG2_BINARY": str(link)}
+    ) == str(python)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_borg2_index_size_parses_the_script_output(monkeypatch):
+    monkeypatch.setattr(
+        storage_usage, "borg2_interpreter", lambda b, env=None: "/venv/bin/python"
+    )
+    spawn = AsyncMock(
+        return_value=FakeProcess(
+            stdout=json.dumps({"objects": 4, "bytes": 301284}).encode()
+        )
+    )
+    monkeypatch.setattr(storage_usage.asyncio, "create_subprocess_exec", spawn)
+    assert await borg2_index_size(
+        "sftp://u:secret@h/r", borg2_binary="borg2", env={"A": "1"}
+    ) == (301284, 4)
+    args = spawn.call_args.args
+    assert args[0] == "/venv/bin/python" and args[1] == "-c" and len(args) == 3
+    # the URL (it may carry credentials) travels in the environment, not argv
+    assert "secret" not in " ".join(args)
+    assert (
+        spawn.call_args.kwargs["env"]["BORG_UI_REPOSITORY_URL"] == "sftp://u:secret@h/r"
+    )
+    assert spawn.call_args.kwargs["env"]["A"] == "1"
+    assert "lock=False" in args[2]
+    # streamed in pages, never one list of every object
+    assert "marker" in args[2] and "[size for" not in args[2]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_borg2_index_size_is_none_without_interpreter_or_on_failure(monkeypatch):
+    monkeypatch.setattr(storage_usage, "borg2_interpreter", lambda b, env=None: None)
+    assert await borg2_index_size("/r", borg2_binary="borg2") is None
+    monkeypatch.setattr(
+        storage_usage, "borg2_interpreter", lambda b, env=None: "/venv/bin/python"
+    )
+    monkeypatch.setattr(
+        storage_usage.asyncio,
+        "create_subprocess_exec",
+        AsyncMock(return_value=FakeProcess(returncode=2, stderr=b"LockTimeout")),
+    )
+    assert await borg2_index_size("/r", borg2_binary="borg2") is None
+
+
+@pytest.mark.unit
+def test_rclone_remote_for_sftp_and_rclone_urls():
+    assert (
+        rclone_remote_for("sftp://u1@box.example:23/./backups/repo")
+        == ":sftp,host=box.example,user=u1,port=23:backups/repo"
+    )
+    assert (
+        rclone_remote_for("sftp://u@h/abs/repo", key_file="/tmp/k")
+        == ":sftp,host=h,user=u,key_file=/tmp/k:/abs/repo"
+    )
+    # an explicit port 0 is a port, not "no port": rclone must not fall
+    # back to 22
+    assert rclone_remote_for("sftp://u@h:0/./r") == ":sftp,host=h,user=u,port=0:r"
+    assert rclone_remote_for("rclone:remote:bucket/repo") == "remote:bucket/repo"
+    assert rclone_remote_for("/local/path") is None
+    assert rclone_remote_for("s3:profile@bucket/path") is None
+    # upper-case scheme, remote name kept as written (rclone remotes are
+    # case-sensitive)
+    assert rclone_remote_for("RCLONE:Remote:bucket/repo") == "Remote:bucket/repo"
+    assert store_target("RCLONE:Remote:bucket/repo") == (
+        "rclone",
+        "RCLONE:Remote:bucket/repo",
+    )
+
+
+@pytest.mark.unit
+def test_store_target_by_scheme():
+    assert store_target("http://u:p@srv:8000/store") == (
+        "http",
+        "http://u:p@srv:8000/store",
+    )
+    assert store_target("sftp://u@h:23/./r") == ("rclone", "sftp://u@h:23/./r")
+    assert store_target("rclone:remote:r") == ("rclone", "rclone:remote:r")
+    # borgstore's rest://user@host/path runs the REST server over ssh behind
+    # a forced command, so no shell command (du) reaches the files.
+    assert store_target("rest://borg@host/repos/repo") == ("", None)
+    assert store_target("rest://borg@host:2222/repos/repo") == ("", None)
+    assert store_target("rest:///srv/store") == ("du", "/srv/store")
+    assert store_target("ssh://u@h/r") == ("du", "ssh://u@h/r")
+    assert store_target("/backups/repo") == ("du", "/backups/repo")
+    assert store_target("s3:profile|k:s@endpoint/bucket") == ("", None)
+    # schemes are case-insensitive, the target keeps the URL as written
+    assert store_target("HTTP://srv/store") == ("http", "HTTP://srv/store")
+    assert store_target("SFTP://u@h/./r") == ("rclone", "SFTP://u@h/./r")
+    assert store_target("REST://borg@host/repos/repo") == ("", None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_http_storage_used_walks_the_rest_listing(monkeypatch):
+    listings = {
+        "http://u:p@srv/store/": [
+            {"name": "config", "size": 582, "directory": False},
+            {"name": "packs", "size": 0, "directory": True},
+        ],
+        "http://u:p@srv/store/packs/": [
+            {"name": "aa", "size": 0, "directory": True},
+        ],
+        "http://u:p@srv/store/packs/aa/": [
+            {"name": "obj1", "size": 300000, "directory": False},
+            {"name": "obj2", "size": 2708, "directory": False},
+        ],
+    }
+    seen = []
+
+    def fake_get(
+        url, auth=None, headers=None, timeout=None, allow_redirects=True, **kw
+    ):
+        assert allow_redirects is False and kw.get("stream") is True
+        seen.append((url, auth, headers["Accept"]))
+        key = url.replace("http://srv/", "http://u:p@srv/")
+        return _listing(listings[key])
+
+    with patch("requests.get", fake_get):
+        assert await storage_usage.http_storage_used("http://u:p@srv/store") == 303290
+    assert seen[0][1] == ("u", "p")
+    assert seen[0][2] == "application/vnd.x.borgstore.rest.v1"
+    assert seen[0][0] == "http://srv/store/"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_measure_borg1_reads_cache_stats_and_last_modified():
+    repo = _repo(borg_version=1, path="/backups/repo")
+    payload = {
+        "cache": {"stats": {"unique_csize": 2048}},
+        "repository": {"last_modified": "2026-09-05T12:29:48.000000"},
+    }
+    execute = AsyncMock(return_value={"success": True, "stdout": json.dumps(payload)})
+    with patch("app.core.borg.borg._execute_command", execute):
+        result = await measure_repository_size(
+            repo, env={"A": "1"}, use_bypass_lock=True
+        )
+    assert result == SizeResult(
+        bytes=2048,
+        source=SOURCE_BORG1_CACHE_STATS,
+        last_modified=datetime(2026, 9, 5, 12, 29, 48),
+    )
+    cmd = execute.call_args.args[0]
+    assert cmd[:3] == ["borg", "info", "--json"] and "--bypass-lock" in cmd
+    assert execute.call_args.kwargs["env"]["TZ"] == "UTC"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stats",
+    [None, {}, {"unique_csize": None}, {"unique_csize": 0}, {"unique_csize": -1}]
+    + [{"unique_csize": "2048"}, {"unique_csize": True}],
+)
+async def test_measure_borg1_without_a_usable_size_reports_no_source(stats):
+    """`source` describes `bytes`; a size that is not a positive number
+    yields neither, and a null `cache.stats` is not an error."""
+    repo = _repo(borg_version=1, path="/backups/repo")
+    payload = {
+        "cache": {"stats": stats},
+        "repository": {"last_modified": "2026-09-05T12:29:48.000000"},
+    }
+    execute = AsyncMock(return_value={"success": True, "stdout": json.dumps(payload)})
+    with patch("app.core.borg.borg._execute_command", execute):
+        result = await measure_repository_size(repo, env={})
+    assert result == SizeResult(
+        bytes=None, source=None, last_modified=datetime(2026, 9, 5, 12, 29, 48)
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_measure_borg2_prefers_the_index_and_keeps_last_modified(monkeypatch):
+    repo = _repo()
+    rinfo = AsyncMock(
+        return_value={
+            "success": True,
+            "stdout": json.dumps(
+                {"repository": {"last_modified": "2026-09-06T08:57:17.922941+00:00"}}
+            ),
+        }
+    )
+    index = AsyncMock(return_value=(301284, 4))
+    used = AsyncMock(return_value=999)
+    monkeypatch.setattr(storage_usage, "borg2_index_size", index)
+    monkeypatch.setattr(storage_usage, "storage_used", used)
+    with (
+        patch("app.core.borg2.borg2.rinfo", rinfo),
+        patch("app.core.borg2._get_borg2_binary", return_value="/opt/venv/bin/borg"),
+    ):
+        result = await measure_repository_size(repo, env={"BORG_RSH": "ssh"})
+    assert result == SizeResult(
+        bytes=301284,
+        objects=4,
+        source=SOURCE_BORG2_INDEX,
+        last_modified=datetime(2026, 9, 6, 8, 57, 17, 922941),
+    )
+    assert index.call_args.kwargs["borg2_binary"] == "/opt/venv/bin/borg"
+    assert index.call_args.kwargs["env"]["BORG_PASSPHRASE"] == "x"
+    used.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_measure_borg2_falls_back_to_the_store_and_never_reports_zero(
+    monkeypatch,
+):
+    repo = _repo()
+    monkeypatch.setattr(storage_usage, "borg2_index_size", AsyncMock(return_value=None))
+    used = AsyncMock(return_value=424242)
+    monkeypatch.setattr(storage_usage, "storage_used", used)
+    with (
+        patch("app.core.borg2.borg2.rinfo", AsyncMock(return_value={"success": False})),
+        patch("app.core.borg2._get_borg2_binary", return_value="borg2"),
+    ):
+        result = await measure_repository_size(repo, temp_key_file="/tmp/k")
+    assert result == SizeResult(bytes=424242, source=SOURCE_STORAGE_USED)
+    assert used.call_args.kwargs["key_file"] == "/tmp/k"
+    assert used.call_args.kwargs["env"] is None
+
+    monkeypatch.setattr(storage_usage, "storage_used", AsyncMock(return_value=None))
+    with (
+        patch("app.core.borg2.borg2.rinfo", AsyncMock(return_value={"success": False})),
+        patch("app.core.borg2._get_borg2_binary", return_value="borg2"),
+    ):
+        assert await measure_repository_size(repo) == SizeResult()
+
+    monkeypatch.setattr(
+        storage_usage, "borg2_index_size", AsyncMock(return_value=(0, 0))
+    )
+    with (
+        patch("app.core.borg2.borg2.rinfo", AsyncMock(return_value={"success": False})),
+        patch("app.core.borg2._get_borg2_binary", return_value="borg2"),
+    ):
+        empty = await measure_repository_size(repo)
+    assert empty.bytes is None and empty.source is None and empty.objects == 0
+
+
+@pytest.mark.unit
+def test_safe_url_redacts_credentials():
+    assert safe_url("http://u:s3cr%40t@srv:8000/store") == "http://u:***@srv:8000/store"
+    assert safe_url("sftp://u:s3cr%40t@box:23/./r") == "sftp://u:***@box:23/./r"
+    assert safe_url("/backups/repo") == "/backups/repo"
+    assert safe_url("sftp://box:23/./r") == "sftp://box:23/./r"
+    # a userinfo without a password is the whole credential (Basic auth
+    # sends it as the user name), so nothing of it survives
+    assert safe_url("http://token@srv/store") == "http://***@srv/store"
+    assert safe_url("sftp://u@box:23/./r") == "sftp://***@box:23/./r"
+    assert "token" not in safe_url("HTTPS://token@srv/store")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_http_storage_used_decodes_credentials_and_tolerates_no_password():
+    seen = []
+
+    def fake_get(
+        url, auth=None, headers=None, timeout=None, allow_redirects=True, **kw
+    ):
+        assert allow_redirects is False
+        seen.append(auth)
+        return _listing([])
+
+    with patch("requests.get", fake_get):
+        await storage_usage.http_storage_used("http://us%40er:p%40ss@srv/store")
+        await storage_usage.http_storage_used("http://token@srv/store")
+    assert seen == [("us@er", "p@ss"), ("token", "")]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_timed_out_children_are_killed(monkeypatch):
+    """wait_for only cancels the wait; a timed-out borg or rclone must not
+    keep running."""
+    monkeypatch.setattr(
+        storage_usage, "borg2_interpreter", lambda b, env=None: "/venv/bin/python"
+    )
+    hung = FakeProcess(hang=True)
+    monkeypatch.setattr(
+        storage_usage.asyncio, "create_subprocess_exec", AsyncMock(return_value=hung)
+    )
+    assert await borg2_index_size("/r", borg2_binary="borg2", timeout=0.01) is None
+    assert hung.killed and hung.waited
+
+    hung = FakeProcess(hang=True)
+    monkeypatch.setattr(storage_usage.shutil, "which", lambda name: "/usr/bin/rclone")
+    monkeypatch.setattr(
+        storage_usage.asyncio, "create_subprocess_exec", AsyncMock(return_value=hung)
+    )
+    assert (
+        await storage_usage.rclone_storage_used("sftp://u@h/./r", timeout=0.01) is None
+    )
+    assert hung.killed and hung.waited
+
+
+@pytest.mark.unit
+def test_rclone_remote_decodes_and_quotes_url_components():
+    # percent-encoded user and path are decoded; values with rclone syntax
+    # characters are quoted, quotes doubled
+    assert (
+        rclone_remote_for("sftp://us%40er@h/./dir%20one/repo")
+        == ":sftp,host=h,user=us@er:dir one/repo"
+    )
+    assert (
+        rclone_remote_for("sftp://a%2Cb@h/r", key_file='/k/my"key')
+        == ':sftp,host=h,user="a,b",key_file="/k/my""key":/r'
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cancelled_reads_kill_the_child(monkeypatch):
+    monkeypatch.setattr(
+        storage_usage, "borg2_interpreter", lambda b, env=None: "/venv/bin/python"
+    )
+    hung = FakeProcess(hang=True)
+    monkeypatch.setattr(
+        storage_usage.asyncio, "create_subprocess_exec", AsyncMock(return_value=hung)
+    )
+    task = asyncio.ensure_future(
+        borg2_index_size("/r", borg2_binary="borg2", timeout=60)
+    )
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert hung.killed and hung.waited
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cancellation_survives_a_child_that_already_exited(monkeypatch):
+    """`Process.kill()` raises ProcessLookupError once the child is gone;
+    that must not turn the cancellation into an OSError that the index read
+    reports as "failed to start" and then falls through to the store-level
+    fallback on a task that was meant to stop."""
+    monkeypatch.setattr(
+        storage_usage, "borg2_interpreter", lambda b, env=None: "/venv/bin/python"
+    )
+    gone = FakeProcess(hang=True, kill_raises=ProcessLookupError())
+    monkeypatch.setattr(
+        storage_usage.asyncio, "create_subprocess_exec", AsyncMock(return_value=gone)
+    )
+    task = asyncio.ensure_future(
+        borg2_index_size("/r", borg2_binary="borg2", timeout=60)
+    )
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert gone.killed and gone.waited
+
+
+@pytest.mark.unit
+def test_index_sum_script_compiles():
+    """The child is always mocked in these tests; at least the script must
+    parse, and it must read the URL from the documented variable."""
+    compile(storage_usage.INDEX_SUM_SCRIPT, "<index>", "exec")
+    assert storage_usage.REPOSITORY_URL_ENV in storage_usage.INDEX_SUM_SCRIPT
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value,expected", [(4096, 4096), (0, None), (-1, None)])
+async def test_du_storage_used_runs_du_and_never_reports_zero(value, expected):
+    du = AsyncMock(return_value=value)
+    with patch("app.utils.fs.calculate_path_size_bytes", du):
+        assert (
+            await storage_usage.du_storage_used(
+                "ssh://u@h/r", key_file="/k", timeout=30
+            )
+            == expected
+        )
+    du.assert_awaited_once_with(["ssh://u@h/r"], timeout=30, key_file="/k")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_http_walk_stops_on_a_looping_listing(monkeypatch):
+    """A listing whose directory entry points back at an ancestor must end
+    in `unknown`, not in a RecursionError, and within a bounded number of
+    requests."""
+    seen = []
+
+    def fake_get(
+        url, auth=None, headers=None, timeout=None, allow_redirects=True, **kw
+    ):
+        seen.append(url)
+        return _listing([{"name": "data", "directory": True}])
+
+    with patch("requests.get", fake_get):
+        assert await storage_usage.http_storage_used("http://srv/store") is None
+    assert len(seen) == storage_usage.HTTP_WALK_MAX_DEPTH + 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_http_walk_stops_when_its_budget_is_spent(monkeypatch):
+    # the deadline is taken at the first call, the first directory passes,
+    # the second is past the budget; everything after that stays "late"
+    # (asyncio reads the same clock, so it must never run dry)
+    clock = {"now": 0.0}
+    monkeypatch.setattr(storage_usage.time, "monotonic", lambda: clock["now"])
+    seen = []
+
+    def fake_get(
+        url, auth=None, headers=None, timeout=None, allow_redirects=True, **kw
+    ):
+        seen.append((url, timeout))
+        clock["now"] += 10  # a slow first listing spends the whole budget
+        return _listing([{"name": "sub", "directory": True}])
+
+    with patch("requests.get", fake_get):
+        assert (
+            await storage_usage.http_storage_used("http://srv/store", budget=5) is None
+        )
+    # one request, its socket timeout capped at the remaining budget
+    assert seen == [("http://srv/store/", 5)]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_http_walk_aborts_a_response_that_keeps_sending(monkeypatch):
+    """requests' timeout is per socket operation: a server that keeps
+    sending bytes never trips it. The walk checks the clock between chunks
+    and closes the response once the budget is spent."""
+    clock = {"now": 0.0}
+    monkeypatch.setattr(storage_usage.time, "monotonic", lambda: clock["now"])
+
+    def endless():
+        while True:
+            clock["now"] += 2
+            yield b'[{"name": "x", "size": 1, "directory": false},'
+
+    response = _listing(None, chunks=endless())
+
+    with patch("requests.get", lambda *a, **kw: response):
+        assert (
+            await storage_usage.http_storage_used("http://srv/store", budget=5) is None
+        )
+    assert response.state["closed"] and response.state["read"] <= 3
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_http_walk_refuses_an_oversized_listing(monkeypatch):
+    monkeypatch.setattr(storage_usage, "HTTP_LISTING_MAX_BYTES", 10)
+    response = _listing([{"name": "x", "size": 1, "directory": False}])
+    with patch("requests.get", lambda *a, **kw: response):
+        assert await storage_usage.http_storage_used("http://srv/store") is None
+    assert response.state["closed"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_http_walk_keeps_ipv6_brackets():
+    seen = []
+
+    def fake_get(
+        url, auth=None, headers=None, timeout=None, allow_redirects=True, **kw
+    ):
+        assert allow_redirects is False
+        seen.append(url)
+        return _listing([{"name": "config", "size": 5, "directory": False}])
+
+    with patch("requests.get", fake_get):
+        assert (
+            await storage_usage.http_storage_used("http://u:p@[2001:db8::1]:8000/store")
+            == 5
+        )
+    assert seen == ["http://[2001:db8::1]:8000/store/"]
+    # same for an explicit port 0: kept, no default-port fallback
+    with patch("requests.get", fake_get):
+        assert await storage_usage.http_storage_used("http://h:0/store") == 5
+    assert seen[-1] == "http://h:0/store/"
+    assert (
+        safe_url("http://u:p@[2001:db8::1]:8000/store")
+        == "http://u:***@[2001:db8::1]:8000/store"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rclone_fallback_runs_in_the_prepared_environment(monkeypatch):
+    """The managed rclone.conf is only known through RCLONE_CONFIG on the
+    prepared Borg environment; the fallback must not inherit the server
+    process environment instead (F05)."""
+    repo = _repo(path="rclone:managed:bucket/repo")
+    env = {
+        "RCLONE_CONFIG": "/managed/rclone.conf",
+        "BORG_RSH": "ssh -i /k",
+        "PATH": "/usr/bin",
+    }
+    monkeypatch.setattr(storage_usage, "borg2_index_size", AsyncMock(return_value=None))
+    monkeypatch.setattr(storage_usage.shutil, "which", lambda name: "/usr/bin/rclone")
+    spawn = AsyncMock(
+        return_value=FakeProcess(
+            stdout=json.dumps({"bytes": 4096, "count": 3}).encode()
+        )
+    )
+    monkeypatch.setattr(storage_usage.asyncio, "create_subprocess_exec", spawn)
+    with (
+        patch("app.core.borg2.borg2.rinfo", AsyncMock(return_value={"success": False})),
+        patch("app.core.borg2._get_borg2_binary", return_value="borg2"),
+    ):
+        result = await measure_repository_size(repo, env=env)
+    assert result == SizeResult(bytes=4096, source=SOURCE_STORAGE_USED)
+    assert spawn.call_args.args[:3] == ("/usr/bin/rclone", "size", "--json")
+    assert spawn.call_args.args[3] == "managed:bucket/repo"
+    # the whole prepared environment, not a subset and not the inherited one
+    assert spawn.call_args.kwargs["env"] == env
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_storage_used_passes_the_environment_to_rclone_only(monkeypatch):
+    rclone = AsyncMock(return_value=1)
+    du = AsyncMock(return_value=2)
+    http = AsyncMock(return_value=3)
+    monkeypatch.setattr(storage_usage, "rclone_storage_used", rclone)
+    monkeypatch.setattr(storage_usage, "du_storage_used", du)
+    monkeypatch.setattr(storage_usage, "http_storage_used", http)
+    env = {"RCLONE_CONFIG": "/managed/rclone.conf"}
+    assert (
+        await storage_usage.storage_used("sftp://u@h/./r", env=env, key_file="/k") == 1
+    )
+    assert rclone.call_args.kwargs == {"key_file": "/k", "env": env, "timeout": 600}
+    assert await storage_usage.storage_used("/backups/repo", env=env) == 2
+    assert "env" not in du.call_args.kwargs
+    assert await storage_usage.storage_used("http://srv/store", env=env) == 3
+    assert "env" not in http.call_args.kwargs
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("port", ["99999", "invalid"])
+@pytest.mark.parametrize("scheme", ["http", "sftp", "rclone:x"])
+async def test_invalid_port_is_unknown_not_an_exception(monkeypatch, port, scheme):
+    """`urlsplit(...).port` raises for a port outside 0..65535 or a
+    non-numeric one; that used to escape from the fallback (and again from
+    safe_url while logging it). Such a URL is unmeasurable, and nothing is
+    spawned against another endpoint."""
+    spawn = AsyncMock()
+    monkeypatch.setattr(storage_usage.asyncio, "create_subprocess_exec", spawn)
+    monkeypatch.setattr(storage_usage.shutil, "which", lambda name: "/usr/bin/rclone")
+    if scheme == "rclone:x":
+        url = "rclone:x:bucket/repo"  # no port to be wrong about
+        assert storage_usage.valid_target(url)
+        return
+    url = f"{scheme}://review-user:review-secret@localhost:{port}/store"
+    assert not storage_usage.valid_target(url)
+    assert await storage_usage.storage_used(url) is None
+    spawn.assert_not_awaited()
+    assert rclone_remote_for(url) is None
+    # logging the failure must not raise either, and must still redact
+    assert safe_url(url) == f"{scheme}://review-user:***@localhost:{port}/store"
+    with patch("requests.get") as get:
+        assert await storage_usage.http_storage_used(url) is None
+        get.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "HTTP://u:review-secret@localhost:99999/store",  # upper-case scheme
+        "http://u:alpha@private-tail@localhost:99999/store",  # `@` in the password
+        "http://u:review-secret@[broken:99999/store",  # does not parse at all
+        "sftp://u:review-secret@localhost:invalid/./r",
+    ],
+)
+async def test_redaction_never_leaks_or_raises_on_odd_urls(monkeypatch, url):
+    """Logging a failure must not become the leak: no password fragment in
+    the redacted text, no exception from the redaction, and an unparseable
+    URL is unknown rather than measured."""
+    monkeypatch.setattr(storage_usage.asyncio, "create_subprocess_exec", AsyncMock())
+    redacted = safe_url(url)
+    for fragment in ("review-secret", "alpha", "private-tail"):
+        assert fragment not in redacted
+    assert not storage_usage.valid_target(url)
+    assert await storage_usage.storage_used(url) is None
+    assert await storage_usage.http_storage_used(url) is None


### PR DESCRIPTION
## Description

Borg 2 reports no repository size through any command, and every size path for a Borg 2 store URL ended in `du` on a URL, so `total_size` stayed NULL for such repositories. Both Borg versions report `repository.last_modified`, which Borg UI neither stored nor returned consistently (`updated_at` for agent repositories, `None` for server ones, Borg's value only in the info dialog). Server half of #934.

**One source order, one label** (`app/services/storage_usage.py`, `measure_repository_size`):

1. Borg 1: `info --json` `cache.stats.unique_csize` (`borg1_cache_stats`, the deduplicated size), unchanged.
2. Borg 2: the chunk-index sum through Borg's own Python API (`Repository.list()` yields `(chunk_id, storage_size)` from the store's `index/` fragments), run as a short script with the interpreter next to the configured Borg 2 binary (a venv install; a standalone binary has none and skips to 3). `lock=False`, so a running backup does not block it, and it needs no key. `source = borg2_index`, the repository object size, which is what `compact --stats` prints.
3. Borg 2, store-level (`storage_used`, a different quantity: file bytes including pack headers and the index): `rclone size --json` with an on-the-fly backend for `sftp:` and `rclone:` (rclone is in the runtime image), `du` for local paths and `ssh://`, a `GET <dir>/` listing with `requests` for `http(s)://` borgstore REST servers. **No fallback for `rest://user@host/path`**: that is borgstore's "ssh to host and run `borgstore-server-rest --stdio`" form, and the key on such a host is bound to that server (`command="…",restrict`), so a shell command over ssh never runs `du`.
4. Unknown: the stored size is left alone. `0` is never written.

**Persistence and API**: `repositories.total_size_source` and `repositories.borg_last_modified` (revision `8f2a4c6e1d3b`, `batch_alter_table`). The `stats` executor writes size, source and `last_modified`; `_update_agent_repository_stats` labels its two sources (`borg1_cache_stats` from `rinfo`, `storage_used` from `repository.disk_usage`) and parses `last_modified` from `rinfo` in the agent's reported zone (UTC since #889). `GET /repositories/{id}` and `/stats` return `borg_last_modified` as `last_modified` (instead of `updated_at` / `None`) plus `total_size_source`; the info dialog keeps Borg's live value. `docs/architecture/job-system.md` documents the order.

**One source order for both writers**: `update_repository_stats()` (reached through `BorgRouter.update_stats()` after a wipe, a v2 prune, a config import and the manual stats refresh) measured through the old `du`-based `calculate_total_size_bytes()` and never set the new columns, so it could overwrite a labelled size with a differently measured one. It now calls `measure_repository_size()` and writes size, source and `last_modified` exactly like the `stats` executor; `BorgRouter.calculate_total_size_bytes()` has no caller left and is removed. Routing those call sites through the operations queue instead is a follow-up. `GET /repositories/{id}/stats` returns Borg's `last_modified` from the `info` call it already makes (rendered under `TZ=UTC`), with the stored column as the fallback, so existing repositories show a value before their first `stats` run. Hardening from review: `safe_url` masks a userinfo without a password whole (`http://token@host` is the Basic-auth credential); `store_target` matches schemes case-insensitively; the REST walk has a depth cap and a whole-walk budget, streams each listing and checks the deadline between chunks (requests' `timeout` bounds a socket operation, not a request) with a size cap per listing; the index child's kill on cancel tolerates a child that already exited (`ProcessLookupError` no longer swallows the cancellation); the store-level fallback runs with the `info_timeout` budget because the whole measurement holds the repository's metadata lock; the Borg 1 `cache.stats` value is normalized once (a non-positive or non-numeric value gives neither size nor source, a null block is not an error); the agent branch of the `stats` result names its path `executor` so it cannot be read as a size source.

Not in this PR: the agent job with the same order (#936, needs an agent release), `repo-info --stats` (borgbackup/borg#10329; will replace step 2 when it ships), the UI (#935).

## Related Issue

Fixes #934 (server half)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

New tests (`test_storage_usage.py`): interpreter resolution next to a venv `borg` versus a standalone binary; the index script call and its JSON result, `None` without interpreter or on a non-zero exit; rclone remote strings for `sftp://…/./rel`, absolute paths, key files and `rclone:` passthrough; `store_target` per scheme including `rest://user@host` → none and `rest:///path` → local `du`; the HTTP walk with basic auth and the borgstore `Accept` header; Borg 1 `info` with `--bypass-lock` and `TZ=UTC`; Borg 2 preferring the index over the store fallback and keeping `last_modified`; the store fallback with the temp key file; unknown → empty result; index sum of 0 objects → no size, never `0`.

`test_operations_index_executors.py`: `run_stats` persists size, source and `borg_last_modified` and reports them in the result; leaves the stored size alone when unknown. `test_api_repositories_routes.py`: the agent path stores `total_size_source` and `borg_last_modified` from `rinfo`. `test_repository_size_source_migration.py`: upgrade adds, downgrade drops both columns.

Added for the writer change and the review round: `update_repository_stats` stores `total_size_source` and `borg_last_modified` from the measurement (Borg 1 and Borg 2 fixtures); `/stats` reports `last_modified` from the live `info` payload, the stored column for a payload without one or an unparsable one; cancellation survives a child that already exited; the index script compiles and reads the documented variable; `du_storage_used` runs `du` with the key file and never reports 0; `safe_url` on token-only and upper-case URLs; `store_target` on upper-case schemes; a looping REST listing stops after the depth cap, a spent budget before the next request, a response that keeps sending is closed at the deadline, an oversized listing is refused; Borg 1 `cache.stats` variants (null, empty, None, 0, -1, string, True) give no size and no source; `run_stats` persists `last_modified` when the size is unknown; base-to-head upgrade keeps both branches' columns.

Full unit suite on the final tree: 3287 passed, 13 skipped, 0 failed.

Review round 1: URL credentials are percent-decoded before the Requests auth tuple (a username-only URL sends an empty password, not `None`), and every warning in `storage_usage` logs the repository through `safe_url()` (password replaced by `***`); tests for both. Round 2: a timed-out index read or `rclone size` kills the child and awaits it (`wait_for` only cancels the wait); rclone remote values are percent-decoded and quoted when they carry rclone syntax characters; tests for both. Round 3: the index script streams `Repository.list()` in pages of 100000 with a running sum instead of one list of every object; `_communicate` also kills and reaps the child on `CancelledError`; IPv6 literals keep their brackets in the HTTP authority and in `safe_url`; tests for all three.

Runs (scratch venv, Python 3.12, ruff 0.16.5):

```
pytest tests/unit/test_storage_usage.py tests/unit/test_operations_index_executors.py \
       tests/unit/test_api_repositories_routes.py tests/unit/test_repository_size_source_migration.py \
       tests/unit/test_db_upgrade.py tests/unit/test_operations_runner.py \
       tests/unit/test_api_repositories_import_operations.py
107 passed, 3 skipped

pytest tests/unit   (full suite, untouched clone, first revision of this branch)
5 failed, 3155 passed, 13 skipped in 543s
  2 real, both fixed in the amended commit and re-run green:
    test_borg_version_boundaries: storage_usage built a Borg 1 command literally;
      it now goes through BorgRouter.build_repo_info_command
    test_archive_change_path_index_migration: that test inserted a Repository
      through the ORM into a schema at an older revision, which the two new
      columns break; it now inserts the row with a Core insert of explicit
      columns (same class of change other migration tests already use)
  3 pre-existing: tests/unit/test_source_discovery.py database-scan tests, the same
    three fail on a clean upstream/main (c7f32d1f) in an untouched clone
    (3 failed, 3146 passed)
pytest tests/unit   (full suite, untouched clone, amended branch at 54b6f863)
3 failed, 3157 passed, 13 skipped in 539s   (the same three pre-existing only)

ruff check .            All checks passed!
ruff format --check     clean for every file in this diff
```

Measured (Borg 2.0.0b23 and b24): the index sum reproduces `compact --stats`'s "Repository size" byte for byte, works on an `aes256-ocb` repository without passphrase, and reads under `lock=False` while `with-lock` holds the exclusive lock. `last_modified` moves on `create`/`delete` (Borg 1 also on `prune`), never on `compact` or `check`.

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass (apart from the three pre-existing failures above)

Rebased onto main `37cee432` (head `2638fbfb`), same runs on the rebased branch:

```
pytest tests/unit/test_storage_usage.py tests/unit/test_operations_index_executors.py \
       tests/unit/test_api_repositories_routes.py tests/unit/test_repository_size_source_migration.py \
       tests/unit/test_archive_change_path_index_migration.py
91 passed, 59 warnings in 5.35s
alembic heads
c3d5e7f9a1b2 (head)
ruff check / ruff format --check   clean on every file in this diff
```

Full `pytest tests/unit` in one process on an integration branch carrying this PR together with the rest of the wave on top of main `3b557171` + #945: `3364 passed, 13 skipped`, no failures, no errors.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable.

## Additional Context

Revision `8f2a4c6e1d3b` revises `7de0064b0d99`; the DDL-less merge revision `c3d5e7f9a1b2` joins it with `b7e1a3c95d84` (#919) so `main` keeps a single head after this merges. The compact-statistics revision of the #931 PR sits on top of `8f2a4c6e1d3b` and brings its own merge revision. Background refresh of these columns for agent repositories still needs #917 (`stats` skipped behind a skipped `history_index`). Part of the wave described in #917, #931, #933, #934, #935, #936.


