### PR TITLE
feat(operations): repository status from repository evidence

### DIFF
--- a/app/api/archive_index.py
+++ b/app/api/archive_index.py
@@ -31,8 +31,8 @@ from app.services.operations.executors.history import (
 )
 from app.services.operations.followups import PLAN_GATED_KINDS, history_enabled
 from app.services.operations.history_fold import Change, fold_sequence, rows_to_changes
-from app.services.operations.legacy_status import latest_legacy_terminal
 from app.services.operations.reconcile import enqueue_reconcile_run
+from app.services.operations.repository_status import repository_status
 from app.services.operations.series import cron_for_repository
 from app.services.operations.vocab import PRIORITY_RECONCILE
 
@@ -42,14 +42,6 @@ NOT_FOUND = {"key": "backend.errors.archives.notFound"}
 # Three intervals, so one missed reconcile (a backend restart sleeps a
 # full interval before its first run) does not flip every chip to stale.
 STALE_AFTER_INTERVALS = 3
-STRIP_CELLS: tuple[tuple[str, dict], ...] = (
-    ("backup", {"kinds": ("backup",)}),
-    ("check", {"kinds": ("check",)}),
-    ("prune", {"kinds": ("prune",)}),
-    ("compact", {"kinds": ("compact",)}),
-    ("index", {"category": "index"}),
-    ("mirror", {"category": "mirror"}),
-)
 
 
 def _repo(db: Session, user: User, repo_id: int, role: str = "viewer") -> Repository:
@@ -282,61 +274,33 @@ async def get_archive(
     }
 
 
