### PR TITLE
fix(retention): keep the backup job of a pruned archive, mark it instead of deleting it

### DIFF
--- a/app/api/activity.py
+++ b/app/api/activity.py
@@ -89,6 +89,7 @@ class ActivityItem(BaseModel):
 
     # Type-specific metadata
     archive_name: Optional[str] = None  # For backup/restore
+    archive_pruned_at: Optional[datetime] = None  # backup: its archive is gone
     package_name: Optional[str] = None  # For package installs
     has_logs: bool = False  # Whether logs are available for download
     repository_path: Optional[str] = (
@@ -629,7 +630,8 @@ async def list_recent_activity(
                     "backup_plan_id": job.backup_plan_id,
                     "backup_plan_run_id": job.backup_plan_run_id,
                     "backup_plan_name": backup_plan_name,
-                    "archive_name": getattr(job, "archive_name", None),
+                    "archive_name": job.archive_name,
+                    "archive_pruned_at": job.archive_pruned_at,
                     "package_name": None,
                     "has_logs": job_has_logs_by_policy(
                         job,

--- a/app/api/agents.py
+++ b/app/api/agents.py
@@ -561,23 +561,29 @@ def _finish_linked_repository_operation_job(
             repository.last_compact = completed_at
         repository.updated_at = _now_utc()
 
-    # Archives that no longer exist take their job records with them - same
-    # cascade the server-side prune/delete paths run.
+    # Archives that no longer exist are recorded on their backup jobs - the
+    # same mark the server-side prune/delete paths set. The rows stay.
     if status_value in ("completed", "completed_with_warnings"):
         from app.services.job_history_retention import (
             archive_names_from_prune_output,
-            purge_jobs_for_pruned_archives,
+            mark_jobs_of_pruned_archives,
         )
 
         if kind == "prune":
-            purge_jobs_for_pruned_archives(
+            mark_jobs_of_pruned_archives(
                 db,
                 operation_job.repository_id,
                 archive_names_from_prune_output(operation_job.logs or ""),
+                created_before=agent_job.claimed_at,
+                pruned_at=completed_at,
             )
         elif kind == "delete_archive" and getattr(operation_job, "archive_name", None):
-            purge_jobs_for_pruned_archives(
-                db, operation_job.repository_id, {operation_job.archive_name}
+            mark_jobs_of_pruned_archives(
+                db,
+                operation_job.repository_id,
+                {operation_job.archive_name},
+                created_before=agent_job.claimed_at,
+                pruned_at=completed_at,
             )
 
 

--- a/app/api/backup.py
+++ b/app/api/backup.py
@@ -683,6 +683,7 @@ async def get_all_backup_jobs(
                         else "manual"
                     ),
                     "archive_name": getattr(job, "archive_name", None),
+                    "archive_pruned_at": serialize_datetime(job.archive_pruned_at),
                     "execution_mode": job.execution_mode or "local",
                     "route_strategy": job.route_strategy,
                     **_retry_metadata(job),

--- a/app/api/backup_plans.py
+++ b/app/api/backup_plans.py
@@ -695,6 +695,7 @@ def _serialize_backup_job(
         ),
         "maintenance_status": job.maintenance_status,
         "archive_name": job.archive_name,
+        "archive_pruned_at": serialize_datetime(job.archive_pruned_at),
         "execution_mode": job.execution_mode or "local",
         "route_strategy": job.route_strategy,
         "retry_attempt": job.retry_attempt or 1,

--- a/app/api/dashboard.py
+++ b/app/api/dashboard.py
@@ -1098,6 +1098,7 @@ async def get_dashboard_overview(
                     "timestamp": serialize_datetime(job.started_at),
                     "message": f"Backup {job.status}",
                     "error": job.error_message if job.status == "failed" else None,
+                    "archive_pruned_at": serialize_datetime(job.archive_pruned_at),
                 }
             )
 
@@ -1132,6 +1133,7 @@ async def get_dashboard_overview(
                     "timestamp": serialize_datetime(job.started_at),
                     "message": f"Check {job.status}",
                     "error": job.error_message if job.status == "failed" else None,
+                    "archive_pruned_at": None,
                 }
             )
 
@@ -1166,6 +1168,7 @@ async def get_dashboard_overview(
                     "timestamp": serialize_datetime(job.started_at),
                     "message": f"Compact {job.status}",
                     "error": job.error_message if job.status == "failed" else None,
+                    "archive_pruned_at": None,
                 }
             )
 
@@ -1200,6 +1203,7 @@ async def get_dashboard_overview(
                     "timestamp": serialize_datetime(job.started_at),
                     "message": f"Prune {job.status}",
                     "error": job.error_message if job.status == "failed" else None,
+                    "archive_pruned_at": None,
                 }
             )
 
@@ -1229,6 +1233,7 @@ async def get_dashboard_overview(
                     "timestamp": serialize_datetime(job.started_at),
                     "message": f"Restore check {job.status}",
                     "error": job.error_message if job.status == "failed" else None,
+                    "archive_pruned_at": None,
                 }
             )
 

--- a/app/database/alembic/versions/a5b7c9d1e3f2_add_backup_job_archive_pruned_at.py
+++ b/app/database/alembic/versions/a5b7c9d1e3f2_add_backup_job_archive_pruned_at.py
@@ -1,0 +1,39 @@
+"""add backup_jobs.archive_pruned_at
+
+A backup job whose archive was pruned used to be deleted with the archive
+(job_history_retention.purge_jobs_for_pruned_archives). The row is the only
+record that the backup ran, and everything that shows run history (the
+dashboard activity timeline, the plan history) went blank for pruned runs.
+The row now stays and records when its archive went; it falls with
+cleanup_retention_days like every other job row.
+
+Nullable, no backfill: rows deleted before this revision are gone, and a
+NULL means "archive not known to be pruned".
+
+Revision ID: a5b7c9d1e3f2
+Revises: c3d5e7f9a1b2
+Create Date: 2026-09-07 12:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a5b7c9d1e3f2"
+down_revision: Union[str, Sequence[str], None] = "c3d5e7f9a1b2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "backup_jobs", sa.Column("archive_pruned_at", sa.DateTime(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("backup_jobs", "archive_pruned_at")

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -723,6 +723,10 @@ class BackupJob(Base):
     archive_name = Column(
         String, nullable=True
     )  # Name of the archive created (e.g., "manual-backup-2024-04-13T10:30:00")
+    # Set when the archive this run created was pruned or deleted. The row
+    # stays: it is the record that the backup ran, and it falls with
+    # cleanup_retention_days like every other job row.
+    archive_pruned_at = Column(DateTime, nullable=True)
 
     # Maintenance status tracking
     maintenance_status = Column(

--- a/app/services/delete_archive_service.py
+++ b/app/services/delete_archive_service.py
@@ -249,14 +249,23 @@ class DeleteArchiveService:
                     "Delete job failed", job_id=job_id, return_code=process.returncode
                 )
 
-            # A deleted archive takes its job records with it - same cascade
-            # the prune paths run.
+            # A deleted archive is recorded on its backup job - the same mark
+            # the prune paths set. The row stays as the run's record.
+            # one completion time for the job row and for the mark on the
+            # backup job of the deleted archive
+            completed_at = datetime.utcnow()
             if job.status in ("completed", "completed_with_warnings"):
                 from app.services.job_history_retention import (
-                    purge_jobs_for_pruned_archives,
+                    mark_jobs_of_pruned_archives,
                 )
 
-                purge_jobs_for_pruned_archives(db, repository_id, {archive_name})
+                mark_jobs_of_pruned_archives(
+                    db,
+                    repository_id,
+                    {archive_name},
+                    created_before=job.started_at,
+                    pruned_at=completed_at,
+                )
 
             # Save logs
             if log_buffer:
@@ -266,7 +275,6 @@ class DeleteArchiveService:
                 job.log_file_path = str(log_file_path)
                 job.has_logs = True
 
-            completed_at = datetime.utcnow()
             final_status = job.status
             final_progress = job.progress
             final_progress_message = job.progress_message

--- a/app/services/job_history_retention.py
+++ b/app/services/job_history_retention.py
@@ -25,6 +25,12 @@ user-visible:
                           unbounded job table is never what anyone wants, so
                           only the window moves.
 
+A pruned or deleted archive does not take its backup job with it: the row
+is the record that the backup ran (the dashboard timeline and the plan
+history are built from it), so it is marked with archive_pruned_at and
+falls with cleanup_retention_days like everything else. The log content
+follows the two windows above as before.
+
 Deletes are chunked so SQLite never holds a giant transaction;
 DB-level FK actions (agent_job_logs CASCADE, script_executions CASCADE,
 various SET NULL) handle the children — SQLite connections run with
@@ -37,14 +43,14 @@ the file; the manual cleanup endpoint runs VACUUM for that.
 from __future__ import annotations
 
 import re
-from datetime import timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from app.config import settings as app_config
 from typing import Dict, Iterable, Optional
 
 import structlog
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
 from app.services.log_policy import DEFAULT_LOG_SAVE_POLICY, LOG_SAVE_POLICIES
@@ -345,82 +351,90 @@ def archive_names_from_prune_output(output: str) -> set:
     return {match.group("name") for match in _PRUNED_ARCHIVE_LINE.finditer(output)}
 
 
-def purge_jobs_for_pruned_archives(
-    db: Session, repository_id: Optional[int], archive_names: Iterable[str]
+def mark_jobs_of_pruned_archives(
+    db: Session,
+    repository_id: Optional[int],
+    archive_names: Iterable[str],
+    *,
+    created_before: Optional[datetime] = None,
+    pruned_at: Optional[datetime] = None,
 ) -> int:
-    """Delete the job records of archives that no longer exist.
+    """Record on the backup jobs of `archive_names` that their archive is gone.
 
-    A backup job whose archive was pruned is not history anymore but a
-    reference into the void, so the whole record goes: its log file on disk,
-    the linked agent job (whose log rows die via the DB cascade, as do the
-    job's script executions), and the backup_jobs row itself.
+    The job row stays: it is the record that the backup ran, which the
+    dashboard timeline, the plan history and the activity feed are built
+    from. Only `archive_pruned_at` is set (once; a second call for the same
+    archive is a no-op), and the row still falls with cleanup_retention_days.
+    Log content is untouched here; log_retention_days and the save policy
+    handle it like for any other job.
+
+    Jobs belong to the repository by id or, for rows written before the id
+    column existed, by path. `created_before` is when the prune or delete
+    started, on the server clock, compared with the job's server-set
+    `created_at`: Borg 1 lets a name be reused once its archive is gone, so
+    a job created once the prune was under way made a different archive and
+    is left alone. (`completed_at` would not do for the comparison: an agent
+    reports it from its own clock.) `pruned_at` is the time recorded on the
+    row, normally when the prune or delete finished; it defaults to now.
 
     Borg 2 repositories are skipped: an archive *series* shares one name
     across all its archives, so a name match would hit jobs whose archives
     still exist. Lifting that needs the archive id captured per job first.
     """
-    names = {name for name in archive_names if name}
+    names = sorted({name for name in archive_names if name})
     if not names or repository_id is None:
         return 0
     repository = db.get(Repository, repository_id)
     if repository is None or int(getattr(repository, "borg_version", 1) or 1) == 2:
         return 0
 
-    jobs = (
-        db.query(BackupJob)
-        .filter(
-            BackupJob.repository_id == repository_id,
-            BackupJob.archive_name.in_(names),
+    owner = BackupJob.repository_id == repository_id
+    if repository.path:
+        # older rows carry the path only, some with a trailing slash
+        owner = or_(
+            owner,
+            func.rtrim(BackupJob.repository, "/") == repository.path.rstrip("/"),
         )
-        .all()
-    )
-    if not jobs:
-        return 0
+    filters = [owner, BackupJob.archive_pruned_at.is_(None)]
+    if created_before is not None:
+        created = func.coalesce(
+            BackupJob.created_at, BackupJob.started_at, BackupJob.completed_at
+        )
+        filters.append(created <= created_before)
+    pruned_at = pruned_at or utc_now()
 
-    # Captured before the delete: afterwards the ORM objects are gone. The
-    # files are only unlinked once the DB delete has committed, so a failed
-    # commit never leaves surviving rows pointing at vanished log files.
-    log_files = [job.log_file_path for job in jobs if job.log_file_path]
-    ids = [job.id for job in jobs]
-    db.query(AgentJob).filter(AgentJob.backup_job_id.in_(ids)).delete(
-        synchronize_session=False
-    )
-    removed = (
-        db.query(BackupJob)
-        .filter(BackupJob.id.in_(ids))
-        .delete(synchronize_session=False)
-    )
-    db.commit()
-    for path in log_files:
-        try:
-            Path(path).unlink(missing_ok=True)
-        except OSError:
-            pass
-    # The bulk delete bypasses the identity map: detach only the rows we
-    # removed. Callers run this mid-flow in long-lived sessions and still
-    # update their own objects afterwards - those must stay attached.
-    for job in jobs:
-        db.expunge(job)
-    logger.info(
-        "Removed job records for pruned archives",
-        repository_id=repository_id,
-        archives=sorted(names),
-        backup_jobs_removed=removed,
-    )
-    return removed
+    marked = 0
+    # one transaction per chunk, like the module's deletes
+    for start in range(0, len(names), CHUNK_SIZE):
+        marked += (
+            db.query(BackupJob)
+            .filter(
+                *filters, BackupJob.archive_name.in_(names[start : start + CHUNK_SIZE])
+            )
+            .update({BackupJob.archive_pruned_at: pruned_at}, synchronize_session=False)
+        )
+        db.commit()
+    if marked:
+        logger.info(
+            "Marked job records of pruned archives",
+            repository_id=repository_id,
+            archives=names,
+            backup_jobs_marked=marked,
+        )
+    return marked
 
 
 def sweep_pruned_archive_records(
     db: Session, lookback: timedelta = timedelta(days=2)
 ) -> int:
-    """Re-parse recent agent prune logs and cascade any pruned archives.
+    """Re-parse recent agent prune logs and mark any pruned archives' jobs.
 
     The completion hook in the agents API often runs before the agent's log
     lines have all been ingested (log streaming races the command result), so
     it can miss the 'Pruning archive:' lines entirely. By the time the daily
-    retention pass runs they are all there: parse again, cascade
-    idempotently, and while at it repair the linked prune job's stored log -
-    the same race leaves it truncated to whatever had arrived at completion.
+    retention pass runs they are all there: parse again, mark idempotently,
+    and while at it repair the linked prune job's stored log - the same race
+    leaves it truncated to whatever had arrived at completion.
     """
     since = utc_now() - lookback
     candidates = (
@@ -432,7 +446,7 @@ def sweep_pruned_archive_records(
         )
         .all()
     )
-    removed = 0
+    marked = 0
     for agent_job in candidates:
         payload = agent_job.payload if isinstance(agent_job.payload, dict) else {}
         if str(payload.get("job_kind") or "") != "repository.prune":
@@ -462,12 +476,16 @@ def sweep_pruned_archive_records(
             prune_job.has_logs = True
             db.commit()
 
-        removed += purge_jobs_for_pruned_archives(
+        marked += mark_jobs_of_pruned_archives(
             db,
             prune_job.repository_id,
             archive_names_from_prune_output(full_log),
+            # claimed_at is the server's clock; the prune cannot have started
+            # before the agent claimed the job
+            created_before=agent_job.claimed_at or prune_job.started_at,
+            pruned_at=prune_job.completed_at or agent_job.completed_at,
         )
-    return removed
+    return marked
 
 
 def _policy_discarded_statuses(policy: str) -> tuple:
@@ -504,7 +522,11 @@ def run_retention(db: Session, settings: Optional[SystemSettings] = None) -> Dic
 
     now = utc_now()
     log_cutoff = now - timedelta(days=log_days)
-    results = {
+    # First: the sweep reads recent agent prune logs, and the save policy
+    # below drops the logs of completed jobs regardless of age (the default
+    # policy keeps failures and warnings only). Read before deleting.
+    results = {"pruned_archive_records_marked": sweep_pruned_archive_records(db)}
+    results |= {
         "agent_log_rows_deleted": purge_agent_job_logs(
             db, _older_than(AgentJob, log_cutoff)
         ),
@@ -536,7 +558,6 @@ def run_retention(db: Session, settings: Optional[SystemSettings] = None) -> Dic
         "orphaned_log_files_deleted": sweep_orphaned_log_files(
             db, now - timedelta(days=row_days)
         ),
-        "pruned_archive_records_removed": sweep_pruned_archive_records(db),
     }
     if any(results.values()):
         logger.info(

--- a/app/services/prune_service.py
+++ b/app/services/prune_service.py
@@ -1,9 +1,14 @@
 import asyncio
+import json
 from datetime import datetime
 from pathlib import Path
 import structlog
 from sqlalchemy.orm import Session
 from app.database.models import Repository
+from app.services.job_history_retention import (
+    archive_names_from_prune_output,
+    mark_jobs_of_pruned_archives,
+)
 from app.database.database import SessionLocal
 from app.config import settings
 from app.core.borg import borg
@@ -17,6 +22,21 @@ from app.utils.borg_env import (
 from app.services.operations.job_facade import refresh_job, resolve_maintenance_job
 
 logger = structlog.get_logger()
+
+
+def _log_message(line: str) -> str:
+    """The text of a Borg `--log-json` record, or the line itself.
+
+    Archive names are matched against the record's `message`: in the raw
+    line a name containing `"` or `\\` is JSON-escaped and would not match."""
+    if line.startswith("{"):
+        try:
+            message = json.loads(line).get("message")
+        except (ValueError, AttributeError):
+            return line
+        if isinstance(message, str):
+            return message
+    return line
 
 
 class PruneService:
@@ -195,6 +215,10 @@ class PruneService:
             # In-memory log buffer
             log_buffer = []
             MAX_BUFFER_SIZE = 1000
+            # Collected while streaming: the buffer above is capped, and a
+            # large prune's early "Pruning archive:" lines would fall out of
+            # it before they are parsed.
+            pruned_archive_names: set[str] = set()
 
             async def check_cancellation():
                 """Periodic heartbeat to check for cancellation"""
@@ -233,6 +257,11 @@ class PruneService:
                                 ).strip()
                                 if line_str:
                                     log_buffer.append(f"[{name}] {line_str}")
+                                    pruned_archive_names.update(
+                                        archive_names_from_prune_output(
+                                            _log_message(line_str)
+                                        )
+                                    )
                                     if len(log_buffer) > MAX_BUFFER_SIZE:
                                         log_buffer.pop(0)
                         except asyncio.CancelledError:
@@ -295,18 +324,15 @@ class PruneService:
                     "Prune failed", job_id=job_id, exit_code=process.returncode
                 )
 
-            # Archives that no longer exist take their job records with them:
-            # parse the pruned names from the --list output and cascade.
+            # Archives that no longer exist are recorded on their backup jobs:
+            # the names were collected from the --list output while it streamed.
             if not dry_run and job.status in ("completed", "completed_with_warnings"):
-                from app.services.job_history_retention import (
-                    archive_names_from_prune_output,
-                    purge_jobs_for_pruned_archives,
-                )
-
-                purge_jobs_for_pruned_archives(
+                mark_jobs_of_pruned_archives(
                     db,
                     repository_id,
-                    archive_names_from_prune_output("\n".join(log_buffer)),
+                    pruned_archive_names,
+                    created_before=job.started_at,
+                    pruned_at=job.completed_at,
                 )
 
             # Save logs for all completed/failed/cancelled/warning jobs

--- a/docs/architecture/job-system.md
+++ b/docs/architecture/job-system.md
@@ -216,6 +216,10 @@ Rules:
 - Operations write their logs to files under `data/logs/`. Retention deletes
   those files at `log_retention_days` and again with the row itself at
   `cleanup_retention_days`.
+- A backup job outlives its archive. When a prune or an archive deletion
+  removes the archive a job created, the job row is marked
+  (`archive_pruned_at`) and kept as the record that the backup ran; it falls
+  with `cleanup_retention_days` like every other job row.
 - A failed listing is never written as derived state: if borg or the agent
   fails, `archive_sync` fails rather than recording the repository as empty.
 - Cancelling a running operation is cooperative: the executor observes the

--- a/frontend/src/components/BackupJobsTable.stories.tsx
+++ b/frontend/src/components/BackupJobsTable.stories.tsx
@@ -162,6 +162,51 @@ export const TransportModes: Story = {
   ),
 }
 
+const prunedArchiveJobs: Job[] = [
+  {
+    id: 301,
+    repository: '/backups/server',
+    repository_path: '/backups/server',
+    type: 'backup',
+    status: 'completed',
+    started_at: '2026-05-20T02:00:00Z',
+    completed_at: '2026-05-20T02:06:00Z',
+    triggered_by: 'schedule',
+    scheduled_job_id: 8,
+    execution_mode: 'local',
+    archive_name: 'server-2026-05-20T02:00',
+    // the nightly prune removed this archive two days later
+    archive_pruned_at: '2026-05-22T03:00:00Z',
+  },
+  {
+    id: 302,
+    repository: '/backups/server',
+    repository_path: '/backups/server',
+    type: 'backup',
+    status: 'completed',
+    started_at: '2026-05-22T02:00:00Z',
+    completed_at: '2026-05-22T02:05:00Z',
+    triggered_by: 'schedule',
+    scheduled_job_id: 8,
+    execution_mode: 'local',
+    archive_name: 'server-2026-05-22T02:00',
+  },
+]
+
+/** A run whose archive was pruned keeps its row; "View Archive" stays but is disabled. */
+export const PrunedArchive: Story = {
+  args: {
+    jobs: prunedArchiveJobs,
+    showTriggerColumn: true,
+    actions: { viewArchive: true },
+  },
+  render: (args) => (
+    <Box sx={{ p: 3 }}>
+      <BackupJobsTable {...args} />
+    </Box>
+  ),
+}
+
 export const RetryableFailedBackupJob: Story = {
   args: {
     jobs: retryableFailedBackupJobs,

--- a/frontend/src/components/BackupJobsTable.tsx
+++ b/frontend/src/components/BackupJobsTable.tsx
@@ -733,7 +733,12 @@ export const BackupJobsTable = <T extends Job = Job>({
         })
       },
       color: 'success',
-      tooltip: t('backupJobsTable.actions.viewArchive'),
+      // the row outlives its archive: the button stays, greyed out, and says why
+      disabled: (job) => !!job.archive_pruned_at,
+      tooltip: (job) =>
+        job.archive_pruned_at
+          ? t('backupJobsTable.actions.viewArchivePruned')
+          : t('backupJobsTable.actions.viewArchive'),
       show: (job) =>
         !!job.archive_name &&
         (job.type === 'backup' || !job.type) &&

--- a/frontend/src/components/__tests__/BackupJobsTable.test.tsx
+++ b/frontend/src/components/__tests__/BackupJobsTable.test.tsx
@@ -713,6 +713,36 @@ describe('BackupJobsTable', () => {
     })
   })
 
+  describe('View Archive action', () => {
+    const completedJob = {
+      id: 41,
+      type: 'backup',
+      repository: '/backup/repo1',
+      status: 'completed',
+      archive_name: 'host-2026-09-01',
+      started_at: '2026-09-01T02:00:00Z',
+      completed_at: '2026-09-01T02:10:00Z',
+    }
+
+    it('is offered while the archive exists', () => {
+      renderWithProviders(<BackupJobsTable jobs={[completedJob]} repositories={mockRepositories} />)
+      expect(screen.getByRole('button', { name: /View Archive/i })).toBeInTheDocument()
+    })
+
+    it('stays visible but disabled once the archive was pruned, and says so', () => {
+      renderWithProviders(
+        <BackupJobsTable
+          jobs={[{ ...completedJob, archive_pruned_at: '2026-09-02T03:00:00Z' }]}
+          repositories={mockRepositories}
+        />
+      )
+      expect(screen.getAllByText('/backup/repo1').length).toBeGreaterThan(0)
+      const button = screen.getByRole('button', { name: /Archive pruned/i })
+      expect(button).toBeDisabled()
+      expect(screen.queryByRole('button', { name: /^View Archive$/i })).not.toBeInTheDocument()
+    })
+  })
+
   describe('Action Configuration', () => {
     it('shows actions with internal handlers when callbacks are not provided', () => {
       renderWithProviders(<BackupJobsTable jobs={mockJobs} actions={{ viewLogs: true }} />)

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -3100,6 +3100,7 @@
       "delete": "Löschen",
       "viewLogs": "Protokolle anzeigen",
       "viewArchive": "Archiv anzeigen",
+      "viewArchivePruned": "Archiv wurde entfernt",
       "downloadLogs": "Protokolle herunterladen",
       "errorDetails": "Fehlerdetails",
       "cancel": "Abbrechen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -3100,6 +3100,7 @@
       "delete": "Delete",
       "viewLogs": "View Logs",
       "viewArchive": "View Archive",
+      "viewArchivePruned": "Archive pruned",
       "downloadLogs": "Download Logs",
       "errorDetails": "Error Details",
       "cancel": "Cancel",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -3100,6 +3100,7 @@
       "delete": "Eliminar",
       "viewLogs": "Ver registros",
       "viewArchive": "Ver archivo",
+      "viewArchivePruned": "Archivo eliminado",
       "downloadLogs": "Descargar registros",
       "errorDetails": "Detalles del error",
       "cancel": "Cancelar",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -3100,6 +3100,7 @@
       "delete": "Elimina",
       "viewLogs": "Visualizza Log",
       "viewArchive": "Visualizza Archivio",
+      "viewArchivePruned": "Archivio rimosso",
       "downloadLogs": "Scarica Log",
       "errorDetails": "Dettagli Errore",
       "cancel": "Annulla",

--- a/frontend/src/pages/dashboard-v3/types.ts
+++ b/frontend/src/pages/dashboard-v3/types.ts
@@ -73,6 +73,8 @@ export interface DashboardOverview {
     timestamp: string
     message: string
     error: string | null
+    // backup entries: set once the archive this run created was pruned
+    archive_pruned_at?: string | null
   }>
   system_metrics: {
     cpu_usage: number

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -173,6 +173,7 @@ export interface BackupJob {
   backup_plan_run_id?: number | null
   backup_plan_name?: string | null
   archive_name?: string | null
+  archive_pruned_at?: string | null
   execution_mode?: 'local' | 'remote_ssh' | 'agent' | string
   route_strategy?: string | null
   retry_attempt?: number | null

--- a/frontend/src/types/jobs.ts
+++ b/frontend/src/types/jobs.ts
@@ -23,6 +23,7 @@ export interface Job {
   error_message?: string | null
   skip_reason?: 'minimum_interval_not_elapsed' | 'source_unavailable' | null
   archive_name?: string | null
+  archive_pruned_at?: string | null
   package_name?: string | null
   has_logs?: boolean
   triggered_by?: string

--- a/tests/unit/test_api_activity.py
+++ b/tests/unit/test_api_activity.py
@@ -257,6 +257,8 @@ class TestRecentActivityEndpoint:
                 started_at=base + timedelta(minutes=5),
                 completed_at=base + timedelta(minutes=6),
                 scheduled_job_id=schedule.id,
+                archive_name="archive-pruned-since",
+                archive_pruned_at=base + timedelta(minutes=30),
             ),
             RestoreJob(
                 repository=repository.path,
@@ -320,8 +322,11 @@ class TestRecentActivityEndpoint:
         assert activity[0]["schedule_id"] == schedule.id
         assert activity[0]["schedule_name"] == schedule.name
         assert activity[0]["repository"] == repository.name
+        # the run outlives its archive and says so
+        assert activity[0]["archive_pruned_at"] is not None
         check_activity = next(item for item in activity if item["type"] == "check")
         assert check_activity["triggered_by"] == "schedule"
+        assert check_activity["archive_pruned_at"] is None
         restore_check_activity = next(
             item for item in activity if item["type"] == "restore_check"
         )

--- a/tests/unit/test_api_backup.py
+++ b/tests/unit/test_api_backup.py
@@ -692,6 +692,11 @@ class TestBackupStart:
             {"line_number": 1, "content": "Creating archive"}
         ]
 
+        # the archive gets pruned later: the row stays and reports it in the
+        # same UTC-stamped form as its other timestamps
+        backup_job.archive_pruned_at = datetime(2026, 9, 7, 12, 30)
+        test_db.commit()
+
         jobs_response = test_client.get(
             "/api/backup/jobs", params={"manual_only": True}, headers=admin_headers
         )
@@ -702,6 +707,7 @@ class TestBackupStart:
         assert history_job["triggered_by"] == "manual"
         assert history_job["execution_mode"] == "agent"
         assert history_job["archive_name"] == "agent-archive"
+        assert history_job["archive_pruned_at"] == "2026-09-07T12:30:00+00:00"
         assert history_job["has_logs"] is True
 
 

--- a/tests/unit/test_api_backup_plans.py
+++ b/tests/unit/test_api_backup_plans.py
@@ -5238,3 +5238,28 @@ class TestUniquePlanName:
         self._plan(test_db, "NIGHTLY (2)")
 
         assert _unique_backup_plan_name(test_db, "Nightly") == "Nightly (2)"
+
+
+@pytest.mark.unit
+def test_serialize_backup_job_reports_a_pruned_archive():
+    from datetime import datetime
+
+    from app.api.backup_plans import _serialize_backup_job
+    from app.database.models import BackupJob
+
+    job = BackupJob(
+        id=7,
+        repository="/srv/repo",
+        status="completed",
+        archive_name="host-old",
+        archive_pruned_at=datetime(2026, 9, 7, 12, 30),
+    )
+    payload = _serialize_backup_job(job, None)
+    assert payload["archive_name"] == "host-old"
+    assert payload["archive_pruned_at"] == "2026-09-07T12:30:00+00:00"
+    assert (
+        _serialize_backup_job(BackupJob(id=8, status="completed"), None)[
+            "archive_pruned_at"
+        ]
+        is None
+    )

--- a/tests/unit/test_api_dashboard.py
+++ b/tests/unit/test_api_dashboard.py
@@ -795,6 +795,8 @@ class TestDashboardScheduleAndOverview:
                     completed_at=now - timedelta(days=2, minutes=10),
                     progress=100,
                     scheduled_job_id=schedule.id,
+                    # its archive was pruned since: the run still counts
+                    archive_pruned_at=now - timedelta(days=1),
                 ),
                 BackupJob(
                     repository=full_repo.path,
@@ -912,6 +914,10 @@ class TestDashboardScheduleAndOverview:
             "prune",
         ]
         assert data["activity_feed"][0]["repository"] == "Full Repo"
+        # the pruned run is still in the feed, and says so
+        assert data["activity_feed"][1]["archive_pruned_at"] is None
+        assert data["activity_feed"][2]["status"] == "completed"
+        assert data["activity_feed"][2]["archive_pruned_at"] is not None
         assert [item["name"] for item in data["upcoming_tasks"]] == [
             "Nightly Full Repo"
         ]

--- a/tests/unit/test_backup_job_archive_pruned_at_migration.py
+++ b/tests/unit/test_backup_job_archive_pruned_at_migration.py
@@ -1,0 +1,50 @@
+"""Tests for revision a5b7c9d1e3f2 (backup_jobs.archive_pruned_at)."""
+
+import pytest
+from alembic import command
+from sqlalchemy import inspect
+
+from app.database.db_upgrade import _alembic_config, _engine
+
+REVISION = "a5b7c9d1e3f2"
+PREVIOUS = "c3d5e7f9a1b2"
+
+
+def _migrate(url, target, *, down=False):
+    engine = _engine(url)
+    config = _alembic_config(url)
+    with engine.connect() as connection:
+        config.attributes["connection"] = connection
+        (command.downgrade if down else command.upgrade)(config, target)
+        connection.commit()
+    engine.dispose()
+
+
+def _columns(url):
+    engine = _engine(url)
+    try:
+        return {c["name"] for c in inspect(engine).get_columns("backup_jobs")}
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.unit
+def test_upgrade_adds_and_downgrade_drops_the_column(tmp_path):
+    url = f"sqlite:///{tmp_path / 'borg.db'}"
+    _migrate(url, PREVIOUS)
+    assert "archive_pruned_at" not in _columns(url)
+
+    _migrate(url, REVISION)
+    assert "archive_pruned_at" in _columns(url)
+
+    _migrate(url, PREVIOUS, down=True)
+    assert "archive_pruned_at" not in _columns(url)
+
+
+@pytest.mark.unit
+def test_revision_chains_on_the_previous_head_and_leaves_one_head():
+    from alembic.script import ScriptDirectory
+
+    script = ScriptDirectory.from_config(_alembic_config("sqlite://"))
+    assert script.get_revision(REVISION).down_revision == PREVIOUS
+    assert len(script.get_heads()) == 1

--- a/tests/unit/test_delete_archive_service.py
+++ b/tests/unit/test_delete_archive_service.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, mock_open, patch
 
 import pytest
 
-from app.database.models import DeleteArchiveJob, Repository
+from app.database.models import BackupJob, DeleteArchiveJob, Repository
 from app.services.delete_archive_service import (
     DeleteArchiveService,
     get_process_start_time,
@@ -104,10 +104,14 @@ async def test_execute_delete_completes_and_persists_logs(
     job = DeleteArchiveJob(
         repository_id=repo.id, archive_name="daily-1", status="pending"
     )
-    db_session_commit.add(job)
+    # the backup that created the archive: its row must survive the delete
+    backup = BackupJob(
+        repository_id=repo.id, status="completed", archive_name="daily-1"
+    )
+    db_session_commit.add_all([job, backup])
     db_session_commit.commit()
     db_session_commit.refresh(job)
-    job_id = job.id
+    job_id, backup_id = job.id, backup.id
 
     process = FakeProcess(returncode=0, stderr_lines=[b"deleting archive\n", b"done\n"])
 
@@ -136,6 +140,8 @@ async def test_execute_delete_completes_and_persists_logs(
     assert refreshed.progress == 100
     assert refreshed.has_logs is True
     assert refreshed.log_file_path is not None
+    backup_row = db_session_commit.get(BackupJob, backup_id)
+    assert backup_row is not None and backup_row.archive_pruned_at is not None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_job_history_retention.py
+++ b/tests/unit/test_job_history_retention.py
@@ -30,7 +30,8 @@ from app.database.models import (
 )
 from app.services.job_history_retention import (
     archive_names_from_prune_output,
-    purge_jobs_for_pruned_archives,
+    mark_jobs_of_pruned_archives,
+    purge_job_rows,
     run_retention,
     sweep_pruned_archive_records,
 )
@@ -357,7 +358,9 @@ def _repo(db, borg_version=1):
 
 
 @pytest.mark.unit
-def test_pruned_archives_take_their_job_records_along(db, tmp_path):
+def test_pruned_archives_mark_their_job_records_and_keep_them(db, tmp_path):
+    """The job row is the record that the backup ran: a prune marks it and
+    leaves it, its agent job, its log rows and its log file alone."""
     _settings(db)
     machine = _machine(db)
     repo = _repo(db)
@@ -384,18 +387,59 @@ def test_pruned_archives_take_their_job_records_along(db, tmp_path):
     agent_run = _agent_job(db, machine, "completed", age_days=3, log_lines=2)
     agent_run.backup_job_id = pruned.id
     db.commit()
+    repo_id = repo.id
     pruned_id, kept_id, agent_id = pruned.id, kept.id, agent_run.id
 
-    removed = purge_jobs_for_pruned_archives(db, repo.id, {"host-old"})
+    marked = mark_jobs_of_pruned_archives(db, repo_id, {"host-old"})
 
     db.expunge_all()
-    assert removed == 1
-    assert db.get(BackupJob, pruned_id) is None
-    assert db.get(BackupJob, kept_id) is not None
-    # The linked agent job dies with its backup job, its log rows cascade.
-    assert db.get(AgentJob, agent_id) is None
-    assert db.query(AgentJobLog).count() == 0
-    assert not log_file.exists()
+    assert marked == 1
+    pruned_row = db.get(BackupJob, pruned_id)
+    assert pruned_row is not None and pruned_row.archive_pruned_at is not None
+    assert pruned_row.status == "completed"
+    assert db.get(BackupJob, kept_id).archive_pruned_at is None
+    assert db.get(AgentJob, agent_id) is not None
+    assert db.query(AgentJobLog).count() == 2
+    assert log_file.exists()
+    # A second prune report for the same archive changes nothing.
+    first_mark = pruned_row.archive_pruned_at
+    assert mark_jobs_of_pruned_archives(db, repo_id, {"host-old"}) == 0
+    db.expunge_all()
+    assert db.get(BackupJob, pruned_id).archive_pruned_at == first_mark
+
+
+@pytest.mark.unit
+def test_marked_rows_fall_with_cleanup_retention_like_any_other(db):
+    _settings(db, cleanup_retention_days=30)
+    repo = _repo(db)
+    old = utc_now() - timedelta(days=40)
+    recent = utc_now() - timedelta(days=3)
+    db.add_all(
+        [
+            BackupJob(
+                repository_id=repo.id,
+                status="completed",
+                archive_name="host-a",
+                completed_at=old,
+                created_at=old,
+            ),
+            BackupJob(
+                repository_id=repo.id,
+                status="completed",
+                archive_name="host-b",
+                completed_at=recent,
+                created_at=recent,
+            ),
+        ]
+    )
+    db.commit()
+    repo_id = repo.id
+    assert mark_jobs_of_pruned_archives(db, repo_id, {"host-a", "host-b"}) == 2
+
+    # The mark is not "activity": age comes from the job's own timestamps.
+    assert purge_job_rows(db, utc_now() - timedelta(days=30)) == 1
+    db.expunge_all()
+    assert [j.archive_name for j in db.query(BackupJob).all()] == ["host-b"]
 
 
 @pytest.mark.unit
@@ -415,15 +459,15 @@ def test_borg2_repositories_are_skipped(db):
 
     # An archive series shares one name across archives: a name match would
     # hit jobs whose archives still exist, so borg2 is skipped for now.
-    assert purge_jobs_for_pruned_archives(db, repo.id, {"series-name"}) == 0
-    assert db.query(BackupJob).count() == 1
+    assert mark_jobs_of_pruned_archives(db, repo.id, {"series-name"}) == 0
+    db.expunge_all()
+    assert db.query(BackupJob).one().archive_pruned_at is None
 
 
-@pytest.mark.unit
-def test_sweep_cascades_from_late_arriving_prune_logs(db, tmp_path):
-    # The completion hook races log ingestion and can see an empty log; the
-    # sweep re-parses the full agent log later and cascades idempotently.
-    _settings(db)
+def _late_prune_log_scenario(db):
+    """An agent prune whose 'Pruning archive:' line arrived after the
+    completion hook ran (the hook saw a truncated log). Returns the ids of
+    the pruned backup's job and of the prune job, and when the prune finished."""
     machine = _machine(db)
     repo = _repo(db)
     when = utc_now() - timedelta(hours=6)
@@ -431,15 +475,17 @@ def test_sweep_cascades_from_late_arriving_prune_logs(db, tmp_path):
         repository_id=repo.id,
         status="completed",
         archive_name="host-old",
-        completed_at=when,
-        created_at=when,
+        completed_at=when - timedelta(hours=1),
+        created_at=when - timedelta(hours=1),
     )
     db.add(pruned_backup)
     db.flush()
+    finished = when + timedelta(minutes=5)
     prune_row = PruneJob(
         repository_id=repo.id,
         status="completed",
-        completed_at=when,
+        started_at=when,
+        completed_at=finished,
         created_at=when,
         logs="Starting repository.prune",  # truncated by the race
         has_logs=True,
@@ -454,7 +500,8 @@ def test_sweep_cascades_from_late_arriving_prune_logs(db, tmp_path):
             "job_kind": "repository.prune",
             "operation": {"maintenance_job": {"kind": "prune", "id": prune_row.id}},
         },
-        completed_at=when,
+        claimed_at=when,
+        completed_at=finished,
         created_at=when,
         updated_at=when,
     )
