### PR TITLE
fix(archives): say "< 1%" instead of "0%" for a non-zero unique share

### DIFF
--- a/frontend/src/components/archives/ArchiveInfoTab.stories.tsx
+++ b/frontend/src/components/archives/ArchiveInfoTab.stories.tsx
@@ -58,3 +58,21 @@ export const SizesUnknown: Story = {
     },
   },
 }
+
+// 566.6 MiB unique of 820 GiB: 0.07 %, which used to render as "0%".
+export const UniqueShareBelowOnePercent: Story = {
+  args: {
+    archive: {
+      ...Default.args.archive,
+      original_size: 820 * 1024 ** 3,
+      compressed_size: 731 * 1024 ** 3,
+      deduplicated_size: 566.6 * 1024 ** 2,
+    },
+  },
+}
+
+export const NoUniqueData: Story = {
+  args: {
+    archive: { ...Default.args.archive, deduplicated_size: 0 },
+  },
+}

--- a/frontend/src/components/archives/ArchiveInfoTab.tsx
+++ b/frontend/src/components/archives/ArchiveInfoTab.tsx
@@ -130,10 +130,11 @@ export default function ArchiveInfoTab({ archive }: ArchiveInfoTabProps) {
 
   const original = archive.original_size
   const stored = archive.deduplicated_size
-  const percent =
-    original != null && stored != null && original > 0
-      ? Math.min(100, Math.round((stored / original) * 100))
-      : null
+  const share = original != null && stored != null && original > 0 ? stored / original : null
+  const percent = share != null ? Math.min(100, Math.round(share * 100)) : null
+  // Rounding a small non-zero share to "0%" or "1%" would contradict the
+  // size next to it; the meter keeps the rounded value.
+  const percentLabel = share != null && share > 0 && share < 0.01 ? '< 1' : percent
 
   return (
     <Stack spacing={3}>
@@ -202,7 +203,10 @@ export default function ArchiveInfoTab({ archive }: ArchiveInfoTabProps) {
               />
             </Box>
             <Typography variant="body2" sx={{ mt: 1 }}>
-              {t('archives.detail.storedShare', { stored: formatBytes(stored), percent })}{' '}
+              {t('archives.detail.storedShare', {
+                stored: formatBytes(stored),
+                percent: percentLabel,
+              })}{' '}
               <Typography component="span" variant="body2" sx={{ color: 'text.secondary' }}>
                 {t('archives.detail.storedSaved', { size: formatBytes(stored) })}
               </Typography>

--- a/frontend/src/components/archives/__tests__/ArchiveInfoTab.test.tsx
+++ b/frontend/src/components/archives/__tests__/ArchiveInfoTab.test.tsx
@@ -47,6 +47,33 @@ describe('ArchiveInfoTab', () => {
     expect(screen.getByRole('meter')).toHaveAttribute('aria-valuenow', '25')
   })
 
+  it('says "< 1%" instead of "0%" when the unique share rounds to zero', () => {
+    render(
+      <ArchiveInfoTab
+        archive={archive({ original_size: 820 * 1024 ** 3, deduplicated_size: 566.6 * 1024 ** 2 })}
+      />
+    )
+    expect(
+      screen.getByText(/566\.60 MB of this archive is unique to it, < 1%/i)
+    ).toBeInTheDocument()
+    expect(screen.getByRole('meter')).toHaveAttribute('aria-valuenow', '0')
+  })
+
+  it('says "< 1%" for a share that would round up to 1%', () => {
+    render(
+      <ArchiveInfoTab
+        archive={archive({ original_size: 1000 * 1024, deduplicated_size: 6 * 1024 })}
+      />
+    )
+    expect(screen.getByText(/6\.00 KB of this archive is unique to it, < 1%/i)).toBeInTheDocument()
+    expect(screen.getByRole('meter')).toHaveAttribute('aria-valuenow', '1')
+  })
+
+  it('keeps "0%" for an archive with no unique data', () => {
+    render(<ArchiveInfoTab archive={archive({ deduplicated_size: 0 })} />)
+    expect(screen.getByText(/0 B of this archive is unique to it, 0%/i)).toBeInTheDocument()
+  })
+
   it('leaves the storage bar out when the sizes are unknown', () => {
     render(<ArchiveInfoTab archive={archive({ original_size: null, deduplicated_size: null })} />)
     expect(screen.queryByRole('meter')).not.toBeInTheDocument()


### PR DESCRIPTION
## Description

The Info tab of an archive rounds the unique share to whole percent, so any archive whose unique data is below 0.5 % of its original size read "566.60 MB of this archive is unique to it, 0% of its original size": a non-zero amount that is "0 %" of the whole. For a daily backup of a large, mostly unchanged tree that is the normal case.

Below 1 % the sentence now says `< 1%`. `0%` stays reserved for an archive with no unique data. The bar width (already clamped to 1 %) and `aria-valuenow` keep the rounded integer. All four locales interpolate `{{percent}}%` in `archives.detail.storedShare`, so the label is passed as the interpolated value and no strings change.

## Related Issue

Fixes #954


## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring


## Testing

Two tests added to `ArchiveInfoTab.test.tsx`: a share that rounds to zero renders `< 1%` with `aria-valuenow="0"`, and `deduplicated_size: 0` still renders `0%`.

```
$ npx vitest run src/components/archives/__tests__/ArchiveInfoTab.test.tsx
 Test Files  1 passed (1)
      Tests  7 passed (7)

$ npm run format:check   # All matched files use Prettier code style!
$ npm run typecheck      # exit 0
$ npm run lint           # exit 0
$ npm run check:locales  # Locale parity check PASSED. All 4 locale files share the same 5000 keys.
```

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass


## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none affected)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


## Screenshots (if applicable)

Before: `566.60 MB of this archive is unique to it, 0% of its original size.`
After: `566.60 MB of this archive is unique to it, < 1% of its original size.`


## Additional Context

One-line change in `ArchiveInfoTab.tsx`; the percent for the bar and the meter is untouched.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU Affero General Public License v3.0 (AGPL-3.0), the same license as this project.