+@router.get("/{repo_id}/status")
+async def repository_status_route(
+    repo_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Per-category status from the best evidence available (#935): the
+    archive list for backups, detected removals for prune, job rows for
+    check and compact, with expectations from the series cadence and the
+    repository's own plans and schedules."""
+    repository = _repo(db, current_user, repo_id)
+    return repository_status(
+        db,
+        repository,
+        now=utc_now().replace(tzinfo=None),
+        pro=history_enabled(db),
+    )
+
+
 @router.get("/{repo_id}/status-strip")
 async def status_strip(
     repo_id: int,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    repository = _repo(db, current_user, repo_id)
-    pro = history_enabled(db)
-    now = utc_now().replace(tzinfo=None)
-    # `repository_type` is the persisted rclone/mirror marker (spec 6.4);
-    # `cloud_mirror_enabled` is only a create-time request field, not a
-    # Repository column.
-    mirror_applies = repository.repository_type == "rclone"
-    cells = []
-    for cell, spec in STRIP_CELLS:
-        if cell == "mirror" and not mirror_applies:
-            continue
-        q = db.query(Operation).filter(Operation.repository_id == repository.id)
-        if "kinds" in spec:
-            q = q.filter(Operation.kind.in_(spec["kinds"]))
-        else:
-            q = q.filter(Operation.category == spec["category"])
-        running = q.filter(Operation.status == "running").first() is not None
-        latest = (
-            q.filter(
-                Operation.status.in_(
-                    ("completed", "completed_with_warnings", "failed", "cancelled")
-                )
-            )
-            .order_by(Operation.completed_at.desc())
-            .first()
-        )
-        status, completed_at, source = (
-            (latest.status, latest.completed_at, "operations")
-            if latest
-            else (None, None, None)
-        )
-        legacy = latest_legacy_terminal(db, repository.id, cell)
-        if legacy and (completed_at is None or legacy[1] > completed_at):
-            status, completed_at, source = legacy[0], legacy[1], "legacy"
-        cells.append(
-            {
-                "cell": cell,
-                "status": status,
-                "completed_at": completed_at,
-                "age_seconds": (now - completed_at).total_seconds()
-                if completed_at
-                else None,
-                "threshold_days": anomalies.OVERDUE_THRESHOLD_DAYS[cell],
-                "overdue": anomalies.overdue(cell, completed_at, now) if pro else None,
-                "running": running,
-                "source": source,
-            }
-        )
-    return {"cells": cells, "overdue_available": pro}
+    """Same payload as /status; kept for the strip until it moves."""
+    return await repository_status_route(repo_id, current_user, db)
 
 
 class RebuildRequest(BaseModel):

--- a/app/services/operations/anomalies.py
+++ b/app/services/operations/anomalies.py
@@ -135,13 +135,13 @@ def missed_run_days(
     return {d for d in expected if d not in present and d >= first.date()}
 
 
-def overdue(cell: str, last_completed_at: Optional[datetime], now: datetime) -> bool:
-    threshold = OVERDUE_THRESHOLD_DAYS.get(cell)
-    if threshold is None:
-        return False
+def overdue_after(
+    last_completed_at: Optional[datetime], now: datetime, threshold: timedelta
+) -> bool:
+    """Overdue against an explicit threshold; nothing recorded counts as overdue."""
     if last_completed_at is None:
         return True
-    return now - last_completed_at > timedelta(days=threshold)
+    return now - last_completed_at > threshold
 
 
 def series_flags(archives: Sequence) -> dict[int, list[str]]:

--- a/app/services/operations/repository_status.py
+++ b/app/services/operations/repository_status.py
@@ -1,0 +1,398 @@
+"""Repository status from repository evidence (#935, spec 10.2).
+
+Each cell uses the best evidence available. Backup and prune have evidence
+in the repository itself (the archive list, archives that disappeared
+between two listings); check and compact only have Borg UI's own job
+rows, since Borg records neither. Job rows stay secondary evidence for the
+first two: a failed attempt newer than the newest archive is real
+information about the last run, and a repository with no archives at all
+falls back to whatever job ran last.
+
+The `source` of a cell is kept for precedence and debugging; the UI does
+not label it.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from math import ceil
+from typing import Optional
+
+from sqlalchemy import and_, func, or_
+from sqlalchemy.orm import Session
+
+from app.database.models import (
+    Archive,
+    BackupPlan,
+    BackupPlanRepository,
+    Operation,
+    Repository,
+    ScheduledJob,
+    ScheduledJobRepository,
+)
+from app.services.operations import anomalies
+from app.services.operations.legacy_status import latest_legacy_terminal
+from app.services.operations.vocab import SUCCESS_STATUSES
+
+TERMINAL = ("completed", "completed_with_warnings", "failed", "cancelled")
+FAILED = ("failed", "cancelled")
+CELLS: tuple[tuple[str, dict], ...] = (
+    ("backup", {"kinds": ("backup",)}),
+    ("check", {"kinds": ("check",)}),
+    ("prune", {"kinds": ("prune",)}),
+    ("compact", {"kinds": ("compact",)}),
+    ("index", {"category": "index"}),
+    ("mirror", {"category": "mirror"}),
+)
+CADENCE_FACTOR = 2
+
+
+@dataclass
+class CellStatus:
+    cell: str
+    status: Optional[str] = None
+    completed_at: Optional[datetime] = None
+    running: bool = False
+    source: Optional[str] = None
+    threshold_days: Optional[int] = None
+    overdue: Optional[bool] = None
+
+    def as_dict(self, now: datetime) -> dict:
+        return {
+            "cell": self.cell,
+            "status": self.status,
+            "completed_at": self.completed_at,
+            "age_seconds": (now - self.completed_at).total_seconds()
+            if self.completed_at
+            else None,
+            "threshold_days": self.threshold_days,
+            "overdue": self.overdue,
+            "running": self.running,
+            "source": self.source,
+        }
+
+
+# -- evidence ---------------------------------------------------------------------
+
+
+def _operations(db: Session, repository_id: int, spec: dict):
+    q = db.query(Operation).filter(Operation.repository_id == repository_id)
+    if "kinds" in spec:
+        return q.filter(Operation.kind.in_(spec["kinds"]))
+    return q.filter(Operation.category == spec["category"])
+
+
+def job_evidence(db: Session, repository_id: int, cell: str, spec: dict) -> CellStatus:
+    """The newest terminal job row for a cell, operations first, legacy
+    tables until phase 9 removes them; plus whether one is running."""
+    q = _operations(db, repository_id, spec)
+    running = q.filter(Operation.status == "running").first() is not None
+    # completed_at is required: PostgreSQL sorts NULL first on DESC, so a
+    # terminal row without a timestamp would hide newer evidence.
+    latest = (
+        q.filter(Operation.status.in_(TERMINAL), Operation.completed_at.isnot(None))
+        .order_by(Operation.completed_at.desc())
+        .first()
+    )
+    result = CellStatus(cell=cell, running=running)
+    if latest:
+        result.status, result.completed_at, result.source = (
+            latest.status,
+            latest.completed_at,
+            "operations",
+        )
+    legacy = latest_legacy_terminal(db, repository_id, cell)
+    if legacy and (result.completed_at is None or legacy[1] > result.completed_at):
+        result.status, result.completed_at, result.source = (
+            legacy[0],
+            legacy[1],
+            "legacy",
+        )
+    return result
+
+
+def pending_removed_ids(db: Session, repository_id: int) -> set[int]:
+    """Archive rows the newest successful archive_sync reported removed and
+    history_merge has not deleted yet: archive_sync never deletes (spec
+    6.4), so between the two the rows are still in the table. The same
+    exclusion `write_repository_archive_columns` applies to last_backup."""
+    row = (
+        db.query(Operation.result)
+        .filter(
+            Operation.repository_id == repository_id,
+            Operation.kind == "archive_sync",
+            Operation.status.in_(SUCCESS_STATUSES),
+            Operation.completed_at.isnot(None),
+        )
+        .order_by(Operation.completed_at.desc())
+        .first()
+    )
+    if row is None:
+        return set()
+    return set((row[0] or {}).get("removed_archive_ids") or [])
+
+
+def series_starts(
+    db: Session, repository_id: int, exclude: set[int] = frozenset()
+) -> dict[str, list[datetime]]:
+    """Archive start times per series, each ascending. Archives without a
+    series form one group of their own: a cadence is a property of a
+    series, and timestamps of different series interleave (two nightly
+    hosts a minute apart look hourly when mixed).
+
+    Bounded to the newest CADENCE_SAMPLE archives per series: the cadence
+    reads no further back and the newest archive is among them, while the
+    strip polls this every 30 s per card, so a long hourly history is not
+    scanned on every poll."""
+    rank = (
+        func.row_number()
+        .over(
+            partition_by=Archive.series,
+            order_by=(Archive.start.desc(), Archive.id.desc()),
+        )
+        .label("rank")
+    )
+    ranked = db.query(
+        Archive.series.label("series"), Archive.start.label("start"), rank
+    ).filter(Archive.repository_id == repository_id)
+    if exclude:
+        ranked = ranked.filter(Archive.id.notin_(list(exclude)))
+    ranked = ranked.subquery()
+    result: dict[str, list[datetime]] = {}
+    for series, start in (
+        db.query(ranked.c.series, ranked.c.start)
+        .filter(ranked.c.rank <= anomalies.CADENCE_SAMPLE)
+        .order_by(ranked.c.start.asc())
+        .all()
+    ):
+        result.setdefault(series or "", []).append(start)
+    return result
+
+
+def latest_removal(db: Session, repository_id: int) -> Optional[datetime]:
+    """When archives were last seen to disappear: the newest successful
+    archive_sync whose result lists removed archives. An upper bound, since
+    the removal happened between that listing and the one before. A sync
+    the runner marked cancelled keeps its listing but gets no follow-ups,
+    so its removals are not applied and the next successful listing
+    reports them again."""
+    # Newest first, streamed in pages and stopped at the first listing with
+    # removals: the JSON result is only loaded up to that row. A SQL-side
+    # filter on the JSON list would need dialect-specific functions (SQLite
+    # and PostgreSQL spell json_array_length differently); retention bounds
+    # how far a repository without removals is scanned.
+    rows = (
+        db.query(Operation.completed_at, Operation.result)
+        .filter(
+            Operation.repository_id == repository_id,
+            Operation.kind == "archive_sync",
+            Operation.status.in_(SUCCESS_STATUSES),
+            Operation.completed_at.isnot(None),
+        )
+        .order_by(Operation.completed_at.desc())
+        .yield_per(100)
+    )
+    for completed_at, result in rows:
+        if (result or {}).get("removed_archive_ids"):
+            return completed_at
+    return None
+
+
+def backup_cell(
+    db: Session, repository: Repository, spec: dict, starts: list[datetime]
+) -> CellStatus:
+    """`starts` are the repository's archive start times ascending (the
+    series lists flattened), so the archives table is read once per call."""
+    jobs = job_evidence(db, repository.id, "backup", spec)
+    if not starts:
+        return jobs
+    cell = CellStatus(
+        cell="backup",
+        status="completed",
+        completed_at=starts[-1],
+        running=jobs.running,
+        source="archive",
+    )
+    if jobs.completed_at and jobs.completed_at > starts[-1] and jobs.status in FAILED:
+        cell.status, cell.completed_at, cell.source = (
+            jobs.status,
+            jobs.completed_at,
+            jobs.source,
+        )
+    return cell
+
+
+def prune_cell(db: Session, repository: Repository, spec: dict) -> CellStatus:
+    jobs = job_evidence(db, repository.id, "prune", spec)
+    removed_at = latest_removal(db, repository.id)
+    if removed_at is None:
+        return jobs
+    if jobs.completed_at and jobs.completed_at > removed_at:
+        return jobs
+    return CellStatus(
+        cell="prune",
+        status="completed",
+        completed_at=removed_at,
+        running=jobs.running,
+        source="removal",
+    )
+
+
+# -- expectations -------------------------------------------------------------------
+
+
+def _plan_runs(db: Session, repository_id: int, column: str) -> bool:
+    """A backup plan that will run the step for this repository on its
+    own: enabled, scheduled (a manual-only plan promises nothing, the
+    dispatcher requires schedule_enabled too), dispatchable (availability
+    mode or a cron expression: `_next_plan_run` yields no due time for a
+    cron plan without one), with this repository's association enabled,
+    and the step switched on."""
+    return (
+        db.query(BackupPlan.id)
+        .join(
+            BackupPlanRepository, BackupPlanRepository.backup_plan_id == BackupPlan.id
+        )
+        .filter(
+            BackupPlanRepository.repository_id == repository_id,
+            BackupPlanRepository.enabled.is_(True),
+            BackupPlan.enabled.is_(True),
+            BackupPlan.schedule_enabled.is_(True),
+            or_(
+                BackupPlan.schedule_mode == "availability",
+                and_(
+                    BackupPlan.cron_expression.isnot(None),
+                    BackupPlan.cron_expression != "",
+                ),
+            ),
+            getattr(BackupPlan, column).is_(True),
+        )
+        .first()
+        is not None
+    )
+
+
+def _schedule_runs(db: Session, repository: Repository, column: str) -> bool:
+    """A legacy scheduled job that will run the step for this repository,
+    resolved the way the scheduler dispatches it: association rows when
+    the job has any, else the direct repository_id, else the repository
+    path (app/api/schedule.py)."""
+    jobs = [
+        job
+        for job in db.query(ScheduledJob)
+        .filter(ScheduledJob.enabled.is_(True), getattr(ScheduledJob, column).is_(True))
+        .all()
+        # the scheduler dispatches an availability job on its interval and a
+        # cron job only with an expression; anything else never runs
+        if job.schedule_mode == "availability" or job.cron_expression
+    ]
+    if not jobs:
+        return False
+    linked: dict[int, set[int]] = {}
+    for job_id, repository_id in db.query(
+        ScheduledJobRepository.scheduled_job_id, ScheduledJobRepository.repository_id
+    ).filter(ScheduledJobRepository.scheduled_job_id.in_([j.id for j in jobs])):
+        linked.setdefault(job_id, set()).add(repository_id)
+    for job in jobs:
+        if job.id in linked:
+            if repository.id in linked[job.id]:
+                return True
+            continue
+        if job.repository_id is not None:
+            if job.repository_id == repository.id:
+                return True
+            continue
+        if job.repository and job.repository == repository.path:
+            return True
+    return False
+
+
+def _planned(db: Session, repository: Repository, column: str) -> bool:
+    """Whether a backup plan or scheduled job of this repository runs the
+    step; without one there is nothing to be overdue against. ScheduledJob
+    has no run_check_after, so only plans can expect a check."""
+    if _plan_runs(db, repository.id, column):
+        return True
+    return hasattr(ScheduledJob, column) and _schedule_runs(db, repository, column)
+
+
+def backup_threshold(starts: list[datetime]) -> timedelta:
+    """Twice one series' cadence, the fixed default with too few archives."""
+    gap = anomalies.median_gap(starts) if len(starts) >= 2 else None
+    if gap is None:
+        return timedelta(days=anomalies.OVERDUE_THRESHOLD_DAYS["backup"])
+    return max(gap * CADENCE_FACTOR, timedelta(hours=1))
+
+
+def backup_expectation(
+    by_series: dict[str, list[datetime]], now: datetime
+) -> tuple[timedelta, bool]:
+    """(strictest threshold, overdue) across the repository's series. Each
+    series is judged against its own cadence; the repository is overdue as
+    soon as one of its series is, since every series is a backup someone
+    expects. The reported threshold is the strictest one."""
+    if not by_series:
+        threshold = backup_threshold([])
+        return threshold, True
+    thresholds = {name: backup_threshold(starts) for name, starts in by_series.items()}
+    overdue = any(
+        anomalies.overdue_after(starts[-1], now, thresholds[name])
+        for name, starts in by_series.items()
+    )
+    return min(thresholds.values()), overdue
+
+
+def repository_status(
+    db: Session, repository: Repository, *, now: datetime, pro: bool
+) -> dict:
+    """The strip payload: one cell per applicable category."""
+    pending = pending_removed_ids(db, repository.id)
+    by_series = series_starts(db, repository.id, pending)
+    starts = sorted(start for group in by_series.values() for start in group)
+    mirror_applies = repository.repository_type == "rclone"
+    cells = []
+    for name, spec in CELLS:
+        if name == "mirror" and not mirror_applies:
+            continue
+        if name == "backup":
+            cell = backup_cell(db, repository, spec, starts)
+        elif name == "prune":
+            cell = prune_cell(db, repository, spec)
+        else:
+            cell = job_evidence(db, repository.id, name, spec)
+        _apply(db, repository, cell, by_series, now=now, pro=pro)
+        cells.append(cell.as_dict(now))
+    return {"cells": cells, "overdue_available": pro}
+
+
+def _apply(db, repository, cell, by_series, *, now, pro) -> None:
+    fixed = anomalies.OVERDUE_THRESHOLD_DAYS.get(cell.cell)
+    overdue: Optional[bool] = None
+    if cell.cell == "backup":
+        threshold, overdue = backup_expectation(by_series, now)
+        cell.threshold_days = max(1, ceil(threshold / timedelta(days=1)))
+        expected = True
+        # a failed attempt newer than every archive is judged like a run
+        if cell.source != "archive":
+            overdue = anomalies.overdue_after(cell.completed_at, now, threshold)
+    elif cell.cell == "check":
+        threshold = timedelta(days=fixed)
+        cell.threshold_days = fixed
+        # the repository's own check schedule, or a scheduled plan that
+        # checks after its backups (the executor runs that check)
+        expected = bool(repository.check_schedule_enabled) or _planned(
+            db, repository, "run_check_after"
+        )
+    elif cell.cell in ("prune", "compact"):
+        threshold = timedelta(days=fixed)
+        cell.threshold_days = fixed
+        expected = _planned(db, repository, f"run_{cell.cell}_after")
+    else:
+        threshold = timedelta(days=fixed)
+        cell.threshold_days = fixed
+        expected = True
+    if not pro or not expected:
+        cell.overdue = None
+        return
+    if overdue is None:
+        overdue = anomalies.overdue_after(cell.completed_at, now, threshold)
+    cell.overdue = overdue

--- a/docs/architecture/job-system.md
+++ b/docs/architecture/job-system.md
@@ -207,6 +207,20 @@ Rules:
   indexed repository. An unknown size leaves the stored value alone,
   never `0`. Both versions' `repository.last_modified` (the last manifest
   write) lands in `repositories.borg_last_modified`.
+- The repository status (`GET /repositories/{id}/status`, also served as
+  `/status-strip`) reads repository evidence first: backup is the newest
+  archive, whatever created it, unless a failed or cancelled Borg UI
+  attempt is newer, and with no archives at all the newest job row; prune
+  is the newest successful `archive_sync` that reported removed archives
+  unless a prune run through Borg UI is newer; check and compact keep
+  their job rows. Overdue is judged per series against its own cadence (the
+  repository is overdue when one series is), against the check schedule
+  or a scheduled plan that checks after backups, and against the plans or
+  scheduled jobs that run prune or compact (a plan counts only when
+  enabled, scheduled, dispatchable and linked through an enabled
+  association); it is
+  null where nothing is expected. Details and the `source` field: spec
+  section 10.2.
 - The reconcile scheduler replaces the old stats refresh loop. Every
   `stats_refresh_interval_minutes` it enqueues an index run for each
   repository that has none queued or running. `0` disables it.

--- a/docs/engineering/specs/2026-09-03-repository-operations-and-archive-history.md
+++ b/docs/engineering/specs/2026-09-03-repository-operations-and-archive-history.md
@@ -645,7 +645,8 @@ list responses when `collapse_runs=true`).
 | Method | Route | Purpose |
 | --- | --- | --- |
 | POST | `/repositories/{id}/rebuild` | Body `{"from": "stats" \| "archives" \| "history"}`. Invalidates that stage and later ones, enqueues a manual run at priority 20. `history` sets all archives `pending` and deletes their change rows. |
-| GET | `/repositories/{id}/status-strip` | Latest terminal operation per category for this repository, plus age thresholds. |
+| GET | `/repositories/{id}/status` | Repository status per category from repository evidence: one cell per applicable category with status, `completed_at`, `threshold_days`, `overdue`, `running` and `source`; evidence precedence and overdue rules in section 10.2. |
+| GET | `/repositories/{id}/status-strip` | Same payload as `/status` (kept for the status strip component). |
 | GET | `/repositories/{id}/archives` | From `archives`. Query: `series`, `since`, `until`. Includes `sync_state` (`fresh`, `syncing`, `stale`, `never`). |
 | GET | `/repositories/{id}/archives/heatmap` | Per series, per day: count, total deduplicated size, anomaly flags. |
 | GET | `/repositories/{id}/archives/{archive_id}` | One archive with history state. |
@@ -690,7 +691,12 @@ and status-strip routes. Pure functions with unit tests.
   the previous 7.
 - `overdue_<category>`: last terminal operation in a category older than
   the category's threshold. Defaults: backup 2 days, check 30 days, prune
-  14 days, compact 30 days, index 2 days, mirror 1 day.
+  14 days, compact 30 days, index 2 days, mirror 1 day. These fixed
+  thresholds are what `anomalies.overdue` implements and what the heatmap
+  uses. The status strip does not apply them as such: section 10.2
+  judges each cell against what the repository can expect (series cadence
+  for backup, the check schedule, the plans that run prune or compact) and
+  falls back to the fixed defaults only where noted there.
 
 ## 10. Frontend
 
@@ -752,7 +758,35 @@ nas-backup                                     41.2 GB · 38 archives
 Cells render only for categories that apply (no Mirror cell without rclone
 storage). One `CategoryToken` component owns icon and colour per category
 and is reused by Activity, the pipeline board, and the archive page. The
-warning state comes from `overdue_<category>` anomalies.
+warning state comes from the cell's own `overdue` value (below), which
+is null where the repository expects nothing.
+
+Evidence per cell (#935, `app/services/operations/repository_status.py`,
+served by `GET /repositories/{id}/status` and, unchanged in shape, by
+`/status-strip`): backup is the newest archive in the archives table,
+whatever created it (rows the newest listing reported removed and
+`history_merge` has not deleted yet are excluded, as for `last_backup`);
+a failed or cancelled Borg UI attempt newer than that archive shows as
+that attempt; with no archives the newest job row stands. Prune is the
+newest successful `archive_sync` that reported removed archives (a
+cancelled sync gets no follow-ups, so its removals are not applied and
+the next successful listing reports them again), unless a prune run
+through Borg UI is newer. Check and compact have no repository evidence and
+keep their job rows. Overdue: backup per series, each against twice its
+own cadence (median gap of the series' last 14 archives, the fixed 2 days
+with fewer than two); the repository is overdue as soon as one series is,
+and the reported threshold is the strictest one. Timestamps of different
+series are never mixed into one cadence. Check when the repository's check
+schedule is enabled or a scheduled plan runs a check after its backups;
+prune and compact only when a plan or scheduled job runs them. A plan
+counts only when it is enabled, scheduled (not manual-only), dispatchable
+(availability mode or a cron expression; the scheduler yields no due time
+for a cron plan without one) and its association with the repository is
+enabled; a legacy scheduled job counts by the same dispatch rule and the
+scheduler's own target precedence (association rows, else the direct
+repository, else the repository path). Otherwise `overdue` is
+null. The `source` field is kept for precedence and debugging, the UI does
+not label it.
 
 ### 10.3 Archives page
 

