### PR TITLE
fix(db): add the agent upgrade tracking columns as an Alembic revision

### DIFF
--- a/app/database/alembic/versions/f7a2b8c4d1e5_add_agent_upgrade_tracking.py
+++ b/app/database/alembic/versions/f7a2b8c4d1e5_add_agent_upgrade_tracking.py
@@ -1,0 +1,48 @@
+"""add agent upgrade tracking columns
+
+The columns landed in the model with the centralized agent upgrades work but
+only ever got a legacy ladder file (129), which is frozen and no longer runs at
+startup. Every Alembic-managed database is therefore missing them.
+
+Revision ID: f7a2b8c4d1e5
+Revises: e5f6a7b8c9d0
+Create Date: 2026-09-08
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "f7a2b8c4d1e5"
+down_revision = "e5f6a7b8c9d0"
+branch_labels = None
+depends_on = None
+
+
+_COLUMNS = (
+    sa.Column("desired_agent_version", sa.String(), nullable=True),
+    sa.Column("desired_borg_version", sa.String(), nullable=True),
+    sa.Column("upgrade_state", sa.String(), nullable=True),
+    sa.Column("upgrade_requested_at", sa.DateTime(), nullable=True),
+    sa.Column("upgrade_target_version", sa.String(), nullable=True),
+    sa.Column("upgrade_error", sa.Text(), nullable=True),
+)
+
+
+def upgrade() -> None:
+    existing = {
+        column["name"]
+        for column in sa.inspect(op.get_bind()).get_columns("agent_machines")
+    }
+    missing = [column for column in _COLUMNS if column.name not in existing]
+    if not missing:
+        return
+    with op.batch_alter_table("agent_machines") as batch_op:
+        for column in missing:
+            batch_op.add_column(column)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("agent_machines") as batch_op:
+        for column in _COLUMNS:
+            batch_op.drop_column(column.name)

--- a/app/database/alembic/versions/f7a2b8c4d1e5_add_agent_upgrade_tracking.py
+++ b/app/database/alembic/versions/f7a2b8c4d1e5_add_agent_upgrade_tracking.py
@@ -20,29 +20,22 @@ depends_on = None
 
 
 _COLUMNS = (
-    sa.Column("desired_agent_version", sa.String(), nullable=True),
-    sa.Column("desired_borg_version", sa.String(), nullable=True),
-    sa.Column("upgrade_state", sa.String(), nullable=True),
-    sa.Column("upgrade_requested_at", sa.DateTime(), nullable=True),
-    sa.Column("upgrade_target_version", sa.String(), nullable=True),
-    sa.Column("upgrade_error", sa.Text(), nullable=True),
+    ("desired_agent_version", sa.String()),
+    ("desired_borg_version", sa.String()),
+    ("upgrade_state", sa.String()),
+    ("upgrade_requested_at", sa.DateTime()),
+    ("upgrade_target_version", sa.String()),
+    ("upgrade_error", sa.Text()),
 )
 
 
 def upgrade() -> None:
-    existing = {
-        column["name"]
-        for column in sa.inspect(op.get_bind()).get_columns("agent_machines")
-    }
-    missing = [column for column in _COLUMNS if column.name not in existing]
-    if not missing:
-        return
     with op.batch_alter_table("agent_machines") as batch_op:
-        for column in missing:
-            batch_op.add_column(column)
+        for name, column_type in _COLUMNS:
+            batch_op.add_column(sa.Column(name, column_type, nullable=True))
 
 
 def downgrade() -> None:
     with op.batch_alter_table("agent_machines") as batch_op:
-        for column in _COLUMNS:
-            batch_op.drop_column(column.name)
+        for name, _ in _COLUMNS:
+            batch_op.drop_column(name)

--- a/tests/unit/test_agent_upgrade_tracking_migration.py
+++ b/tests/unit/test_agent_upgrade_tracking_migration.py
@@ -1,0 +1,78 @@
+"""Tests for revision f7a2b8c4d1e5 (agent_machines upgrade tracking columns)."""
+
+import pytest
+from alembic import command
+from sqlalchemy import inspect
+
+from app.database.db_upgrade import _alembic_config, _engine
+
+REVISION = "f7a2b8c4d1e5"
+PREVIOUS = "e5f6a7b8c9d0"
+COLUMNS = {
+    "desired_agent_version",
+    "desired_borg_version",
+    "upgrade_state",
+    "upgrade_requested_at",
+    "upgrade_target_version",
+    "upgrade_error",
+}
+
+
+def _migrate(url, target, *, down=False):
+    engine = _engine(url)
+    config = _alembic_config(url)
+    with engine.connect() as connection:
+        config.attributes["connection"] = connection
+        (command.downgrade if down else command.upgrade)(config, target)
+        connection.commit()
+    engine.dispose()
+
+
+def _columns(url):
+    engine = _engine(url)
+    try:
+        return {c["name"] for c in inspect(engine).get_columns("agent_machines")}
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.unit
+def test_upgrade_adds_and_downgrade_drops_the_columns(tmp_path):
+    url = f"sqlite:///{tmp_path / 'borg.db'}"
+    _migrate(url, PREVIOUS)
+    assert not COLUMNS & _columns(url)
+
+    _migrate(url, REVISION)
+    assert COLUMNS <= _columns(url)
+
+    _migrate(url, PREVIOUS, down=True)
+    assert not COLUMNS & _columns(url)
+
+
+@pytest.mark.unit
+def test_upgrade_is_idempotent_when_a_column_already_exists(tmp_path):
+    """A database that ran legacy migration 129 already has them."""
+    url = f"sqlite:///{tmp_path / 'borg.db'}"
+    _migrate(url, PREVIOUS)
+
+    engine = _engine(url)
+    with engine.connect() as connection:
+        from sqlalchemy import text
+
+        connection.execute(
+            text("ALTER TABLE agent_machines ADD COLUMN desired_agent_version VARCHAR")
+        )
+        connection.commit()
+    engine.dispose()
+
+    _migrate(url, REVISION)
+    assert COLUMNS <= _columns(url)
+
+
+@pytest.mark.unit
+def test_revision_chains_on_the_previous_head_and_leaves_one_head():
+    from alembic.script import ScriptDirectory
+
+    script = ScriptDirectory.from_config(_alembic_config("sqlite://"))
+    assert script.get_revision(REVISION).down_revision == PREVIOUS
+    assert len(script.get_heads()) == 1

--- a/tests/unit/test_agent_upgrade_tracking_migration.py
+++ b/tests/unit/test_agent_upgrade_tracking_migration.py
@@ -50,26 +50,6 @@ def test_upgrade_adds_and_downgrade_drops_the_columns(tmp_path):
 
 
 @pytest.mark.unit
-def test_upgrade_is_idempotent_when_a_column_already_exists(tmp_path):
-    """A database that ran legacy migration 129 already has them."""
-    url = f"sqlite:///{tmp_path / 'borg.db'}"
-    _migrate(url, PREVIOUS)
-
-    engine = _engine(url)
-    with engine.connect() as connection:
-        from sqlalchemy import text
-
-        connection.execute(
-            text("ALTER TABLE agent_machines ADD COLUMN desired_agent_version VARCHAR")
-        )
-        connection.commit()
-    engine.dispose()
-
-    _migrate(url, REVISION)
-    assert COLUMNS <= _columns(url)
-
-
-@pytest.mark.unit
 def test_revision_chains_on_the_previous_head_and_leaves_one_head():
     from alembic.script import ScriptDirectory
 


### PR DESCRIPTION
## Problem

Any request that reads `agent_machines` fails on a live database:

```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such column: agent_machines.desired_agent_version
```

The centralized agent upgrades work (#951) added six columns to `AgentMachine` in the model, but the only schema change it shipped was a legacy ladder file, `129_add_agent_upgrade_tracking.py`. That ladder is frozen and no longer runs at startup. It is replayed only on a throwaway copy of a pre-Alembic database, whose rows are then copied onto the Alembic baseline, and the baseline predates these columns. So no Alembic-managed database has ever had them.

Missing columns: `desired_agent_version`, `desired_borg_version`, `upgrade_state`, `upgrade_requested_at`, `upgrade_target_version`, `upgrade_error`.

The unit tests did not catch it because they build the schema from the model metadata rather than from the revision chain.

## Fix

A new revision `f7a2b8c4d1e5` on the current head `e5f6a7b8c9d0`, adding the six nullable columns and dropping them again on downgrade.

Tests cover the upgrade, the downgrade, and that the revision chains on the previous head and leaves a single head.

## CodeRabbit

One finding (major): `downgrade()` dropped columns that `upgrade()` might not have created, because the first version of this revision skipped columns that already existed.

Fixed by removing that guard rather than by tracking created columns. It was defending against a state `db_upgrade` cannot produce, since the copy target is always a freshly built baseline, and it was the only source of the asymmetry.