@@ -477,13 +524,21 @@ def test_sweep_cascades_from_late_arriving_prune_logs(db, tmp_path):
             )
         )
     db.commit()
-    pruned_id, prune_row_id = pruned_backup.id, prune_row.id
+    return pruned_backup.id, prune_row.id, finished
 
-    removed = sweep_pruned_archive_records(db)
+
+@pytest.mark.unit
+def test_sweep_marks_from_late_arriving_prune_logs(db):
+    _settings(db)
+    pruned_id, prune_row_id, prune_finished = _late_prune_log_scenario(db)
+
+    # The daily pass is what runs the sweep; it reports the count.
+    assert run_retention(db)["pruned_archive_records_marked"] == 1
 
     db.expunge_all()
-    assert removed == 1
-    assert db.get(BackupJob, pruned_id) is None
+    row = db.get(BackupJob, pruned_id)
+    # the recorded time is when the prune finished, not when the pass ran
+    assert row is not None and row.archive_pruned_at == prune_finished
     # The truncated stored log got repaired from the full agent log.
     assert "Pruning archive" in db.get(PruneJob, prune_row_id).logs
     # Idempotent: a second sweep finds nothing left to do.
@@ -508,6 +563,158 @@ def test_retention_covers_operations_and_the_legacy_maintenance_tables():
     assert {CheckJob, PruneJob, CompactJob, RestoreCheckJob, DeleteArchiveJob} <= models
 
 