--- a/frontend/src/types/operations.ts
+++ b/frontend/src/types/operations.ts
@@ -103,7 +103,7 @@ export interface StatusStripCell {
   threshold_days: number
   overdue: boolean | null
   running: boolean
-  source: 'operations' | 'legacy' | null
+  source: 'archive' | 'removal' | 'operations' | 'legacy' | null
 }
 
 export interface StatusStripResponse {

--- a/tests/unit/test_anomalies.py
+++ b/tests/unit/test_anomalies.py
@@ -101,10 +101,11 @@ def test_overdue_thresholds():
         "index": 2,
         "mirror": 1,
     }
-    assert an.overdue("backup", now - timedelta(days=2, seconds=1), now) is True
-    assert an.overdue("backup", now - timedelta(days=2), now) is False
-    assert an.overdue("check", None, now) is True
-    assert an.overdue("unknown", now, now) is False
+    # the fixed thresholds feed the heatmap and the default cadence; the
+    # strip judges against overdue_after with a schedule-aware threshold
+    assert an.overdue_after(now - timedelta(days=2, seconds=1), now, timedelta(days=2))
+    assert not an.overdue_after(now - timedelta(days=2), now, timedelta(days=2))
+    assert an.overdue_after(None, now, timedelta(days=30))
 
 
 @pytest.mark.unit

