### PR TITLE
test(ssh): check the -i identity flag as an argv token, not a substring

### DIFF
--- a/tests/unit/test_ssh_key_in_maintenance_services.py
+++ b/tests/unit/test_ssh_key_in_maintenance_services.py
@@ -9,6 +9,7 @@ IP bans on providers that block repeated failed login attempts.
 
 import base64
 import pytest
+import shlex
 import tempfile
 from unittest.mock import AsyncMock, MagicMock, patch
 from cryptography.fernet import Fernet
@@ -86,10 +87,17 @@ def _mock_process(returncode=0):
 # ---------------------------------------------------------------------------
 
 
+def _rsh_tokens(captured_env: dict) -> list[str]:
+    """BORG_RSH as argv. The string embeds paths (the test data dir among
+    them), so a substring check for "-i" can match inside a random temp
+    name; only a whole token is the identity flag."""
+    return shlex.split(captured_env.get("BORG_RSH", ""))
+
+
 def assert_borg_rsh_has_identity(captured_env: dict):
     """Assert that BORG_RSH contains an -i flag pointing to a key file."""
     borg_rsh = captured_env.get("BORG_RSH", "")
-    assert "-i" in borg_rsh, (
+    assert "-i" in _rsh_tokens(captured_env), (
         f"BORG_RSH does not contain -i (identity) flag: {borg_rsh!r}\n"
         "SSH key was not passed to borg — this is the regression from issue #354."
     )
@@ -217,8 +225,7 @@ class TestPruneServiceSSHKey:
                         keep_yearly=1,
                     )
 
-        borg_rsh = captured_env.get("BORG_RSH", "")
-        assert "-i" not in borg_rsh
+        assert "-i" not in _rsh_tokens(captured_env)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

`TestPruneServiceSSHKey::test_no_ssh_key_borg_rsh_has_no_identity_flag` asserts `"-i" not in borg_rsh` on the `BORG_RSH` **string**. That string carries the test data directory in `-o UserKnownHostsFile=<data dir>/ssh_keys/known_hosts.d/shared`, and the data directory gets a random name from `tempfile.mkdtemp(prefix="borg-test-data-")`. Whenever that name contains `-i` (`borg-test-data-iitfqn6_` on a recent CI shard of #948), the substring check matches inside the path and the test fails although no identity flag was passed.

The shared positive assertion `assert_borg_rsh_has_identity` has the mirror problem: a path containing `-i` satisfies `"-i" in borg_rsh` without any key.

Both checks now split `BORG_RSH` with `shlex` and look for the whole `-i` token. Test-only change.

## Related Issue

Flaky CI shard, first noted on #948 (comment there).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

Deterministic reproduction: point `TMPDIR` at a directory whose name ends in `-i`, so the data dir path contains it.

On `main` (`37cee432`):

```
TMPDIR=<dir ending in -i> pytest tests/unit/test_ssh_key_in_maintenance_services.py
FAILED tests/unit/test_ssh_key_in_maintenance_services.py::TestPruneServiceSSHKey::test_no_ssh_key_borg_rsh_has_no_identity_flag
1 failed, 6 passed, 28 warnings in 0.21s
```

With this branch, same `TMPDIR`, and with a plain one:

```
7 passed, 28 warnings in 0.18s
7 passed, 28 warnings in 0.21s
```

`ruff check` / `ruff format --check` clean on the file. `test_api_repositories_helpers.py` has a similar-looking `"-i" not in opts`, but `opts` is the list from `get_standard_ssh_opts()`, so that one is already a token check and is left alone.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