+def test_sweep_runs_before_the_save_policy_drops_the_logs_it_reads(db):
+    """Under the default policy the pass deletes the log rows of every
+    completed agent job regardless of age; the sweep must read the prune
+    log first or it never marks anything."""
+    _settings(db, log_save_policy="failed_and_warnings")
+    pruned_id, _, _ = _late_prune_log_scenario(db)
+
+    results = run_retention(db)
+
+    assert results["pruned_archive_records_marked"] == 1
+    assert results["policy_log_rows_deleted"] == 2  # the logs did go afterwards
+    db.expunge_all()
+    assert db.get(BackupJob, pruned_id).archive_pruned_at is not None
+
+
+@pytest.mark.unit
+def test_jobs_that_carry_only_the_repository_path_are_marked_too(db):
+    """Rows written before repository_id existed (or after the FK was
+    nulled) match by path, as every other job-to-repository lookup does."""
+    _settings(db)
+    repo = _repo(db)
+    when = utc_now() - timedelta(days=3)
+    db.add(
+        BackupJob(
+            repository=repo.path + "/",
+            status="completed",
+            archive_name="host-old",
+            completed_at=when,
+            created_at=when,
+        )
+    )
+    db.commit()
+    assert mark_jobs_of_pruned_archives(db, repo.id, {"host-old"}) == 1
+    db.expunge_all()
+    assert db.query(BackupJob).one().archive_pruned_at is not None
+
+
+@pytest.mark.unit
+def test_a_backup_that_ran_after_the_prune_keeps_its_reused_name(db):
+    """Borg 1 lets a name be reused once its archive is gone: a job created
+    once the prune was under way made a different archive and must not be
+    marked, even when a late sweep re-reads that prune's log."""
+    _settings(db)
+    repo = _repo(db)
+    prune_started = utc_now() - timedelta(hours=6)
+    prune_finished = prune_started + timedelta(minutes=5)
+    before_prune = prune_started - timedelta(hours=1)
+    # queued while the prune ran, created its archive once the lock was free
+    during_prune = prune_started + timedelta(minutes=2)
+    after_prune = prune_started + timedelta(hours=1)
+    db.add_all(
+        [
+            BackupJob(
+                repository_id=repo.id,
+                status="completed",
+                archive_name="weekly",
+                completed_at=before_prune,
+                created_at=before_prune,
+            ),
+            BackupJob(
+                repository_id=repo.id,
+                status="completed",
+                archive_name="weekly",
+                completed_at=prune_finished + timedelta(minutes=1),
+                created_at=during_prune,
+            ),
+            BackupJob(
+                repository_id=repo.id,
+                status="completed",
+                archive_name="weekly",
+                completed_at=after_prune,
+                created_at=after_prune,
+            ),
+        ]
+    )
+    db.commit()
+    marked = mark_jobs_of_pruned_archives(
+        db,
+        repo.id,
+        {"weekly"},
+        created_before=prune_started,
+        pruned_at=prune_finished,
+    )
+    assert marked == 1
+    db.expunge_all()
+    rows = db.query(BackupJob).order_by(BackupJob.created_at).all()
+    # the recorded time is when the prune finished, not when it started
+    assert rows[0].archive_pruned_at == prune_finished
+    assert rows[1].archive_pruned_at is None
+    assert rows[2].archive_pruned_at is None
+
+
+@pytest.mark.unit
+def test_agent_prune_completion_marks_the_pruned_archives_jobs(db):
+    """The agents API completion hook is a production call site."""
+    from app.api.agents import _finish_linked_repository_operation_job
+
+    _settings(db)
+    machine = _machine(db)
+    repo = _repo(db)
+    when = utc_now() - timedelta(hours=1)
+    backup = BackupJob(
+        repository_id=repo.id,
+        status="completed",
+        archive_name="host-old",
+        completed_at=when,
+        created_at=when,
+    )
+    prune_row = PruneJob(
+        repository_id=repo.id, status="running", started_at=utc_now(), created_at=when
+    )
+    db.add_all([backup, prune_row])
+    db.flush()
+    agent_job = AgentJob(
+        agent_machine_id=machine.id,
+        job_type="repository",
+        status="completed",
+        payload={
+            "job_kind": "repository.prune",
+            "operation": {"maintenance_job": {"kind": "prune", "id": prune_row.id}},
+        },
+        claimed_at=utc_now(),
+        started_at=utc_now(),
+        created_at=when,
+        updated_at=when,
+    )
+    db.add(agent_job)
+    db.flush()
+    db.add(
+        AgentJobLog(
+            agent_job_id=agent_job.id,
+            sequence=0,
+            stream="stderr",
+            message="Pruning archive: host-old"
+            "                     Mon, 2026-07-20 03:00:00 [aa00] (1/1)",
+            created_at=when,
+        )
+    )
+    db.commit()
+    backup_id = backup.id
+
+    _finish_linked_repository_operation_job(
+        agent_job, db, status_value="completed", completed_at=utc_now()
+    )
+    db.commit()
+
+    db.expunge_all()
+    row = db.get(BackupJob, backup_id)
+    assert row is not None and row.archive_pruned_at is not None
+
+
+@pytest.mark.unit
 def test_operations_rows_fall_with_cleanup_retention(db):
     from app.database.models import Operation
     from app.services.operations.enqueue import enqueue

