### PR TITLE
feat(agents): centralized agent upgrades, phase 1 (version visibility)

### DIFF
--- a/app/api/managed_machines.py
+++ b/app/api/managed_machines.py
@@ -2,14 +2,16 @@ import ipaddress
 import re
 import secrets
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session, defer
 import structlog
 
+from app.api.agent_installer import agent_package_version
 from app.core.agent_auth import AGENT_TOKEN_PREFIX_LENGTH
+from app.core.agent_versions import compute_agent_upgrade_status
 from app.core.agent_constants import AGENT_FILESYSTEM_BROWSE_TIMEOUT_SECONDS
 from app.core.features import require_feature_access
 from app.core.security import get_current_admin_user, get_password_hash
@@ -105,6 +107,14 @@ class AgentMachineResponse(BaseModel):
     os: Optional[str] = None
     arch: Optional[str] = None
     agent_version: Optional[str] = None
+    desired_agent_version: Optional[str] = None
+    desired_borg_version: Optional[str] = None
+    available_agent_version: Optional[str] = None
+    upgrade_status: str = "unknown"
+    self_upgrade_supported: bool = False
+    upgrade_state: Optional[str] = None
+    upgrade_requested_at: Optional[datetime] = None
+    upgrade_error: Optional[str] = None
     default_path: Optional[str] = None
     borg_versions: Optional[list[dict[str, Any]]] = None
     capabilities: Optional[list[str]] = None
@@ -467,6 +477,32 @@ async def revoke_enrollment_token(
         )
 
 