--- a/tests/unit/test_api_archive_index.py
+++ b/tests/unit/test_api_archive_index.py
@@ -4,6 +4,9 @@ import pytest
 
 from app.database.models import (
     Archive,
+    BackupPlan,
+    BackupPlanRepository,
+    PruneJob,
     ArchiveChange,
     BackupJob,
     LicensingState,
@@ -233,11 +236,40 @@ class TestHeatmap:
         assert r.json()["flags_available"]["size_outlier"] is True
 
 
+def _plan(test_db, repo, **flags):
+    """An enabled, scheduled plan: only such a plan runs on its own and is
+    an expectation (a manual-only plan is not)."""
+    flags.setdefault("schedule_enabled", True)
+    flags.setdefault("cron_expression", "0 0 * * *")
+    plan = BackupPlan(
+        name=f"plan-{repo.id}", source_directories="[]", enabled=True, **flags
+    )
+    test_db.add(plan)
+    test_db.flush()
+    test_db.add(
+        BackupPlanRepository(
+            backup_plan_id=plan.id,
+            repository_id=repo.id,
+            enabled=True,
+            execution_order=0,
+        )
+    )
+    test_db.commit()
+    return plan
+
+
+def _cells(test_client, admin_headers, repo, route="status-strip"):
+    r = test_client.get(f"/api/repositories/{repo.id}/{route}", headers=admin_headers)
+    assert r.status_code == 200
+    return r.json(), {c["cell"]: c for c in r.json()["cells"]}
+
+
 @pytest.mark.unit
 class TestStatusStrip:
     def test_cells_from_operations_and_legacy(
         self, test_client, test_db, admin_headers
     ):
+        """With no archives the job rows are the only evidence (as before)."""
         repo = _repo(test_db)
         now = utc_now()
         _op(test_db, repo, "prune", completed_at=now - timedelta(days=20))
@@ -251,11 +283,7 @@ class TestStatusStrip:
             )
         )
         test_db.commit()