--- a/tests/unit/test_prune_service.py
+++ b/tests/unit/test_prune_service.py
@@ -1,9 +1,10 @@
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy.orm import sessionmaker
 
-from app.database.models import PruneJob, Repository
+from app.database.models import BackupJob, PruneJob, Repository
 from app.services.prune_service import PruneService
 
 
@@ -78,3 +79,198 @@ async def test_execute_prune_command_includes_keep_within(db_engine):
 
     cmd = list(create_subprocess.await_args.args)
     assert "--keep-within=1d" in cmd
+
+
+class LinesAsyncStream:
+    def __init__(self, lines):
+        self._lines = list(lines)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._lines:
+            raise StopAsyncIteration
+        return self._lines.pop(0)
+
+
+def _log_record(message):
+    """One `--log-json` record as borg prints it (one JSON object per line)."""
+    return (
+        json.dumps(
+            {
+                "type": "log_message",
+                "time": 1758000000.0,
+                "message": message,
+                "levelname": "INFO",
+                "name": "borg.output.list",
+            }
+        )
+        + "\n"
+    ).encode()
+
+
+class PruningFakeProcess(FakeProcess):
+    def __init__(self, pruned_names, trailing_lines=0):
+        super().__init__(returncode=0)
+        lines = [
+            _log_record(
+                f"Pruning archive: {name}        Mon, 2026-07-20 03:00:00 [aa00] (1/1)"
+            )
+            for name in pruned_names
+        ]
+        # --list chatter after the prune lines, enough to overflow the buffer
+        lines += [
+            _log_record(f"Keeping archive: keep-{i}") for i in range(trailing_lines)
+        ]
+        self.stderr = LinesAsyncStream(lines)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_prune_marks_the_jobs_of_pruned_archives(db_engine):
+    """The server-side prune is a production call site of the mark: the
+    backup job of a pruned archive stays and records the prune."""
+    testing_session_local = sessionmaker(bind=db_engine)
+    session = testing_session_local()
+    repo = Repository(
+        name="V1 Repo",
+        path="/tmp/v1-repo",
+        encryption="repokey",
+        repository_type="local",
+        borg_version=1,
+    )
+    session.add(repo)
+    session.commit()
+    session.refresh(repo)
+    backup = BackupJob(
+        repository_id=repo.id, status="completed", archive_name="host-old"
+    )
+    job = PruneJob(repository_id=repo.id, repository_path=repo.path, status="pending")
+    session.add_all([backup, job])
+    session.commit()
+    repo_id, job_id, backup_id = repo.id, job.id, backup.id
+    session.close()
+
+    with (
+        patch("app.services.prune_service.SessionLocal", testing_session_local),
+        patch(
+            "app.services.prune_service.build_repository_borg_env",
+            return_value=({}, None),
+        ),
+        patch(
+            "app.services.prune_service.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=PruningFakeProcess(["host-old"])),
+        ),
+    ):
+        await PruneService().execute_prune(job_id, repo_id, 0, 7, 4, 6, 0, 1)
+
+    session = testing_session_local()
+    row = session.get(BackupJob, backup_id)
+    assert row is not None and row.archive_pruned_at is not None
+    assert session.get(PruneJob, job_id).status == "completed"
+    session.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_prune_marks_archives_whose_lines_left_the_log_buffer(db_engine):
+    """The in-memory log buffer keeps the last 1000 lines only; a prune line
+    that scrolled out of it must still mark the job, since the names are
+    collected while the output streams."""
+    testing_session_local = sessionmaker(bind=db_engine)
+    session = testing_session_local()
+    repo = Repository(
+        name="V1 Repo",
+        path="/tmp/v1-repo",
+        encryption="repokey",
+        repository_type="local",
+        borg_version=1,
+    )
+    session.add(repo)
+    session.commit()
+    session.refresh(repo)
+    backup = BackupJob(
+        repository_id=repo.id, status="completed", archive_name="host-old"
+    )
+    job = PruneJob(repository_id=repo.id, repository_path=repo.path, status="pending")
+    session.add_all([backup, job])
+    session.commit()
+    repo_id, job_id, backup_id = repo.id, job.id, backup.id
+    session.close()
+
+    with (
+        patch("app.services.prune_service.SessionLocal", testing_session_local),
+        patch(
+            "app.services.prune_service.build_repository_borg_env",
+            return_value=({}, None),
+        ),
+        patch(
+            "app.services.prune_service.asyncio.create_subprocess_exec",
+            new=AsyncMock(
+                return_value=PruningFakeProcess(["host-old"], trailing_lines=1200)
+            ),
+        ),
+    ):
+        await PruneService().execute_prune(job_id, repo_id, 0, 7, 4, 6, 0, 1)
+
+    session = testing_session_local()
+    assert session.get(BackupJob, backup_id).archive_pruned_at is not None
+    prune_row = session.get(PruneJob, job_id)
+    # proof that the buffer really lost the line
+    assert "Pruning archive" not in (prune_row.logs or "")
+    session.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_prune_matches_names_that_json_escapes(db_engine):
+    """`--log-json` escapes quotes and backslashes inside the record; the
+    name is matched from the decoded message, not the raw line."""
+    name = 'quote"d\\name'
+    testing_session_local = sessionmaker(bind=db_engine)
+    session = testing_session_local()
+    repo = Repository(
+        name="V1 Repo",
+        path="/tmp/v1-repo",
+        encryption="repokey",
+        repository_type="local",
+        borg_version=1,
+    )
+    session.add(repo)
+    session.commit()
+    session.refresh(repo)
+    backup = BackupJob(repository_id=repo.id, status="completed", archive_name=name)
+    job = PruneJob(repository_id=repo.id, repository_path=repo.path, status="pending")
+    session.add_all([backup, job])
+    session.commit()
+    repo_id, job_id, backup_id = repo.id, job.id, backup.id
+    session.close()
+
+    with (
+        patch("app.services.prune_service.SessionLocal", testing_session_local),
+        patch(
+            "app.services.prune_service.build_repository_borg_env",
+            return_value=({}, None),
+        ),
+        patch(
+            "app.services.prune_service.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=PruningFakeProcess([name])),
+        ),
+    ):
+        await PruneService().execute_prune(job_id, repo_id, 0, 7, 4, 6, 0, 1)
+
+    session = testing_session_local()
+    assert session.get(BackupJob, backup_id).archive_pruned_at is not None
+    session.close()
+
+
+@pytest.mark.unit
+def test_log_message_falls_back_to_the_raw_line():
+    from app.services.prune_service import _log_message
+
+    assert _log_message("Pruning archive: x") == "Pruning archive: x"
+    assert _log_message("{not json") == "{not json"
+    progress = '{"type": "progress", "current": 1}'
+    assert _log_message(progress) == progress
+    assert _log_message('{"message": "Pruning archive: y"}') == "Pruning archive: y"