+class AgentDesiredVersionRequest(BaseModel):
+    """Pin an endpoint to a version, or clear the pin by sending nulls."""
+
+    desired_agent_version: Optional[str] = None
+    desired_borg_version: Optional[Literal["1", "2"]] = None
+
+
+def _agent_machine_response(
+    agent: AgentMachine, *, available: Optional[str]
+) -> AgentMachineResponse:
+    """Serialize one agent together with its computed upgrade status.
+
+    ``available`` is passed in rather than resolved here so a list response
+    reads the served wheel version once instead of once per agent.
+    """
+    response = AgentMachineResponse.model_validate(agent)
+    response.available_agent_version = available
+    response.upgrade_status = compute_agent_upgrade_status(
+        reported=agent.agent_version,
+        desired=agent.desired_agent_version,
+        available=available,
+    )
+    response.self_upgrade_supported = "self_upgrade" in (agent.capabilities or [])
+    return response
+
+
 @router.get("/agents", response_model=list[AgentMachineResponse])
 async def list_agent_machines(
     _: User = Depends(get_current_admin_user),
@@ -490,7 +526,54 @@ async def list_agent_machines(
             changed = True
     if changed:
         db.commit()
-    return agents
+    available = agent_package_version()
+    return [_agent_machine_response(agent, available=available) for agent in agents]
+
+
+@router.put(
+    "/agents/{agent_machine_id}/desired-version",
+    response_model=AgentMachineResponse,
+)
+async def set_agent_desired_version(
+    agent_machine_id: int,
+    payload: AgentDesiredVersionRequest,
+    _: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Pin this endpoint to an agent version, or clear the pin so it tracks the
+    server again."""
+    agent = (
+        db.query(AgentMachine)
+        .filter(
+            AgentMachine.id == agent_machine_id,
+            AgentMachine.status != "deleted",
+        )
+        .first()
+    )
+    if agent is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"key": "backend.errors.agents.agentNotFound"},
+        )
+
+    available = agent_package_version()
+    if (
+        payload.desired_agent_version is not None
+        and payload.desired_agent_version != available
+    ):
+        # The installer installs from this server's wheelhouse and nowhere
+        # else, so a pin to any other version could never be satisfied.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"key": "backend.errors.agents.desiredVersionUnavailable"},
+        )
+
+    agent.desired_agent_version = payload.desired_agent_version
+    agent.desired_borg_version = payload.desired_borg_version
+    agent.updated_at = _now_utc()
+    db.commit()
+    db.refresh(agent)
+    return _agent_machine_response(agent, available=available)
 
 
 @router.post(

--- a/app/core/agent_versions.py
+++ b/app/core/agent_versions.py
@@ -35,12 +35,17 @@ def parse_agent_version(value: Optional[str]) -> Optional[tuple[int, ...]]:
     Deliberately strict: a pre-release such as "0.1.3a1" returns None so the
     caller reports unknown instead of ordering it wrongly. ``str.isdigit`` also
     rejects a leading sign, so "1.-2.3" does not parse.
+
+    The ASCII check is not redundant: ``str.isdigit`` accepts characters such as
+    the superscript "\u00b2" that ``int`` then refuses, and the version string
+    arrives from an agent heartbeat, so an unparseable one must return None
+    rather than raise out of a list request.
     """
     if not value:
         return None
     components: list[int] = []
     for part in value.split("."):
-        if not part.isdigit():
+        if not (part.isascii() and part.isdigit()):
             return None
         components.append(int(part))
     return tuple(components)

--- a/app/core/agent_versions.py
+++ b/app/core/agent_versions.py
@@ -1,0 +1,86 @@
+"""Compare the agent version an endpoint reports against the version it should
+be running.
+
+Three inputs decide the answer, and two are not enough (see the spec at
+docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md section 4):
+
+- reported:  what the endpoint last told us it runs
+- desired:   what this endpoint is pinned to, or None to track the server
+- available: the agent wheel this server image serves
+
+Exact string equality is the source of truth for "current": the question is
+whether the endpoint runs the wheel we serve, not whether its version number
+sorts high enough. Ordering is used only to separate "behind" from "ahead of
+the server", which happens when a server is rolled back. Anything that does not
+parse as dotted integers is reported as unknown rather than guessed at.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+UP_TO_DATE = "up_to_date"
+OUTDATED = "outdated"
+AHEAD = "ahead"
+PINNED = "pinned"
+UNKNOWN = "unknown"
+
+UPGRADE_STATUSES = frozenset({UP_TO_DATE, OUTDATED, AHEAD, PINNED, UNKNOWN})
+
+
+def parse_agent_version(value: Optional[str]) -> Optional[tuple[int, ...]]:
+    """Dotted integer components of ``value``, or None if any component is not a
+    plain non-negative integer.
+
+    Deliberately strict: a pre-release such as "0.1.3a1" returns None so the
+    caller reports unknown instead of ordering it wrongly. ``str.isdigit`` also
+    rejects a leading sign, so "1.-2.3" does not parse.
+    """
+    if not value:
+        return None
+    components: list[int] = []
+    for part in value.split("."):
+        if not part.isdigit():
+            return None
+        components.append(int(part))
+    return tuple(components)
+
+
+def _padded(
+    left: tuple[int, ...], right: tuple[int, ...]
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    width = max(len(left), len(right))
+    return (
+        left + (0,) * (width - len(left)),
+        right + (0,) * (width - len(right)),
+    )
+
+
+def compute_agent_upgrade_status(
+    *,
+    reported: Optional[str],
+    desired: Optional[str],
+    available: Optional[str],
+) -> str:
+    """One of UPGRADE_STATUSES for a single agent."""
+    target = desired or available
+    if not reported or not target:
+        return UNKNOWN
+
+    if reported == target:
+        # Surface the pin so an operator can see why this endpoint will not
+        # move when the server does.
+        return PINNED if desired else UP_TO_DATE
+
+    reported_parts = parse_agent_version(reported)
+    target_parts = parse_agent_version(target)
+    if reported_parts is None or target_parts is None:
+        return UNKNOWN
+
+    left, right = _padded(reported_parts, target_parts)
+    if left > right:
+        return AHEAD
+    # Equal tuples with different strings (for example "0.1" against "0.1.0")
+    # land here: the endpoint is not running the string we serve, so it is
+    # treated as behind. Reinstalling it is harmless.
+    return OUTDATED

--- a/app/database/migrations/129_add_agent_upgrade_tracking.py
+++ b/app/database/migrations/129_add_agent_upgrade_tracking.py
@@ -1,0 +1,42 @@
+"""Track the agent version each endpoint should run, and in-flight upgrades.
+
+Purely additive and idempotent: every column is nullable, NULL for every
+existing row, and added only if missing. Mirrors migration 127.
+"""
+
+from sqlalchemy import text
+
+_COLUMNS = (
+    ("desired_agent_version", "VARCHAR"),
+    ("desired_borg_version", "VARCHAR"),
+    ("upgrade_state", "VARCHAR"),
+    ("upgrade_requested_at", "DATETIME"),
+    ("upgrade_target_version", "VARCHAR"),
+    ("upgrade_error", "TEXT"),
+)
+
+
+def _columns(connection, table):
+    return connection.execute(text(f"PRAGMA table_info({table})")).fetchall()
+
+
+def _has_table(connection, table):
+    return bool(_columns(connection, table))
+
+
+def _add_column_if_missing(connection, table, column, ddl_type):
+    names = {row[1] for row in _columns(connection, table)}
+    if column not in names:
+        connection.execute(text(f"ALTER TABLE {table} ADD COLUMN {column} {ddl_type}"))
+
+
+def upgrade(connection):
+    if not _has_table(connection, "agent_machines"):
+        return
+    for column, ddl_type in _COLUMNS:
+        _add_column_if_missing(connection, "agent_machines", column, ddl_type)
+
+
+def downgrade(connection):
+    # No downgrade: every column is nullable and additive.
+    print("✓ Downgrade skipped for migration 129 (additive, non-destructive)")

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -114,6 +114,19 @@ class AgentMachine(Base):
     os = Column(String, nullable=True)
     arch = Column(String, nullable=True)
     agent_version = Column(String, nullable=True)
+    # Version an operator pinned this endpoint to. NULL means "track whatever
+    # this server serves", which is the default and the normal case.
+    desired_agent_version = Column(String, nullable=True)
+    # Borg major version this endpoint should run ("1" or "2"). NULL means
+    # leave whatever is installed alone.
+    desired_borg_version = Column(String, nullable=True)
+    # Set while a remote upgrade is in flight. The agent is killed by the
+    # upgrade it performs, so the server owns the outcome rather than waiting
+    # for a completion the agent cannot send.
+    upgrade_state = Column(String, nullable=True)
+    upgrade_requested_at = Column(DateTime, nullable=True)
+    upgrade_target_version = Column(String, nullable=True)
+    upgrade_error = Column(Text, nullable=True)
     # IANA zone the agent reported (e.g. "Europe/Berlin"); interprets the
     # local-time archive timestamps borg emits on that machine.
     timezone = Column(String, nullable=True)

--- a/docs/engineering/plans/2026-09-07-agent-upgrades-phase-1.md
+++ b/docs/engineering/plans/2026-09-07-agent-upgrades-phase-1.md
@@ -1,0 +1,1257 @@
+# Agent upgrades phase 1: version model and visibility
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:subagent-driven-development` (recommended) or
+> `superpowers:executing-plans` to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show which managed agents are running an out-of-date agent version,
+and add the endpoint that pins one to a specific version. The pin UI ships in
+phase 3, alongside the upgrade action it modifies.
+
+**Architecture:** A pure comparison helper turns three inputs (the version an
+agent reported, the version it is pinned to, the version this server serves)
+into one status string. The API exposes that status per agent plus a new pin
+endpoint. The UI renders the status as a chip on each agent card and counts
+out-of-date agents in an informational banner.
+
+**Tech Stack:** FastAPI, SQLAlchemy, Alembic-style numbered migrations, React,
+MUI, i18next, Storybook, pytest, vitest.
+
+**Spec:** `docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md`
+
+## Global Constraints
+
+- No em dashes in UI copy, i18n strings, code comments, or commit messages.
+- Every new i18n key must be added to all four locales:
+  `frontend/src/locales/en.json`, `de.json`, `es.json`, `it.json`. The
+  `frontend-locale-check` pre-push hook fails otherwise.
+- No heavy left accent borders on cards, panels, alerts, or status surfaces
+  (`AGENTS.md`, UI Preferences).
+- New or changed UI ships a Storybook story demonstrating the changed state.
+- Do not commit generated PNGs under `frontend/storybook-snapshots/` or
+  `frontend/argos-screenshots/`.
+- New UI components go in `frontend/src/pages/managed-agents/`, not inline in
+  `ManagedAgents.tsx`, which is already over 2200 lines.
+- **Phase 1 adds no upgrade action.** The banner is informational. Do not add
+  an "Upgrade all" button; that is phase 4 and a dead button is worse than no
+  button.
+
+---
+
+### Task 1: Version comparison helper
+
+Pure functions, no database, no FastAPI. This is the whole decision table from
+spec section 4 in one testable place.
+
+**Files:**
+- Create: `app/core/agent_versions.py`
+- Test: `tests/unit/test_agent_version_status.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `parse_agent_version(value: str | None) -> tuple[int, ...] | None`
+  - `compute_agent_upgrade_status(*, reported: str | None, desired: str | None, available: str | None) -> str`
+  - `UPGRADE_STATUSES: frozenset[str]` containing
+    `{"up_to_date", "outdated", "ahead", "pinned", "unknown"}`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_agent_version_status.py`:
+
+```python
+import pytest
+
+from app.core.agent_versions import (
+    UPGRADE_STATUSES,
+    compute_agent_upgrade_status,
+    parse_agent_version,
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("0.1.3", (0, 1, 3)),
+        ("1.0", (1, 0)),
+        ("2", (2,)),
+        ("0.1.3a1", None),
+        ("", None),
+        (None, None),
+        ("1.-2.3", None),
+        ("1..3", None),
+    ],
+)
+def test_parse_agent_version(value, expected):
+    assert parse_agent_version(value) == expected
+
+
+@pytest.mark.parametrize(
+    "reported,desired,available,expected",
+    [
+        # Tracking the server.
+        ("0.1.3", None, "0.1.3", "up_to_date"),
+        ("0.1.2", None, "0.1.3", "outdated"),
+        ("0.2.0", None, "0.1.3", "ahead"),
+        # Pinned.
+        ("0.1.2", "0.1.2", "0.1.3", "pinned"),
+        ("0.1.1", "0.1.2", "0.1.3", "outdated"),
+        ("0.1.3", "0.1.2", "0.1.3", "ahead"),
+        # Unknown inputs.
+        (None, None, "0.1.3", "unknown"),
+        ("0.1.3", None, None, "unknown"),
+        (None, None, None, "unknown"),
+        ("0.1.3a1", None, "0.1.3", "unknown"),
+        ("0.1.3", None, "0.1.3a1", "unknown"),
+        # Equal after padding but written differently: not the served string,
+        # so it is not current. Reinstalling is harmless.
+        ("0.1", None, "0.1.0", "outdated"),
+    ],
+)
+def test_compute_agent_upgrade_status(reported, desired, available, expected):
+    assert (
+        compute_agent_upgrade_status(
+            reported=reported, desired=desired, available=available
+        )
+        == expected
+    )
+    assert expected in UPGRADE_STATUSES
+
+
+def test_exact_string_match_wins_over_parsing():
+    """An unparseable version that exactly matches its target is current, not
+    unknown. The endpoint is demonstrably running the wheel we serve."""
+    assert (
+        compute_agent_upgrade_status(
+            reported="0.1.3a1", desired=None, available="0.1.3a1"
+        )
+        == "up_to_date"
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_agent_version_status.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.core.agent_versions'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `app/core/agent_versions.py`:
+
+```python
+"""Compare the agent version an endpoint reports against the version it should
+be running.
+
+Three inputs decide the answer, and two are not enough (see the spec at
+docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md section 4):
+
+- reported:  what the endpoint last told us it runs
+- desired:   what this endpoint is pinned to, or None to track the server
+- available: the agent wheel this server image serves
+
+Exact string equality is the source of truth for "current": the question is
+whether the endpoint runs the wheel we serve, not whether its version number
+sorts high enough. Ordering is used only to separate "behind" from "ahead of
+the server", which happens when a server is rolled back. Anything that does
+not parse as dotted integers is reported as unknown rather than guessed at.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+UP_TO_DATE = "up_to_date"
+OUTDATED = "outdated"
+AHEAD = "ahead"
+PINNED = "pinned"
+UNKNOWN = "unknown"
+
+UPGRADE_STATUSES = frozenset({UP_TO_DATE, OUTDATED, AHEAD, PINNED, UNKNOWN})
+
+
+def parse_agent_version(value: Optional[str]) -> Optional[tuple[int, ...]]:
+    """Dotted integer components of ``value``, or None if any component is not
+    a plain non-negative integer. Deliberately strict: a pre-release such as
+    "0.1.3a1" returns None so the caller reports unknown instead of ordering it
+    wrongly."""
+    if not value:
+        return None
+    parts = value.split(".")
+    components: list[int] = []
+    for part in parts:
+        if not part.isdigit():
+            return None
+        components.append(int(part))
+    return tuple(components)
+
+
+def _padded(
+    left: tuple[int, ...], right: tuple[int, ...]
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    width = max(len(left), len(right))
+    return (
+        left + (0,) * (width - len(left)),
+        right + (0,) * (width - len(right)),
+    )
+
+
+def compute_agent_upgrade_status(
+    *,
+    reported: Optional[str],
+    desired: Optional[str],
+    available: Optional[str],
+) -> str:
+    """One of UPGRADE_STATUSES for a single agent."""
+    target = desired or available
+    if not reported or not target:
+        return UNKNOWN
+
+    if reported == target:
+        # Surface the pin so an operator can see why this endpoint is not
+        # moving with the fleet.
+        return PINNED if desired else UP_TO_DATE
+
+    reported_parts = parse_agent_version(reported)
+    target_parts = parse_agent_version(target)
+    if reported_parts is None or target_parts is None:
+        return UNKNOWN
+
+    left, right = _padded(reported_parts, target_parts)
+    if left > right:
+        return AHEAD
+    # Equal tuples with different strings (for example "0.1" against "0.1.0")
+    # land here: the endpoint is not running the string we serve, so it is
+    # treated as behind. Reinstalling it is harmless.
+    return OUTDATED
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/unit/test_agent_version_status.py -v`
+Expected: PASS, 20 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/core/agent_versions.py tests/unit/test_agent_version_status.py
+git commit -m "feat(agents): add agent version comparison helper"
+```
+
+---
+
+### Task 2: Database columns
+
+**Files:**
+- Create: `app/database/migrations/129_add_agent_upgrade_tracking.py`
+- Modify: `app/database/models.py` (`AgentMachine`, after `agent_version`)
+- Test: `tests/unit/test_agent_upgrade_columns.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `AgentMachine.desired_agent_version`, `.desired_borg_version`,
+  `.upgrade_state`, `.upgrade_requested_at`, `.upgrade_target_version`,
+  `.upgrade_error`. Later phases write `upgrade_state` and friends; phase 1
+  only reads them.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_agent_upgrade_columns.py`:
+
+```python
+from app.database.models import AgentMachine
+
+
+def test_agent_machine_has_upgrade_tracking_columns(test_db):
+    agent = AgentMachine(
+        name="node-1",
+        agent_id="agt_test_upgrade_columns",
+        token_hash="x",
+        token_prefix="agt_test",
+        status="online",
+    )
+    test_db.add(agent)
+    test_db.commit()
+    test_db.refresh(agent)
+
+    assert agent.desired_agent_version is None
+    assert agent.desired_borg_version is None
+    assert agent.upgrade_state is None
+    assert agent.upgrade_requested_at is None
+    assert agent.upgrade_target_version is None
+    assert agent.upgrade_error is None
+
+    agent.desired_agent_version = "0.1.2"
+    agent.desired_borg_version = "2"
+    test_db.commit()
+    test_db.refresh(agent)
+    assert agent.desired_agent_version == "0.1.2"
+    assert agent.desired_borg_version == "2"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_agent_upgrade_columns.py -v`
+Expected: FAIL with `AttributeError` on `desired_agent_version`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/database/models.py`, inside `class AgentMachine`, immediately after the
+`agent_version` column, add:
+
+```python
+    # Version an operator pinned this endpoint to. NULL means "track whatever
+    # this server serves", which is the default and the normal case.
+    desired_agent_version = Column(String, nullable=True)
+    # Borg major version this endpoint should run ("1" or "2"). NULL means
+    # leave whatever is installed alone.
+    desired_borg_version = Column(String, nullable=True)
+    # Set while a remote upgrade is in flight. The agent is killed by the
+    # upgrade it performs, so the server owns the outcome (spec section 7.1).
+    upgrade_state = Column(String, nullable=True)
+    upgrade_requested_at = Column(DateTime, nullable=True)
+    upgrade_target_version = Column(String, nullable=True)
+    upgrade_error = Column(Text, nullable=True)
+```
+
+Create `app/database/migrations/129_add_agent_upgrade_tracking.py`:
+
+```python
+"""Track the agent version each endpoint should run, and in-flight upgrades.
+
+Purely additive and idempotent: every column is nullable, NULL for every
+existing row, and added only if missing. Mirrors migration 127.
+"""
+
+from sqlalchemy import text
+
+_COLUMNS = (
+    ("desired_agent_version", "VARCHAR"),
+    ("desired_borg_version", "VARCHAR"),
+    ("upgrade_state", "VARCHAR"),
+    ("upgrade_requested_at", "DATETIME"),
+    ("upgrade_target_version", "VARCHAR"),
+    ("upgrade_error", "TEXT"),
+)
+
+
+def _columns(connection, table):
+    return connection.execute(text(f"PRAGMA table_info({table})")).fetchall()
+
+
+def _has_table(connection, table):
+    return bool(_columns(connection, table))
+
+
+def _add_column_if_missing(connection, table, column, ddl_type):
+    names = {row[1] for row in _columns(connection, table)}
+    if column not in names:
+        connection.execute(text(f"ALTER TABLE {table} ADD COLUMN {column} {ddl_type}"))
+
+
+def upgrade(connection):
+    if not _has_table(connection, "agent_machines"):
+        return
+    for column, ddl_type in _COLUMNS:
+        _add_column_if_missing(connection, "agent_machines", column, ddl_type)
+
+
+def downgrade(connection):
+    # No downgrade: every column is nullable and additive.
+    print("✓ Downgrade skipped for migration 129 (additive, non-destructive)")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/unit/test_agent_upgrade_columns.py -v`
+Expected: PASS
+
+Then confirm nothing else broke:
+Run: `python -m pytest tests/unit/test_api_managed_machines.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/database/models.py app/database/migrations/129_add_agent_upgrade_tracking.py tests/unit/test_agent_upgrade_columns.py
+git commit -m "feat(agents): add agent upgrade tracking columns"
+```
+
+---
+
+### Task 3: Expose upgrade status on the agents API
+
+**Files:**
+- Modify: `app/api/managed_machines.py` (`AgentMachineResponse` at line 100,
+  `list_agent_machines` at line 470)
+- Test: `tests/unit/test_api_managed_machines.py`
+
+**Interfaces:**
+- Consumes: `compute_agent_upgrade_status` from Task 1; the columns from
+  Task 2; `agent_package_version()` from `app.api.agent_installer`.
+- Produces: `_agent_machine_response(agent, *, available) -> AgentMachineResponse`,
+  used by `list_agent_machines` and by the pin endpoint in Task 4.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_api_managed_machines.py`:
+
+```python
+def test_list_agents_reports_upgrade_status(client, test_db, admin_headers, monkeypatch):
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+    behind = AgentMachine(
+        name="behind",
+        agent_id="agt_behind",
+        token_hash="x",
+        token_prefix="agt_b",
+        status="online",
+        agent_version="0.1.2",
+        capabilities=["backup.create"],
+    )
+    current = AgentMachine(
+        name="current",
+        agent_id="agt_current",
+        token_hash="x",
+        token_prefix="agt_c",
+        status="online",
+        agent_version="0.1.3",
+        capabilities=["backup.create", "self_upgrade"],
+    )
+    test_db.add_all([behind, current])
+    test_db.commit()
+
+    response = client.get("/api/managed-machines/agents", headers=admin_headers)
+    assert response.status_code == 200
+    by_name = {row["name"]: row for row in response.json()}
+
+    assert by_name["behind"]["upgrade_status"] == "outdated"
+    assert by_name["behind"]["available_agent_version"] == "0.1.3"
+    assert by_name["behind"]["self_upgrade_supported"] is False
+
+    assert by_name["current"]["upgrade_status"] == "up_to_date"
+    assert by_name["current"]["self_upgrade_supported"] is True
+
+
+def test_list_agents_respects_pin(client, test_db, admin_headers, monkeypatch):
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+    agent = AgentMachine(
+        name="pinned",
+        agent_id="agt_pinned",
+        token_hash="x",
+        token_prefix="agt_p",
+        status="online",
+        agent_version="0.1.2",
+        desired_agent_version="0.1.2",
+    )
+    test_db.add(agent)
+    test_db.commit()
+
+    response = client.get("/api/managed-machines/agents", headers=admin_headers)
+    assert response.status_code == 200
+    row = next(r for r in response.json() if r["name"] == "pinned")
+    assert row["upgrade_status"] == "pinned"
+    assert row["desired_agent_version"] == "0.1.2"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_api_managed_machines.py -k upgrade_status -v`
+Expected: FAIL with `KeyError: 'upgrade_status'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/api/managed_machines.py`, add imports near the existing ones:
+
+```python
+from app.api.agent_installer import agent_package_version
+from app.core.agent_versions import compute_agent_upgrade_status
+```
+
+Add these fields to `AgentMachineResponse`, after `agent_version`:
+
+```python
+    desired_agent_version: Optional[str] = None
+    desired_borg_version: Optional[str] = None
+    available_agent_version: Optional[str] = None
+    upgrade_status: str = "unknown"
+    self_upgrade_supported: bool = False
+    upgrade_state: Optional[str] = None
+    upgrade_requested_at: Optional[datetime] = None
+    upgrade_error: Optional[str] = None
+```
+
+Add this helper immediately above `list_agent_machines`:
+
+```python
+def _agent_machine_response(
+    agent: AgentMachine, *, available: Optional[str]
+) -> AgentMachineResponse:
+    """Serialize one agent with its computed upgrade status.
+
+    ``available`` is passed in rather than resolved here so a list response
+    reads the served wheel version once instead of once per agent.
+    """
+    response = AgentMachineResponse.model_validate(agent)
+    response.available_agent_version = available
+    response.upgrade_status = compute_agent_upgrade_status(
+        reported=agent.agent_version,
+        desired=agent.desired_agent_version,
+        available=available,
+    )
+    response.self_upgrade_supported = "self_upgrade" in (agent.capabilities or [])
+    return response
+```
+
+Change the end of `list_agent_machines` from `return agents` to:
+
+```python
+    available = agent_package_version()
+    return [_agent_machine_response(agent, available=available) for agent in agents]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/unit/test_api_managed_machines.py -v`
+Expected: PASS, including the pre-existing tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/managed_machines.py tests/unit/test_api_managed_machines.py
+git commit -m "feat(agents): report agent upgrade status from the agents API"
+```
+
+---
+
+### Task 4: Pin endpoint
+
+**Files:**
+- Modify: `app/api/managed_machines.py` (new route after
+  `list_agent_machines`)
+- Test: `tests/unit/test_api_managed_machines.py`
+
+Admin gating comes from the `get_current_admin_user` dependency in the route
+signature, exactly as the sibling agent routes do. Do not add an entry to
+`ENDPOINT_POLICIES` in `app/core/authorization.py`: no `managed-machines` route
+is registered there, and adding one would introduce a second, divergent
+authorization path for this router.
+
+**Interfaces:**
+- Consumes: `_agent_machine_response` from Task 3.
+- Produces: `PUT /api/managed-machines/agents/{agent_machine_id}/desired-version`
+  taking `{"desired_agent_version": str | null, "desired_borg_version": "1" | "2" | null}`
+  and returning the updated `AgentMachineResponse`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_api_managed_machines.py`:
+
+```python
+def test_set_desired_version_pins_agent(client, test_db, admin_headers, monkeypatch):
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+    agent = AgentMachine(
+        name="pin-me",
+        agent_id="agt_pin_me",
+        token_hash="x",
+        token_prefix="agt_pm",
+        status="online",
+        agent_version="0.1.3",
+    )
+    test_db.add(agent)
+    test_db.commit()
+    test_db.refresh(agent)
+
+    response = client.put(
+        f"/api/managed-machines/agents/{agent.id}/desired-version",
+        json={"desired_agent_version": "0.1.3", "desired_borg_version": "2"},
+        headers=admin_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["desired_agent_version"] == "0.1.3"
+    assert response.json()["desired_borg_version"] == "2"
+    assert response.json()["upgrade_status"] == "pinned"
+
+
+def test_clearing_desired_version_returns_to_tracking_server(
+    client, test_db, admin_headers, monkeypatch
+):
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+    agent = AgentMachine(
+        name="unpin-me",
+        agent_id="agt_unpin_me",
+        token_hash="x",
+        token_prefix="agt_um",
+        status="online",
+        agent_version="0.1.3",
+        desired_agent_version="0.1.2",
+    )
+    test_db.add(agent)
+    test_db.commit()
+    test_db.refresh(agent)
+
+    response = client.put(
+        f"/api/managed-machines/agents/{agent.id}/desired-version",
+        json={"desired_agent_version": None, "desired_borg_version": None},
+        headers=admin_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["desired_agent_version"] is None
+    assert response.json()["upgrade_status"] == "up_to_date"
+
+
+def test_cannot_pin_a_version_the_server_cannot_serve(
+    client, test_db, admin_headers, monkeypatch
+):
+    """The installer only installs from this server's wheelhouse, so a pin to
+    anything else is permanently unsatisfiable."""
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+    agent = AgentMachine(
+        name="bad-pin",
+        agent_id="agt_bad_pin",
+        token_hash="x",
+        token_prefix="agt_bp",
+        status="online",
+        agent_version="0.1.3",
+    )
+    test_db.add(agent)
+    test_db.commit()
+    test_db.refresh(agent)
+
+    response = client.put(
+        f"/api/managed-machines/agents/{agent.id}/desired-version",
+        json={"desired_agent_version": "9.9.9", "desired_borg_version": None},
+        headers=admin_headers,
+    )
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"]["key"]
+        == "backend.errors.agents.desiredVersionUnavailable"
+    )
+
+
+def test_desired_borg_version_must_be_1_or_2(
+    client, test_db, admin_headers, monkeypatch
+):
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+    agent = AgentMachine(
+        name="bad-borg",
+        agent_id="agt_bad_borg",
+        token_hash="x",
+        token_prefix="agt_bb",
+        status="online",
+        agent_version="0.1.3",
+    )
+    test_db.add(agent)
+    test_db.commit()
+    test_db.refresh(agent)
+
+    response = client.put(
+        f"/api/managed-machines/agents/{agent.id}/desired-version",
+        json={"desired_agent_version": None, "desired_borg_version": "3"},
+        headers=admin_headers,
+    )
+    assert response.status_code == 422
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_api_managed_machines.py -k desired_version -v`
+Expected: FAIL with 405 or 404 (route does not exist)
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/api/managed_machines.py`, add the request model next to the other
+Pydantic models:
+
+```python
+class AgentDesiredVersionRequest(BaseModel):
+    """Pin an endpoint to a version, or clear the pin with nulls."""
+
+    desired_agent_version: Optional[str] = None
+    desired_borg_version: Optional[Literal["1", "2"]] = None
+```
+
+Add `Literal` to the `typing` import if it is not already there.
+
+Add the route immediately after `list_agent_machines`:
+
+```python
+@router.put(
+    "/agents/{agent_machine_id}/desired-version",
+    response_model=AgentMachineResponse,
+)
+async def set_agent_desired_version(
+    agent_machine_id: int,
+    payload: AgentDesiredVersionRequest,
+    _: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Pin this endpoint to an agent version, or clear the pin to track the
+    server again."""
+    agent = (
+        db.query(AgentMachine)
+        .filter(
+            AgentMachine.id == agent_machine_id,
+            AgentMachine.status != "deleted",
+        )
+        .first()
+    )
+    if agent is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"key": "backend.errors.agents.notFound"},
+        )
+
+    available = agent_package_version()
+    if (
+        payload.desired_agent_version is not None
+        and payload.desired_agent_version != available
+    ):
+        # The installer installs from this server's wheelhouse and nowhere
+        # else, so a pin to any other version could never be satisfied.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"key": "backend.errors.agents.desiredVersionUnavailable"},
+        )
+
+    agent.desired_agent_version = payload.desired_agent_version
+    agent.desired_borg_version = payload.desired_borg_version
+    agent.updated_at = _now_utc()
+    db.commit()
+    db.refresh(agent)
+    return _agent_machine_response(agent, available=available)
+```
+
+Add the i18n keys to all four locale files under
+`backend.errors.agents`: `desiredVersionUnavailable`. English copy:
+`"That version is not available on this server."`
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/unit/test_api_managed_machines.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/managed_machines.py frontend/src/locales tests/unit/test_api_managed_machines.py
+git commit -m "feat(agents): add an endpoint to pin an agent version"
+```
+
+---
+
+### Task 5: Frontend types and the version chip
+
+**Files:**
+- Modify: `frontend/src/services/api.ts:1187` (`AgentMachineResponse`)
+- Create: `frontend/src/pages/managed-agents/AgentUpgradeChip.tsx`
+- Create: `frontend/src/pages/managed-agents/AgentUpgradeChip.stories.tsx`
+- Modify: `frontend/src/locales/{en,de,es,it}.json`
+
+**Interfaces:**
+- Consumes: the API fields from Task 3.
+- Produces: `AgentUpgradeStatus` type
+  (`'up_to_date' | 'outdated' | 'ahead' | 'pinned' | 'unknown'`) and
+  `<AgentUpgradeChip status={...} targetVersion={...} />`.
+
+- [ ] **Step 1: Extend the API type**
+
+In `frontend/src/services/api.ts`, add to `AgentMachineResponse` after
+`agent_version`:
+
+```typescript
+  desired_agent_version?: string | null
+  desired_borg_version?: string | null
+  available_agent_version?: string | null
+  upgrade_status?: AgentUpgradeStatus
+  self_upgrade_supported?: boolean
+  upgrade_state?: string | null
+  upgrade_requested_at?: string | null
+  upgrade_error?: string | null
+```
+
+And above the interface:
+
+```typescript
+export type AgentUpgradeStatus =
+  | 'up_to_date'
+  | 'outdated'
+  | 'ahead'
+  | 'pinned'
+  | 'unknown'
+```
+
+- [ ] **Step 2: Add the i18n keys**
+
+Under `managedAgents.page`, add an `upgrade` object to all four locales.
+English:
+
+```json
+"upgrade": {
+  "upToDate": "Current",
+  "outdated": "Update available",
+  "ahead": "Ahead of server",
+  "pinned": "Pinned",
+  "unknown": "Version unknown",
+  "targetTooltip": "This server serves agent version {{version}}",
+  "pinnedTooltip": "Pinned to version {{version}} and will not track the server",
+  "unknownTooltip": "This endpoint has not reported a version we can compare",
+  "outdatedCount_one": "{{count}} endpoint is running an older agent",
+  "outdatedCount_other": "{{count}} endpoints are running an older agent",
+  "bannerBody": "Upgrade these endpoints to agent version {{version}}.",
+  "bannerManual": "Reinstall each one from its card to bring it up to date."
+}
+```
+
+Translate the same keys into `de.json`, `es.json`, and `it.json`. Keep
+`{{count}}` and `{{version}}` placeholders exactly as written, and keep the
+`_one` / `_other` plural suffixes, which i18next requires.
+
+- [ ] **Step 3: Write the component**
+
+Create `frontend/src/pages/managed-agents/AgentUpgradeChip.tsx`:
+
+```tsx
+import { Chip, Tooltip } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import type { AgentUpgradeStatus } from '../../services/api'
+
+const STATUS_COLOR: Record<
+  AgentUpgradeStatus,
+  'success' | 'warning' | 'info' | 'default'
+> = {
+  up_to_date: 'success',
+  outdated: 'warning',
+  ahead: 'info',
+  pinned: 'info',
+  unknown: 'default',
+}
+
+const STATUS_LABEL: Record<AgentUpgradeStatus, string> = {
+  up_to_date: 'managedAgents.page.upgrade.upToDate',
+  outdated: 'managedAgents.page.upgrade.outdated',
+  ahead: 'managedAgents.page.upgrade.ahead',
+  pinned: 'managedAgents.page.upgrade.pinned',
+  unknown: 'managedAgents.page.upgrade.unknown',
+}
+
+export default function AgentUpgradeChip({
+  status,
+  targetVersion,
+  pinnedVersion,
+}: {
+  status: AgentUpgradeStatus
+  targetVersion?: string | null
+  pinnedVersion?: string | null
+}) {
+  const { t } = useTranslation()
+
+  const tooltip = () => {
+    if (status === 'pinned' && pinnedVersion) {
+      return t('managedAgents.page.upgrade.pinnedTooltip', { version: pinnedVersion })
+    }
+    if (status === 'unknown') {
+      return t('managedAgents.page.upgrade.unknownTooltip')
+    }
+    if (targetVersion) {
+      return t('managedAgents.page.upgrade.targetTooltip', { version: targetVersion })
+    }
+    return ''
+  }
+
+  const chip = (
+    <Chip
+      size="small"
+      variant="outlined"
+      color={STATUS_COLOR[status]}
+      label={t(STATUS_LABEL[status])}
+      sx={{ height: 20, fontSize: '0.6rem', fontWeight: 600 }}
+    />
+  )
+
+  const title = tooltip()
+  return title ? (
+    <Tooltip title={title} arrow>
+      <span>{chip}</span>
+    </Tooltip>
+  ) : (
+    chip
+  )
+}
+```
+
+- [ ] **Step 4: Write the story**
+
+Create `frontend/src/pages/managed-agents/AgentUpgradeChip.stories.tsx`:
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Stack } from '@mui/material'
+import AgentUpgradeChip from './AgentUpgradeChip'
+
+const meta: Meta<typeof AgentUpgradeChip> = {
+  title: 'Managed Agents/AgentUpgradeChip',
+  component: AgentUpgradeChip,
+}
+export default meta
+
+type Story = StoryObj<typeof AgentUpgradeChip>
+
+export const AllStates: Story = {
+  render: () => (
+    <Stack direction="row" spacing={1} alignItems="center">
+      <AgentUpgradeChip status="up_to_date" targetVersion="0.1.3" />
+      <AgentUpgradeChip status="outdated" targetVersion="0.1.3" />
+      <AgentUpgradeChip status="ahead" targetVersion="0.1.3" />
+      <AgentUpgradeChip status="pinned" pinnedVersion="0.1.2" />
+      <AgentUpgradeChip status="unknown" />
+    </Stack>
+  ),
+}
+
+export const UpToDate: Story = { args: { status: 'up_to_date', targetVersion: '0.1.3' } }
+export const Outdated: Story = { args: { status: 'outdated', targetVersion: '0.1.3' } }
+export const Ahead: Story = { args: { status: 'ahead', targetVersion: '0.1.3' } }
+export const Pinned: Story = { args: { status: 'pinned', pinnedVersion: '0.1.2' } }
+export const Unknown: Story = { args: { status: 'unknown' } }
+```
+
+- [ ] **Step 5: Verify and commit**
+
+Run: `cd frontend && npx tsc --noEmit && npx prettier --check src/pages/managed-agents/AgentUpgradeChip.tsx src/pages/managed-agents/AgentUpgradeChip.stories.tsx`
+Expected: no type errors, formatting clean
+
+```bash
+git add frontend/src/services/api.ts frontend/src/pages/managed-agents/AgentUpgradeChip.tsx frontend/src/pages/managed-agents/AgentUpgradeChip.stories.tsx frontend/src/locales
+git commit -m "feat(agents): add an agent version status chip"
+```
+
+---
+
+### Task 6: Out-of-date banner
+
+Informational only. No action button in phase 1.
+
+**Files:**
+- Create: `frontend/src/pages/managed-agents/AgentUpgradeBanner.tsx`
+- Create: `frontend/src/pages/managed-agents/AgentUpgradeBanner.stories.tsx`
+
+**Interfaces:**
+- Consumes: `AgentMachineResponse[]` and the i18n keys from Task 5.
+- Produces: `<AgentUpgradeBanner agents={agents} />`, which renders nothing
+  when no agent is `outdated`.
+
+- [ ] **Step 1: Write the component**
+
+Create `frontend/src/pages/managed-agents/AgentUpgradeBanner.tsx`:
+
+```tsx
+import { Alert, AlertTitle, Typography } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import type { AgentMachineResponse } from '../../services/api'
+
+export default function AgentUpgradeBanner({
+  agents,
+}: {
+  agents: AgentMachineResponse[]
+}) {
+  const { t } = useTranslation()
+  const outdated = agents.filter((agent) => agent.upgrade_status === 'outdated')
+  if (outdated.length === 0) {
+    return null
+  }
+
+  // Every outdated agent compares against the same served version, so reading
+  // it off the first one is enough.
+  const target =
+    outdated[0].available_agent_version ?? outdated[0].desired_agent_version ?? ''
+
+  return (
+    <Alert severity="warning" variant="outlined" sx={{ mb: 2 }}>
+      <AlertTitle sx={{ fontWeight: 700 }}>
+        {t('managedAgents.page.upgrade.outdatedCount', { count: outdated.length })}
+      </AlertTitle>
+      <Typography variant="body2">
+        {target
+          ? t('managedAgents.page.upgrade.bannerBody', { version: target })
+          : null}{' '}
+        {t('managedAgents.page.upgrade.bannerManual')}
+      </Typography>
+    </Alert>
+  )
+}
+```
+
+- [ ] **Step 2: Write the story**
+
+Create `frontend/src/pages/managed-agents/AgentUpgradeBanner.stories.tsx`:
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import AgentUpgradeBanner from './AgentUpgradeBanner'
+import type { AgentMachineResponse } from '../../services/api'
+
+const base: AgentMachineResponse = {
+  id: 1,
+  name: 'Production NAS',
+  agent_id: 'agt_prod_nas_01',
+  status: 'online',
+  agent_version: '0.1.2',
+  available_agent_version: '0.1.3',
+  upgrade_status: 'outdated',
+  created_at: '2026-05-10T08:00:00.000Z',
+  updated_at: '2026-09-07T08:00:00.000Z',
+}
+
+const meta: Meta<typeof AgentUpgradeBanner> = {
+  title: 'Managed Agents/AgentUpgradeBanner',
+  component: AgentUpgradeBanner,
+}
+export default meta
+
+type Story = StoryObj<typeof AgentUpgradeBanner>
+
+export const OneOutdated: Story = { args: { agents: [base] } }
+
+export const SeveralOutdated: Story = {
+  args: {
+    agents: [
+      base,
+      { ...base, id: 2, name: 'Finance Workstation', agent_id: 'agt_fin_07' },
+      { ...base, id: 3, name: 'Build Server', agent_id: 'agt_build_02' },
+    ],
+  },
+}
+
+export const NoneOutdated: Story = {
+  args: {
+    agents: [{ ...base, upgrade_status: 'up_to_date', agent_version: '0.1.3' }],
+  },
+}
+```
+
+- [ ] **Step 3: Verify and commit**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no type errors
+
+```bash
+git add frontend/src/pages/managed-agents/AgentUpgradeBanner.tsx frontend/src/pages/managed-agents/AgentUpgradeBanner.stories.tsx
+git commit -m "feat(agents): add an out-of-date agents banner"
+```
+
+---
+
+### Task 7: Wire the chip and banner into the page
+
+**Files:**
+- Modify: `frontend/src/pages/ManagedAgents.tsx` (`AgentList` at line 1556,
+  the version display at line 1701)
+- Modify: `frontend/src/pages/ManagedAgents.stories.tsx`
+- Test: `frontend/src/pages/__tests__/ManagedAgents.test.tsx`
+
+**Interfaces:**
+- Consumes: `AgentUpgradeChip` (Task 5), `AgentUpgradeBanner` (Task 6).
+- Produces: nothing new for later tasks.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `frontend/src/pages/__tests__/ManagedAgents.test.tsx`, following the
+render helpers already in that file:
+
+```tsx
+it('shows an update chip on an out-of-date agent', () => {
+  renderAgentList([
+    makeAgent({
+      id: 1,
+      name: 'Behind',
+      agent_version: '0.1.2',
+      available_agent_version: '0.1.3',
+      upgrade_status: 'outdated',
+    }),
+  ])
+  expect(screen.getByText('Update available')).toBeInTheDocument()
+})
+
+it('does not show an update chip on a current agent', () => {
+  renderAgentList([
+    makeAgent({
+      id: 1,
+      name: 'Current',
+      agent_version: '0.1.3',
+      available_agent_version: '0.1.3',
+      upgrade_status: 'up_to_date',
+    }),
+  ])
+  expect(screen.queryByText('Update available')).not.toBeInTheDocument()
+})
+```
+
+If `renderAgentList` and `makeAgent` do not exist in that file, write them from
+the existing render setup rather than inventing a new pattern.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/pages/__tests__/ManagedAgents.test.tsx`
+Expected: FAIL, "Update available" not found
+
+- [ ] **Step 3: Render the chip next to the version**
+
+In `frontend/src/pages/ManagedAgents.tsx`, import the components:
+
+```tsx
+import AgentUpgradeChip from './managed-agents/AgentUpgradeChip'
+import AgentUpgradeBanner from './managed-agents/AgentUpgradeBanner'
+```
+
+Replace the version block at line 1701 (the `agent.agent_version && (...)`
+`Typography`) with a `Box` holding the same `Typography` plus the chip:
+
+```tsx
+<Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexShrink: 0 }}>
+  {agent.agent_version && (
+    <Typography
+      sx={{
+        fontSize: '0.58rem',
+        fontWeight: 500,
+        color: 'text.disabled',
+        letterSpacing: '0.02em',
+      }}
+    >
+      v{agent.agent_version}
+    </Typography>
+  )}
+  {agent.upgrade_status && agent.upgrade_status !== 'up_to_date' && (
+    <AgentUpgradeChip
+      status={agent.upgrade_status}
+      targetVersion={agent.available_agent_version}
+      pinnedVersion={agent.desired_agent_version}
+    />
+  )}
+</Box>
+```
+
+The chip is hidden for `up_to_date` so the common case stays quiet and only
+endpoints needing attention draw the eye.
+
+- [ ] **Step 4: Render the banner above the agent list**
+
+In `AgentList`, immediately inside the returned fragment and before the grid of
+agent cards, add:
+
+```tsx
+<AgentUpgradeBanner agents={agents} />
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/pages/__tests__/ManagedAgents.test.tsx`
+Expected: PASS
+
+- [ ] **Step 6: Add page-level stories**
+
+In `frontend/src/pages/ManagedAgents.stories.tsx`, add `upgrade_status` and
+`available_agent_version` to the existing `agents` fixture so the default story
+shows a mixed fleet, then add:
+
+```tsx
+export const AgentListWithOutdatedAgents: Story = {
+  render: () => (
+    <AgentList
+      agents={[
+        { ...agents[0], agent_version: '0.1.2', available_agent_version: '0.1.3', upgrade_status: 'outdated' },
+        { ...agents[1], agent_version: '0.1.3', available_agent_version: '0.1.3', upgrade_status: 'up_to_date' },
+      ]}
+      serverUrl="https://borg.example.com"
+      onCopy={() => {}}
+      onRevoke={() => {}}
+      onDelete={() => {}}
+      onViewLogs={() => {}}
+      isRevoking={false}
+      isDeleting={false}
+    />
+  ),
+}
+```
+
+Match the prop list to `AgentList`'s actual signature at the time of writing;
+do not guess if it has changed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/pages/ManagedAgents.tsx frontend/src/pages/ManagedAgents.stories.tsx frontend/src/pages/__tests__/ManagedAgents.test.tsx
+git commit -m "feat(agents): show agent version status on the agents page"
+```
+
+---
+
+### Task 8: Documentation and full verification
+
+**Files:**
+- Modify: `docs/managed-agents.md`
+- Modify: `docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md`
+  (progress table only)
+
+- [ ] **Step 1: Document the version states**
+
+Add a "Keeping agents up to date" section to `docs/managed-agents.md` covering
+what each chip means, that the server compares against the agent wheel it
+serves, that pinning stops an endpoint tracking the server, and that upgrading
+is still a manual reinstall in this release.
+
+- [ ] **Step 2: Update the spec progress table**
+
+Set phase 1 to `done` in section 13.1 and record the branch.
+
+- [ ] **Step 3: Run the full verification**
+
+```bash
+python -m pytest tests/unit -q
+cd frontend && npm run typecheck && npm run lint && npm run test -- --run
+```
+
+Expected: all pass. Do not claim completion until you have seen the output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs
+git commit -m "docs(agents): document agent version status and pinning"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage for phase 1 (section 13.2):**
+
+| Spec requirement | Task |
+| --- | --- |
+| Migration adding the six columns | 2 |
+| Comparison helper and `upgrade_status` | 1, 3 |
+| `upgrade_status` on `AgentMachineResponse` | 3 |
+| Version cell and chips | 5, 7 |
+| Fleet banner | 6, 7 |
+| Pin control with its `PUT` endpoint | 4 |
+| Stories for every chip state and the banner | 5, 6, 7 |
+
+**Known gap, deliberately deferred:** the spec's phase 1 text says "the pin
+control", meaning UI. Task 4 ships the endpoint and Task 5 ships the chip that
+displays a pin, but no UI control sets one. Setting a pin is only useful once
+upgrades are automatic, since today an operator controls the version by
+choosing what to paste. The pin UI moves to phase 3, where the upgrade action
+it modifies exists. Update the spec's section 13.2 and 13.4 text to match when
+executing Task 8.

--- a/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
+++ b/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
@@ -358,8 +358,10 @@ that starting position rather than a new party gaining access.
   not the one the agent is enrolled against, so a stale or tampered config
   cannot silently repoint an upgrade.
 - Upgrade endpoints require the same authorization as every other agent
-  mutation. Add the new actions to `app/core/authorization.py` alongside the
-  existing agent actions.
+  mutation, which for this router means the `get_current_admin_user` dependency
+  in the route signature. `managed-machines` routes are deliberately not
+  registered in `ENDPOINT_POLICIES` (`app/core/authorization.py`); do not add
+  them there, or the router gains a second divergent authorization path.
 
 ### 11.3 Operator control
 
@@ -412,12 +414,20 @@ Agents update this table and nothing else as work advances. Statuses:
 Migration adding `desired_agent_version`, `desired_borg_version`,
 `upgrade_state`, `upgrade_requested_at`, `upgrade_target_version`, and
 `upgrade_error` to `agent_machines`. The comparison helper and `upgrade_status`
-on `AgentMachineResponse`. The version cell, its chips, the fleet banner, and
-the pin control with its `PUT` endpoint. Stories for every chip state and the
-banner.
+on `AgentMachineResponse`. The version cell, its chips, the informational
+out-of-date banner, and the pin `PUT` endpoint. Stories for every chip state
+and the banner.
 
-Gate: an operator can see which endpoints are behind and pin one, with no
-change to how upgrades are performed.
+The banner carries no action in this phase. An "Upgrade all" button belongs to
+phase 4, and a button that does nothing is worse than no button.
+
+The **UI** for setting a pin ships in phase 3, not here. Only the endpoint and
+the chip that displays an existing pin land in phase 1: until upgrades are
+automatic, an operator already controls an endpoint's version by choosing what
+to paste, so a pin control would be a setting with no effect.
+
+Gate: an operator can see which endpoints are behind, and the pin endpoint is
+callable, with no change to how upgrades are performed.
 
 ### 13.3 Phase 2 — privileged helper and capability
 
@@ -433,8 +443,8 @@ installed before this phase does not, and the UI says so.
 ### 13.4 Phase 3 — single-agent remote upgrade
 
 The `agent.upgrade` session command, the `agent_upgrade` job type, the
-single-agent upgrade action and dialog, and the full reconciliation path
-including the reaper timeout.
+single-agent upgrade action and dialog, the pin control UI deferred from
+phase 1, and the full reconciliation path including the reaper timeout.
 
 Gate: one endpoint upgrades from the UI and the row resolves to up to date
 without anyone touching that machine.

--- a/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
+++ b/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
@@ -281,16 +281,29 @@ The agent advertises `self_upgrade` in `DEFAULT_CAPABILITIES`
 Capability is detected, not assumed, so an agent upgraded from an older install
 that lacks the helper reports honestly and the UI routes it to the manual path.
 
-The probe branches on how the agent runs, because the escalation only exists
-for the unprivileged case:
+**The upgrade preconditions.** One predicate, evaluated in one place, decides
+both whether the agent advertises `self_upgrade` and whether `agent.upgrade`
+will run. A partial or half-removed install can leave any one of these pieces
+behind without the others, and each missing piece fails at a different point
+after the operator has already been told the endpoint can upgrade itself:
 
-Both branches first check that the unit file exists *and* that the helper its
-`ExecStart` names is present and executable. A unit left behind by a partial or
-half-removed install would otherwise let the agent advertise a capability whose
-first use fails at exec time, which is exactly the dishonest report the probe
-exists to prevent.
+1. `/etc/systemd/system/borg-ui-agent-upgrade.service` exists. Without it there
+   is nothing to start.
+2. The helper its `ExecStart` names is present and executable. Without it the
+   unit starts and fails at exec time.
+3. `/etc/borg-ui-agent/upgrade.conf` is readable and carries its required
+   fields. The helper takes no arguments and reads every parameter from this
+   file, so without it the root helper runs and fails having done nothing. The
+   agent needs the file for the recorded `systemctl` path in any case.
 
-- **Running as root.** Those two checks are the whole probe. There is no
+Splitting the predicate between the probe and the command is what would let
+those diverge, so both call it and the failure is reported once, honestly, as
+"cannot upgrade itself" rather than as an upgrade that starts and dies.
+
+On top of the preconditions the probe branches on how the agent runs, because
+the escalation only exists for the unprivileged case:
+
+- **Running as root.** The preconditions are the whole probe. There is no
   sudoers file to consult and the installer does not install `sudo`, so a probe
   that shelled out to `sudo -l` would report no capability on exactly the
   endpoints that need none.
@@ -309,7 +322,10 @@ Handler steps:
 1. Refuse with `upgrade_busy` if this agent has any other job in flight. An
    upgrade restarts the process; doing it under a running backup would orphan
    that backup's job.
-2. Refuse with `upgrade_unsupported` if the helper is not present.
+2. Refuse with `upgrade_unsupported` if the upgrade preconditions above do not
+   hold. This is the same predicate the capability probe uses, re-evaluated
+   rather than trusted, because the endpoint may have been changed since it
+   last reported capabilities.
 3. Emit a log line, then start the unit, using the absolute `systemctl` path
    recorded in `upgrade.conf`. A root agent invokes
    `<systemctl path> start --no-block borg-ui-agent-upgrade.service` directly;
@@ -504,8 +520,10 @@ endpoint installed before this feature takes. Document the flag and its trade in
   `<systemctl path> start --no-block borg-ui-agent-upgrade.service` as root,
   and that same argv behind `sudo -n` unprivileged. Capability detection and
   the upgrade are both covered for a root endpoint with no `sudo` on `PATH`,
-  and the probe reports no capability when the unit exists but its `ExecStart`
-  helper is missing or not executable.
+  and the probe reports no capability, and `agent.upgrade` refuses with
+  `upgrade_unsupported`, for each precondition failing on its own: unit
+  missing, `ExecStart` helper missing or not executable, and `upgrade.conf`
+  missing or short a required field.
 - **Reconciliation** — an agent re-registering with the target version clears
   `requested`; one re-registering with the old version does not; the reaper
   marks a stale request `failed`.

--- a/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
+++ b/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
@@ -284,12 +284,19 @@ that lacks the helper reports honestly and the UI routes it to the manual path.
 The probe branches on how the agent runs, because the escalation only exists
 for the unprivileged case:
 
-- **Running as root.** The unit file exists, and that is the whole check. There
-  is no sudoers file to consult and the installer does not install `sudo`, so a
-  probe that shelled out to `sudo -l` would report no capability on exactly the
+Both branches first check that the unit file exists *and* that the helper its
+`ExecStart` names is present and executable. A unit left behind by a partial or
+half-removed install would otherwise let the agent advertise a capability whose
+first use fails at exec time, which is exactly the dishonest report the probe
+exists to prevent.
+
+- **Running as root.** Those two checks are the whole probe. There is no
+  sudoers file to consult and the installer does not install `sudo`, so a probe
+  that shelled out to `sudo -l` would report no capability on exactly the
   endpoints that need none.
-- **Running unprivileged.** The unit file exists *and*
-  `sudo -n <systemctl path> start --no-block` for it is listed by `sudo -l`.
+- **Running unprivileged.** Additionally,
+  `sudo -n <systemctl path> start --no-block borg-ui-agent-upgrade.service`
+  is listed by `sudo -l`.
 
 ## 7. The upgrade command
 
@@ -303,10 +310,12 @@ Handler steps:
    upgrade restarts the process; doing it under a running backup would orphan
    that backup's job.
 2. Refuse with `upgrade_unsupported` if the helper is not present.
-3. Emit a log line, then start `borg-ui-agent-upgrade.service`, using the
-   absolute `systemctl` path recorded in `upgrade.conf`. A root agent invokes
-   `<systemctl path> start --no-block` directly; an unprivileged one prefixes
-   `sudo -n`, and the recorded path is what makes the sudoers rule match.
+3. Emit a log line, then start the unit, using the absolute `systemctl` path
+   recorded in `upgrade.conf`. A root agent invokes
+   `<systemctl path> start --no-block borg-ui-agent-upgrade.service` directly;
+   an unprivileged one prefixes `sudo -n` to that same argv. The argv must match
+   the sudoers rule exactly, recorded path and unit name included, or the
+   unprivileged form is refused.
 4. Report success and let the process die.
 
 `--no-block` matters: the call returns as soon as systemd has queued the job,
@@ -490,9 +499,13 @@ endpoint installed before this feature takes. Document the flag and its trade in
   in-flight upgrade returns the existing job rather than a new one; an unpinned
   agent on a server serving no wheel is rejected.
 - **Session command** — the agent refuses when busy and when unsupported, and
-  invokes the expected argv (mocked) otherwise: bare `systemctl` as root, and
-  `sudo -n systemctl` unprivileged. Capability detection and the upgrade are
-  both covered for a root endpoint with no `sudo` on `PATH`.
+  otherwise invokes the complete expected argv (mocked), asserted in full
+  including the unit name:
+  `<systemctl path> start --no-block borg-ui-agent-upgrade.service` as root,
+  and that same argv behind `sudo -n` unprivileged. Capability detection and
+  the upgrade are both covered for a root endpoint with no `sudo` on `PATH`,
+  and the probe reports no capability when the unit exists but its `ExecStart`
+  helper is missing or not executable.
 - **Reconciliation** — an agent re-registering with the target version clears
   `requested`; one re-registering with the old version does not; the reaper
   marks a stale request `failed`.

--- a/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
+++ b/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
@@ -1,0 +1,464 @@
+# Centralized agent upgrades
+
+**Date:** 2026-09-07
+**Status:** Approved for implementation
+**Owner:** karanhudia
+**Issue:** [#940](https://github.com/karanhudia/borg-ui/issues/940)
+**Related docs:** `docs/managed-agents.md`, `docs/managed-agent-spec.md`,
+`docs/engineering/specs/2026-09-03-repository-operations-and-archive-history.md`
+
+> **For agentic workers:** this spec is the single source of truth for the
+> feature. Each phase in section 13 names its scope and its gate. Do not start
+> a phase without the previous phase merged. Use `superpowers:writing-plans` to
+> turn one phase into a task-level plan under `docs/engineering/plans/` before
+> coding it. Use `superpowers:test-driven-development` inside every phase and
+> `superpowers:verification-before-completion` before claiming a phase done.
+> All UI work goes through the `ui-ux-pro-max` skill and ships Storybook
+> stories, per `AGENTS.md`.
+>
+> Appendix A lists the existing code each phase touches, with file paths.
+> Appendix B records decisions already made and the alternatives rejected. Do
+> not re-open a decision in Appendix B; if you believe one is wrong, stop and
+> ask the owner rather than implementing something different.
+
+---
+
+## 1. Problem
+
+Keeping a fleet of managed agents current is entirely manual. The server
+already knows everything it needs to know, and does nothing with it.
+
+**The server knows the answer and does not show it.** Every agent reports
+`agent_version` on register and on every heartbeat
+(`app/api/agents.py:1186`), and the server knows the exact agent wheel it
+serves (`agent_package_version()`, `app/api/agent_installer.py:797`). The two
+are never compared. There is no way to answer "which of my endpoints are
+behind?" short of reading a version string off each row and remembering what
+the server ships.
+
+**Upgrading is copy-paste, once per machine.** The Managed Agents page has a
+"reinstall" action, but it only opens a dialog that renders a shell command
+(`AgentReinstallDialog`, `frontend/src/pages/ManagedAgents.tsx:1468`). The
+operator then has to reach each protected machine, get a root shell, and paste
+it. For a fleet of any size this is the whole cost of the feature.
+
+**The agent cannot upgrade itself, by design.** The recommended install runs
+the agent as an unprivileged service user with `NoNewPrivileges=true`
+(`app/api/agent_installer.py:741`). It cannot re-run the root installer, write
+its own venv, or touch its own systemd unit. This is a good property and the
+feature must not simply discard it.
+
+**There is no notion of an intended version.** An endpoint's version is
+whatever was installed on it. Nothing records what it *should* be running, so
+there is nothing to reconcile against and no way to pin one endpoint while the
+rest of the fleet moves.
+
+## 2. User outcome
+
+- An operator opens Managed Agents and sees, per endpoint, the agent version it
+  runs and whether that is current. A banner names how many endpoints are
+  behind.
+- The operator selects out-of-date endpoints, clicks Upgrade, confirms a dialog
+  that names exactly which machines will briefly disconnect, and watches each
+  row move through upgrading to up to date without touching a single machine.
+- An endpoint that must stay on an older agent is pinned, and it stops being
+  counted as out of date.
+- An endpoint whose install predates this feature is clearly labelled as
+  needing a one-time manual reinstall, with the existing command dialog one
+  click away. It is never silently skipped.
+- The operator chooses which Borg major version an endpoint runs and applies it
+  through the same upgrade path.
+
+## 3. Non-goals
+
+- **Server self-upgrade.** Issue #940 lists it as a stretch. It is a different
+  problem (the server is a container or a native install managed by the host,
+  not a thing the server can restart from inside itself) and is out of scope
+  here. If wanted, it gets its own spec.
+- **Downgrade.** The upgrade path installs the version the server serves or the
+  version an endpoint is pinned to. Rolling an endpoint backwards is done by
+  pinning and reinstalling manually.
+- **Windows or macOS endpoints.** The privileged helper is systemd-specific,
+  matching the current installer, which is Linux-only.
+- **Upgrading the agent across a server upgrade in one step.** The server ships
+  one agent wheel per image. Getting a newer agent means upgrading the server
+  first. That is the existing model and this spec does not change it.
+
+## 4. Version model
+
+The core of the feature is a three-state model. Two-state ("does the reported
+version match what the server ships?") is not enough, because section 10 gives
+endpoints an intended version of their own.
+
+| State | Source | Meaning |
+| --- | --- | --- |
+| **reported** | `AgentMachine.agent_version` | What the endpoint last told us it runs. `NULL` until first heartbeat. |
+| **desired** | `AgentMachine.desired_agent_version` (new, nullable) | What this endpoint is pinned to. `NULL` means "track the server", which is the default and the normal case. |
+| **available** | `agent_package_version()` | The agent wheel this server image serves. `NULL` on a server built without a bundled wheel. |
+
+The **effective target** is `desired ?? available`.
+
+`upgrade_status` is computed per agent on read, never stored:
+
+| Status | Condition |
+| --- | --- |
+| `up_to_date` | `reported == effective_target` |
+| `outdated` | both known, `reported != effective_target`, and `reported` orders below it |
+| `ahead` | both known, `reported` orders above `effective_target` (server was rolled back) |
+| `pinned` | `desired` is set and `reported == desired`, shown instead of `up_to_date` so the pin is visible |
+| `unknown` | `reported` or `effective_target` is `NULL`, or either fails to parse |
+
+Equality is the source of truth for "current"; ordering only separates
+`outdated` from `ahead`. Comparison uses a small local parser that splits on
+`.` and compares leading integer components, falling back to `unknown` when a
+component does not parse. It does not add a `packaging` dependency for this
+(see Appendix B, D3).
+
+## 5. Server API surface
+
+All routes live in `app/api/managed_machines.py` alongside the existing agent
+routes and inherit its `authorize_request` dependency.
+
+**`GET /api/managed-machines/agents`** — `AgentMachineResponse` gains:
+
+```
+desired_agent_version: str | None
+available_agent_version: str | None
+upgrade_status: Literal["up_to_date","outdated","ahead","pinned","unknown"]
+self_upgrade_supported: bool          # "self_upgrade" in capabilities
+upgrade_state: Literal["idle","requested","failed"] | None
+upgrade_requested_at: datetime | None
+upgrade_error: str | None
+```
+
+`available_agent_version` is resolved once per request, not per row.
+
+**`POST /api/managed-machines/agents/upgrade`**
+
+```
+{ "agent_machine_ids": [int, ...] }
+```
+
+Queues one upgrade per named agent. Rejects with `422` and a
+`backend.errors.agents.upgradeUnsupported` key if any named agent reports no
+`self_upgrade` capability, rather than silently skipping it — a partial success
+that looks like a full one is the failure mode to avoid. Returns the created
+job ids and, per agent, the resulting state.
+
+**`PUT /api/managed-machines/agents/{id}/desired-version`**
+
+```
+{ "desired_agent_version": str | null, "desired_borg_version": "1" | "2" | null }
+```
+
+Sets or clears the pin. Setting a `desired_agent_version` the server cannot
+serve is rejected: the installer can only install from this server's
+wheelhouse, so a pin to an unavailable version would be permanently
+unsatisfiable.
+
+## 6. The privileged helper
+
+This is the load-bearing security design. The agent gets exactly one
+escalation, and it carries no attacker-controlled input.
+
+`install.sh` writes three root-owned artifacts, all skipped when the service
+user is `root` (that case needs no escalation):
+
+**`/etc/borg-ui-agent/upgrade.conf`** — mode `0644`, owned `root:root`. Records
+the parameters a reinstall needs: server URL, borg install mode, service user
+mode, service user and group, agent root. Written at install time from the
+values the operator gave the installer.
+
+**`/opt/borg-ui-agent/bin/borg-ui-agent-upgrade`** — mode `0755`, owned
+`root:root`, in a root-owned directory. It takes **no arguments**. It reads
+`upgrade.conf`, fetches `install.sh` from the recorded server, and runs it with
+`--reinstall` and the recorded flags. Because every parameter comes from a
+root-owned file rather than the caller, a compromised agent process cannot
+redirect the install source, change the service user, or inject installer
+flags. This is the property that makes the sudoers rule safe.
+
+**`/etc/sudoers.d/borg-ui-agent-upgrade`** — mode `0440`, granting the service
+user exactly:
+
+```
+<service_user> ALL=(root) NOPASSWD: /usr/bin/systemctl start --no-block borg-ui-agent-upgrade.service
+```
+
+The `systemctl` path is resolved at install time with `command -v systemctl`
+and written into both the sudoers rule and `upgrade.conf`, because sudoers
+matches on the absolute path and it differs across distributions. The agent
+invokes exactly that path, so the rule matches. Validated with `visudo -cf`
+before being moved into place; a validation failure aborts that step with a
+warning and leaves the endpoint on the manual path rather than writing a broken
+sudoers file.
+
+**`/etc/systemd/system/borg-ui-agent-upgrade.service`** — `Type=oneshot`,
+`ExecStart=/opt/borg-ui-agent/bin/borg-ui-agent-upgrade`. It is not enabled;
+it only ever runs when started. Running the reinstall inside a separate unit is
+what lets the upgrade survive the restart of `borg-ui-agent` that it performs:
+the upgrade is not in the agent's own process tree, so systemd killing the
+agent does not kill the upgrade.
+
+The agent advertises `self_upgrade` in `DEFAULT_CAPABILITIES`
+(`agent/borg_ui_agent/runtime.py:19`) only when it can actually see the helper:
+the unit file exists and `sudo -n systemctl start --no-block` for it passes
+`sudo -l`. Capability is detected, not assumed, so an agent upgraded from an
+older install that lacks the helper reports honestly and the UI routes it to
+the manual path.
+
+## 7. The upgrade command
+
+New session command `agent.upgrade`, dispatched through the existing
+`_handle_command` chain (`agent/borg_ui_agent/session.py:593`) next to
+`diagnostics.run`.
+
+Handler steps:
+
+1. Refuse with `upgrade_busy` if this agent has any other job in flight. An
+   upgrade restarts the process; doing it under a running backup would orphan
+   that backup's job.
+2. Refuse with `upgrade_unsupported` if the helper is not present.
+3. Emit a log line, then run
+   `sudo -n <systemctl path> start --no-block borg-ui-agent-upgrade.service`,
+   using the absolute path recorded in `upgrade.conf` so the sudoers rule matches.
+4. Report success and let the process die.
+
+`--no-block` matters: the call returns as soon as systemd has queued the job,
+so the agent gets to report "upgrade started" before the restart kills it.
+
+### 7.1 The agent cannot report its own outcome
+
+The agent is killed by the thing it is reporting on. Therefore **the server
+owns the outcome**, and this is explicit rather than incidental:
+
+- The `agent_upgrade` job is completed at "upgrade started". It records that
+  the upgrade was successfully *requested*, nothing more.
+- The server sets `upgrade_state = "requested"`, `upgrade_requested_at = now`,
+  and `upgrade_target_version = <effective target>` on the agent machine.
+- **Success** is recognised in the register/heartbeat path: an agent that comes
+  back reporting `agent_version == upgrade_target_version` has its
+  `upgrade_state` cleared to `idle`.
+- **Failure** is recognised by timeout. A sweep in `agent_job_reaper` (which
+  already runs on a timer for exactly this class of problem, see
+  `app/services/agent_job_reaper.py:1`) marks any agent whose
+  `upgrade_requested_at` is older than `AGENT_UPGRADE_TIMEOUT_SECONDS`
+  (default 600) without a matching re-register as `upgrade_state = "failed"`,
+  with a message pointing at the manual reinstall path.
+- An agent that comes back reporting the *old* version before the timeout is
+  left in `requested`; the reinstall may still be mid-flight. Only the timeout
+  resolves it.
+
+## 8. Fleet upgrades
+
+`POST .../agents/upgrade` with many ids queues many jobs, but they are released
+in waves of `AGENT_UPGRADE_CONCURRENCY` (default 5). Every upgrading endpoint
+is briefly offline, and taking a whole fleet down at once turns a routine
+maintenance action into an outage. Waves are advanced by the same reconciler
+that resolves outcomes: a slot frees when an agent leaves `requested`, by
+success or by timeout.
+
+Jobs are ordinary `agent_jobs` rows with `job_type="agent_upgrade"`, so they
+appear in the existing agent job list, logs, and activity views for free.
+
+## 9. UI
+
+All on the Managed Agents page (`frontend/src/pages/ManagedAgents.tsx`),
+composed from small components per `AGENTS.md`, no left accent borders.
+
+**Fleet banner** — shown only when at least one endpoint is `outdated`. Names
+the count and the target version, with an Upgrade all action. Endpoints without
+`self_upgrade_supported` are excluded from the count in the action and called
+out separately, so the number in the button is the number that will actually
+move.
+
+**Per-agent version cell** — the reported version, with a chip: `Current`,
+`Update available`, `Pinned`, `Ahead of server`, or `Unknown`. A pinned agent
+shows the pin target next to it.
+
+**Row state while upgrading** — the row shows a progress indicator and
+"Upgrading…" with the target version, driven by `upgrade_state`. On timeout the
+row shows a failure state with the error and a link to the existing reinstall
+dialog.
+
+**Upgrade dialog** — a `ResponsiveDialog` listing the affected endpoints by
+name and hostname, stating plainly that each will disconnect for a short period
+and that running backups block the upgrade. Confirm queues the jobs.
+
+**Manual-path affordance** — an endpoint with `self_upgrade_supported: false`
+gets an explanatory chip and its row action opens the existing
+`AgentReinstallDialog` rather than the new one. The copy says this endpoint
+needs one manual reinstall to gain remote upgrades, so the dead end is
+explained rather than just presented.
+
+**Pin control** — in the agent detail area, a select for the desired agent
+version (default "Track server") and the desired Borg major version.
+
+Stories are required for: fleet banner with and without unsupported endpoints,
+each version-cell chip state, the row upgrading state, the row failed state,
+the upgrade confirmation dialog, and the pin control. Each in default and
+mobile viewports, per existing `ManagedAgents.stories.tsx` conventions.
+
+## 10. Per-endpoint Borg version
+
+`AgentMachine.desired_borg_version` (`"1"`, `"2"`, or `NULL` for "leave as
+installed") is recorded on the pin endpoint and written into
+`upgrade.conf` by the server-side reinstall path, so the next upgrade installs
+that Borg major version. Reported Borg versions already arrive in
+`borg_versions` and are already displayed, so the comparison surface is the
+same pattern as the agent version and reuses the chip component.
+
+This is the last phase because it depends on the upgrade path existing: without
+it, setting a desired Borg version does nothing an operator can act on.
+
+## 11. Security
+
+- The escalation is one command with no caller-supplied input (section 6). The
+  agent cannot influence what gets installed or from where.
+- The sudoers file is validated before installation and never written on a
+  root-mode install.
+- `upgrade.conf` is root-owned and not writable by the service user, so a
+  compromised agent cannot rewrite the server URL and turn its own upgrade into
+  arbitrary code execution from an attacker-controlled host.
+- The helper fetches `install.sh` over the same channel and pinning the
+  installer already uses; this feature does not widen that trust boundary.
+- Upgrade endpoints require the same authorization as every other agent
+  mutation. Add the new actions to `app/core/authorization.py` alongside the
+  existing agent actions.
+
+## 12. Testing
+
+- **Version comparison** — table-driven unit tests over the `upgrade_status`
+  matrix in section 4, including unparseable versions, `NULL` on either side,
+  and a pinned agent matching and not matching its pin.
+- **Installer packaging** — extend `tests/unit/test_native_install_packaging.py`
+  style guard tests: the served script writes all four artifacts, skips them in
+  root mode, and the sudoers line names only the one command.
+- **Session command** — the agent refuses when busy and when unsupported, and
+  invokes the expected `sudo` argv (mocked) otherwise.
+- **Reconciliation** — an agent re-registering with the target version clears
+  `requested`; one re-registering with the old version does not; the reaper
+  marks a stale request `failed`.
+- **Fleet waves** — queuing more agents than the concurrency cap releases them
+  in waves.
+- **Frontend** — tests for the banner counts (particularly the unsupported
+  exclusion), each chip state, and that the manual path opens the existing
+  dialog. Stories per section 9.
+
+## 13. Phases
+
+### 13.1 Progress
+
+Agents update this table and nothing else as work advances. Statuses:
+`not started`, `plan drafted`, `plan approved`, `in progress`, `in review`,
+`done`, `blocked`.
+
+| Phase | Status | Plan file | Branch | Notes |
+| --- | --- | --- | --- | --- |
+| 1. Version model and visibility | not started | | | |
+| 2. Privileged helper and capability | not started | | | |
+| 3. Single-agent remote upgrade | not started | | | |
+| 4. Fleet upgrade | not started | | | |
+| 5. Per-endpoint Borg version | not started | | | |
+
+### 13.2 Phase 1 — version model and visibility
+
+Migration adding `desired_agent_version`, `desired_borg_version`,
+`upgrade_state`, `upgrade_requested_at`, `upgrade_target_version`, and
+`upgrade_error` to `agent_machines`. The comparison helper and `upgrade_status`
+on `AgentMachineResponse`. The version cell, its chips, the fleet banner, and
+the pin control with its `PUT` endpoint. Stories for every chip state and the
+banner.
+
+Gate: an operator can see which endpoints are behind and pin one, with no
+change to how upgrades are performed.
+
+### 13.3 Phase 2 — privileged helper and capability
+
+The four installer artifacts, the root-mode skip, `visudo` validation, and
+capability detection in the agent. No server behavior change beyond
+`self_upgrade_supported` appearing in the response and the manual-path
+affordance in the UI becoming meaningful.
+
+Gate: a freshly installed endpoint reports `self_upgrade`; an endpoint
+installed before this phase does not, and the UI says so.
+
+### 13.4 Phase 3 — single-agent remote upgrade
+
+The `agent.upgrade` session command, the `agent_upgrade` job type, the
+single-agent upgrade action and dialog, and the full reconciliation path
+including the reaper timeout.
+
+Gate: one endpoint upgrades from the UI and the row resolves to up to date
+without anyone touching that machine.
+
+### 13.5 Phase 4 — fleet upgrade
+
+Multi-select, the bulk endpoint, the wave scheduler, and the banner's
+Upgrade all action.
+
+Gate: a fleet of endpoints upgrades in waves, and no more than the cap are
+offline at once.
+
+### 13.6 Phase 5 — per-endpoint Borg version
+
+`desired_borg_version` written through to `upgrade.conf`, the Borg version
+chip, and the selector.
+
+Gate: an operator moves an endpoint from Borg 1 to Borg 2 from the UI.
+
+---
+
+## Appendix A — existing code this touches
+
+| Area | File | Note |
+| --- | --- | --- |
+| Agent model |  `app/database/models.py:105` | `AgentMachine`; new columns land here |
+| Agent jobs | `app/database/models.py:152` | `AgentJob`; `agent_upgrade` is a new `job_type` |
+| Version reporting | `app/api/agents.py:1186` | heartbeat sets `agent_version`; success reconciliation hooks here |
+| Register | `app/api/agents.py:1138` | same, for the post-restart re-register |
+| Agent responses | `app/api/managed_machines.py:100` | `AgentMachineResponse` gains the new fields |
+| Agent routes | `app/api/managed_machines.py:470` | new upgrade and pin routes sit alongside |
+| Served installer | `app/api/agent_installer.py:29` | `INSTALLER_SCRIPT`; the four new artifacts |
+| Served version | `app/api/agent_installer.py:797` | `agent_package_version()` is `available` |
+| Systemd unit | `app/api/agent_installer.py:726` | unprivileged service user, the constraint |
+| Session dispatch | `agent/borg_ui_agent/session.py:593` | `agent.upgrade` slots in here |
+| Capabilities | `agent/borg_ui_agent/runtime.py:19` | `self_upgrade` added by detection |
+| Reaper | `app/services/agent_job_reaper.py` | hosts the upgrade timeout sweep |
+| Agents page | `frontend/src/pages/ManagedAgents.tsx` | version cell, banner, dialogs |
+| Reinstall dialog | `frontend/src/pages/ManagedAgents.tsx:1468` | the manual fallback, kept |
+| Stories | `frontend/src/pages/ManagedAgents.stories.tsx` | new states added here |
+
+## Appendix B — decisions made
+
+**D1. Escalation is a dedicated oneshot unit plus a narrow sudoers rule.**
+Rejected: only upgrading root-mode installs, which leaves the recommended
+install unable to use the headline feature. Rejected: an agent-writable venv,
+which weakens the agent's own code path and still cannot update the systemd
+unit or the bundled Borg binary.
+
+**D2. The helper takes no arguments; all parameters come from a root-owned
+config file.** The alternative — the agent passing a server URL or flags
+through sudo — would make a compromised agent able to install arbitrary code as
+root. The sudoers rule is only safe because the escalated command has no input
+surface.
+
+**D3. Version comparison uses equality plus a local integer-tuple ordering, not
+`packaging`.** `packaging` is not a direct dependency and the only ordering
+question is `outdated` versus `ahead`, which a few lines answer. Adding a
+dependency for a cosmetic distinction is not worth it.
+
+**D4. Outcome is owned by the server, not reported by the agent.** The agent is
+killed by the upgrade it is performing, so it structurally cannot report
+completion. Making this explicit — request, then reconcile on re-register, then
+time out — avoids a design where the terminal state depends on a message that
+can never arrive.
+
+**D5. Upgrades run in waves, not all at once.** Every upgrading endpoint is
+briefly offline. An uncapped fleet upgrade is an outage.
+
+**D6. The bulk endpoint rejects unsupported agents rather than skipping them.**
+A partial success that reports as a full one is worse than a clear rejection
+naming the endpoints that need a manual reinstall first.
+
+**D7. Server self-upgrade is out of scope.** It is a different problem with a
+different failure model and belongs in its own spec.

--- a/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
+++ b/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
@@ -161,8 +161,11 @@ unsatisfiable.
 This is the load-bearing security design. The agent gets exactly one
 escalation, and it carries no attacker-controlled input.
 
-`install.sh` writes three root-owned artifacts, all skipped when the service
-user is `root` (that case needs no escalation):
+`install.sh` writes four root-owned artifacts. They are skipped entirely when
+the service user is `root` (that case needs no escalation) and when the operator
+passes `--no-remote-upgrade` (section 11.3). A reinstall preserves the existing
+choice unless the flag is given explicitly, matching how the installer already
+preserves the service user (`app/api/agent_installer.py:279`):
 
 **`/etc/borg-ui-agent/upgrade.conf`** — mode `0644`, owned `root:root`. Records
 the parameters a reinstall needs: server URL, borg install mode, service user
@@ -176,6 +179,11 @@ values the operator gave the installer.
 root-owned file rather than the caller, a compromised agent process cannot
 redirect the install source, change the service user, or inject installer
 flags. This is the property that makes the sudoers rule safe.
+
+Before fetching anything it compares the server URL in `upgrade.conf` against
+the one in `/etc/borg-ui-agent/config.toml` and aborts if they differ, so a
+config left behind by an earlier enrollment cannot point a live agent's upgrade
+at a host it no longer talks to.
 
 **`/etc/sudoers.d/borg-ui-agent-upgrade`** — mode `0440`, granting the service
 user exactly:
@@ -312,18 +320,55 @@ it, setting a desired Borg version does nothing an operator can act on.
 
 ## 11. Security
 
-- The escalation is one command with no caller-supplied input (section 6). The
-  agent cannot influence what gets installed or from where.
-- The sudoers file is validated before installation and never written on a
-  root-mode install.
-- `upgrade.conf` is root-owned and not writable by the service user, so a
-  compromised agent cannot rewrite the server URL and turn its own upgrade into
-  arbitrary code execution from an attacker-controlled host.
-- The helper fetches `install.sh` over the same channel and pinning the
-  installer already uses; this feature does not widen that trust boundary.
+### 11.1 What this actually grants
+
+State the escalation plainly rather than minimising it.
+
+Before this feature, a compromised Borg UI server can already, on every
+endpoint: run arbitrary code as the service user (`script.run`,
+`agent/borg_ui_agent/runtime.py:52`) and read any file on the machine, because
+the unit carries `CAP_DAC_READ_SEARCH` (`app/api/agent_installer.py:722`). It
+also already dictates which agent code the endpoint runs, since the endpoint
+installs the wheel the server serves.
+
+After this feature, on endpoints that carry the helper, it can additionally
+obtain **root** on demand: write access, persistence, and everything the read
+capability did not cover.
+
+That is a genuine escalation, not a repackaging of existing trust. It is
+accepted because the alternative — restricting upgrades to root-mode installs —
+excludes the installer's own default service user mode (`current`,
+`app/api/agent_installer.py:51`) and therefore excludes most installs from the
+feature. The escalation is bounded to "the server that already controls this
+endpoint's agent code can also restart it as root", which is a step up from
+that starting position rather than a new party gaining access.
+
+### 11.2 Properties the design must preserve
+
+- The escalation is one command with no caller-supplied input (section 6). A
+  compromised **agent** cannot influence what gets installed or from where; only
+  a compromised **server** can, and only into the reinstall path.
+- `upgrade.conf` is root-owned and not writable by the service user, so the
+  agent cannot rewrite the server URL and redirect its own upgrade to an
+  attacker-controlled host.
+- The sudoers file is validated with `visudo -cf` before installation, names one
+  absolute command path, and is never written on a root-mode install or when the
+  operator opted out (section 6).
+- The helper is refused entirely when `upgrade.conf` names a server URL that is
+  not the one the agent is enrolled against, so a stale or tampered config
+  cannot silently repoint an upgrade.
 - Upgrade endpoints require the same authorization as every other agent
   mutation. Add the new actions to `app/core/authorization.py` alongside the
   existing agent actions.
+
+### 11.3 Operator control
+
+Remote upgrade is installed by default, because a fleet feature that is off by
+default is not a fleet feature. `install.sh` accepts `--no-remote-upgrade` to
+skip all four artifacts; such an endpoint reports no `self_upgrade` capability
+and lands on the manual path described in section 9, which is the same path an
+endpoint installed before this feature takes. Document the flag and its trade in
+`docs/managed-agents.md` in the same phase that adds it.
 
 ## 12. Testing
 
@@ -332,7 +377,9 @@ it, setting a desired Borg version does nothing an operator can act on.
   and a pinned agent matching and not matching its pin.
 - **Installer packaging** — extend `tests/unit/test_native_install_packaging.py`
   style guard tests: the served script writes all four artifacts, skips them in
-  root mode, and the sudoers line names only the one command.
+  root mode and under `--no-remote-upgrade`, preserves the choice across a
+  reinstall that does not pass the flag, and emits a sudoers line naming exactly
+  one absolute command path.
 - **Session command** — the agent refuses when busy and when unsupported, and
   invokes the expected `sudo` argv (mocked) otherwise.
 - **Reconciliation** — an agent re-registering with the target version clears
@@ -374,10 +421,11 @@ change to how upgrades are performed.
 
 ### 13.3 Phase 2 — privileged helper and capability
 
-The four installer artifacts, the root-mode skip, `visudo` validation, and
-capability detection in the agent. No server behavior change beyond
-`self_upgrade_supported` appearing in the response and the manual-path
-affordance in the UI becoming meaningful.
+The four installer artifacts, the root-mode skip, the `--no-remote-upgrade`
+opt-out, `visudo` validation, and capability detection in the agent. Update
+`docs/managed-agents.md` with what the helper grants (section 11.1) and how to
+decline it. No server behavior change beyond `self_upgrade_supported` appearing
+in the response and the manual-path affordance in the UI becoming meaningful.
 
 Gate: a freshly installed endpoint reports `self_upgrade`; an endpoint
 installed before this phase does not, and the UI says so.
@@ -431,10 +479,13 @@ Gate: an operator moves an endpoint from Borg 1 to Borg 2 from the UI.
 ## Appendix B — decisions made
 
 **D1. Escalation is a dedicated oneshot unit plus a narrow sudoers rule.**
-Rejected: only upgrading root-mode installs, which leaves the recommended
-install unable to use the headline feature. Rejected: an agent-writable venv,
-which weakens the agent's own code path and still cannot update the systemd
-unit or the bundled Borg binary.
+The decisive argument is that the installer's default service user mode is
+`current` — an unprivileged user (`app/api/agent_installer.py:51`). Rejected:
+only upgrading root-mode installs, which would ship a fleet feature that does
+not work on the installer's own default and would leave most endpoints on the
+copy-paste path permanently. Rejected: an agent-writable venv, which weakens the
+agent's own code path and still cannot update the systemd unit or the bundled
+Borg binary. Section 11.1 states what the accepted option grants.
 
 **D2. The helper takes no arguments; all parameters come from a root-owned
 config file.** The alternative — the agent passing a server URL or flags
@@ -462,3 +513,17 @@ naming the endpoints that need a manual reinstall first.
 
 **D7. Server self-upgrade is out of scope.** It is a different problem with a
 different failure model and belongs in its own spec.
+
+**D8. The helper is installed by default, with `--no-remote-upgrade` to opt
+out.** Rejected: opt-in by default, which reintroduces the problem D1 rejects —
+the feature would not work on a normal install until someone knew to ask for it.
+An operator with one sensitive host opts that host out and keeps the manual
+path.
+
+**D9. Upgrades are pulled by the agent, not pushed by the server over SSH.**
+A server that could SSH into each endpoint could push upgrades directly, and at
+least one comparable product appears to be built that way. Borg UI's managed
+agents deliberately dial out, which is what lets them sit behind NAT with no
+inbound access and no server-held credentials for the endpoint. Adding
+server-to-endpoint SSH to enable upgrades would undo that property for the sake
+of one feature.

--- a/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
+++ b/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
@@ -235,7 +235,9 @@ database rather than on the endpoint.
 - The recorded server URL must be `https`, with certificate and hostname
   verification on. An `http` URL is refused rather than downgraded, and a
   redirect that changes scheme or host aborts the upgrade. `curl` is invoked
-  without `--insecure` and with `--proto '=https' --location-trusted` omitted.
+  with `--proto '=https'`, which holds across redirects, so an https URL that
+  redirects to http fails instead of downloading in cleartext. `--insecure` and
+  `--location-trusted` are both omitted.
 - The server publishes a SHA256 for the script it serves, and the helper
   verifies the download against it before executing. This mirrors what the
   native installer already does for its own artifacts, where checksums are
@@ -275,11 +277,19 @@ the upgrade is not in the agent's own process tree, so systemd killing the
 agent does not kill the upgrade.
 
 The agent advertises `self_upgrade` in `DEFAULT_CAPABILITIES`
-(`agent/borg_ui_agent/runtime.py:19`) only when it can actually see the helper:
-the unit file exists and `sudo -n systemctl start --no-block` for it passes
-`sudo -l`. Capability is detected, not assumed, so an agent upgraded from an
-older install that lacks the helper reports honestly and the UI routes it to
-the manual path.
+(`agent/borg_ui_agent/runtime.py:19`) only when it can actually see the helper.
+Capability is detected, not assumed, so an agent upgraded from an older install
+that lacks the helper reports honestly and the UI routes it to the manual path.
+
+The probe branches on how the agent runs, because the escalation only exists
+for the unprivileged case:
+
+- **Running as root.** The unit file exists, and that is the whole check. There
+  is no sudoers file to consult and the installer does not install `sudo`, so a
+  probe that shelled out to `sudo -l` would report no capability on exactly the
+  endpoints that need none.
+- **Running unprivileged.** The unit file exists *and*
+  `sudo -n <systemctl path> start --no-block` for it is listed by `sudo -l`.
 
 ## 7. The upgrade command
 
@@ -293,9 +303,10 @@ Handler steps:
    upgrade restarts the process; doing it under a running backup would orphan
    that backup's job.
 2. Refuse with `upgrade_unsupported` if the helper is not present.
-3. Emit a log line, then run
-   `sudo -n <systemctl path> start --no-block borg-ui-agent-upgrade.service`,
-   using the absolute path recorded in `upgrade.conf` so the sudoers rule matches.
+3. Emit a log line, then start `borg-ui-agent-upgrade.service`, using the
+   absolute `systemctl` path recorded in `upgrade.conf`. A root agent invokes
+   `<systemctl path> start --no-block` directly; an unprivileged one prefixes
+   `sudo -n`, and the recorded path is what makes the sudoers rule match.
 4. Report success and let the process die.
 
 `--no-block` matters: the call returns as soon as systemd has queued the job,
@@ -479,7 +490,9 @@ endpoint installed before this feature takes. Document the flag and its trade in
   in-flight upgrade returns the existing job rather than a new one; an unpinned
   agent on a server serving no wheel is rejected.
 - **Session command** — the agent refuses when busy and when unsupported, and
-  invokes the expected `sudo` argv (mocked) otherwise.
+  invokes the expected argv (mocked) otherwise: bare `systemctl` as root, and
+  `sudo -n systemctl` unprivileged. Capability detection and the upgrade are
+  both covered for a root endpoint with no `sudo` on `PATH`.
 - **Reconciliation** — an agent re-registering with the target version clears
   `requested`; one re-registering with the old version does not; the reaper
   marks a stale request `failed`.
@@ -551,7 +564,9 @@ Multi-select, the bulk endpoint, the wave scheduler, and the banner's
 Upgrade all action.
 
 Gate: a fleet of endpoints upgrades in waves, and no more than the cap are
-offline at once.
+in flight at once. The gate is on upgrades in flight, not endpoints offline,
+because a timed-out endpoint releases its slot while possibly still down
+(section 8).
 
 ### 13.6 Phase 5 — per-endpoint Borg version
 

--- a/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
+++ b/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
@@ -60,7 +60,7 @@ rest of the fleet moves.
   behind.
 - The operator selects out-of-date endpoints, clicks Upgrade, confirms a dialog
   that names exactly which machines will briefly disconnect, and watches each
-  row move through upgrading to up to date without touching a single machine.
+  row move through upgrading to up-to-date without touching a single machine.
 - An endpoint that must stay on an older agent is pinned, and it stops being
   counted as out of date.
 - An endpoint whose install predates this feature is clearly labelled as
@@ -121,34 +121,60 @@ routes and inherit its `authorize_request` dependency.
 
 **`GET /api/managed-machines/agents`** — `AgentMachineResponse` gains:
 
-```
+```text
 desired_agent_version: str | None
+desired_borg_version: "1" | "2" | None
 available_agent_version: str | None
 upgrade_status: Literal["up_to_date","outdated","ahead","pinned","unknown"]
 self_upgrade_supported: bool          # "self_upgrade" in capabilities
-upgrade_state: Literal["idle","requested","failed"] | None
+upgrade_state: Literal["idle","queued","requested","failed"] | None
 upgrade_requested_at: datetime | None
 upgrade_error: str | None
 ```
 
 `available_agent_version` is resolved once per request, not per row.
 
+`desired_borg_version` is returned as well as accepted, so the pin control can
+restore what an operator selected rather than resetting on reload, and so the
+UI can compare the intended Borg major version against the ones the endpoint
+actually reports in `borg_versions`.
+
+`upgrade_state` distinguishes an endpoint accepted into a fleet upgrade but
+still waiting for a wave (`queued`) from one whose upgrade has actually been
+dispatched (`requested`). Without that split, every endpoint in a large bulk
+request would read as idle until its wave started, and the operator would think
+the request had been dropped.
+
 **`POST /api/managed-machines/agents/upgrade`**
 
-```
-{ "agent_machine_ids": [int, ...] }
+```json
+{ "agent_machine_ids": [1, 2, 3] }
 ```
 
-Queues one upgrade per named agent. Rejects with `422` and a
-`backend.errors.agents.upgradeUnsupported` key if any named agent reports no
-`self_upgrade` capability, rather than silently skipping it — a partial success
-that looks like a full one is the failure mode to avoid. Returns the created
-job ids and, per agent, the resulting state.
+Queues one upgrade per named agent. Returns the created job ids and, per agent,
+the resulting state.
+
+Validation runs over the whole request before any job is created, and any
+failure rejects the entire request rather than partially applying it. A partial
+success that reports as a full one is the failure mode to avoid. Three checks,
+each with its own error key:
+
+| Condition | Key |
+| --- | --- |
+| An agent reports no `self_upgrade` capability | `backend.errors.agents.upgradeUnsupported` |
+| An agent has no effective target, because it is unpinned and this server serves no agent wheel | `backend.errors.agents.upgradeTargetUnavailable` |
+
+`agent_machine_ids` is deduplicated before validation, and an agent that
+already has an `agent_upgrade` job in a non-terminal state returns that job
+rather than queueing a second one. An upgrade restarts the endpoint, so
+queueing two for one machine could restart it twice or race two reinstalls
+against each other. This makes the endpoint idempotent under a double-click or
+a client retry.
 
 **`PUT /api/managed-machines/agents/{id}/desired-version`**
 
-```
-{ "desired_agent_version": str | null, "desired_borg_version": "1" | "2" | null }
+```json
+{ "desired_agent_version": "0.1.3", "desired_borg_version": "2" }
 ```
 
 Sets or clears the pin. Setting a `desired_agent_version` the server cannot
@@ -161,11 +187,18 @@ unsatisfiable.
 This is the load-bearing security design. The agent gets exactly one
 escalation, and it carries no attacker-controlled input.
 
-`install.sh` writes four root-owned artifacts. They are skipped entirely when
-the service user is `root` (that case needs no escalation) and when the operator
+`install.sh` writes four root-owned artifacts, skipped only when the operator
 passes `--no-remote-upgrade` (section 11.3). A reinstall preserves the existing
 choice unless the flag is given explicitly, matching how the installer already
-preserves the service user (`app/api/agent_installer.py:279`):
+preserves the service user (`app/api/agent_installer.py:279`).
+
+**A root-mode install gets three of the four.** The unit, the helper script and
+`upgrade.conf` are installed exactly as for an unprivileged agent; only the
+sudoers file is skipped, because a root agent can already start the unit. An
+earlier draft skipped the whole set for root, which left root endpoints with
+nothing to trigger and therefore no upgrade path at all: strictly worse than
+the unprivileged case the escalation exists to serve. The escalation is what
+root does not need; the mechanism it escalates to is needed either way.
 
 **`/etc/borg-ui-agent/upgrade.conf`** — mode `0644`, owned `root:root`. Records
 the parameters a reinstall needs: server URL, borg install mode, service user
@@ -174,11 +207,45 @@ values the operator gave the installer.
 
 **`/opt/borg-ui-agent/bin/borg-ui-agent-upgrade`** — mode `0755`, owned
 `root:root`, in a root-owned directory. It takes **no arguments**. It reads
-`upgrade.conf`, fetches `install.sh` from the recorded server, and runs it with
-`--reinstall` and the recorded flags. Because every parameter comes from a
-root-owned file rather than the caller, a compromised agent process cannot
-redirect the install source, change the service user, or inject installer
-flags. This is the property that makes the sudoers rule safe.
+`upgrade.conf`, fetches `install.sh` from the recorded server, verifies it
+(below), and runs it with `--reinstall` and the recorded flags. Because every
+parameter comes from a root-owned file rather than the caller, a compromised
+agent process cannot redirect the install source, change the service user, or
+inject installer flags. This is the property that makes the sudoers rule safe.
+
+*Which version it installs.* `upgrade.conf` records the endpoint's `agent_id`,
+not a version. The helper requests the installer as that agent, and **the
+server** resolves which versions to pin into the script it serves, from the
+endpoint's stored `desired_agent_version` and `desired_borg_version` (falling
+back to the served wheel and the installed Borg when unpinned). The mechanism
+already exists: the served script carries `PINNED_AGENT_VERSION` and the Borg
+pinning block, rewritten per request (`app/api/agent_installer.py:829`).
+
+This is the only propagation path, and it is deliberate. A pin set in the UI
+after install time has to reach the endpoint somehow, and every alternative is
+worse: writing the version into `upgrade.conf` needs a root-writable channel
+from the agent, and passing it through sudo would hand the agent the argument
+surface section 11.2 exists to deny. Resolving it server-side means the agent
+never names a version, so it can neither install one of its own choosing nor
+escape a pin, and the pin survives a server upgrade because it lives in the
+database rather than on the endpoint.
+
+*Transport and integrity.* The helper runs the fetched script as root, so:
+
+- The recorded server URL must be `https`, with certificate and hostname
+  verification on. An `http` URL is refused rather than downgraded, and a
+  redirect that changes scheme or host aborts the upgrade. `curl` is invoked
+  without `--insecure` and with `--proto '=https' --location-trusted` omitted.
+- The server publishes a SHA256 for the script it serves, and the helper
+  verifies the download against it before executing. This mirrors what the
+  native installer already does for its own artifacts, where checksums are
+  published alongside the release rather than fetched from a mutable branch.
+- Verification failure aborts without executing anything, leaves the agent
+  running, and reports through the upgrade's timeout path (section 7.1).
+
+Pinning versions is not integrity: `PINNED_AGENT_VERSION` says which wheel to
+install, not that the script asking for it is the script we published. Both are
+needed.
 
 Before fetching anything it compares the server URL in `upgrade.conf` against
 the one in `/etc/borg-ui-agent/config.toml` and aborts if they differ, so a
@@ -188,7 +255,7 @@ at a host it no longer talks to.
 **`/etc/sudoers.d/borg-ui-agent-upgrade`** — mode `0440`, granting the service
 user exactly:
 
-```
+```text
 <service_user> ALL=(root) NOPASSWD: /usr/bin/systemctl start --no-block borg-ui-agent-upgrade.service
 ```
 
@@ -202,7 +269,7 @@ sudoers file.
 
 **`/etc/systemd/system/borg-ui-agent-upgrade.service`** — `Type=oneshot`,
 `ExecStart=/opt/borg-ui-agent/bin/borg-ui-agent-upgrade`. It is not enabled;
-it only ever runs when started. Running the reinstall inside a separate unit is
+it only ever runs when started. Running the reinstall inside a separate one-shot unit is
 what lets the upgrade survive the restart of `borg-ui-agent` that it performs:
 the upgrade is not in the agent's own process tree, so systemd killing the
 agent does not kill the upgrade.
@@ -265,6 +332,17 @@ maintenance action into an outage. Waves are advanced by the same reconciler
 that resolves outcomes: a slot frees when an agent leaves `requested`, by
 success or by timeout.
 
+**The cap bounds upgrades in flight, not endpoints offline.** A timeout frees
+its slot even though that endpoint may still be mid-reinstall, so in the worst
+case more than `AGENT_UPGRADE_CONCURRENCY` endpoints are briefly down at once.
+This is deliberate. The alternative, holding a slot until the endpoint
+reconnects, lets one machine that never comes back stall every remaining
+upgrade in the fleet indefinitely, which is a worse failure than a transient
+overshoot. The timeout is set generously (600s, far longer than a reinstall
+takes) so an endpoint that hits it is far more likely broken than slow, and a
+timed-out endpoint is marked `failed` and excluded from further automatic waves
+until an operator acts on it, so the overshoot cannot compound.
+
 Jobs are ordinary `agent_jobs` rows with `job_type="agent_upgrade"`, so they
 appear in the existing agent job list, logs, and activity views for free.
 
@@ -274,10 +352,17 @@ All on the Managed Agents page (`frontend/src/pages/ManagedAgents.tsx`),
 composed from small components per `AGENTS.md`, no left accent borders.
 
 **Fleet banner** — shown only when at least one endpoint is `outdated`. Names
-the count and the target version, with an Upgrade all action. Endpoints without
+the count, with an Upgrade all action. Endpoints without
 `self_upgrade_supported` are excluded from the count in the action and called
 out separately, so the number in the button is the number that will actually
 move.
+
+The banner names a target version only when every outdated endpoint agrees on
+one. They do not always: an endpoint pinned below the served version is
+outdated against its pin, not against what the server serves, so its effective
+target is its own. When targets differ the banner says each endpoint targets
+its configured version rather than naming one, and Upgrade all upgrades each to
+its own effective target rather than to a single shared version.
 
 **Per-agent version cell** — the reported version, with a chip: `Current`,
 `Update available`, `Pinned`, `Ahead of server`, or `Unknown`. A pinned agent
@@ -378,10 +463,21 @@ endpoint installed before this feature takes. Document the flag and its trade in
   matrix in section 4, including unparseable versions, `NULL` on either side,
   and a pinned agent matching and not matching its pin.
 - **Installer packaging** — extend `tests/unit/test_native_install_packaging.py`
-  style guard tests: the served script writes all four artifacts, skips them in
-  root mode and under `--no-remote-upgrade`, preserves the choice across a
-  reinstall that does not pass the flag, and emits a sudoers line naming exactly
-  one absolute command path.
+  style guard tests: the served script writes all four artifacts, writes the
+  unit, helper and `upgrade.conf` but not the sudoers file in root mode, skips
+  all four under `--no-remote-upgrade`, preserves the choice across a reinstall
+  that does not pass the flag, and emits a sudoers line naming exactly one
+  absolute command path.
+- **Helper transport and integrity** — the helper refuses an `http` server URL,
+  refuses a redirect that changes scheme or host, refuses a script whose SHA256
+  does not match the published one, and executes nothing in each case.
+- **Version resolution** — the installer served to a pinned endpoint carries
+  that endpoint's pinned versions, and the one served to an unpinned endpoint
+  carries the wheel this server ships.
+- **Bulk validation** — a request naming one unsupported agent creates no jobs
+  at all; duplicate ids create one job; a second request for an agent with an
+  in-flight upgrade returns the existing job rather than a new one; an unpinned
+  agent on a server serving no wheel is rejected.
 - **Session command** — the agent refuses when busy and when unsupported, and
   invokes the expected `sudo` argv (mocked) otherwise.
 - **Reconciliation** — an agent re-registering with the target version clears
@@ -446,7 +542,7 @@ The `agent.upgrade` session command, the `agent_upgrade` job type, the
 single-agent upgrade action and dialog, the pin control UI deferred from
 phase 1, and the full reconciliation path including the reaper timeout.
 
-Gate: one endpoint upgrades from the UI and the row resolves to up to date
+Gate: one endpoint upgrades from the UI and the row resolves to up-to-date
 without anyone touching that machine.
 
 ### 13.5 Phase 4 — fleet upgrade
@@ -530,7 +626,25 @@ the feature would not work on a normal install until someone knew to ask for it.
 An operator with one sensitive host opts that host out and keeps the manual
 path.
 
-**D9. Upgrades are pulled by the agent, not pushed by the server over SSH.**
+**D9. The server resolves which version an endpoint installs, not the endpoint.**
+`upgrade.conf` records the endpoint's identity, and the server pins versions
+into the installer it serves for that identity. Rejected: recording the version
+on the endpoint, which needs a root-writable channel from the agent to change a
+pin set later; and passing it through sudo, which would hand the agent exactly
+the argument surface D2 exists to deny.
+
+**D10. Root-mode endpoints get the helper and the unit, only the sudoers file
+is skipped.** Skipping the whole set for root left those endpoints with no
+upgrade path at all, which is worse than the unprivileged case the escalation
+exists to serve. Root does not need the escalation; it still needs the thing
+being escalated to.
+
+**D11. The concurrency cap bounds upgrades in flight, not endpoints offline.**
+A timeout frees its slot even though that endpoint may still be reinstalling.
+Rejected: holding the slot until the endpoint reconnects, which lets a single
+machine that never returns stall every remaining upgrade indefinitely.
+
+**D12. Upgrades are pulled by the agent, not pushed by the server over SSH.**
 A server that could SSH into each endpoint could push upgrades directly, and at
 least one comparable product appears to be built that way. Borg UI's managed
 agents deliberately dial out, which is what lets them sit behind NAT with no

--- a/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
+++ b/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
@@ -403,7 +403,7 @@ Agents update this table and nothing else as work advances. Statuses:
 
 | Phase | Status | Plan file | Branch | Notes |
 | --- | --- | --- | --- | --- |
-| 1. Version model and visibility | not started | | | |
+| 1. Version model and visibility | done | `docs/engineering/plans/2026-09-07-agent-upgrades-phase-1.md` | `feat/agent-upgrades` | Pin UI moved to phase 3 |
 | 2. Privileged helper and capability | not started | | | |
 | 3. Single-agent remote upgrade | not started | | | |
 | 4. Fleet upgrade | not started | | | |

--- a/docs/managed-agents.md
+++ b/docs/managed-agents.md
@@ -83,6 +83,41 @@ the registration step, refreshes the installed package and systemd unit, and
 restarts `borg-ui-agent`. You do not need a new enrollment token unless you are
 enrolling a different machine or recreating a missing local agent config.
 
+## Knowing Which Agents Are Out of Date
+
+Every agent reports the version it runs each time it checks in. Borg UI compares
+that against the agent package the server itself ships, and shows the result as
+a chip on the agent card:
+
+| Chip | Meaning |
+| --- | --- |
+| No chip | The agent runs the version this server serves. Nothing to do. |
+| **Update available** | The agent is older than the version this server serves. Reinstall it using the command above. |
+| **Ahead of server** | The agent is newer than the version this server serves, which happens after a server rollback. Upgrade the server rather than downgrading the agent. |
+| **Pinned** | The agent is held at a specific version and will not follow the server. |
+| **Version unknown** | The agent has not reported a version yet, or the version cannot be compared. A freshly enrolled agent shows this until its first check-in. |
+
+A banner above the fleet counts how many endpoints are running an older agent.
+
+Upgrading is still a manual reinstall on each machine in this release. The
+comparison tells you which machines need it, so you are not reinstalling
+everything to be sure.
+
+### Pinning an Agent Version
+
+An endpoint can be held at a specific agent version so it stops tracking the
+server. Pinning is available through the API:
+
+```bash
+curl -X PUT http://borg-ui-host:8083/api/managed-machines/agents/<id>/desired-version \
+  -H 'Content-Type: application/json' \
+  -d '{"desired_agent_version": "0.1.3", "desired_borg_version": null}'
+```
+
+Send `null` for `desired_agent_version` to clear the pin and track the server
+again. You can only pin to a version this server can actually serve, because
+the installer installs from this server and nowhere else.
+
 ## Server URL and Localhost
 
 The `--server` value must be reachable from the client machine. If Borg UI and

--- a/docs/managed-agents.md
+++ b/docs/managed-agents.md
@@ -109,12 +109,15 @@ An endpoint can be held at a specific agent version so it stops tracking the
 server. Pinning is available through the API:
 
 ```bash
-curl -X PUT http://borg-ui-host:8083/api/managed-machines/agents/<id>/desired-version \
+curl -X PUT "$BASE_URL/api/managed-machines/agents/<id>/desired-version" \
+  -H "X-Borg-Authorization: Bearer $TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"desired_agent_version": "0.1.3", "desired_borg_version": null}'
 ```
 
-Send `null` for `desired_agent_version` to clear the pin and track the server
+This is an admin endpoint. `$TOKEN` is an API token for an admin account; see
+[the API guide](api.md) for how to obtain one. Send `null` for
+`desired_agent_version` to clear the pin and track the server
 again. You can only pin to a version this server can actually serve, because
 the installer installs from this server and nowhere else.
 

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -411,7 +411,8 @@
         "outdatedCount_one": "{{count}} Endpunkt verwendet einen älteren Agenten",
         "outdatedCount_other": "{{count}} Endpunkte verwenden einen älteren Agenten",
         "bannerBody": "Die aktuelle Agent-Version ist {{version}}.",
-        "bannerManual": "Installieren Sie jeden Endpunkt über seine Karte neu, um ihn zu aktualisieren."
+        "bannerManual": "Installieren Sie jeden Endpunkt über seine Karte neu, um ihn zu aktualisieren.",
+        "bannerMixedTargets": "Jeder Endpunkt zielt auf seine eigene konfigurierte Version."
       }
     },
     "installCommand": {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -398,6 +398,20 @@
         "tcpFailed": "TCP fehlgeschlagen",
         "emptyResult": "Führen Sie eine Prüfung aus, um die aktive Agent-Sitzung zu bestätigen. Fügen Sie Host und Port hinzu, um die TCP-Erreichbarkeit vom Agent-Host zu testen.",
         "unavailable": "Diagnosen sind in dieser Story- oder Testansicht nicht verfügbar."
+      },
+      "upgrade": {
+        "upToDate": "Aktuell",
+        "outdated": "Update verfügbar",
+        "ahead": "Neuer als der Server",
+        "pinned": "Angeheftet",
+        "unknown": "Version unbekannt",
+        "targetTooltip": "Dieser Server stellt Agent-Version {{version}} bereit",
+        "pinnedTooltip": "Auf Version {{version}} angeheftet und folgt dem Server nicht",
+        "unknownTooltip": "Dieser Endpunkt hat keine vergleichbare Version gemeldet",
+        "outdatedCount_one": "{{count}} Endpunkt verwendet einen älteren Agenten",
+        "outdatedCount_other": "{{count}} Endpunkte verwenden einen älteren Agenten",
+        "bannerBody": "Die aktuelle Agent-Version ist {{version}}.",
+        "bannerManual": "Installieren Sie jeden Endpunkt über seine Karte neu, um ihn zu aktualisieren."
       }
     },
     "installCommand": {
@@ -5525,7 +5539,8 @@
         "jobNotStartable": "Dieser Agent-Auftrag kann nicht gestartet werden",
         "repositoryOperationFailed": "Die Repository-Operation des Agenten ist fehlgeschlagen",
         "repositoryOperationTimeout": "Zeitüberschreitung bei der Repository-Operation des Agenten",
-        "unsupportedJobKind": "Nicht unterstützter Agent-Auftragstyp"
+        "unsupportedJobKind": "Nicht unterstützter Agent-Auftragstyp",
+        "desiredVersionUnavailable": "Diese Agent-Version ist auf diesem Server nicht verfügbar."
       },
       "repo": {
         "repositoryNotFound": "Repository nicht gefunden",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -411,7 +411,8 @@
         "outdatedCount_one": "{{count}} endpoint is running an older agent",
         "outdatedCount_other": "{{count}} endpoints are running an older agent",
         "bannerBody": "The current agent version is {{version}}.",
-        "bannerManual": "Reinstall each one from its card to bring it up to date."
+        "bannerManual": "Reinstall each one from its card to bring it up to date.",
+        "bannerMixedTargets": "Each one targets its own configured version."
       }
     },
     "installCommand": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -398,6 +398,20 @@
         "tcpFailed": "TCP failed",
         "emptyResult": "Run a check to verify the active agent session. Add a host and port to test TCP reachability from the agent host.",
         "unavailable": "Diagnostics are unavailable in this story or test surface."
+      },
+      "upgrade": {
+        "upToDate": "Current",
+        "outdated": "Update available",
+        "ahead": "Ahead of server",
+        "pinned": "Pinned",
+        "unknown": "Version unknown",
+        "targetTooltip": "This server serves agent version {{version}}",
+        "pinnedTooltip": "Pinned to version {{version}} and will not track the server",
+        "unknownTooltip": "This endpoint has not reported a version we can compare",
+        "outdatedCount_one": "{{count}} endpoint is running an older agent",
+        "outdatedCount_other": "{{count}} endpoints are running an older agent",
+        "bannerBody": "The current agent version is {{version}}.",
+        "bannerManual": "Reinstall each one from its card to bring it up to date."
       }
     },
     "installCommand": {
@@ -5525,7 +5539,8 @@
         "jobNotStartable": "This agent job cannot be started",
         "repositoryOperationFailed": "The agent repository operation failed",
         "repositoryOperationTimeout": "The agent repository operation timed out",
-        "unsupportedJobKind": "Unsupported agent job type"
+        "unsupportedJobKind": "Unsupported agent job type",
+        "desiredVersionUnavailable": "That agent version is not available on this server."
       },
       "repo": {
         "repositoryNotFound": "Repository not found",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -398,6 +398,20 @@
         "tcpFailed": "TCP falló",
         "emptyResult": "Ejecute una comprobación para verificar la sesión activa del agente. Añada un host y un puerto para probar la conectividad TCP desde el host del agente.",
         "unavailable": "Los diagnósticos no están disponibles en esta vista de historia o prueba."
+      },
+      "upgrade": {
+        "upToDate": "Actual",
+        "outdated": "Actualización disponible",
+        "ahead": "Más reciente que el servidor",
+        "pinned": "Fijado",
+        "unknown": "Versión desconocida",
+        "targetTooltip": "Este servidor ofrece la versión {{version}} del agente",
+        "pinnedTooltip": "Fijado en la versión {{version}} y no seguirá al servidor",
+        "unknownTooltip": "Este endpoint no ha informado una versión que podamos comparar",
+        "outdatedCount_one": "{{count}} endpoint ejecuta un agente antiguo",
+        "outdatedCount_other": "{{count}} endpoints ejecutan un agente antiguo",
+        "bannerBody": "La versión actual del agente es {{version}}.",
+        "bannerManual": "Reinstale cada uno desde su tarjeta para actualizarlo."
       }
     },
     "installCommand": {
@@ -5525,7 +5539,8 @@
         "jobNotStartable": "Este trabajo de agente no se puede iniciar",
         "repositoryOperationFailed": "La operación de repositorio del agente falló",
         "repositoryOperationTimeout": "La operación de repositorio del agente agotó el tiempo de espera",
-        "unsupportedJobKind": "Tipo de trabajo de agente no admitido"
+        "unsupportedJobKind": "Tipo de trabajo de agente no admitido",
+        "desiredVersionUnavailable": "Esa versión del agente no está disponible en este servidor."
       },
       "repo": {
         "repositoryNotFound": "Repositorio no encontrado",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -411,7 +411,8 @@
         "outdatedCount_one": "{{count}} endpoint ejecuta un agente antiguo",
         "outdatedCount_other": "{{count}} endpoints ejecutan un agente antiguo",
         "bannerBody": "La versión actual del agente es {{version}}.",
-        "bannerManual": "Reinstale cada uno desde su tarjeta para actualizarlo."
+        "bannerManual": "Reinstale cada uno desde su tarjeta para actualizarlo.",
+        "bannerMixedTargets": "Cada uno apunta a su propia versión configurada."
       }
     },
     "installCommand": {

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -411,7 +411,8 @@
         "outdatedCount_one": "{{count}} endpoint esegue un agente più vecchio",
         "outdatedCount_other": "{{count}} endpoint eseguono un agente più vecchio",
         "bannerBody": "La versione attuale dell'agente è {{version}}.",
-        "bannerManual": "Reinstalla ciascuno dalla sua scheda per aggiornarlo."
+        "bannerManual": "Reinstalla ciascuno dalla sua scheda per aggiornarlo.",
+        "bannerMixedTargets": "Ognuno punta alla propria versione configurata."
       }
     },
     "installCommand": {

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -398,6 +398,20 @@
         "tcpFailed": "TCP non riuscito",
         "emptyResult": "Esegui un controllo per verificare la sessione agente attiva. Aggiungi un host e una porta per testare la raggiungibilità TCP dall'host dell'agente.",
         "unavailable": "La diagnostica non è disponibile in questa superficie di storia o test."
+      },
+      "upgrade": {
+        "upToDate": "Aggiornato",
+        "outdated": "Aggiornamento disponibile",
+        "ahead": "Più recente del server",
+        "pinned": "Bloccato",
+        "unknown": "Versione sconosciuta",
+        "targetTooltip": "Questo server fornisce la versione {{version}} dell'agente",
+        "pinnedTooltip": "Bloccato alla versione {{version}} e non seguirà il server",
+        "unknownTooltip": "Questo endpoint non ha segnalato una versione confrontabile",
+        "outdatedCount_one": "{{count}} endpoint esegue un agente più vecchio",
+        "outdatedCount_other": "{{count}} endpoint eseguono un agente più vecchio",
+        "bannerBody": "La versione attuale dell'agente è {{version}}.",
+        "bannerManual": "Reinstalla ciascuno dalla sua scheda per aggiornarlo."
       }
     },
     "installCommand": {
@@ -5525,7 +5539,8 @@
         "jobNotStartable": "Questo lavoro agente non può essere avviato",
         "repositoryOperationFailed": "L'operazione repository dell'agente non è riuscita",
         "repositoryOperationTimeout": "L'operazione repository dell'agente è scaduta",
-        "unsupportedJobKind": "Tipo di lavoro agente non supportato"
+        "unsupportedJobKind": "Tipo di lavoro agente non supportato",
+        "desiredVersionUnavailable": "Quella versione dell'agente non è disponibile su questo server."
       },
       "repo": {
         "repositoryNotFound": "Repository non trovato",

--- a/frontend/src/pages/ManagedAgents.stories.tsx
+++ b/frontend/src/pages/ManagedAgents.stories.tsx
@@ -640,3 +640,53 @@ export const AgentJobLogs: Story = {
     </Box>
   ),
 }
+
+export const AgentFleetVersionStates: Story = {
+  name: 'Agent list with mixed agent versions',
+  render: () => (
+    <AgentList
+      agents={[
+        {
+          ...agents[0],
+          name: 'Production NAS',
+          agent_version: '0.1.2',
+          available_agent_version: '0.1.3',
+          upgrade_status: 'outdated',
+        },
+        {
+          ...agents[1],
+          name: 'Finance Workstation',
+          agent_version: '0.1.3',
+          available_agent_version: '0.1.3',
+          upgrade_status: 'up_to_date',
+        },
+        {
+          ...agents[0],
+          id: 91,
+          agent_id: 'agt_pinned_91',
+          name: 'Legacy Print Server',
+          agent_version: '0.1.1',
+          desired_agent_version: '0.1.1',
+          available_agent_version: '0.1.3',
+          upgrade_status: 'pinned',
+        },
+        {
+          ...agents[0],
+          id: 92,
+          agent_id: 'agt_unknown_92',
+          name: 'Newly Enrolled Laptop',
+          agent_version: null,
+          available_agent_version: '0.1.3',
+          upgrade_status: 'unknown',
+        },
+      ]}
+      serverUrl="https://borg-ui.example.com"
+      onCopy={() => {}}
+      onRevoke={() => {}}
+      onDelete={() => {}}
+      onViewLogs={() => {}}
+      isRevoking={false}
+      isDeleting={false}
+    />
+  ),
+}

--- a/frontend/src/pages/ManagedAgents.tsx
+++ b/frontend/src/pages/ManagedAgents.tsx
@@ -64,6 +64,8 @@ import LogViewerDialog, { type LogViewerFetchLogs } from '../components/shared/L
 import ResponsiveDialog from '../components/shared/ResponsiveDialog'
 import DiagnosticsTcpTargetFields from '../components/shared/DiagnosticsTcpTargetFields'
 import AddAgentDialog from './managed-agents/AddAgentDialog'
+import AgentUpgradeBanner from './managed-agents/AgentUpgradeBanner'
+import AgentUpgradeChip from './managed-agents/AgentUpgradeChip'
 import BorgInstallModeRadioGroup from './managed-agents/BorgInstallModeRadioGroup'
 import { resolveAgentServerUrl } from './managed-agents/agentServerUrl'
 import {
@@ -1614,6 +1616,7 @@ export function AgentList({
 
   return (
     <>
+      <AgentUpgradeBanner agents={agents} />
       <Box
         sx={{
           display: 'grid',
@@ -1698,19 +1701,34 @@ export function AgentList({
                         {agent.status}
                       </Typography>
                     </Box>
-                    {agent.agent_version && (
-                      <Typography
-                        sx={{
-                          fontSize: '0.58rem',
-                          fontWeight: 500,
-                          color: 'text.disabled',
-                          letterSpacing: '0.02em',
-                          flexShrink: 0,
-                        }}
-                      >
-                        v{agent.agent_version}
-                      </Typography>
-                    )}
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 0.5,
+                        flexShrink: 0,
+                      }}
+                    >
+                      {agent.agent_version && (
+                        <Typography
+                          sx={{
+                            fontSize: '0.58rem',
+                            fontWeight: 500,
+                            color: 'text.disabled',
+                            letterSpacing: '0.02em',
+                          }}
+                        >
+                          v{agent.agent_version}
+                        </Typography>
+                      )}
+                      {agent.upgrade_status && agent.upgrade_status !== 'up_to_date' && (
+                        <AgentUpgradeChip
+                          status={agent.upgrade_status}
+                          targetVersion={agent.available_agent_version}
+                          pinnedVersion={agent.desired_agent_version}
+                        />
+                      )}
+                    </Box>
                   </Box>
 
                   <Typography

--- a/frontend/src/pages/__tests__/ManagedAgents.test.tsx
+++ b/frontend/src/pages/__tests__/ManagedAgents.test.tsx
@@ -1269,4 +1269,41 @@ describe('ManagedAgents', () => {
     expect(screen.queryByText('Update available')).not.toBeInTheDocument()
     expect(screen.queryByText(/running an older agent/i)).not.toBeInTheDocument()
   })
+
+  it('names the pin, not the served version, for an agent behind its pin', async () => {
+    // Pinned to 0.1.2 while the server serves 0.1.3: the endpoint is outdated
+    // against its pin. Naming 0.1.3 here would point the operator at a version
+    // the pin forbids.
+    const user = userEvent.setup()
+    const agent = {
+      id: 14,
+      agent_id: 'agent-behind-pin-14',
+      name: 'behind-pin',
+      hostname: 'behind-pin-01',
+      status: 'online',
+      agent_version: '0.1.1',
+      desired_agent_version: '0.1.2',
+      available_agent_version: '0.1.3',
+      upgrade_status: 'outdated',
+      created_at: '2026-05-18T09:00:00.000Z',
+      updated_at: '2026-05-18T10:00:00.000Z',
+    } as AgentMachineResponse
+
+    renderWithProviders(
+      <AgentList
+        agents={[agent]}
+        serverUrl="https://borg-ui.example.com"
+        onCopy={vi.fn()}
+        onRevoke={vi.fn()}
+        onDelete={vi.fn()}
+        onViewLogs={vi.fn()}
+        isRevoking={false}
+        isDeleting={false}
+      />
+    )
+
+    await user.hover(screen.getByText('Update available'))
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(/Pinned to version 0\.1\.2/i)
+    expect(screen.queryByText(/serves agent version 0\.1\.3/i)).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/pages/__tests__/ManagedAgents.test.tsx
+++ b/frontend/src/pages/__tests__/ManagedAgents.test.tsx
@@ -1173,4 +1173,100 @@ describe('ManagedAgents', () => {
     expect(buttons[1]).toBeDisabled()
     expect(buttons[2]).toBeDisabled()
   })
+
+  it('shows an update chip and a banner for an out-of-date agent', () => {
+    const agent = {
+      id: 11,
+      agent_id: 'agent-behind-11',
+      name: 'behind',
+      hostname: 'behind-01',
+      status: 'online',
+      agent_version: '0.1.2',
+      available_agent_version: '0.1.3',
+      upgrade_status: 'outdated',
+      created_at: '2026-05-18T09:00:00.000Z',
+      updated_at: '2026-05-18T10:00:00.000Z',
+    } as AgentMachineResponse
+
+    renderWithProviders(
+      <AgentList
+        agents={[agent]}
+        serverUrl="https://borg-ui.example.com"
+        onCopy={vi.fn()}
+        onRevoke={vi.fn()}
+        onDelete={vi.fn()}
+        onViewLogs={vi.fn()}
+        isRevoking={false}
+        isDeleting={false}
+      />
+    )
+
+    expect(screen.getByText('Update available')).toBeInTheDocument()
+    expect(screen.getByText(/1 endpoint is running an older agent/i)).toBeInTheDocument()
+  })
+
+  it('stays quiet for an agent running the served version', () => {
+    const agent = {
+      id: 12,
+      agent_id: 'agent-current-12',
+      name: 'current',
+      hostname: 'current-01',
+      status: 'online',
+      agent_version: '0.1.3',
+      available_agent_version: '0.1.3',
+      upgrade_status: 'up_to_date',
+      created_at: '2026-05-18T09:00:00.000Z',
+      updated_at: '2026-05-18T10:00:00.000Z',
+    } as AgentMachineResponse
+
+    renderWithProviders(
+      <AgentList
+        agents={[agent]}
+        serverUrl="https://borg-ui.example.com"
+        onCopy={vi.fn()}
+        onRevoke={vi.fn()}
+        onDelete={vi.fn()}
+        onViewLogs={vi.fn()}
+        isRevoking={false}
+        isDeleting={false}
+      />
+    )
+
+    expect(screen.queryByText('Update available')).not.toBeInTheDocument()
+    expect(screen.queryByText('Current')).not.toBeInTheDocument()
+    expect(screen.queryByText(/running an older agent/i)).not.toBeInTheDocument()
+  })
+
+  it('shows the pin state instead of an update prompt for a pinned agent', () => {
+    const agent = {
+      id: 13,
+      agent_id: 'agent-pinned-13',
+      name: 'pinned',
+      hostname: 'pinned-01',
+      status: 'online',
+      agent_version: '0.1.2',
+      desired_agent_version: '0.1.2',
+      available_agent_version: '0.1.3',
+      upgrade_status: 'pinned',
+      created_at: '2026-05-18T09:00:00.000Z',
+      updated_at: '2026-05-18T10:00:00.000Z',
+    } as AgentMachineResponse
+
+    renderWithProviders(
+      <AgentList
+        agents={[agent]}
+        serverUrl="https://borg-ui.example.com"
+        onCopy={vi.fn()}
+        onRevoke={vi.fn()}
+        onDelete={vi.fn()}
+        onViewLogs={vi.fn()}
+        isRevoking={false}
+        isDeleting={false}
+      />
+    )
+
+    expect(screen.getByText('Pinned')).toBeInTheDocument()
+    expect(screen.queryByText('Update available')).not.toBeInTheDocument()
+    expect(screen.queryByText(/running an older agent/i)).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/pages/managed-agents/AgentUpgradeBanner.stories.tsx
+++ b/frontend/src/pages/managed-agents/AgentUpgradeBanner.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import AgentUpgradeBanner from './AgentUpgradeBanner'
+import type { AgentMachineResponse } from '../../services/api'
+
+const base: AgentMachineResponse = {
+  id: 1,
+  name: 'Production NAS',
+  agent_id: 'agt_prod_nas_01',
+  hostname: 'nas-01.local',
+  status: 'online',
+  agent_version: '0.1.2',
+  available_agent_version: '0.1.3',
+  upgrade_status: 'outdated',
+  created_at: '2026-05-10T08:00:00.000Z',
+  updated_at: '2026-09-07T08:00:00.000Z',
+}
+
+const meta: Meta<typeof AgentUpgradeBanner> = {
+  title: 'Managed Agents/AgentUpgradeBanner',
+  component: AgentUpgradeBanner,
+}
+export default meta
+
+type Story = StoryObj<typeof AgentUpgradeBanner>
+
+export const OneOutdated: Story = {
+  args: { agents: [base] },
+}
+
+export const SeveralOutdated: Story = {
+  args: {
+    agents: [
+      base,
+      { ...base, id: 2, name: 'Finance Workstation', agent_id: 'agt_fin_07' },
+      { ...base, id: 3, name: 'Build Server', agent_id: 'agt_build_02' },
+    ],
+  },
+}
+
+export const NoneOutdated: Story = {
+  args: {
+    agents: [{ ...base, upgrade_status: 'up_to_date', agent_version: '0.1.3' }],
+  },
+}

--- a/frontend/src/pages/managed-agents/AgentUpgradeBanner.stories.tsx
+++ b/frontend/src/pages/managed-agents/AgentUpgradeBanner.stories.tsx
@@ -23,6 +23,11 @@ export default meta
 
 type Story = StoryObj<typeof AgentUpgradeBanner>
 
+// There is deliberately no story for a fleet with nothing outdated: the banner
+// renders null, and the snapshot harness waits for a visible #storybook-root,
+// so an empty story times out the visual job. That case is asserted in
+// __tests__/AgentUpgradeBanner.test.tsx instead.
+
 export const OneOutdated: Story = {
   args: { agents: [base] },
 }
@@ -52,11 +57,5 @@ export const MixedTargets: Story = {
         available_agent_version: '0.1.3',
       },
     ],
-  },
-}
-
-export const NoneOutdated: Story = {
-  args: {
-    agents: [{ ...base, upgrade_status: 'up_to_date', agent_version: '0.1.3' }],
   },
 }

--- a/frontend/src/pages/managed-agents/AgentUpgradeBanner.stories.tsx
+++ b/frontend/src/pages/managed-agents/AgentUpgradeBanner.stories.tsx
@@ -37,6 +37,24 @@ export const SeveralOutdated: Story = {
   },
 }
 
+export const MixedTargets: Story = {
+  name: 'Outdated agents with different targets',
+  args: {
+    agents: [
+      base,
+      {
+        ...base,
+        id: 2,
+        name: 'Legacy Print Server',
+        agent_id: 'agt_legacy_02',
+        agent_version: '0.1.1',
+        desired_agent_version: '0.1.2',
+        available_agent_version: '0.1.3',
+      },
+    ],
+  },
+}
+
 export const NoneOutdated: Story = {
   args: {
     agents: [{ ...base, upgrade_status: 'up_to_date', agent_version: '0.1.3' }],

--- a/frontend/src/pages/managed-agents/AgentUpgradeBanner.tsx
+++ b/frontend/src/pages/managed-agents/AgentUpgradeBanner.tsx
@@ -3,7 +3,14 @@ import { useTranslation } from 'react-i18next'
 import type { AgentMachineResponse } from '../../services/api'
 
 /**
- * Counts endpoints running an older agent than this server serves.
+ * The version an endpoint should be running: its pin if it has one, otherwise
+ * whatever this server serves.
+ */
+const effectiveTarget = (agent: AgentMachineResponse): string =>
+  agent.desired_agent_version ?? agent.available_agent_version ?? ''
+
+/**
+ * Counts endpoints running an older agent than they should be.
  *
  * Informational only: upgrading is still a manual reinstall from each agent's
  * card, so this deliberately carries no action button.
@@ -15,9 +22,12 @@ export default function AgentUpgradeBanner({ agents }: { agents: AgentMachineRes
     return null
   }
 
-  // Every outdated agent compares against the same served version, so reading
-  // it off the first one is enough.
-  const target = outdated[0].available_agent_version ?? ''
+  // Outdated endpoints do not necessarily share a target: one pinned below the
+  // served version is outdated against its pin, not against what the server
+  // serves. Naming a single version when they differ would tell the operator
+  // to install something a pin forbids, so only name it when it is unambiguous.
+  const targets = new Set(outdated.map(effectiveTarget).filter(Boolean))
+  const sharedTarget = targets.size === 1 ? [...targets][0] : null
 
   return (
     <Alert severity="warning" variant="outlined" sx={{ mb: 2 }}>
@@ -25,7 +35,9 @@ export default function AgentUpgradeBanner({ agents }: { agents: AgentMachineRes
         {t('managedAgents.page.upgrade.outdatedCount', { count: outdated.length })}
       </AlertTitle>
       <Typography variant="body2" color="text.secondary">
-        {target ? `${t('managedAgents.page.upgrade.bannerBody', { version: target })} ` : ''}
+        {sharedTarget
+          ? `${t('managedAgents.page.upgrade.bannerBody', { version: sharedTarget })} `
+          : `${t('managedAgents.page.upgrade.bannerMixedTargets')} `}
         {t('managedAgents.page.upgrade.bannerManual')}
       </Typography>
     </Alert>

--- a/frontend/src/pages/managed-agents/AgentUpgradeBanner.tsx
+++ b/frontend/src/pages/managed-agents/AgentUpgradeBanner.tsx
@@ -1,0 +1,33 @@
+import { Alert, AlertTitle, Typography } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import type { AgentMachineResponse } from '../../services/api'
+
+/**
+ * Counts endpoints running an older agent than this server serves.
+ *
+ * Informational only: upgrading is still a manual reinstall from each agent's
+ * card, so this deliberately carries no action button.
+ */
+export default function AgentUpgradeBanner({ agents }: { agents: AgentMachineResponse[] }) {
+  const { t } = useTranslation()
+  const outdated = agents.filter((agent) => agent.upgrade_status === 'outdated')
+  if (outdated.length === 0) {
+    return null
+  }
+
+  // Every outdated agent compares against the same served version, so reading
+  // it off the first one is enough.
+  const target = outdated[0].available_agent_version ?? ''
+
+  return (
+    <Alert severity="warning" variant="outlined" sx={{ mb: 2 }}>
+      <AlertTitle sx={{ fontWeight: 700, mb: 0.25 }}>
+        {t('managedAgents.page.upgrade.outdatedCount', { count: outdated.length })}
+      </AlertTitle>
+      <Typography variant="body2" color="text.secondary">
+        {target ? `${t('managedAgents.page.upgrade.bannerBody', { version: target })} ` : ''}
+        {t('managedAgents.page.upgrade.bannerManual')}
+      </Typography>
+    </Alert>
+  )
+}

--- a/frontend/src/pages/managed-agents/AgentUpgradeChip.stories.tsx
+++ b/frontend/src/pages/managed-agents/AgentUpgradeChip.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Stack } from '@mui/material'
+import AgentUpgradeChip from './AgentUpgradeChip'
+
+const meta: Meta<typeof AgentUpgradeChip> = {
+  title: 'Managed Agents/AgentUpgradeChip',
+  component: AgentUpgradeChip,
+}
+export default meta
+
+type Story = StoryObj<typeof AgentUpgradeChip>
+
+export const AllStates: Story = {
+  render: () => (
+    <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+      <AgentUpgradeChip status="up_to_date" targetVersion="0.1.3" />
+      <AgentUpgradeChip status="outdated" targetVersion="0.1.3" />
+      <AgentUpgradeChip status="ahead" targetVersion="0.1.3" />
+      <AgentUpgradeChip status="pinned" pinnedVersion="0.1.2" />
+      <AgentUpgradeChip status="unknown" />
+    </Stack>
+  ),
+}
+
+export const UpToDate: Story = {
+  args: { status: 'up_to_date', targetVersion: '0.1.3' },
+}
+
+export const Outdated: Story = {
+  args: { status: 'outdated', targetVersion: '0.1.3' },
+}
+
+export const Ahead: Story = {
+  args: { status: 'ahead', targetVersion: '0.1.3' },
+}
+
+export const Pinned: Story = {
+  args: { status: 'pinned', pinnedVersion: '0.1.2' },
+}
+
+export const Unknown: Story = {
+  args: { status: 'unknown' },
+}

--- a/frontend/src/pages/managed-agents/AgentUpgradeChip.tsx
+++ b/frontend/src/pages/managed-agents/AgentUpgradeChip.tsx
@@ -35,7 +35,11 @@ export default function AgentUpgradeChip({
   const { t } = useTranslation()
 
   const tooltipText = () => {
-    if (status === 'pinned' && pinnedVersion) {
+    // A pin decides the target whatever the status is. An endpoint pinned below
+    // the served version reads as `outdated` against its pin, so naming the
+    // served version here would point the operator at a version the pin
+    // forbids. This mirrors `desired or available` in app/core/agent_versions.py.
+    if (pinnedVersion) {
       return t('managedAgents.page.upgrade.pinnedTooltip', { version: pinnedVersion })
     }
     if (status === 'unknown') {

--- a/frontend/src/pages/managed-agents/AgentUpgradeChip.tsx
+++ b/frontend/src/pages/managed-agents/AgentUpgradeChip.tsx
@@ -1,0 +1,68 @@
+import { Chip, Tooltip } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import type { AgentUpgradeStatus } from '../../services/api'
+
+const STATUS_COLOR: Record<AgentUpgradeStatus, 'success' | 'warning' | 'info' | 'default'> = {
+  up_to_date: 'success',
+  outdated: 'warning',
+  ahead: 'info',
+  pinned: 'info',
+  unknown: 'default',
+}
+
+const STATUS_LABEL: Record<AgentUpgradeStatus, string> = {
+  up_to_date: 'managedAgents.page.upgrade.upToDate',
+  outdated: 'managedAgents.page.upgrade.outdated',
+  ahead: 'managedAgents.page.upgrade.ahead',
+  pinned: 'managedAgents.page.upgrade.pinned',
+  unknown: 'managedAgents.page.upgrade.unknown',
+}
+
+/**
+ * How the agent version an endpoint reports compares to the version it should
+ * be running. `targetVersion` is what this server serves; `pinnedVersion` is
+ * set only when an operator pinned the endpoint to a specific version.
+ */
+export default function AgentUpgradeChip({
+  status,
+  targetVersion,
+  pinnedVersion,
+}: {
+  status: AgentUpgradeStatus
+  targetVersion?: string | null
+  pinnedVersion?: string | null
+}) {
+  const { t } = useTranslation()
+
+  const tooltipText = () => {
+    if (status === 'pinned' && pinnedVersion) {
+      return t('managedAgents.page.upgrade.pinnedTooltip', { version: pinnedVersion })
+    }
+    if (status === 'unknown') {
+      return t('managedAgents.page.upgrade.unknownTooltip')
+    }
+    if (targetVersion) {
+      return t('managedAgents.page.upgrade.targetTooltip', { version: targetVersion })
+    }
+    return ''
+  }
+
+  const chip = (
+    <Chip
+      size="small"
+      variant="outlined"
+      color={STATUS_COLOR[status]}
+      label={t(STATUS_LABEL[status])}
+      sx={{ height: 18, fontSize: '0.58rem', fontWeight: 600, '& .MuiChip-label': { px: 0.75 } }}
+    />
+  )
+
+  const title = tooltipText()
+  return title ? (
+    <Tooltip title={title} arrow>
+      <span>{chip}</span>
+    </Tooltip>
+  ) : (
+    chip
+  )
+}

--- a/frontend/src/pages/managed-agents/__tests__/AgentUpgradeBanner.test.tsx
+++ b/frontend/src/pages/managed-agents/__tests__/AgentUpgradeBanner.test.tsx
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '../../../test/test-utils'
+import AgentUpgradeBanner from '../AgentUpgradeBanner'
+import type { AgentMachineResponse } from '../../../services/api'
+
+const agent = (overrides: Partial<AgentMachineResponse>): AgentMachineResponse =>
+  ({
+    id: 1,
+    agent_id: 'agt_1',
+    name: 'node',
+    status: 'online',
+    created_at: '2026-05-10T08:00:00.000Z',
+    updated_at: '2026-09-07T08:00:00.000Z',
+    ...overrides,
+  }) as AgentMachineResponse
+
+describe('AgentUpgradeBanner', () => {
+  it('renders nothing when no agent is behind', () => {
+    renderWithProviders(
+      <AgentUpgradeBanner
+        agents={[
+          agent({ upgrade_status: 'up_to_date', available_agent_version: '0.1.3' }),
+          agent({ id: 2, upgrade_status: 'pinned', available_agent_version: '0.1.3' }),
+        ]}
+      />
+    )
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('names the served version when every outdated agent shares it', () => {
+    renderWithProviders(
+      <AgentUpgradeBanner
+        agents={[
+          agent({
+            upgrade_status: 'outdated',
+            agent_version: '0.1.2',
+            available_agent_version: '0.1.3',
+          }),
+          agent({
+            id: 2,
+            upgrade_status: 'outdated',
+            agent_version: '0.1.1',
+            available_agent_version: '0.1.3',
+          }),
+        ]}
+      />
+    )
+    expect(screen.getByText(/2 endpoints are running an older agent/i)).toBeInTheDocument()
+    expect(screen.getByText(/current agent version is 0\.1\.3/i)).toBeInTheDocument()
+  })
+
+  it('does not name one version when outdated agents have different targets', () => {
+    // A pinned agent that is behind its own pin is outdated against the pin,
+    // not against the version the server serves. Naming the served version
+    // here would tell the operator to install something the pin forbids.
+    renderWithProviders(
+      <AgentUpgradeBanner
+        agents={[
+          agent({
+            upgrade_status: 'outdated',
+            agent_version: '0.1.2',
+            available_agent_version: '0.1.3',
+          }),
+          agent({
+            id: 2,
+            upgrade_status: 'outdated',
+            agent_version: '0.1.1',
+            desired_agent_version: '0.1.2',
+            available_agent_version: '0.1.3',
+          }),
+        ]}
+      />
+    )
+    expect(screen.getByText(/2 endpoints are running an older agent/i)).toBeInTheDocument()
+    expect(screen.queryByText(/current agent version is 0\.1\.3/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/each one targets its own configured version/i)).toBeInTheDocument()
+  })
+
+  it('names the pinned target when every outdated agent shares that pin', () => {
+    renderWithProviders(
+      <AgentUpgradeBanner
+        agents={[
+          agent({
+            upgrade_status: 'outdated',
+            agent_version: '0.1.1',
+            desired_agent_version: '0.1.2',
+            available_agent_version: '0.1.3',
+          }),
+        ]}
+      />
+    )
+    expect(screen.getByText(/current agent version is 0\.1\.2/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1184,6 +1184,8 @@ export interface SSHHostKeyResponse {
   observed_key: string | null
 }
 
+export type AgentUpgradeStatus = 'up_to_date' | 'outdated' | 'ahead' | 'pinned' | 'unknown'
+
 export interface AgentMachineResponse {
   id: number
   name: string
@@ -1192,6 +1194,14 @@ export interface AgentMachineResponse {
   os?: string | null
   arch?: string | null
   agent_version?: string | null
+  desired_agent_version?: string | null
+  desired_borg_version?: string | null
+  available_agent_version?: string | null
+  upgrade_status?: AgentUpgradeStatus
+  self_upgrade_supported?: boolean
+  upgrade_state?: string | null
+  upgrade_requested_at?: string | null
+  upgrade_error?: string | null
   default_path?: string | null
   borg_versions?: Array<Record<string, unknown>> | null
   capabilities?: string[] | null

--- a/tests/unit/test_agent_upgrade_columns.py
+++ b/tests/unit/test_agent_upgrade_columns.py
@@ -1,0 +1,28 @@
+from app.database.models import AgentMachine
+
+
+def test_agent_machine_has_upgrade_tracking_columns(test_db):
+    agent = AgentMachine(
+        name="node-1",
+        agent_id="agt_test_upgrade_columns",
+        token_hash="x",
+        token_prefix="agt_test",
+        status="online",
+    )
+    test_db.add(agent)
+    test_db.commit()
+    test_db.refresh(agent)
+
+    assert agent.desired_agent_version is None
+    assert agent.desired_borg_version is None
+    assert agent.upgrade_state is None
+    assert agent.upgrade_requested_at is None
+    assert agent.upgrade_target_version is None
+    assert agent.upgrade_error is None
+
+    agent.desired_agent_version = "0.1.2"
+    agent.desired_borg_version = "2"
+    test_db.commit()
+    test_db.refresh(agent)
+    assert agent.desired_agent_version == "0.1.2"
+    assert agent.desired_borg_version == "2"

--- a/tests/unit/test_agent_version_status.py
+++ b/tests/unit/test_agent_version_status.py
@@ -18,10 +18,23 @@ from app.core.agent_versions import (
         (None, None),
         ("1.-2.3", None),
         ("1..3", None),
+        # str.isdigit accepts these but int refuses them, so an agent
+        # reporting one must read as unparseable rather than raise.
+        ("1.\u00b2.3", None),
+        ("\u0661.0.0", None),
     ],
 )
 def test_parse_agent_version(value, expected):
     assert parse_agent_version(value) == expected
+
+
+def test_unparseable_version_reads_as_unknown_rather_than_raising():
+    assert (
+        compute_agent_upgrade_status(
+            reported="1.\u00b2.3", desired=None, available="0.1.3"
+        )
+        == "unknown"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_agent_version_status.py
+++ b/tests/unit/test_agent_version_status.py
@@ -1,0 +1,78 @@
+import pytest
+
+from app.core.agent_versions import (
+    UPGRADE_STATUSES,
+    compute_agent_upgrade_status,
+    parse_agent_version,
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("0.1.3", (0, 1, 3)),
+        ("1.0", (1, 0)),
+        ("2", (2,)),
+        ("0.1.3a1", None),
+        ("", None),
+        (None, None),
+        ("1.-2.3", None),
+        ("1..3", None),
+    ],
+)
+def test_parse_agent_version(value, expected):
+    assert parse_agent_version(value) == expected
+
+
+@pytest.mark.parametrize(
+    "reported,desired,available,expected",
+    [
+        # Tracking the server.
+        ("0.1.3", None, "0.1.3", "up_to_date"),
+        ("0.1.2", None, "0.1.3", "outdated"),
+        ("0.2.0", None, "0.1.3", "ahead"),
+        # Pinned.
+        ("0.1.2", "0.1.2", "0.1.3", "pinned"),
+        ("0.1.1", "0.1.2", "0.1.3", "outdated"),
+        ("0.1.3", "0.1.2", "0.1.3", "ahead"),
+        # Unknown inputs.
+        (None, None, "0.1.3", "unknown"),
+        ("0.1.3", None, None, "unknown"),
+        (None, None, None, "unknown"),
+        ("0.1.3a1", None, "0.1.3", "unknown"),
+        ("0.1.3", None, "0.1.3a1", "unknown"),
+        # Equal after padding but written differently: not the served string,
+        # so it is not current. Reinstalling is harmless.
+        ("0.1", None, "0.1.0", "outdated"),
+    ],
+)
+def test_compute_agent_upgrade_status(reported, desired, available, expected):
+    assert (
+        compute_agent_upgrade_status(
+            reported=reported, desired=desired, available=available
+        )
+        == expected
+    )
+    assert expected in UPGRADE_STATUSES
+
+
+def test_exact_string_match_wins_over_parsing():
+    """An unparseable version that exactly matches its target is current, not
+    unknown. The endpoint is demonstrably running the wheel we serve."""
+    assert (
+        compute_agent_upgrade_status(
+            reported="0.1.3a1", desired=None, available="0.1.3a1"
+        )
+        == "up_to_date"
+    )
+
+
+def test_pin_to_the_served_version_still_reads_as_pinned():
+    """A pin that happens to match what the server serves is still a pin, so
+    the operator can see the endpoint will not move when the server does."""
+    assert (
+        compute_agent_upgrade_status(
+            reported="0.1.3", desired="0.1.3", available="0.1.3"
+        )
+        == "pinned"
+    )

--- a/tests/unit/test_api_managed_machines.py
+++ b/tests/unit/test_api_managed_machines.py
@@ -974,3 +974,166 @@ def test_agent_job_logs_keep_running_logs_visible(
 
     assert response.status_code == 200
     assert response.json()[0]["message"] == "live agent log"
+
+
+def test_list_agents_reports_upgrade_status(
+    test_client, admin_headers, test_db, monkeypatch
+):
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+    _agent(
+        test_db,
+        name="behind",
+        agent_id="agt_behind",
+        agent_version="0.1.2",
+        capabilities=["filesystem.browse"],
+    )
+    _agent(
+        test_db,
+        name="current",
+        agent_id="agt_current",
+        agent_version="0.1.3",
+        capabilities=["filesystem.browse", "self_upgrade"],
+    )
+
+    response = test_client.get("/api/managed-machines/agents", headers=admin_headers)
+    assert response.status_code == 200
+    by_name = {row["name"]: row for row in response.json()}
+
+    assert by_name["behind"]["upgrade_status"] == "outdated"
+    assert by_name["behind"]["available_agent_version"] == "0.1.3"
+    assert by_name["behind"]["self_upgrade_supported"] is False
+
+    assert by_name["current"]["upgrade_status"] == "up_to_date"
+    assert by_name["current"]["self_upgrade_supported"] is True
+
+
+def test_list_agents_respects_pin(test_client, admin_headers, test_db, monkeypatch):
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+    _agent(
+        test_db,
+        name="pinned",
+        agent_id="agt_pinned",
+        agent_version="0.1.2",
+        desired_agent_version="0.1.2",
+    )
+
+    response = test_client.get("/api/managed-machines/agents", headers=admin_headers)
+    assert response.status_code == 200
+    row = next(r for r in response.json() if r["name"] == "pinned")
+    assert row["upgrade_status"] == "pinned"
+    assert row["desired_agent_version"] == "0.1.2"
+
+
+def test_list_agents_report_unknown_when_server_serves_no_wheel(
+    test_client, admin_headers, test_db, monkeypatch
+):
+    """A server built without a bundled agent wheel has nothing to compare
+    against, and must say so rather than calling every endpoint current."""
+    monkeypatch.setattr("app.api.managed_machines.agent_package_version", lambda: None)
+    _agent(test_db, name="no-target", agent_id="agt_no_target", agent_version="0.1.2")
+
+    response = test_client.get("/api/managed-machines/agents", headers=admin_headers)
+    assert response.status_code == 200
+    row = next(r for r in response.json() if r["name"] == "no-target")
+    assert row["upgrade_status"] == "unknown"
+    assert row["available_agent_version"] is None
+
+
+def test_set_desired_version_pins_agent(
+    test_client, admin_headers, test_db, monkeypatch
+):
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+    agent = _agent(test_db, name="pin-me", agent_id="agt_pin_me", agent_version="0.1.3")
+
+    response = test_client.put(
+        f"/api/managed-machines/agents/{agent.id}/desired-version",
+        json={"desired_agent_version": "0.1.3", "desired_borg_version": "2"},
+        headers=admin_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["desired_agent_version"] == "0.1.3"
+    assert body["desired_borg_version"] == "2"
+    assert body["upgrade_status"] == "pinned"
+
+
+def test_clearing_desired_version_returns_to_tracking_server(
+    test_client, admin_headers, test_db, monkeypatch
+):
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+    agent = _agent(
+        test_db,
+        name="unpin-me",
+        agent_id="agt_unpin_me",
+        agent_version="0.1.3",
+        desired_agent_version="0.1.2",
+    )
+
+    response = test_client.put(
+        f"/api/managed-machines/agents/{agent.id}/desired-version",
+        json={"desired_agent_version": None, "desired_borg_version": None},
+        headers=admin_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["desired_agent_version"] is None
+    assert response.json()["upgrade_status"] == "up_to_date"
+
+
+def test_cannot_pin_a_version_the_server_cannot_serve(
+    test_client, admin_headers, test_db, monkeypatch
+):
+    """The installer installs from this server's wheelhouse and nowhere else,
+    so a pin to any other version could never be satisfied."""
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+    agent = _agent(
+        test_db, name="bad-pin", agent_id="agt_bad_pin", agent_version="0.1.3"
+    )
+
+    response = test_client.put(
+        f"/api/managed-machines/agents/{agent.id}/desired-version",
+        json={"desired_agent_version": "9.9.9", "desired_borg_version": None},
+        headers=admin_headers,
+    )
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"]["key"]
+        == "backend.errors.agents.desiredVersionUnavailable"
+    )
+
+
+def test_desired_borg_version_must_be_1_or_2(
+    test_client, admin_headers, test_db, monkeypatch
+):
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+    agent = _agent(
+        test_db, name="bad-borg", agent_id="agt_bad_borg", agent_version="0.1.3"
+    )
+
+    response = test_client.put(
+        f"/api/managed-machines/agents/{agent.id}/desired-version",
+        json={"desired_agent_version": None, "desired_borg_version": "3"},
+        headers=admin_headers,
+    )
+    assert response.status_code == 422
+
+
+def test_set_desired_version_requires_a_known_agent(test_client, admin_headers):
+    response = test_client.put(
+        "/api/managed-machines/agents/999999/desired-version",
+        json={"desired_agent_version": None, "desired_borg_version": None},
+        headers=admin_headers,
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"]["key"] == "backend.errors.agents.agentNotFound"


### PR DESCRIPTION
Implements phase 1 of issue #940, plus the design spec for the whole feature.

## What ships here

The server already knew everything needed to answer "which endpoints are behind?" and did nothing with it. Agents report `agent_version` on every heartbeat, and the server knows the agent wheel it serves. This compares them.

- **Version model.** Three states, not two: `reported`, `desired` (a per-endpoint pin, null to track the server), and `available`. Two states would break as soon as endpoints get their own intended version, so the model that carries the rest of the feature lands first.
- **`app/core/agent_versions.py`.** Exact string equality decides "current"; ordering only separates behind from ahead-of-server. Anything unparseable reports unknown rather than being guessed at.
- **API.** `upgrade_status`, `available_agent_version`, `desired_borg_version` and `self_upgrade_supported` on the agents list, resolved once per request. New `PUT /agents/{id}/desired-version` to pin, which rejects a pin this server cannot serve rather than storing something permanently unsatisfiable.
- **UI.** A status chip on each agent card, hidden when the agent is current so only endpoints needing attention draw the eye, and a banner counting endpoints that are behind. Stories for all five chip states, the banner states that render something, and a mixed-fleet page story. The empty-fleet banner renders null, which the snapshot harness cannot capture, so that case is covered by a unit test instead.

## What deliberately does not ship

**No upgrade button.** Upgrading is still a manual reinstall per machine. The remote upgrade path is phase 3, and a button that cannot do anything yet is worse than no button.

**No pin UI.** The endpoint ships; the control is phase 3. Until upgrades are automatic an operator already picks the version by choosing what to paste, so a pin selector today would be a setting with no effect.

## The design decision worth reviewing

The recommended install runs the agent as an unprivileged user with `NoNewPrivileges=true`, so it cannot reinstall itself. Remote upgrade therefore needs a deliberate escalation: a root-owned one-shot unit plus a sudoers rule granting exactly one command. Spec section 11.1 states plainly what that grants, rather than minimising it: a compromised server can already run code as the service user and read every file via `CAP_DAC_READ_SEARCH`, and this adds root. It is accepted because restricting upgrades to root-mode installs would exclude the installer's own default service user mode. `--no-remote-upgrade` lets an operator decline per endpoint.

## Verification

- Backend: 3270 passed. Two failures (`test_db_session_timezone` postgres cases) and 39 teardown errors in mounts/source-discovery reproduce on `main` without these changes; those files pass 36/36 in isolation here.
- Frontend: lint clean, 2576 tests across 223 files.

Closes #940 partially. Phases 2 to 5 are tracked in the spec's progress table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 0 changed, 24 added, 0 removed, 690 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-951/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/34111127709
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- `components-archives-archiveinfotab--no-unique-data--mobile.png`
- `components-archives-archiveinfotab--no-unique-data.png`
- `components-archives-archiveinfotab--unique-share-below-one-percent--mobile.png`
- `components-archives-archiveinfotab--unique-share-below-one-percent.png`
- `managed-agents-agentupgradebanner--mixed-targets--mobile.png`
- `managed-agents-agentupgradebanner--mixed-targets.png`
- `managed-agents-agentupgradebanner--one-outdated--mobile.png`
- `managed-agents-agentupgradebanner--one-outdated.png`
- `managed-agents-agentupgradebanner--several-outdated--mobile.png`
- `managed-agents-agentupgradebanner--several-outdated.png`
- `managed-agents-agentupgradechip--ahead--mobile.png`
- `managed-agents-agentupgradechip--ahead.png`
- `managed-agents-agentupgradechip--all-states--mobile.png`
- `managed-agents-agentupgradechip--all-states.png`
- `managed-agents-agentupgradechip--outdated--mobile.png`
- `managed-agents-agentupgradechip--outdated.png`
- `managed-agents-agentupgradechip--pinned--mobile.png`
- `managed-agents-agentupgradechip--pinned.png`
- `managed-agents-agentupgradechip--unknown--mobile.png`
- `managed-agents-agentupgradechip--unknown.png`
- `managed-agents-agentupgradechip--up-to-date--mobile.png`
- `managed-agents-agentupgradechip--up-to-date.png`
- `pages-managedagents--agent-fleet-version-states--mobile.png`
- `pages-managedagents--agent-fleet-version-states.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->