-        r = test_client.get(
-            f"/api/repositories/{repo.id}/status-strip", headers=admin_headers
-        )
-        assert r.status_code == 200
-        cells = {c["cell"]: c for c in r.json()["cells"]}
+        body, cells = _cells(test_client, admin_headers, repo)
         assert set(cells) == {"backup", "check", "prune", "compact", "index"}
         assert (
             cells["backup"]["source"] == "legacy"
@@ -267,7 +295,7 @@ class TestStatusStrip:
             cells["check"]["running"] is True and cells["check"]["completed_at"] is None
         )
         assert cells["index"]["age_seconds"] < 4000
-        assert r.json()["overdue_available"] is False
+        assert body["overdue_available"] is False
 
     def test_status_strip_prefers_a_new_check_operation_over_the_legacy_row(
         self, test_client, test_db, admin_headers
@@ -290,19 +318,374 @@ class TestStatusStrip:
         assert cells["check"]["status"] == "completed"
         assert cells["check"]["source"] == "operations"
 
-    def test_overdue_flags_for_pro_and_mirror_cell(
+    def test_status_route_serves_the_same_payload(
         self, test_client, test_db, admin_headers
     ):
-        repo = _repo(test_db, repository_type="rclone")
+        repo = _repo(test_db)
+        _archive(test_db, repo, "a1", 1)
+        strip, _ = _cells(test_client, admin_headers, repo)
+        status, _ = _cells(test_client, admin_headers, repo, route="status")
+        for body in (strip, status):
+            for cell in body["cells"]:
+                cell.pop("age_seconds")  # wall clock between the two calls
+        assert strip == status
+
+    def test_backup_comes_from_the_archive_list(
+        self, test_client, test_db, admin_headers
+    ):
+        """An archive created outside Borg UI (cron, CLI) is the backup; an
+        older Borg UI job row does not make it look overdue (#935)."""
+        repo = _repo(test_db)
+        newest = _archive(test_db, repo, "a2", 5)
+        _archive(test_db, repo, "a1", 1)
+        test_db.add(
+            BackupJob(
+                repository_id=repo.id,
+                status="completed",
+                completed_at=datetime(2026, 8, 14, 8, 45),
+            )
+        )
+        test_db.commit()
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["backup"]["source"] == "archive"
+        assert cells["backup"]["status"] == "completed"
+        assert cells["backup"]["completed_at"].startswith(newest.start.isoformat()[:19])
+
+    def test_failed_attempt_newer_than_the_archive_shows_the_failure(
+        self, test_client, test_db, admin_headers
+    ):
+        repo = _repo(test_db)
+        _archive(test_db, repo, "a1", 1)
+        _op(test_db, repo, "backup", status="failed", completed_at=datetime(2026, 9, 3))
+        # a terminal row without completed_at (PostgreSQL sorts NULL first on
+        # DESC) must not hide the timestamped one
+        _op(test_db, repo, "backup", status="cancelled", completed_at=None)
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["backup"]["status"] == "failed"
+        assert cells["backup"]["source"] == "operations"
+        assert cells["backup"]["completed_at"].startswith("2026-09-03")
+
+    def test_removed_archive_pending_history_merge_is_no_backup_evidence(
+        self, test_client, test_db, admin_headers
+    ):
+        """archive_sync reports a removed archive and leaves the row to
+        history_merge; until that runs the row is no evidence, as for
+        last_backup."""
+        repo = _repo(test_db)
+        older = _archive(test_db, repo, "a1", 1)
+        removed = _archive(test_db, repo, "a2", 5)
+        sync = _op(
+            test_db, repo, "archive_sync", completed_at=datetime(2026, 9, 5, 9, 54)
+        )
+        sync.result = {"listed": 1, "removed_archive_ids": [removed.id]}
+        test_db.commit()
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["backup"]["source"] == "archive"
+        assert cells["backup"]["completed_at"].startswith(older.start.isoformat()[:19])
+
+    def test_archive_evidence_reads_a_bounded_window_per_series(
+        self, test_client, test_db, admin_headers
+    ):
+        """The strip is polled every 30 s per card; only the newest
+        CADENCE_SAMPLE archives per series are read, and the newest archive
+        (the backup evidence) is among them."""
+        from app.services.operations import anomalies
+        from app.services.operations.repository_status import series_starts
+
+        repo = _repo(test_db)
+        for day in range(1, 21):
+            _archive(test_db, repo, f"nas-{day}", day)
+        for day in range(1, 4):
+            _archive(test_db, repo, f"db-{day}", day, series="db")
+        by_series = series_starts(test_db, repo.id)
+        assert len(by_series["nas"]) == anomalies.CADENCE_SAMPLE == 14
+        assert by_series["nas"][-1] == datetime(2026, 9, 20, 2)
+        assert by_series["nas"][0] == datetime(2026, 9, 7, 2)
+        assert len(by_series["db"]) == 3
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["backup"]["completed_at"].startswith("2026-09-20T02")
+
+    def test_cancelled_attempt_newer_than_the_archive_shows_the_cancellation(
+        self, test_client, test_db, admin_headers
+    ):
+        repo = _repo(test_db)
+        _archive(test_db, repo, "a1", 1)
+        _op(
+            test_db,
+            repo,
+            "backup",
+            status="cancelled",
+            completed_at=datetime(2026, 9, 3),
+        )
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["backup"]["status"] == "cancelled"
+        assert cells["backup"]["source"] == "operations"
+        assert cells["backup"]["completed_at"].startswith("2026-09-03")
+
+    def test_cancelled_sync_is_no_prune_evidence(
+        self, test_client, test_db, admin_headers
+    ):
+        """The runner keeps the listing of a sync it marks cancelled but
+        enqueues no follow-ups, so its removals are not applied."""
+        repo = _repo(test_db)
+        sync = _op(
+            test_db,
+            repo,
+            "archive_sync",
+            status="cancelled",
+            completed_at=datetime(2026, 9, 5, 9, 54),
+        )
+        sync.result = {"listed": 19, "removed_archive_ids": [99]}
+        test_db.commit()
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["prune"]["source"] != "removal"
+        assert cells["prune"]["status"] is None
+
+    def test_prune_comes_from_detected_removals(
+        self, test_client, test_db, admin_headers
+    ):
+        repo = _repo(test_db)
+        sync = _op(
+            test_db, repo, "archive_sync", completed_at=datetime(2026, 9, 5, 9, 54)
+        )
+        sync.result = {"listed": 19, "removed_archive_ids": [99]}
+        test_db.add(
+            PruneJob(
+                repository_id=repo.id,
+                status="completed",
+                completed_at=datetime(2026, 8, 14, 8, 45),
+            )
+        )
+        test_db.commit()
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["prune"]["source"] == "removal"
+        assert cells["prune"]["completed_at"].startswith("2026-09-05T09:54")
+        # a newer prune run through Borg UI is exact evidence and wins
+        _op(test_db, repo, "prune", completed_at=datetime(2026, 9, 6, 1, 0))
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["prune"]["source"] == "operations"
+
+    def test_overdue_is_judged_against_plans_schedules_and_cadence(
+        self, test_client, test_db, admin_headers
+    ):
+        """Pro: backup against twice the series cadence; prune and compact
+        only when a plan runs them; check only when scheduled."""
+        repo = _repo(test_db, repository_type="rclone", check_schedule_enabled=False)
         _pro(test_db)
         _op(test_db, repo, "prune", completed_at=utc_now() - timedelta(days=20))
-        r = test_client.get(
-            f"/api/repositories/{repo.id}/status-strip", headers=admin_headers
-        )
-        cells = {c["cell"]: c for c in r.json()["cells"]}
+        _, cells = _cells(test_client, admin_headers, repo)
         assert "mirror" in cells
+        # nothing planned: no expectation, no warning
+        assert cells["prune"]["overdue"] is None
+        assert cells["compact"]["overdue"] is None
+        assert cells["check"]["overdue"] is None
+        # no archives at all: the backup is overdue
+        assert cells["backup"]["overdue"] is True
+
+        plan = _plan(test_db, repo, run_prune_after=True, run_compact_after=True)
+        repo.check_schedule_enabled = True
+        test_db.commit()
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["prune"]["overdue"] is True
+        assert cells["compact"]["overdue"] is True
+        assert cells["check"]["overdue"] is True
+
+        # an enabled plan whose association with this repository is disabled
+        # skips it at run time, so it is no expectation either
+        association = (
+            test_db.query(BackupPlanRepository)
+            .filter_by(backup_plan_id=plan.id, repository_id=repo.id)
+            .one()
+        )
+        association.enabled = False
+        test_db.commit()
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["prune"]["overdue"] is None
+        assert cells["compact"]["overdue"] is None
+        association.enabled = True
+        test_db.commit()
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["prune"]["overdue"] is True
+
+        # a cron plan without an expression never gets a due time from the
+        # scheduler, so it is no expectation either; availability mode is
+        plan.cron_expression = None
+        test_db.commit()
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["prune"]["overdue"] is None
+        assert cells["compact"]["overdue"] is None
+        plan.schedule_mode = "availability"
+        test_db.commit()
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["prune"]["overdue"] is True
+        plan.schedule_mode = "cron"
+        plan.cron_expression = "0 0 * * *"
+        test_db.commit()
+
+    def test_backup_cadence_threshold(self, test_client, test_db, admin_headers):
+        """Daily archives: the fixed two-day rule; weekly archives: two weeks."""
+        repo = _repo(test_db)
+        _pro(test_db)
+        now = utc_now().replace(tzinfo=None)
+        for i in range(4):
+            a = _archive(test_db, repo, f"w{i}", 1)
+            a.start = now - timedelta(days=7 * (4 - i))
+        test_db.commit()
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["backup"]["threshold_days"] == 14
+        assert cells["backup"]["overdue"] is False  # 7 days old, cadence 7 days
+
+        for a in test_db.query(Archive).filter_by(repository_id=repo.id):
+            a.start = a.start - timedelta(days=10)
+        test_db.commit()
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["backup"]["overdue"] is True  # 17 days old
+
+    def test_two_daily_series_are_not_one_hourly_cadence(self, test_db):
+        """Review F09: two nightly hosts a minute apart interleave into
+        one-minute gaps; each series is daily and on time at noon."""
+        from app.services.operations.repository_status import repository_status
+
+        repo = _repo(test_db)
+        now = datetime(2026, 9, 6, 12)
+        for day in range(7):
+            for minute, series in enumerate(("host-a", "host-b")):
+                a = _archive(test_db, repo, f"{series}-{day}", 1, series=series)
+                a.start = datetime(2026, 9, 6, 0, minute) - timedelta(days=day)
+        test_db.commit()
+        cell = {
+            c["cell"]: c
+            for c in repository_status(test_db, repo, now=now, pro=True)["cells"]
+        }["backup"]
+        assert cell["overdue"] is False
+        assert cell["threshold_days"] == 2
+
+        # one series falling silent makes the repository overdue even while
+        # the other keeps going
+        for a in test_db.query(Archive).filter_by(series="host-b"):
+            a.start = a.start - timedelta(days=5)
+        test_db.commit()
+        cell = {
+            c["cell"]: c
+            for c in repository_status(test_db, repo, now=now, pro=True)["cells"]
+        }["backup"]
+        assert cell["overdue"] is True
+
+    def test_manual_only_plan_is_no_expectation(
+        self, test_client, test_db, admin_headers
+    ):
+        """Review F10: the dispatcher requires schedule_enabled, so a plan
+        that is only run by hand promises no prune, compact or check."""
+        repo = _repo(test_db, check_schedule_enabled=False)
+        _pro(test_db)
+        _plan(
+            test_db,
+            repo,
+            schedule_enabled=False,
+            run_prune_after=True,
+            run_compact_after=True,
+            run_check_after=True,
+        )
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["prune"]["overdue"] is None
+        assert cells["compact"]["overdue"] is None
+        assert cells["check"]["overdue"] is None
+
+    def test_legacy_schedule_targets_follow_the_scheduler(
+        self, test_client, test_db, admin_headers
+    ):
+        """Review F11: association rows first, else the direct repository,
+        else the path, as app/api/schedule.py dispatches."""
+        from app.database.models import ScheduledJob, ScheduledJobRepository
+
+        repo = _repo(test_db)
+        other = _repo(test_db, name="other")
+        _pro(test_db)
+        direct = ScheduledJob(
+            name="direct",
+            repository_id=repo.id,
+            enabled=True,
+            cron_expression="0 0 * * *",
+            run_prune_after=True,
+            run_compact_after=True,
+        )
+        test_db.add(direct)
+        test_db.commit()
+        _, cells = _cells(test_client, admin_headers, repo)
         assert cells["prune"]["overdue"] is True and cells["compact"]["overdue"] is True
-        assert r.json()["overdue_available"] is True
+
+        # association rows take precedence over a stale direct field
+        test_db.add(
+            ScheduledJobRepository(
+                scheduled_job_id=direct.id, repository_id=other.id, execution_order=0
+            )
+        )
+        test_db.commit()
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["prune"]["overdue"] is None
+        _, cells = _cells(test_client, admin_headers, other)
+        assert cells["prune"]["overdue"] is True
+
+        # an enabled cron job without an expression is never dispatched, so
+        # it is no expectation either (CodeRabbit on the F11 change)
+        idle = ScheduledJob(
+            name="idle",
+            repository_id=repo.id,
+            enabled=True,
+            cron_expression=None,
+            run_compact_after=True,
+        )
+        test_db.add(idle)
+        test_db.commit()
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["compact"]["overdue"] is None
+        test_db.delete(idle)
+        test_db.commit()
+
+        # path-only legacy job
+        by_path = ScheduledJob(
+            name="by-path",
+            repository=repo.path,
+            enabled=True,
+            cron_expression="0 0 * * *",
+            run_compact_after=True,
+        )
+        test_db.add(by_path)
+        test_db.commit()
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["compact"]["overdue"] is True
+        assert cells["prune"]["overdue"] is None
+
+    def test_scheduled_plan_check_after_backup_is_an_expectation(
+        self, test_client, test_db, admin_headers
+    ):
+        """Review F12: the executor runs run_check_after, so it expects a
+        check even with the repository's own check schedule off."""
+        repo = _repo(test_db, check_schedule_enabled=False)
+        _pro(test_db)
+        _plan(test_db, repo, run_check_after=True)
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["check"]["overdue"] is True
+        _op(test_db, repo, "check", completed_at=utc_now() - timedelta(days=1))
+        _, cells = _cells(test_client, admin_headers, repo)
+        assert cells["check"]["overdue"] is False
+
+    def test_latest_removal_stops_at_the_first_listing_with_removals(self, test_db):
+        """The newest listing with removals wins; newer listings without
+        removals do not hide it, and rows past it are not read."""
+        from app.services.operations.repository_status import latest_removal
+
+        repo = _repo(test_db)
+        now = utc_now()
+        _op(test_db, repo, "archive_sync", completed_at=now - timedelta(days=3))
+        removal = _op(
+            test_db, repo, "archive_sync", completed_at=now - timedelta(days=2)
+        )
+        removal.result = {"removed_archive_ids": [7]}
+        newer = _op(test_db, repo, "archive_sync", completed_at=now - timedelta(days=1))
+        newer.result = {"removed_archive_ids": []}
+        test_db.commit()
+        assert latest_removal(test_db, repo.id) == removal.completed_at
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Description

The repository card shows two answers to "when did this repository last get a backup": the key stat `Last backup` (from `repositories.last_backup`, derived from the archives table) and the status strip's `Backup` cell (from the newest `backup` operation or `BackupJob`). For a repository whose backups are created outside Borg UI (a cron job, the CLI, another Borg UI instance) the card says "today" and the strip says "x days ago, overdue" on the same screen; `Prune` and `Compact` behave the same way. Backend half of #935.

`app/services/operations/repository_status.py` builds each cell from the best evidence available:

- **backup**: the newest archive in the archives table, whatever created it (rows the newest listing reported removed and `history_merge` has not deleted yet are excluded, as `last_backup` already does); a failed or cancelled Borg UI attempt newer than that archive shows as that attempt (real information about the last attempt); with no archives at all the newest job row stands, as before.
- **prune**: the newest successful `archive_sync` whose result lists removed archives (an upper bound: the removal happened between that listing and the one before; a sync the runner marked cancelled gets no follow-ups, so its removals are not applied and the next successful listing reports them again), unless a prune run through Borg UI is newer.
- **check, compact**: job rows (operations first, legacy tables until phase 9), since Borg records neither.
- **index, mirror**: unchanged.

The archives table is read once per request, bounded to the newest 14 archives per series (`CADENCE_SAMPLE`, a window function): the cadence reads no further back and the newest archive is among them, so the 30-second poll per card does not scan a long hourly history each time. `anomalies.overdue()` (fixed thresholds) had no caller left and is removed; the heatmap keeps `OVERDUE_THRESHOLD_DAYS`.

**Overdue** is judged against what the repository can expect, and is `null` where nothing is expected: backup against twice the series cadence (`anomalies.median_gap` over the last 14 archives; the fixed 2 days with fewer than two), check only when the repository's check schedule is enabled, prune and compact only when an enabled backup plan or scheduled job of the repository runs them (`run_prune_after` / `run_compact_after`). A plan counts only when the scheduler would dispatch it: enabled, scheduled, in availability mode or with a cron expression, and linked through an enabled association. Pro gating (`overdue_available`) is unchanged.

`GET /repositories/{id}/status` serves the model; `/status-strip` serves the same payload, so the card shows the new semantics without a frontend change. The `source` field stays for precedence and debugging (`archive`, `removal`, `operations`, `legacy`); the UI does not label it, only the TypeScript union widens. The latest-terminal query requires `completed_at` (PostgreSQL sorts NULL first on DESC). Spec 10.2 and `docs/architecture/job-system.md` record the rules; spec 9.5 states that its fixed thresholds are the heatmap contract and that the strip follows 10.2.

Not in this PR: the single `RepositoryStats` component replacing the V1/V2 pair and the strip reading `/status` directly (frontend follow-up).

## Related Issue

Fixes #935 (backend half)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

`test_api_archive_index.py::TestStatusStrip`, rewritten for the evidence model:

- with no archives the job rows are the only evidence (the previous test, unchanged in expectations);
- `/status` and `/status-strip` serve the same payload;
- an archive created outside Borg UI is the backup, an older Borg UI job row does not make it look overdue;
- a failed attempt newer than the newest archive shows the failure, with a cancelled row without a timestamp in the same test covering the `completed_at` requirement; a cancelled attempt newer than the archive shows the cancellation;
- a cancelled `archive_sync` with removals in its result is no prune evidence;
- an archive the newest listing reported removed is no backup evidence while `history_merge` has not deleted it yet;
- the per-series window: 20 archives in one series read as the newest 14, the newest one is the backup evidence;
- prune comes from detected removals, and a newer prune run through Borg UI wins;
- overdue: nothing planned means no warning for prune, compact and check; attaching a plan with `run_prune_after` / `run_compact_after` and enabling the check schedule turns them on; a disabled association or a cron plan without an expression is no expectation, availability mode is; no archives at all is overdue;
- backup cadence: weekly archives get a 14-day threshold and are not overdue at 7 days, overdue at 17.

Runs (scratch venv, Python 3.12, ruff 0.16.6; frontend under Node 22):

```
pytest tests/unit/test_api_archive_index.py tests/unit/test_anomalies.py tests/unit/test_operations_runner.py
79 passed   (50 in test_api_archive_index.py after the review rounds)

pytest tests/unit   (full suite, untouched clone of this branch on main 323fc784, after the review rounds)
3437 passed, 13 skipped in 603s

ruff check .            All checks passed!
ruff format --check     clean for every file in this diff
frontend: npm run format:check / typecheck / lint / check:locales   all clean
```

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable (no rendering change; the strip shows the new values through the existing component).

## Additional Context

Observed on a repository whose backup, prune and compact run from a cron job: `last_backup` today from the archives table, strip `Backup` / `Prune` / `Compact` weeks old from the last run that went through Borg UI, flagged overdue; the archives table had the new archive and `archive_sync` had reported the pruned one the same day. Spec 10.2 described the strip as job-driven while spec 6.4 already makes `Archive.backup_operation_id` nullable, so archives without a Borg UI operation are a modelled case. Part of the wave described in #917, #931, #933, #934, #935, #936.

Reviewed on the fork (CodeRabbit) and rebased onto `main` at `90e8361a` after #950 merged, then onto `323fc784` after #947 and #946: the only overlap with #947 was `tests/unit/test_api_archive_index.py`, where both sides append tests (its phase-5 check test is kept and passes against the evidence model); no application file here was touched by #947. Maintainer review: the second archives query and the unbounded scan are gone (one bounded query, flat list derived from it), `overdue()` dropped.