### PR DESCRIPTION
## Description

`purge_jobs_for_pruned_archives()` (from #772) deleted the `backup_jobs` row, its agent job and its log file as soon as the archive it created was pruned or deleted. The row is the only record that the backup *ran*: with an hourly plan and a retention of one archive per day, 23 of 24 rows vanished every day, and the dashboard's 14-day activity timeline showed backup runs only on days whose daily archive survived. Borg 2 repositories were exempt from the purge (a series shares one name), so the same plan looked complete there and full of holes on Borg 1.

The function is now `mark_jobs_of_pruned_archives()`: it sets the new `backup_jobs.archive_pruned_at` (revision `a5b7c9d1e3f2`, nullable, no backfill) once and leaves the row, the agent job and the logs alone. The row falls with `cleanup_retention_days` like every other job row; log content follows `log_retention_days` and the save policy as before. Details that came out of review:

- **Matching.** Jobs belong to the repository by id or, for rows written before the id column existed, by path (trailing slash tolerated). Only jobs *created* before the prune or delete started are marked (server clock on both sides; for agent prunes the cutoff is the job's claim time, the one timestamp the server sets): Borg 1 lets a name be reused once its archive is gone, so a backup queued while the prune ran made a different archive. The recorded `archive_pruned_at` is when the prune or delete finished, not when the mark ran. The update commits per chunk of names like the module's other bulk writes. The server-side prune collects the pruned names while its output streams: its log buffer keeps the last 1000 lines, so a large prune's early `Pruning archive:` lines were gone before they were parsed; the names come from the decoded `--log-json` message, where quotes and backslashes in a name are not escaped.
- **Retention pass order.** `run_retention()` now runs the late-prune-log sweep *before* the save policy drops the log rows of completed agent jobs. Under the default `failed_and_warnings` policy that purge is age-independent, so the sweep would otherwise never see the `Pruning archive:` lines the completion hook missed (the hook races log ingestion).
- **API.** `archive_pruned_at` is returned by `GET /api/backup/jobs`, `GET /api/activity/recent` (`ActivityItem`), the plan-run history (`_serialize_backup_job`) and the dashboard `activity_feed` (present on every entry, `null` for kinds without an archive), serialized like the sibling timestamps.
- **UI.** The backup table keeps "View Archive" on a pruned run but disabled, with the tooltip "Archive pruned" (new locale key `backupJobsTable.actions.viewArchivePruned`, four languages). The dashboard timeline needs no change: it counts rows, and the rows are back.
- **Response shape.** The manual cleanup endpoint returns `run_retention()`'s counters verbatim; the counter `pruned_archive_records_removed` is now `pruned_archive_records_marked`.

Not in this PR: the archive heatmap (#943) still derives missed days from `archives` only; with the job rows surviving it can take completed `backup_jobs` as run evidence, separate change.

## Related Issue

Fixes #964
Related: #943, #935


## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring


## Testing

`test_job_history_retention.py`: a prune marks the job and keeps row, agent job, log rows and log file; a second report is a no-op; marked rows fall with `cleanup_retention_days`; Borg 2 skipped; path-only rows matched; a same-name backup created after the prune is not marked; the late-log sweep marks with the prune's time and is idempotent; the sweep still marks under the default save policy; the agents completion hook marks. `test_prune_service.py` and `test_delete_archive_service.py`: the server-side prune and delete mark. `test_api_activity.py`, `test_api_backup.py`, `test_api_backup_plans.py`, `test_api_dashboard.py`: the field's presence and UTC-stamped shape. `test_backup_job_archive_pruned_at_migration.py`: upgrade adds / downgrade drops the column, single head. `BackupJobsTable.test.tsx`: the action is offered for a live archive and disabled with the pruned tooltip otherwise; `BackupJobsTable.stories.tsx` gained a `PrunedArchive` story with both states.

Two rounds of an isolated blind review (full tree, lint and test output, told to assume the diff is broken) before this PR; round 1 found the `ActivityItem` schema dropping the field and the still-enabled "View Archive", round 2 the retention-pass order and the clock mismatch. Both fixed above.

```
$ ruff check app tests && ruff format --check app tests      # clean
$ pytest tests/unit -q -p no:cacheprovider
3251 passed, 13 skipped in 542.21s (0:09:02)
$ npm run format:check && npm run typecheck && npm run lint && npm run check:locales   # clean, 5001 keys x 4
$ npx vitest run      # Node 22
 Test Files  223 passed (223)
      Tests  2578 passed (2578)
```

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass


## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


## Screenshots (if applicable)

Not applicable.


## Additional Context

Revision `a5b7c9d1e3f2` chains on `c3d5e7f9a1b2`, the head after #950 merged (the branch was rebased onto it and the revision re-parented before it was applied anywhere), so the graph keeps a single head.

---

**Note:** By submitting this pull request, you agree that your contributions will be licensed under the GNU Affero General Public License v3.0 (AGPL-3.0), the same license as this project.
