### PR TITLE
feat(borg2): run compact with --stats and persist the repository statistics

### DIFF
--- a/agent/borg_ui_agent/compact_stats.py
+++ b/agent/borg_ui_agent/compact_stats.py
@@ -1,0 +1,243 @@
+"""Repository statistics from `borg compact --stats` (Borg 2).
+
+Borg 2 reports repository-wide statistics only here, on INFO level; there
+is no JSON form (borgbackup/borg#10329). The parser accepts the plain lines
+or the `--log-json` `log_message` entries that wrap them.
+
+Sizes are printed through Borg's `format_file_size`, which follows
+`BORG_UNITS`: `si` (default, `502 kB`, `2.39 TB`), `iec` (`490 KiB`) or
+`raw` (`502000 B`). The human forms are rounded to the digits Borg
+prints, so the parsed byte count is only as exact as those digits; every
+compact path of this application sets `BORG_UNITS=raw` and gets exact
+integers. The result records which it got in `size_precision`, from the
+repository size token, the one figure that is acted on: `exact` for a raw
+byte count, `rounded_to_printed_unit` otherwise. The deduplication and
+compression factors are printed with two decimals in either mode.
+
+A figure Borg cannot have printed (a size or count at or above 2**63, a
+factor that is not a finite number, a digit run `int` refuses) makes its
+line not a statistics line; the same parser reads agent-supplied
+transcripts, so nothing here raises on a line's content.
+
+The lines are matched by their whole wording, not by the logger that
+emitted them (`borg.archiver.compact_cmd` today); a `--log-json` entry of
+any logger is accepted.
+
+This is the agent's copy of `app/services/borg2_compact_stats.py`: the
+agent wheel ships only its own package, and the server keeps the parser
+for its own compacts and as the fallback for an agent that reported no
+statistics. Keep the two the same; a unit test compares them.
+(`is_stats_line` is unused here; it stays so the bodies are identical.)
+"""
+
+import json
+import re
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Iterable, Optional
+
+PRECISION_EXACT = "exact"
+PRECISION_ROUNDED = "rounded_to_printed_unit"
+# A size or count at or above this did not come from Borg (its sizes are
+# 64-bit); a transcript line carrying one is not a statistics line.
+MAX_COUNT = 2**63
+# More digits than that cannot stay below MAX_COUNT, and `int` refuses a
+# long enough digit run outright (sys.int_info.str_digits_check_threshold).
+_MAX_DIGITS = 24
+# A Borg 2 compact prints its statistics as the last lines of the run; this
+# many lines from the end of the output hold all of them.
+TAIL_LINES = 64
+# The Borg 2 beta that added `compact --stats`; an older beta rejects the
+# whole command for the flag.
+COMPACT_STATS_SINCE_BETA = 15
+
+
+# Bounded components: `int` on an unbounded digit run can refuse it.
+_VERSION_TOKEN = (
+    r"(?P<major>\d{1,6})\.(?P<minor>\d{1,6})\.(?P<patch>\d{1,6})(?:b(?P<beta>\d{1,6}))?"
+)
+_VERSION = re.compile(r"\b" + _VERSION_TOKEN)
+_BORG_VERSION = re.compile(r"\bborg\S*\s+" + _VERSION_TOKEN)
+
+
+def parse_borg_version(output: str) -> Optional[str]:
+    """The version token in `borg --version` output ("borg2 2.0.0b24"):
+    the one after the program name where there is one (a wrapper may print
+    its own banner first), else the first version-shaped token, else None;
+    the caller then knows nothing about the binary rather than something
+    wrong."""
+    match = _BORG_VERSION.search(output) or _VERSION.search(output)
+    if not match:
+        return None
+    return match.group(0)[match.start("major") - match.start(0) :]
+
+
+def has_compact_stats(version: str) -> bool:
+    """Whether Borg `version` (a token from `parse_borg_version`) accepts
+    `compact --stats`: any 2.x that is not a beta before b15."""
+    match = _VERSION.search(version)
+    if not match or int(match.group("major")) != 2:
+        return False
+    beta = match.group("beta")
+    return beta is None or int(beta) >= COMPACT_STATS_SINCE_BETA
+
+
+_UNITS = {
+    "B": 1,
+    "kB": 10**3,
+    "MB": 10**6,
+    "GB": 10**9,
+    "TB": 10**12,
+    "PB": 10**15,
+    "EB": 10**18,
+    "KiB": 2**10,
+    "MiB": 2**20,
+    "GiB": 2**30,
+    "TiB": 2**40,
+    "PiB": 2**50,
+    "EiB": 2**60,
+}
+_SIZE = r"(?P<size>\d+(?:\.\d+)?) (?P<unit>[kMGTPE]?B|[KMGTPE]iB)"
+_PATTERNS = {
+    "archive_count": re.compile(
+        r"^Overall statistics, considering all (?P<n>\d+) archives in this repository:$"
+    ),
+    "source": re.compile(rf"^Source data size was {_SIZE} in (?P<n>\d+) files\.$"),
+    "deduplicated_size": re.compile(rf"^Deduplicated size is {_SIZE}\.$"),
+    "deduplication_factor": re.compile(
+        r"^Deduplication factor is (?P<f>\d+(?:\.\d+)?)\.$"
+    ),
+    "repository": re.compile(rf"^Repository size is {_SIZE} in (?P<n>\d+) objects\.$"),
+    "compression_factor": re.compile(r"^Compression factor is (?P<f>\d+(?:\.\d+)?)\.$"),
+    "compaction_saved": re.compile(rf"^Compaction saved {_SIZE}\.$"),
+}
+
+
+def _bytes(match: re.Match) -> Optional[int]:
+    """Integer bytes without a float in between: `int` keeps raw counts
+    exact above 2**53, Decimal scales the human forms as printed. None
+    for a figure Borg cannot have printed."""
+    size, unit = match.group("size"), match.group("unit")
+    if len(size) > _MAX_DIGITS:
+        return None
+    if unit == "B" and "." not in size:
+        value = int(size)
+    else:
+        scaled = Decimal(size) * _UNITS[unit]
+        value = int(scaled.to_integral_value(rounding=ROUND_HALF_UP))
+    return value if value < MAX_COUNT else None
+
+
+def _count(match: re.Match) -> Optional[int]:
+    text = match.group("n")
+    if len(text) > _MAX_DIGITS:
+        return None
+    value = int(text)
+    return value if value < MAX_COUNT else None
+
+
+def _factor(match: re.Match) -> Optional[float]:
+    text = match.group("f")
+    # The pattern admits digits and one point only, so the digit cap is
+    # also what keeps the float finite.
+    return float(text) if len(text) <= _MAX_DIGITS else None
+
+
+def _message(line: str) -> Optional[str]:
+    """The statistics line inside a `--log-json` entry, or the line itself."""
+    text = line.strip()
+    if not text:
+        return None
+    if text[0] != "{":
+        return text
+    try:
+        entry = json.loads(text)
+    except (ValueError, RecursionError):
+        # Agent-supplied bytes: nesting past the interpreter's limit, or an
+        # integer literal past its digit limit (a ValueError that is not a
+        # JSONDecodeError), is not a statistics line either.
+        return None
+    if not isinstance(entry, dict) or entry.get("type") != "log_message":
+        return None
+    message = entry.get("message")
+    return message.strip() if isinstance(message, str) else None
+
+
+_STATS_LINE_PREFIXES = (
+    "Overall statistics",
+    "Source data size",
+    "Deduplicated size",
+    "Deduplication factor",
+    "Repository size",
+    "Compression factor",
+    "Compaction saved",
+)
+
+
+def is_stats_line(line: str) -> bool:
+    """Whether `line` is one of the statistics lines, by its wording alone
+    (a caller that wants them visible must not key on the logger name the
+    parser itself ignores)."""
+    message = _message(line)
+    if message is None or not message.startswith(_STATS_LINE_PREFIXES):
+        # a cheap first cut: --info prints a line per analysed archive
+        return False
+    for pattern in _PATTERNS.values():
+        if m := pattern.match(message):
+            return _figures_in_range(m)
+    return False
+
+
+def _figures_in_range(match: re.Match) -> bool:
+    """Whether every figure the line carries is one Borg could have
+    printed, the test the parser applies before it takes a line."""
+    groups = match.groupdict()
+    if "size" in groups and _bytes(match) is None:
+        return False
+    if "n" in groups and _count(match) is None:
+        return False
+    if "f" in groups and _factor(match) is None:
+        return False
+    return True
+
+
+def parse_compact_stats(lines: Iterable[str]) -> Optional[dict]:
+    """Return the statistics dict, or None when no "Repository size" line
+    was seen (Borg 1, a compact without --stats, a failed run). A line
+    whose figure is out of Borg's range is skipped."""
+    stats: dict = {}
+    exact = True
+
+    for line in lines:
+        message = _message(line)
+        if message is None:
+            continue
+        if m := _PATTERNS["archive_count"].match(message):
+            if (count := _count(m)) is not None:
+                stats["archive_count"] = count
+        elif m := _PATTERNS["source"].match(message):
+            value, count = _bytes(m), _count(m)
+            if value is not None and count is not None:
+                stats["source_size"] = value
+                stats["source_files"] = count
+        elif m := _PATTERNS["deduplicated_size"].match(message):
+            if (value := _bytes(m)) is not None:
+                stats["deduplicated_size"] = value
+        elif m := _PATTERNS["deduplication_factor"].match(message):
+            if (factor := _factor(m)) is not None:
+                stats["deduplication_factor"] = factor
+        elif m := _PATTERNS["repository"].match(message):
+            value, count = _bytes(m), _count(m)
+            if value is not None and count is not None:
+                stats["repository_size"] = value
+                stats["object_count"] = count
+                exact = m.group("unit") == "B" and "." not in m.group("size")
+        elif m := _PATTERNS["compression_factor"].match(message):
+            if (factor := _factor(m)) is not None:
+                stats["compression_factor"] = factor
+        elif m := _PATTERNS["compaction_saved"].match(message):
+            if (value := _bytes(m)) is not None:
+                stats["compaction_saved"] = value
+    if "repository_size" not in stats:
+        return None
+    stats["size_precision"] = PRECISION_EXACT if exact else PRECISION_ROUNDED
+    return stats

--- a/agent/borg_ui_agent/repository_ops.py
+++ b/agent/borg_ui_agent/repository_ops.py
@@ -12,6 +12,7 @@ import subprocess
 import tempfile
 import threading
 import time
+from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -24,6 +25,12 @@ from agent.borg_ui_agent.backup import (
 )
 from agent.borg_ui_agent.borg import is_warning_return_code
 from agent.borg_ui_agent.client import AgentClient
+from agent.borg_ui_agent.compact_stats import (
+    TAIL_LINES,
+    has_compact_stats,
+    parse_borg_version,
+    parse_compact_stats,
+)
 
 
 REPOSITORY_JOB_KINDS = {
@@ -149,7 +156,9 @@ class RepositoryOperationPayload:
             cmd.extend(["--remote-path", self.remote_path])
         return cmd
 
-    def build_command(self, *, rclone_config_path: Optional[str] = None) -> list[str]:
+    def build_command(
+        self, *, rclone_config_path: Optional[str] = None, compact_stats: bool = True
+    ) -> list[str]:
         if self.job_kind == "repository.disk_usage":
             if not self.repository_path:
                 raise ValueError("repository.disk_usage requires a repository path")
@@ -358,14 +367,14 @@ class RepositoryOperationPayload:
         if self.job_kind == "repository.compact":
             if self.borg_version == 2:
                 # --stats: the only place Borg 2 reports repository-wide
-                # statistics; the server parses them from the job log.
-                return [
-                    *self._base_borg2("compact"),
-                    "--stats",
-                    "--progress",
-                    "--verbose",
-                    "--log-json",
-                ]
+                # statistics; parsed from the tail of the output into the
+                # completion report (`_execute_streaming_repository_operation`).
+                # The flag exists from 2.0.0b15 (`compact_stats_supported`).
+                cmd = [*self._base_borg2("compact")]
+                if compact_stats:
+                    cmd.append("--stats")
+                cmd.extend(["--progress", "--verbose", "--log-json"])
+                return cmd
             return [
                 *self._base_borg1("compact"),
                 "--progress",
@@ -559,12 +568,15 @@ def execute_repository_operation_job(
     rclone_config_path: Optional[str] = None
     try:
         payload = RepositoryOperationPayload.from_job_payload(job.get("payload") or {})
+        with_stats = _reports_compact_stats(payload) and compact_stats_supported(
+            payload.borg_cmd
+        )
         try:
             if payload.job_kind == "repository.rclone_sync":
                 rclone_config_path = _write_temp_rclone_config(payload)
                 cmd = payload.build_command(rclone_config_path=rclone_config_path)
             else:
-                cmd = payload.build_command()
+                cmd = payload.build_command(compact_stats=with_stats)
         except Exception:
             _remove_temp_file(rclone_config_path)
             raise
@@ -582,10 +594,10 @@ def execute_repository_operation_job(
         # zone so they come out UTC. Applied after the server-sent overrides:
         # the reported machine timezone is "UTC" on the same contract.
         env["TZ"] = "UTC"
-    if payload.job_kind == "repository.compact" and payload.borg_version == 2:
-        # The server parses the --stats lines from the job log; raw units
-        # print exact byte counts instead of the rounded human form, which
-        # follows whatever BORG_UNITS the machine environment carries.
+    if with_stats:
+        # Raw units print exact byte counts in the --stats lines instead of
+        # the rounded human form, which follows whatever BORG_UNITS the
+        # machine environment carries.
         env["BORG_UNITS"] = "raw"
     if payload.job_kind == "repository.init":
         # Repo creation must not touch the shared pack cache: borgstore
@@ -656,6 +668,7 @@ def execute_repository_operation_job(
             env,
             initial_sequence=sequence,
             should_cancel=should_cancel,
+            compact_stats=with_stats,
         )
     finally:
         _remove_temp_file(rclone_config_path)
@@ -1084,7 +1097,13 @@ def _execute_streaming_repository_operation(
     *,
     initial_sequence: int,
     should_cancel: Optional[Callable[[], bool]],
+    compact_stats: bool = False,
 ) -> RepositoryOperationResult:
+    """Run a Borg (or rclone) command to completion, streaming its output
+    as log lines. `compact_stats`: the command is a Borg 2 `compact
+    --stats`, whose statistics are parsed from the tail of the output into
+    the completion report, and whose Borg warning exit code completes the
+    job with warnings (`_warning_exit`)."""
     try:
         popen_kwargs: dict[str, Any] = {
             "stdout": subprocess.PIPE,
@@ -1106,11 +1125,14 @@ def _execute_streaming_repository_operation(
         )
 
     sequence = initial_sequence
+    tail: deque[str] = deque(maxlen=TAIL_LINES)
     if process.stdout is not None:
         for line in process.stdout:
             message = line.rstrip("\n")
             client.send_log(job_id, sequence=sequence, stream="stdout", message=message)
             sequence += 1
+            if compact_stats:
+                tail.append(message)
             progress = parse_borg_progress(message)
             if progress:
                 client.send_progress(job_id, progress)
@@ -1125,14 +1147,24 @@ def _execute_streaming_repository_operation(
                 )
 
     return_code = process.wait()
-    if return_code == 0:
-        client.complete_job(
-            job_id,
-            result={"return_code": return_code, "command": cmd, "status": "completed"},
-        )
+    if return_code == 0 or _warning_exit(payload, return_code):
+        status = "completed" if return_code == 0 else "completed_with_warnings"
+        result: dict[str, Any] = {
+            "return_code": return_code,
+            "command": cmd,
+            "status": status,
+        }
+        if compact_stats:
+            # The statistics ride with the completion report: the log lines
+            # that carry them are queued behind it on the outbox, so the
+            # server would otherwise have to wait for them.
+            stats = parse_compact_stats(tail)
+            if stats is not None:
+                result["stats"] = stats
+        client.complete_job(job_id, result=result)
         return RepositoryOperationResult(
             job_id=job_id,
-            status="completed",
+            status=status,
             return_code=return_code,
             message=f"{payload.job_kind} exited with code {return_code}",
         )
@@ -1145,6 +1177,71 @@ def _execute_streaming_repository_operation(
         return_code=return_code,
         message=error_message,
     )
+
+
+def _reports_compact_stats(payload: RepositoryOperationPayload) -> bool:
+    """Whether this job is a Borg 2 compact, the one operation with
+    repository statistics (Borg 1 compact has none)."""
+    return payload.job_kind == "repository.compact" and payload.borg_version == 2
+
+
+def _warning_exit(payload: RepositoryOperationPayload, return_code: int) -> bool:
+    """Whether `return_code` is a Borg warning that still leaves this job a
+    completion: a compact that warned ran through and printed its
+    statistics, as the short and backup paths and the server classify it.
+    The other streamed kinds keep failing on any non-zero exit as they did:
+    `check` exits 1 for consistency errors found, which must not count as
+    a repository checked; `prune` is left as it was until its warning
+    semantics are settled with the server's; rclone has no warning range
+    at all."""
+    if payload.job_kind != "repository.compact":
+        return False
+    return is_warning_return_code(return_code)
+
+
+# Whether a Borg 2 binary accepts `compact --stats`, by binary file
+# (path, mtime, size): probed once per file (`borg2 --version` is a
+# subprocess), again when the file changes under a long-lived agent.
+_COMPACT_STATS_SUPPORT: dict[tuple, bool] = {}
+
+
+def _binary_key(binary: str) -> tuple:
+    path = shutil.which(binary) or binary
+    try:
+        stat = os.stat(path)
+    except OSError:
+        return (path, None, None)
+    return (path, stat.st_mtime_ns, stat.st_size)
+
+
+def compact_stats_supported(binary: str) -> bool:
+    """Whether `binary` accepts `compact --stats` (Borg 2.0.0b15 on, see
+    `compact_stats.has_compact_stats`). A binary whose version cannot be
+    read this time (a probe timeout, a banner without a version) does not
+    get the flag: a wrong flag would fail the whole compact, a missing one
+    only its statistics. It is probed again next time; only a read version
+    is remembered."""
+    key = _binary_key(binary)
+    known = _COMPACT_STATS_SUPPORT.get(key)
+    if known is not None:
+        return known
+    try:
+        probe = subprocess.run(
+            [binary, "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        version = parse_borg_version(f"{probe.stdout}\n{probe.stderr}")
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        # ValueError covers a `--version` output the locale cannot decode
+        version = None
+    if version is None:
+        return False
+    supported = has_compact_stats(version)
+    _COMPACT_STATS_SUPPORT[key] = supported
+    return supported
 
 
 def _resolve_restore_target(operation: dict[str, Any]) -> tuple[str, bool]:

--- a/app/api/agents.py
+++ b/app/api/agents.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import math
 import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
@@ -56,6 +57,14 @@ from app.services.agent_job_notifications import (
     notify_check_job_finished,
     orm_identity_id,
 )
+from app.services.borg2_compact_stats import (
+    MAX_COUNT,
+    PRECISION_EXACT,
+    PRECISION_ROUNDED,
+    TAIL_LINES,
+    parse_compact_stats,
+)
+from app.services.maintenance_state import apply_compact_stats
 from app.services.operations.followups import (
     enqueue_backup_followups,
     history_enabled,
@@ -437,6 +446,103 @@ def _collect_agent_logs(job: AgentJob, db: Session) -> str:
     return "\n".join(log.message for log in logs)
 
 
+# The statistics block as `parse_compact_stats` produces it: the counts
+# (non-negative integers below MAX_COUNT), the factors (ratios, bounded)
+# and the precision label. A report from an agent is stored, served and, for the
+# size, acted on as it is, so only these fields in these shapes are taken.
+_COMPACT_STATS_COUNTS = (
+    "archive_count",
+    "source_size",
+    "source_files",
+    "deduplicated_size",
+    "repository_size",
+    "object_count",
+    "compaction_saved",
+)
+_COMPACT_STATS_FACTORS = ("deduplication_factor", "compression_factor")
+
+
+def _compact_stats(
+    agent_job: AgentJob, repository: Repository, logs: str
+) -> Optional[dict]:
+    """The statistics of a Borg 2 compact the agent just completed: the
+    ones its completion report carries (an agent from release 0.1.4 parses
+    its own `compact --stats` output into `result["stats"]`), else the ones
+    the tail of the collected transcript yields, else None. Borg 1 compact
+    prints no statistics, so a report carrying some for a Borg 1 repository
+    is not believed. The transcript is the fallback for an agent that ran
+    `--stats` but reported nothing: its last lines and its completion travel
+    on different paths, so the tail may still be in flight, and then this
+    compact records no statistics, which is logged."""
+    if repository.borg_version != 2:
+        return None
+    result = agent_job.result if isinstance(agent_job.result, dict) else {}
+    stats = _reported_compact_stats(result.get("stats"))
+    if stats is None:
+        stats = parse_compact_stats(logs.splitlines()[-TAIL_LINES:])
+    if stats is None:
+        # The size this compact was asked for is missing. At completion the
+        # cases (an agent that predates the flag or the report, last lines
+        # still in flight, a Borg release that no longer prints them) look
+        # the same, so this is information, not a warning; `ran_stats`
+        # (the report names the command) narrows it for a reader.
+        command = result.get("command")
+        ran_stats = isinstance(command, list) and "--stats" in command
+        (logger.info if ran_stats else logger.debug)(
+            "Agent compact reported no statistics",
+            agent_job_id=agent_job.id,
+            repository_id=repository.id,
+            ran_stats=ran_stats,
+        )
+    return stats
+
+
+def _reported_compact_stats(value) -> Optional[dict]:
+    """`value` reduced to the known statistics fields in their shapes, or
+    None when it is not a statistics block (no usable `repository_size`)."""
+    if not isinstance(value, dict):
+        return None
+    stats: dict = {}
+    for name in _COMPACT_STATS_COUNTS:
+        field = value.get(name)
+        if _is_count(field):
+            stats[name] = field
+    for name in _COMPACT_STATS_FACTORS:
+        field = value.get(name)
+        if _is_factor(field):
+            stats[name] = float(field)
+    if value.get("size_precision") in (PRECISION_EXACT, PRECISION_ROUNDED):
+        stats["size_precision"] = value["size_precision"]
+    if "repository_size" not in stats:
+        return None
+    return stats
+
+
+def _is_count(value) -> bool:
+    return (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and 0 <= value < MAX_COUNT
+    )
+
+
+# Borg prints the factors (ratios) with two decimals; a figure beyond this
+# did not come from Borg.
+_MAX_FACTOR = 1e9
+
+
+def _is_factor(value) -> bool:
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        # bounded before any float conversion: `math.isfinite` itself
+        # refuses an integer too large for a float
+        return 0 <= value < _MAX_FACTOR
+    return (
+        isinstance(value, float) and math.isfinite(value) and 0 <= value < _MAX_FACTOR
+    )
+
+
 def _sync_backup_progress(agent_job: AgentJob, backup_job: BackupJob) -> None:
     for field_name in (
         "progress_percent",
@@ -574,8 +680,9 @@ def _finish_linked_repository_operation_job(
         operation_job.started_at = agent_job.started_at or completed_at
     operation_job.completed_at = completed_at
     operation_job.error_message = error_message
-    operation_job.logs = _collect_agent_logs(agent_job, db)
-    operation_job.has_logs = bool(operation_job.logs)
+    logs = _collect_agent_logs(agent_job, db)
+    operation_job.logs = logs
+    operation_job.has_logs = bool(logs)
     if status_value in ("completed", "completed_with_warnings") and hasattr(
         operation_job, "progress"
     ):
@@ -592,6 +699,9 @@ def _finish_linked_repository_operation_job(
             repository.last_check = completed_at
         elif kind == "compact":
             repository.last_compact = completed_at
+            apply_compact_stats(
+                operation_job, repository, _compact_stats(agent_job, repository, logs)
+            )
         repository.updated_at = _now_utc()
 
     # Archives that no longer exist are recorded on their backup jobs - the

--- a/app/api/maintenance_jobs.py
+++ b/app/api/maintenance_jobs.py
@@ -178,6 +178,12 @@ def serialize_job_status(
         payload["has_logs"] = job_has_logs_for_policy(
             job, log_save_policy=log_save_policy
         )
+    # Compact only: `borg compact --stats` output (Borg 2). The facade would
+    # hand back a `stats` key of any kind's result; keep the contract narrow.
+    if getattr(job, "kind", None) == "compact":
+        stats = getattr(job, "stats", None)
+        if stats is not None:
+            payload["stats"] = stats
     return payload
 
 

--- a/app/core/borg2.py
+++ b/app/core/borg2.py
@@ -39,6 +39,7 @@ Key command differences from Borg 1:
 
 import asyncio
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -128,6 +129,53 @@ def normalize_repo_info_encryption(info: Dict) -> Dict:
 
 
 DEFAULT_BORG2_BINARY = "borg2"
+
+
+# Whether a Borg 2 binary accepts `compact --stats`, by binary file
+# (path, mtime, size): probed once per file, again when the file changes.
+_COMPACT_STATS_SUPPORT: dict[tuple, bool] = {}
+
+
+def _binary_key(binary: str) -> tuple:
+    path = shutil.which(binary) or binary
+    try:
+        stat = os.stat(path)
+    except OSError:
+        return (path, None, None)
+    return (path, stat.st_mtime_ns, stat.st_size)
+
+
+def compact_stats_supported(binary: str) -> bool:
+    """Whether `binary` accepts `compact --stats` (Borg 2.0.0b15 on, see
+    `borg2_compact_stats.has_compact_stats`); a configured binary may be
+    any build. One whose version cannot be read this time (a probe timeout,
+    a banner without a version) does not get the flag: a wrong flag would
+    fail the whole compact, a missing one only its statistics. It is probed
+    again next time; only a read version is remembered."""
+    from app.services.borg2_compact_stats import has_compact_stats, parse_borg_version
+
+    key = _binary_key(binary)
+    known = _COMPACT_STATS_SUPPORT.get(key)
+    if known is not None:
+        return known
+    try:
+        probe = subprocess.run(
+            [binary, "--version"], capture_output=True, text=True, timeout=15
+        )
+        version = parse_borg_version(f"{probe.stdout}\n{probe.stderr}")
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        version = None
+    supported = version is not None and has_compact_stats(version)
+    logger.info(
+        "Probed borg2 for compact --stats",
+        binary=binary,
+        version=version,
+        supported=supported,
+    )
+    if version is not None:
+        # a probe that read nothing is not remembered: it is tried again
+        _COMPACT_STATS_SUPPORT[key] = supported
+    return supported
 
 
 def _get_borg2_binary() -> str:

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -298,7 +298,8 @@ class Repository(Base):
     last_compact = Column(DateTime, nullable=True)  # Last successful compact completion
     total_size = Column(String, nullable=True)
     # Which measurement total_size holds: borg1_cache_stats (deduplicated),
-    # borg2_index (repository object size), storage_used (store file bytes).
+    # borg2_index (repository object size), storage_used (store file bytes),
+    # compact_stats (pack file bytes as `borg compact --stats` reported them).
     total_size_source = Column(String, nullable=True)
     # repository.last_modified as Borg reports it: the last manifest write.
     borg_last_modified = Column(DateTime, nullable=True)

--- a/app/services/borg2_compact_stats.py
+++ b/app/services/borg2_compact_stats.py
@@ -1,0 +1,237 @@
+"""Repository statistics from `borg compact --stats` (Borg 2).
+
+Borg 2 reports repository-wide statistics only here, on INFO level; there
+is no JSON form (borgbackup/borg#10329). The parser accepts the plain lines
+or the `--log-json` `log_message` entries that wrap them.
+
+Sizes are printed through Borg's `format_file_size`, which follows
+`BORG_UNITS`: `si` (default, `502 kB`, `2.39 TB`), `iec` (`490 KiB`) or
+`raw` (`502000 B`). The human forms are rounded to the digits Borg
+prints, so the parsed byte count is only as exact as those digits; every
+compact path of this application sets `BORG_UNITS=raw` and gets exact
+integers. The result records which it got in `size_precision`, from the
+repository size token, the one figure that is acted on: `exact` for a raw
+byte count, `rounded_to_printed_unit` otherwise. The deduplication and
+compression factors are printed with two decimals in either mode.
+
+A figure Borg cannot have printed (a size or count at or above 2**63, a
+factor that is not a finite number, a digit run `int` refuses) makes its
+line not a statistics line; the same parser reads agent-supplied
+transcripts, so nothing here raises on a line's content.
+
+The lines are matched by their whole wording, not by the logger that
+emitted them (`borg.archiver.compact_cmd` today); a `--log-json` entry of
+any logger is accepted.
+"""
+
+import json
+import re
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Iterable, Optional
+
+PRECISION_EXACT = "exact"
+PRECISION_ROUNDED = "rounded_to_printed_unit"
+# A size or count at or above this did not come from Borg (its sizes are
+# 64-bit); a transcript line carrying one is not a statistics line.
+MAX_COUNT = 2**63
+# More digits than that cannot stay below MAX_COUNT, and `int` refuses a
+# long enough digit run outright (sys.int_info.str_digits_check_threshold).
+_MAX_DIGITS = 24
+# A Borg 2 compact prints its statistics as the last lines of the run; this
+# many lines from the end of the output hold all of them.
+TAIL_LINES = 64
+# The Borg 2 beta that added `compact --stats`; an older beta rejects the
+# whole command for the flag.
+COMPACT_STATS_SINCE_BETA = 15
+
+
+# Bounded components: `int` on an unbounded digit run can refuse it.
+_VERSION_TOKEN = (
+    r"(?P<major>\d{1,6})\.(?P<minor>\d{1,6})\.(?P<patch>\d{1,6})(?:b(?P<beta>\d{1,6}))?"
+)
+_VERSION = re.compile(r"\b" + _VERSION_TOKEN)
+_BORG_VERSION = re.compile(r"\bborg\S*\s+" + _VERSION_TOKEN)
+
+
+def parse_borg_version(output: str) -> Optional[str]:
+    """The version token in `borg --version` output ("borg2 2.0.0b24"):
+    the one after the program name where there is one (a wrapper may print
+    its own banner first), else the first version-shaped token, else None;
+    the caller then knows nothing about the binary rather than something
+    wrong."""
+    match = _BORG_VERSION.search(output) or _VERSION.search(output)
+    if not match:
+        return None
+    return match.group(0)[match.start("major") - match.start(0) :]
+
+
+def has_compact_stats(version: str) -> bool:
+    """Whether Borg `version` (a token from `parse_borg_version`) accepts
+    `compact --stats`: any 2.x that is not a beta before b15."""
+    match = _VERSION.search(version)
+    if not match or int(match.group("major")) != 2:
+        return False
+    beta = match.group("beta")
+    return beta is None or int(beta) >= COMPACT_STATS_SINCE_BETA
+
+
+_UNITS = {
+    "B": 1,
+    "kB": 10**3,
+    "MB": 10**6,
+    "GB": 10**9,
+    "TB": 10**12,
+    "PB": 10**15,
+    "EB": 10**18,
+    "KiB": 2**10,
+    "MiB": 2**20,
+    "GiB": 2**30,
+    "TiB": 2**40,
+    "PiB": 2**50,
+    "EiB": 2**60,
+}
+_SIZE = r"(?P<size>\d+(?:\.\d+)?) (?P<unit>[kMGTPE]?B|[KMGTPE]iB)"
+_PATTERNS = {
+    "archive_count": re.compile(
+        r"^Overall statistics, considering all (?P<n>\d+) archives in this repository:$"
+    ),
+    "source": re.compile(rf"^Source data size was {_SIZE} in (?P<n>\d+) files\.$"),
+    "deduplicated_size": re.compile(rf"^Deduplicated size is {_SIZE}\.$"),
+    "deduplication_factor": re.compile(
+        r"^Deduplication factor is (?P<f>\d+(?:\.\d+)?)\.$"
+    ),
+    "repository": re.compile(rf"^Repository size is {_SIZE} in (?P<n>\d+) objects\.$"),
+    "compression_factor": re.compile(r"^Compression factor is (?P<f>\d+(?:\.\d+)?)\.$"),
+    "compaction_saved": re.compile(rf"^Compaction saved {_SIZE}\.$"),
+}
+
+
+def _bytes(match: re.Match) -> Optional[int]:
+    """Integer bytes without a float in between: `int` keeps raw counts
+    exact above 2**53, Decimal scales the human forms as printed. None
+    for a figure Borg cannot have printed."""
+    size, unit = match.group("size"), match.group("unit")
+    if len(size) > _MAX_DIGITS:
+        return None
+    if unit == "B" and "." not in size:
+        value = int(size)
+    else:
+        scaled = Decimal(size) * _UNITS[unit]
+        value = int(scaled.to_integral_value(rounding=ROUND_HALF_UP))
+    return value if value < MAX_COUNT else None
+
+
+def _count(match: re.Match) -> Optional[int]:
+    text = match.group("n")
+    if len(text) > _MAX_DIGITS:
+        return None
+    value = int(text)
+    return value if value < MAX_COUNT else None
+
+
+def _factor(match: re.Match) -> Optional[float]:
+    text = match.group("f")
+    # The pattern admits digits and one point only, so the digit cap is
+    # also what keeps the float finite.
+    return float(text) if len(text) <= _MAX_DIGITS else None
+
+
+def _message(line: str) -> Optional[str]:
+    """The statistics line inside a `--log-json` entry, or the line itself."""
+    text = line.strip()
+    if not text:
+        return None
+    if text[0] != "{":
+        return text
+    try:
+        entry = json.loads(text)
+    except (ValueError, RecursionError):
+        # Agent-supplied bytes: nesting past the interpreter's limit, or an
+        # integer literal past its digit limit (a ValueError that is not a
+        # JSONDecodeError), is not a statistics line either.
+        return None
+    if not isinstance(entry, dict) or entry.get("type") != "log_message":
+        return None
+    message = entry.get("message")
+    return message.strip() if isinstance(message, str) else None
+
+
+_STATS_LINE_PREFIXES = (
+    "Overall statistics",
+    "Source data size",
+    "Deduplicated size",
+    "Deduplication factor",
+    "Repository size",
+    "Compression factor",
+    "Compaction saved",
+)
+
+
+def is_stats_line(line: str) -> bool:
+    """Whether `line` is one of the statistics lines, by its wording alone
+    (a caller that wants them visible must not key on the logger name the
+    parser itself ignores)."""
+    message = _message(line)
+    if message is None or not message.startswith(_STATS_LINE_PREFIXES):
+        # a cheap first cut: --info prints a line per analysed archive
+        return False
+    for pattern in _PATTERNS.values():
+        if m := pattern.match(message):
+            return _figures_in_range(m)
+    return False
+
+
+def _figures_in_range(match: re.Match) -> bool:
+    """Whether every figure the line carries is one Borg could have
+    printed, the test the parser applies before it takes a line."""
+    groups = match.groupdict()
+    if "size" in groups and _bytes(match) is None:
+        return False
+    if "n" in groups and _count(match) is None:
+        return False
+    if "f" in groups and _factor(match) is None:
+        return False
+    return True
+
+
+def parse_compact_stats(lines: Iterable[str]) -> Optional[dict]:
+    """Return the statistics dict, or None when no "Repository size" line
+    was seen (Borg 1, a compact without --stats, a failed run). A line
+    whose figure is out of Borg's range is skipped."""
+    stats: dict = {}
+    exact = True
+
+    for line in lines:
+        message = _message(line)
+        if message is None:
+            continue
+        if m := _PATTERNS["archive_count"].match(message):
+            if (count := _count(m)) is not None:
+                stats["archive_count"] = count
+        elif m := _PATTERNS["source"].match(message):
+            value, count = _bytes(m), _count(m)
+            if value is not None and count is not None:
+                stats["source_size"] = value
+                stats["source_files"] = count
+        elif m := _PATTERNS["deduplicated_size"].match(message):
+            if (value := _bytes(m)) is not None:
+                stats["deduplicated_size"] = value
+        elif m := _PATTERNS["deduplication_factor"].match(message):
+            if (factor := _factor(m)) is not None:
+                stats["deduplication_factor"] = factor
+        elif m := _PATTERNS["repository"].match(message):
+            value, count = _bytes(m), _count(m)
+            if value is not None and count is not None:
+                stats["repository_size"] = value
+                stats["object_count"] = count
+                exact = m.group("unit") == "B" and "." not in m.group("size")
+        elif m := _PATTERNS["compression_factor"].match(message):
+            if (factor := _factor(m)) is not None:
+                stats["compression_factor"] = factor
+        elif m := _PATTERNS["compaction_saved"].match(message):
+            if (value := _bytes(m)) is not None:
+                stats["compaction_saved"] = value
+    if "repository_size" not in stats:
+        return None
+    stats["size_precision"] = PRECISION_EXACT if exact else PRECISION_ROUNDED
+    return stats

--- a/app/services/maintenance_state.py
+++ b/app/services/maintenance_state.py
@@ -1,10 +1,74 @@
 from datetime import datetime
+from typing import Optional
+
+import structlog
 
 from app.core.borg_errors import is_borg_warning_exit_code
+from app.services.borg2_compact_stats import (
+    MAX_COUNT,
+    PRECISION_EXACT,
+    PRECISION_ROUNDED,
+)
+from app.services.storage_usage import SOURCE_COMPACT_STATS, SOURCE_STORAGE_USED
+
+logger = structlog.get_logger()
 
 
-def apply_compact_completion(job, repository, returncode: int, *, now=None) -> None:
-    """Apply the shared terminal compact state to a job and repository."""
+def apply_compact_stats(job, repository, stats: Optional[dict]) -> bool:
+    """Persist `borg compact --stats` output on the job and, where nothing
+    else measures this repository, fill the repository size from it,
+    labelled `compact_stats`: pack file bytes, as exact as Borg printed
+    them (`stats["size_precision"]`). A measured size (the index sum, the
+    Borg 1 cache statistics, or a size that predates the source label) is
+    never replaced: the `stats` follow-up measures again after every
+    compact anyway. A store walk (`storage_used`, store file bytes) and an
+    older compact's figure give way to an exact compact figure; a rounded
+    one (a compact without `BORG_UNITS=raw`) fills an empty size or
+    replaces an older compact's. Returns whether the size was written. On
+    an operation the facade files the statistics under `result["stats"]`;
+    a pre-phase-5 legacy row has nowhere to keep them and drops the
+    attribute with the instance."""
+    if not stats:
+        return False
+    job.stats = stats
+    exact = stats.get("size_precision", PRECISION_ROUNDED) == PRECISION_EXACT
+    replaceable = (
+        {SOURCE_COMPACT_STATS, SOURCE_STORAGE_USED} if exact else {SOURCE_COMPACT_STATS}
+    )
+    source = getattr(repository, "total_size_source", None)
+    measured = (
+        source not in replaceable
+        if source is not None
+        else bool(getattr(repository, "total_size", None))
+    )
+    if measured:
+        logger.debug(
+            "Measured repository size kept over compact statistics",
+            repository_id=getattr(repository, "id", None),
+            total_size_source=source,
+            size_precision=stats.get("size_precision"),
+        )
+        return False
+    size = stats.get("repository_size")
+    # 0 is a measurement here (an emptied repository), unlike the size
+    # fallbacks, where 0 means "could not measure". The upper bound keeps a
+    # figure no Borg printed away from `format_bytes`.
+    if not (
+        isinstance(size, int) and not isinstance(size, bool) and 0 <= size < MAX_COUNT
+    ):
+        return False
+    from app.api.repositories import format_bytes
+
+    repository.total_size = format_bytes(size)
+    repository.total_size_source = SOURCE_COMPACT_STATS
+    return True
+
+
+def apply_compact_completion(
+    job, repository, returncode: int, *, now=None, stats: Optional[dict] = None
+) -> bool:
+    """Apply the shared terminal compact state to a job and repository.
+    Returns whether the repository size was written from `stats`."""
     completed_at = now or datetime.utcnow()
     job.completed_at = completed_at
 
@@ -13,7 +77,7 @@ def apply_compact_completion(job, repository, returncode: int, *, now=None) -> N
         job.progress = 100
         job.progress_message = "Compact completed successfully"
         repository.last_compact = completed_at
-        return
+        return apply_compact_stats(job, repository, stats)
 
     if is_borg_warning_exit_code(returncode):
         job.status = "completed_with_warnings"
@@ -23,7 +87,8 @@ def apply_compact_completion(job, repository, returncode: int, *, now=None) -> N
         )
         job.error_message = job.progress_message
         repository.last_compact = completed_at
-        return
+        return apply_compact_stats(job, repository, stats)
 
     job.status = "failed"
     job.error_message = f"Compact failed with exit code {returncode}"
+    return False

--- a/app/services/operations/executors/maintenance.py
+++ b/app/services/operations/executors/maintenance.py
@@ -100,7 +100,13 @@ async def _run(
             if repository is not None:
                 setattr(repository, column, utc_now())
                 ctx.db.commit()
-        return Outcome(status=status, result={"logs": bool(job.log_file_path)})
+        result = {"logs": bool(job.log_file_path)}
+        if job.stats is not None:
+            # A compact's `--stats` output, filed by the service under
+            # `result["stats"]` (spec 6.1); the runner writes the row's
+            # result from this outcome, so it has to travel through it.
+            result["stats"] = job.stats
+        return Outcome(status=status, result=result)
     if status == "cancelled":
         # `Outcome` has no cancelled status (spec 6.3 gives that to the row,
         # not to the executor's verdict), and the runner rewrites the row to

--- a/app/services/operations/job_facade.py
+++ b/app/services/operations/job_facade.py
@@ -284,6 +284,26 @@ class MaintenanceJobFacade:
         it alongside `logs` keeps working."""
         return None
 
+    # -- summary -----------------------------------------------------------
+
+    @property
+    def stats(self):
+        """Statistics the service recorded for this run (a Borg 2 compact's
+        `--stats` output). Kept under `result["stats"]`, the kind-specific
+        output summary of spec 6.1, next to whatever the executor adds."""
+        result = self.operation.result
+        return result.get("stats") if isinstance(result, dict) else None
+
+    @stats.setter
+    def stats(self, value) -> None:
+        stored = self.operation.result
+        result = dict(stored) if isinstance(stored, dict) else {}
+        if value is None:
+            result.pop("stats", None)
+        else:
+            result["stats"] = value
+        self.operation.result = result or None
+
     # -- kind-specific inputs ---------------------------------------------
 
     def __getattr__(self, name: str):

--- a/app/services/repository_executor.py
+++ b/app/services/repository_executor.py
@@ -20,7 +20,10 @@ from app.services.job_admission import (
 
 EXECUTOR_SERVER = "server"
 EXECUTOR_AGENT = "agent"
-TERMINAL_AGENT_STATUSES = {"completed", "failed", "canceled"}
+# `completed_with_warnings`: the agent ran the command through and the
+# server classified its Borg warning exit code (`_complete_agent_job`).
+TERMINAL_AGENT_STATUSES = {"completed", "completed_with_warnings", "failed", "canceled"}
+SUCCESSFUL_AGENT_STATUSES = {"completed", "completed_with_warnings"}
 REPOSITORY_OPERATION_CAPABILITIES = {
     "repository.init",
     "repository.info",
@@ -409,7 +412,7 @@ async def wait_for_agent_repository_operation_job(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail={"key": "backend.errors.agents.jobNotFound"},
             )
-        if agent_job.status == "completed":
+        if agent_job.status in SUCCESSFUL_AGENT_STATUSES:
             return agent_job.result or {}
         if agent_job.status in TERMINAL_AGENT_STATUSES:
             raise HTTPException(

--- a/app/services/restore_check_service.py
+++ b/app/services/restore_check_service.py
@@ -700,7 +700,10 @@ class RestoreCheckService:
         self, db, agent_job_id: int, *, job=None, poll_interval_seconds: float = 1.0
     ) -> dict:
         from app.database.models import AgentJob
-        from app.services.repository_executor import TERMINAL_AGENT_STATUSES
+        from app.services.repository_executor import (
+            SUCCESSFUL_AGENT_STATUSES,
+            TERMINAL_AGENT_STATUSES,
+        )
 
         started_at = time.monotonic()
         stale_since = started_at
@@ -714,7 +717,7 @@ class RestoreCheckService:
                     status_code=502,
                     detail={"key": "backend.errors.agents.jobNotFound"},
                 )
-            if agent_job.status == "completed":
+            if agent_job.status in SUCCESSFUL_AGENT_STATUSES:
                 return agent_job.result or {}
             if agent_job.status in TERMINAL_AGENT_STATUSES:
                 raise HTTPException(
@@ -745,7 +748,7 @@ class RestoreCheckService:
             if never_claimed or now - stale_since > _AGENT_OP_STALL_TIMEOUT_SECONDS:
                 # Terminalize the agent job so a still-queued job can't be claimed
                 # and run borg extract after the restore check was already failed.
-                if agent_job.status not in ("completed", "failed", "canceled"):
+                if agent_job.status not in TERMINAL_AGENT_STATUSES:
                     agent_job.status = "failed"
                     agent_job.error_message = (
                         "restore check timed out waiting for the agent"

--- a/app/services/restore_service.py
+++ b/app/services/restore_service.py
@@ -65,7 +65,9 @@ def _terminalize_agent_job(agent_job, message: str) -> None:
     """
     if agent_job is None:
         return
-    if agent_job.status in ("completed", "failed", "canceled"):
+    from app.services.repository_executor import TERMINAL_AGENT_STATUSES
+
+    if agent_job.status in TERMINAL_AGENT_STATUSES:
         return
     now = datetime.now(timezone.utc)
     agent_job.status = "failed"
@@ -1141,7 +1143,9 @@ class RestoreService:
             agent_job = db.query(AgentJob).filter(AgentJob.id == agent_job_id).first()
             if agent_job is None:
                 return False
-            if agent_job.status not in {"completed", "failed", "canceled"}:
+            from app.services.repository_executor import TERMINAL_AGENT_STATUSES
+
+            if agent_job.status not in TERMINAL_AGENT_STATUSES:
                 agent_job.status = "cancel_requested"
                 agent_job.updated_at = datetime.now(timezone.utc)
                 db.commit()

--- a/app/services/storage_usage.py
+++ b/app/services/storage_usage.py
@@ -8,7 +8,9 @@ Order for Borg 2, which reports no size through any command:
    backup holds the lock;
 2. a store-level measurement per URL scheme, which counts file bytes
    including pack headers and the index ("storage used");
-3. nothing: the caller leaves the stored size alone.
+3. nothing: the caller leaves the stored size alone, which a Borg 2
+   compact's `--stats` figure then fills (`compact_stats`, written by
+   maintenance_state, never over a measurement from 1).
 
 These are different quantities, which is why the caller records the source
 next to the value. `compact --stats` reports pack file bytes, which include
@@ -41,6 +43,8 @@ logger = structlog.get_logger()
 SOURCE_BORG1_CACHE_STATS = "borg1_cache_stats"
 SOURCE_BORG2_INDEX = "borg2_index"
 SOURCE_STORAGE_USED = "storage_used"
+# Written by the compact paths (maintenance_state), not measured here.
+SOURCE_COMPACT_STATS = "compact_stats"
 
 
 def _port(parts) -> Optional[int]:

--- a/app/services/v2/compact_service.py
+++ b/app/services/v2/compact_service.py
@@ -14,14 +14,16 @@ Both phases emit progress_percent on stderr with --progress --log-json.
 
 import asyncio
 import json
+from collections import deque
 from datetime import datetime
 from pathlib import Path
 import structlog
 
 from app.database.models import Repository
 from app.database.database import SessionLocal
-from app.core.borg2 import _get_borg2_binary
+from app.core.borg2 import _get_borg2_binary, compact_stats_supported
 from app.config import settings
+from app.services.borg2_compact_stats import is_stats_line, parse_compact_stats
 from app.services.maintenance_state import apply_compact_completion
 from app.services.operations.job_facade import (
     claim_running,
@@ -50,6 +52,43 @@ def _get_process_start_time(pid: int) -> int:
     except Exception as e:
         logger.error("Failed to read process start time", pid=pid, error=str(e))
         return 0
+
+
+class _LogWindow:
+    """The lines a compact's saved log keeps: the first `head` lines and
+    the last `tail` lines, with a marker for what fell out between them.
+    `--info` prints a line per analysed archive and `--progress` a frame
+    per step, so a large repository outgrows any flat cap; the start and
+    the end (the statistics, the verdict) are what a reader needs."""
+
+    HEAD = 1000
+    TAIL = 4000
+
+    def __init__(self) -> None:
+        self.head: list[str] = []
+        self.tail: deque[str] = deque(maxlen=self.TAIL)
+        self.dropped = 0
+
+    def append(self, line: str) -> None:
+        if len(self.head) < self.HEAD:
+            self.head.append(line)
+            return
+        if len(self.tail) == self.tail.maxlen:
+            self.dropped += 1
+        self.tail.append(line)
+
+    def __len__(self) -> int:
+        return len(self.head) + len(self.tail)
+
+    def lines(self) -> list[str]:
+        marker = [f"... {self.dropped} lines omitted ..."] if self.dropped else []
+        return [*self.head, *marker, *self.tail]
+
+    def last(self, count: int) -> list[str]:
+        """The newest `count` lines, wherever they sit."""
+        if count <= 0:
+            return []
+        return [*self.head, *self.tail][-count:]
 
 
 class CompactV2Service:
@@ -169,14 +208,18 @@ class CompactV2Service:
             )
 
             borg_cmd = _get_borg2_binary()
-            cmd = [
-                borg_cmd,
-                "-r",
-                repository.path,
-                "compact",
-                "--progress",
-                "--log-json",
-            ]
+            # --stats --info: Borg 2 reports the repository statistics only
+            # here, on INFO level (see borg2_compact_stats), from 2.0.0b15 on.
+            # a subprocess probe, off the event loop
+            with_stats = await asyncio.to_thread(compact_stats_supported, borg_cmd)
+            if with_stats:
+                # Exact byte counts in the statistics lines instead of the
+                # rounded, BORG_UNITS-dependent human form.
+                env["BORG_UNITS"] = "raw"
+            cmd = [borg_cmd, "-r", repository.path, "compact"]
+            if with_stats:
+                cmd.extend(["--stats", "--info"])
+            cmd.extend(["--progress", "--log-json"])
             if remote_path := effective_repository_remote_path(repository):
                 cmd.extend(["--remote-path", remote_path])
 
@@ -216,8 +259,7 @@ class CompactV2Service:
             first_progress_committed = False
             last_progress_update: dict = {}
             PROGRESS_THROTTLE = 2.0
-            log_buffer: list = []
-            MAX_BUFFER = 1000
+            log_buffer = _LogWindow()
 
             async def check_cancellation():
                 nonlocal cancelled
@@ -245,19 +287,44 @@ class CompactV2Service:
                             break
                         line_str = line.decode("utf-8", errors="replace").strip()
                         log_buffer.append(line_str)
-                        if len(log_buffer) > MAX_BUFFER:
-                            log_buffer.pop(0)
 
+                        framed = None
+                        if line_str and line_str[0] == "{":
+                            try:
+                                framed = json.loads(line_str)
+                            except (ValueError, RecursionError):
+                                # not a frame: an integer literal past the
+                                # interpreter's digit limit is a ValueError
+                                # that is not a JSONDecodeError
+                                framed = None
                         if line_str:
-                            logger.info(
+                            # --info makes this stream long (a line per
+                            # analysed archive); framed INFO and progress
+                            # entries go to debug, everything else (borg's
+                            # warnings, errors, criticals, unframed text)
+                            # stays visible, as do the statistics lines
+                            # themselves, so a compact that printed none
+                            # can be told from one whose lines did not
+                            # parse.
+                            quiet = isinstance(framed, dict) and (
+                                framed.get("type") != "log_message"
+                                or (
+                                    framed.get("levelname") in ("DEBUG", "INFO")
+                                    and not is_stats_line(
+                                        str(framed.get("message", ""))
+                                    )
+                                )
+                            )
+                            emit = logger.debug if quiet else logger.info
+                            emit(
                                 "Borg2 compact output",
                                 job_id=job_id,
                                 line=line_str[:200],
                             )
 
                         try:
-                            if line_str and line_str[0] == "{":
-                                msg = json.loads(line_str)
+                            if isinstance(framed, dict):
+                                msg = framed
                                 msg_type = msg.get("type")
 
                                 if msg_type == "progress_percent":
@@ -344,14 +411,37 @@ class CompactV2Service:
             if process.returncode is None:
                 await process.wait()
 
+            size_written = False
             if job.status == "cancelled":
                 job.completed_at = datetime.utcnow()
             else:
-                apply_compact_completion(
+                # the whole window: the parser is line-anchored and cheap,
+                # and the statistics must not depend on how many lines
+                # Borg prints after them
+                stats = parse_compact_stats(log_buffer.lines()) if with_stats else None
+                size_written = apply_compact_completion(
                     job,
                     repository,
                     process.returncode,
+                    stats=stats,
                 )
+                if (
+                    with_stats
+                    and stats is None
+                    and job.status
+                    in (
+                        "completed",
+                        "completed_with_warnings",
+                    )
+                ):
+                    # The size this compact was asked for is missing: a
+                    # Borg release that no longer prints these lines shows
+                    # up here, not as a silently unchanged total_size.
+                    logger.warning(
+                        "Borg2 compact reported no statistics",
+                        job_id=job_id,
+                        repository_id=repository_id,
+                    )
                 if job.status == "completed":
                     logger.info("Borg2 compact completed", job_id=job_id)
                 elif job.status == "completed_with_warnings":
@@ -373,7 +463,7 @@ class CompactV2Service:
                     / f"compact_job_{job_id}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
                 )
                 try:
-                    log_file.write_text("\n".join(log_buffer))
+                    log_file.write_text("\n".join(log_buffer.lines()))
                     job.log_file_path = str(log_file)
                     job.has_logs = True
                     job.logs = f"Logs saved to: {log_file.name}"
@@ -392,7 +482,11 @@ class CompactV2Service:
             final_log_file_path = job.log_file_path
             final_has_logs = job.has_logs
             final_logs = job.logs
+            # A pre-phase-5 legacy row has no statistics attribute at all.
+            final_stats = getattr(job, "stats", None)
             repository_last_compact = repository.last_compact
+            repository_total_size = repository.total_size
+            repository_total_size_source = repository.total_size_source
 
             def persist_final_state():
                 job.status = final_status
@@ -404,6 +498,14 @@ class CompactV2Service:
                 job.has_logs = final_has_logs
                 job.logs = final_logs
                 repository.last_compact = repository_last_compact
+                if final_stats is not None:
+                    job.stats = final_stats
+                if size_written:
+                    # Only a size this compact wrote is restored after a
+                    # rolled-back attempt; one it left alone may have been
+                    # measured by a follow-up in the meantime.
+                    repository.total_size = repository_total_size
+                    repository.total_size_source = repository_total_size_source
 
             await commit_with_retry(
                 db,

--- a/docs/architecture/job-system.md
+++ b/docs/architecture/job-system.md
@@ -105,6 +105,30 @@ against the backup row holding the lane in `running_prune`. An inline
 operation still gets a real row and the same follow-up chain a
 runner-dispatched one would get, just without the runner's queueing.
 
+A Borg 2 compact runs with `--stats` under `BORG_UNITS=raw` (the server
+adds `--info`, the level Borg prints the lines on there). The repository
+statistics Borg 2 reports only there ("Repository size is N B in M
+objects." and the lines around it, exact byte counts) are stored on the
+operation as `result["stats"]`. On the server the compact service parses
+them from its own output. A managed agent from release 0.1.4 parses the
+tail of its own output and sends them in its completion report; the server
+takes `result["stats"]` from that report and otherwise parses the tail of
+the job log once at completion (an agent that ran `--stats` but reported
+nothing may still have those lines in flight, and then that compact records
+no statistics; an older agent never sends them). A Borg warning exit
+completes an agent compact with warnings, as it does on the server, and
+carries the statistics the same way; the agent's other streamed
+operations keep failing on any non-zero exit (a `check` that exits 1
+found consistency errors). A successful compact also writes the
+repository `total_size` from `repository_size`, by priority of source: a
+size from the chunk index (`borg2_index`) or the Borg 1 cache statistics
+(`borg1_cache_stats`) outranks it and stays; a store walk (`storage_used`)
+or an older compact's figure is replaced by an exact compact figure; a
+rounded one (a compact without `BORG_UNITS=raw`) replaces only an older
+compact's figure or fills an empty size. The `stats` follow-up that runs
+after every compact measures again and, where it can measure, replaces
+the compact's figure (see `storage_usage`).
+
 Use them carefully:
 
 - checks can be expensive on large repositories
@@ -291,11 +315,15 @@ Rules:
   pack headers: rclone for `sftp://` and `rclone:` paths with the prepared
   environment, du for local
   paths and `ssh://`, a REST listing for http; none for `rest://user@host`,
-  whose key is bound to the REST server). The labels name different
-  quantities: `compact --stats` counts pack file bytes, which include data
-  no index entry covers, so it and `borg2_index` agree only on a fully
-  indexed repository. Agent repositories get the same order from the
-  agent's `repository.storage_usage` job (agents from 0.1.4; older agents
+  whose key is bound to the REST server); below the index sum and the
+  cache statistics, a Borg 2 compact's `--stats` figure (`compact_stats`,
+  pack file bytes) fills the size and outranks a store walk when exact,
+  until the next `stats` run measures again. The labels name different
+  quantities: `compact --stats` counts
+  pack file bytes, which include data no index entry covers, so it and
+  `borg2_index` agree only on a fully indexed repository. Agent
+  repositories get the same order from the agent's
+  `repository.storage_usage` job (agents from 0.1.4; older agents
   keep `repository.disk_usage`, which only measures local paths). The
   agent measures local paths with du but has no `ssh://` du path; that
   one exists on the server only, where the SSH key is at hand. An

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -593,6 +593,309 @@ def test_repository_init_disables_the_store_cache(monkeypatch):
 
 
 @pytest.mark.unit
+def test_borg2_compact_reports_its_statistics_in_the_completion(monkeypatch):
+    """A Borg 2 compact runs with --stats under BORG_UNITS=raw; the agent
+    parses the statistics from the tail of its own output and sends them
+    with the completion report, so the server does not depend on the log
+    lines that queue behind it."""
+    from agent.borg_ui_agent import repository_ops
+
+    monkeypatch.setattr(repository_ops, "compact_stats_supported", lambda binary: True)
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = kwargs.get("env")
+            self.returncode = 0
+            # a long run: more lines than the tail keeps precede the
+            # statistics, which Borg prints last and the tail therefore holds
+            self.stdout = iter(
+                ["Starting compaction / garbage collection...\n"]
+                + [
+                    f'{{"type": "progress_percent", "current": {i}}}\n'
+                    for i in range(100)
+                ]
+                + [
+                    '{"type": "log_message", "levelname": "INFO", "name": '
+                    '"borg.archiver.compact_cmd", "message": '
+                    '"Repository size is 502000 B in 6 objects."}\n',
+                    "Compaction saved 0 B.\n",
+                ]
+                # progress frames that flush after the block still fit the tail
+                + [
+                    f'{{"type": "progress_percent", "finished": true, "n": {i}}}\n'
+                    for i in range(50)
+                ]
+            )
+
+        def wait(self):
+            return 0
+
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.repository_ops.subprocess.Popen", _FakePopen
+    )
+
+    class _Client:
+        def send_log(self, job_id, *, sequence, message, stream="stdout"):
+            pass
+
+        def send_progress(self, job_id, progress):
+            pass
+
+        def complete_job(self, job_id, *, result):
+            captured["result"] = result
+
+        def fail_job(self, job_id, *, error_message, return_code=None):
+            raise AssertionError(error_message)
+
+    job = {
+        "id": 7,
+        "payload": {
+            "schema_version": 1,
+            "job_kind": "repository.compact",
+            "repository": {"path": "/agent/repo2", "borg_version": 2},
+        },
+    }
+
+    result = execute_repository_operation_job(job, _Client(), should_cancel=None)
+
+    assert result.status == "completed"
+    assert "--stats" in captured["cmd"]
+    assert captured["env"]["BORG_UNITS"] == "raw"
+    assert captured["result"]["stats"] == {
+        "repository_size": 502_000,
+        "object_count": 6,
+        "compaction_saved": 0,
+        "size_precision": "exact",
+    }
+
+
+@pytest.mark.unit
+def test_borg2_compact_without_the_flag_on_an_old_beta(monkeypatch):
+    """Borg 2.0.0b15 added `compact --stats`; on an older beta the flag
+    would fail the whole compact, so it is left out and nothing is parsed
+    or reported."""
+    from agent.borg_ui_agent import repository_ops
+
+    monkeypatch.delenv("BORG_UNITS", raising=False)
+    monkeypatch.setattr(repository_ops, "compact_stats_supported", lambda binary: False)
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = kwargs.get("env")
+            self.returncode = 0
+            self.stdout = iter(["Repository size is 502000 B in 6 objects.\n"])
+
+        def wait(self):
+            return 0
+
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.repository_ops.subprocess.Popen", _FakePopen
+    )
+
+    class _Client:
+        def send_log(self, job_id, *, sequence, message, stream="stdout"):
+            pass
+
+        def send_progress(self, job_id, progress):
+            pass
+
+        def complete_job(self, job_id, *, result):
+            captured["result"] = result
+
+        def fail_job(self, job_id, *, error_message, return_code=None):
+            raise AssertionError(error_message)
+
+    job = {
+        "id": 9,
+        "payload": {
+            "schema_version": 1,
+            "job_kind": "repository.compact",
+            "repository": {"path": "/agent/repo2", "borg_version": 2},
+        },
+    }
+
+    result = execute_repository_operation_job(job, _Client(), should_cancel=None)
+
+    assert result.status == "completed"
+    assert "--stats" not in captured["cmd"]
+    assert "BORG_UNITS" not in captured["env"]
+    assert "stats" not in captured["result"]
+
+
+@pytest.mark.unit
+def test_compact_stats_support_is_probed_once_per_binary(monkeypatch):
+    from agent.borg_ui_agent import repository_ops
+
+    calls = []
+
+    class _Probe:
+        stdout = "borg2 2.0.0b14\n"
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _Probe()
+
+    monkeypatch.setattr(repository_ops.subprocess, "run", fake_run)
+    monkeypatch.setattr(repository_ops, "_COMPACT_STATS_SUPPORT", {})
+    assert repository_ops.compact_stats_supported("/opt/borg2") is False
+    assert repository_ops.compact_stats_supported("/opt/borg2") is False
+    assert calls == [["/opt/borg2", "--version"]]
+
+    # the file changed under the running agent (an in-place upgrade): probed again
+    _Probe.stdout = "borg2 2.0.0b24\n"
+    monkeypatch.setattr(repository_ops, "_binary_key", lambda binary: (binary, 2, 2))
+    assert repository_ops.compact_stats_supported("/opt/borg2") is True
+    assert len(calls) == 2
+
+    def failing_run(cmd, **kwargs):
+        raise OSError("no such binary")
+
+    monkeypatch.setattr(repository_ops.subprocess, "run", failing_run)
+    # unreadable: no flag this time (a wrong flag fails the whole compact),
+    # and nothing is remembered
+    assert repository_ops.compact_stats_supported("/opt/other") is False
+    _Probe.stdout = "borg2 2.0.0b24\n"
+    monkeypatch.setattr(repository_ops.subprocess, "run", fake_run)
+    assert repository_ops.compact_stats_supported("/opt/other") is True
+
+
+@pytest.mark.unit
+def test_borg_warning_exit_completes_a_streamed_operation_with_warnings(monkeypatch):
+    """A Borg warning code on a compact means the run went through: it
+    completes with warnings like the short and backup paths, the server
+    classifies the code, and the statistics stay. Every other streamed
+    kind keeps failing on a non-zero exit."""
+    from agent.borg_ui_agent import repository_ops
+
+    monkeypatch.setattr(repository_ops, "compact_stats_supported", lambda binary: True)
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            self.returncode = 1
+            self.stdout = iter(["Repository size is 502000 B in 6 objects.\n"])
+
+        def wait(self):
+            return 1
+
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.repository_ops.subprocess.Popen", _FakePopen
+    )
+
+    class _Client:
+        def send_log(self, job_id, *, sequence, message, stream="stdout"):
+            pass
+
+        def send_progress(self, job_id, progress):
+            pass
+
+        def complete_job(self, job_id, *, result):
+            captured["result"] = result
+
+        def fail_job(self, job_id, *, error_message, return_code=None):
+            raise AssertionError(error_message)
+
+    job = {
+        "id": 10,
+        "payload": {
+            "schema_version": 1,
+            "job_kind": "repository.compact",
+            "repository": {"path": "/agent/repo2", "borg_version": 2},
+        },
+    }
+
+    result = execute_repository_operation_job(job, _Client(), should_cancel=None)
+
+    assert result.status == "completed_with_warnings"
+    assert result.return_code == 1
+    assert captured["result"]["return_code"] == 1
+    assert captured["result"]["status"] == "completed_with_warnings"
+    assert captured["result"]["stats"]["repository_size"] == 502_000
+
+    compact = RepositoryOperationPayload.from_job_payload(
+        {
+            "schema_version": 1,
+            "job_kind": "repository.compact",
+            "repository": {"path": "/agent/repo2", "borg_version": 2},
+        }
+    )
+    assert repository_ops._warning_exit(compact, 1) is True
+    assert repository_ops._warning_exit(compact, 100) is True
+    assert repository_ops._warning_exit(compact, 2) is False
+    # a check that exits 1 found consistency errors: still a failure
+    for kind in ("repository.check", "repository.prune", "repository.rclone_sync"):
+        assert repository_ops._warning_exit(SimpleNamespace(job_kind=kind), 1) is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "borg_version, lines",
+    [
+        (1, ["compacting segments\n"]),
+        (2, ["Starting compaction / garbage collection...\n"]),
+    ],
+    ids=["borg1", "borg2-without-the-lines"],
+)
+def test_compact_completion_carries_no_stats_key_without_them(
+    monkeypatch, borg_version, lines
+):
+    """Borg 1 compact has no statistics; a Borg 2 run that printed none
+    (a build that no longer does) reports none rather than an empty block,
+    so the server falls back to its log parse for that one."""
+    from agent.borg_ui_agent import repository_ops
+
+    monkeypatch.setattr(repository_ops, "compact_stats_supported", lambda binary: True)
+    monkeypatch.delenv("BORG_UNITS", raising=False)
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            captured["env"] = kwargs.get("env")
+            self.returncode = 0
+            self.stdout = iter(lines)
+
+        def wait(self):
+            return 0
+
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.repository_ops.subprocess.Popen", _FakePopen
+    )
+
+    class _Client:
+        def send_log(self, job_id, *, sequence, message, stream="stdout"):
+            pass
+
+        def send_progress(self, job_id, progress):
+            pass
+
+        def complete_job(self, job_id, *, result):
+            captured["result"] = result
+
+        def fail_job(self, job_id, *, error_message, return_code=None):
+            raise AssertionError(error_message)
+
+    job = {
+        "id": 8,
+        "payload": {
+            "schema_version": 1,
+            "job_kind": "repository.compact",
+            "repository": {"path": "/agent/repo", "borg_version": borg_version},
+        },
+    }
+
+    result = execute_repository_operation_job(job, _Client(), should_cancel=None)
+
+    assert result.status == "completed"
+    assert "stats" not in captured["result"]
+    assert ("BORG_UNITS" in captured["env"]) == (borg_version == 2)
+
+
+@pytest.mark.unit
 def test_repository_rinfo_payload_builds_borg2_command():
     payload = RepositoryOperationPayload.from_job_payload(
         {

--- a/tests/unit/test_api_agents.py
+++ b/tests/unit/test_api_agents.py
@@ -1,7 +1,9 @@
+import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
@@ -1873,6 +1875,370 @@ class TestAgentJobNotifications:
             == "failed"
         )
 
+    def _running_compact_operation(self, test_db, repository):
+        operation = Operation(
+            repository_id=repository.id,
+            kind="compact",
+            category="maintenance",
+            status="running",
+            trigger="manual",
+            priority=10,
+            run_id="run-compact",
+        )
+        test_db.add(operation)
+        test_db.commit()
+        return operation
+
+    def _compact_agent_job(self, test_db, agent, repository, operation):
+        now = datetime.now(timezone.utc)
+        job = AgentJob(
+            agent_machine_id=agent.id,
+            job_type="repository",
+            status="running",
+            payload={
+                "schema_version": 1,
+                "job_kind": "repository.compact",
+                "repository": {"id": repository.id},
+                "operation": {
+                    "maintenance_job": {"kind": "compact", "id": operation.id}
+                },
+            },
+            created_at=now,
+            updated_at=now,
+        )
+        test_db.add(job)
+        test_db.commit()
+        return job
+
+    def _post_stats_line(self, test_client, headers, job, sequence, message):
+        response = test_client.post(
+            f"/api/agents/jobs/{job.id}/logs",
+            json={
+                "sequence": sequence,
+                "stream": "stderr",
+                "message": json.dumps(
+                    {
+                        "type": "log_message",
+                        "levelname": "INFO",
+                        "name": "borg.archiver.compact_cmd",
+                        "message": message,
+                    }
+                ),
+            },
+            headers=headers,
+        )
+        assert response.status_code == 200, response.text
+
+    def test_agent_compact_completion_takes_stats_from_the_completion_report(
+        self, test_client, test_db, admin_headers
+    ):
+        """An agent from release 0.1.4 parses its own `compact --stats`
+        output and sends the statistics with its completion; they land on
+        the operation's result and fill a size nothing has measured (#931).
+        No log line is needed for that."""
+        agent, headers = self._register(test_client, test_db, admin_headers)
+        repository = Repository(
+            name="agent-compact-repo", path="/agent-compact", borg_version=2
+        )
+        test_db.add(repository)
+        test_db.commit()
+        operation = self._running_compact_operation(test_db, repository)
+        job = self._compact_agent_job(test_db, agent, repository, operation)
+        stats = {
+            "repository_size": 502_000,
+            "compaction_saved": 0,
+            "size_precision": "exact",
+        }
+        # stored as reported, so only the known fields in their shapes are
+        reported = {
+            **stats,
+            "deduplication_factor": -1.5,
+            "compression_factor": 2,
+            "object_count": 1e300,
+            "source_size": -1,
+            "archive_count": True,
+            "padding": "x" * 1000,
+        }
+        stats["compression_factor"] = 2.0
+
+        response = test_client.post(
+            f"/api/agents/jobs/{job.id}/complete",
+            json={"result": {"return_code": 0, "stats": reported}},
+            headers=headers,
+        )
+        assert response.status_code == 200
+        test_db.refresh(operation)
+        test_db.refresh(repository)
+        assert operation.status == "completed"
+        assert operation.result["stats"] == stats
+        assert repository.total_size == "490.23 KB"
+        assert repository.total_size_source == "compact_stats"
+
+        status = test_client.get(
+            f"/api/repositories/compact-jobs/{operation.id}",
+            headers=admin_headers,
+        )
+        assert status.status_code == 200, status.text
+        assert status.json()["stats"]["repository_size"] == 502_000
+
+    def test_agent_compact_report_with_a_figure_beyond_borgs_range(
+        self, test_client, test_db, admin_headers
+    ):
+        """A `repository_size` no Borg printed (too large for a float) is not
+        a statistics block: the completion goes through, the compact records
+        no statistics, and a precision label that is not one of the two
+        known values is dropped rather than trusted."""
+        agent, headers = self._register(test_client, test_db, admin_headers)
+        repository = Repository(
+            name="agent-compact-huge",
+            path="/agent-compact-huge",
+            borg_version=2,
+            total_size="keep",
+            total_size_source="storage_used",
+        )
+        test_db.add(repository)
+        test_db.commit()
+        operation = self._running_compact_operation(test_db, repository)
+        job = self._compact_agent_job(test_db, agent, repository, operation)
+
+        response = test_client.post(
+            f"/api/agents/jobs/{job.id}/complete",
+            json={
+                "result": {
+                    "return_code": 0,
+                    "stats": {
+                        "repository_size": 10**400,
+                        "compression_factor": 10**400,
+                        "size_precision": "exact",
+                    },
+                }
+            },
+            headers=headers,
+        )
+        assert response.status_code == 200, response.text
+        test_db.refresh(operation)
+        test_db.refresh(repository)
+        assert operation.status == "completed"
+        assert (operation.result or {}).get("stats") is None
+        assert repository.total_size == "keep"
+
+        # a label outside the known two counts as rounded: a store walk
+        # stays; a factor that is not a finite number is dropped, not stored
+        operation2 = self._running_compact_operation(test_db, repository)
+        job2 = self._compact_agent_job(test_db, agent, repository, operation2)
+        response = test_client.post(
+            f"/api/agents/jobs/{job2.id}/complete",
+            content=json.dumps(
+                {
+                    "result": {
+                        "return_code": 0,
+                        "stats": {
+                            "repository_size": 5,
+                            "deduplication_factor": 1e400,
+                            "size_precision": "guess",
+                        },
+                    }
+                }
+            ),
+            headers={**headers, "Content-Type": "application/json"},
+        )
+        assert response.status_code == 200, response.text
+        test_db.refresh(operation2)
+        test_db.refresh(repository)
+        assert operation2.result["stats"] == {"repository_size": 5}
+        assert repository.total_size == "keep"
+        assert repository.total_size_source == "storage_used"
+        status = test_client.get(
+            f"/api/repositories/compact-jobs/{operation2.id}", headers=admin_headers
+        )
+        assert status.status_code == 200, status.text
+
+    def test_agent_compact_completion_parses_the_log_when_the_report_has_no_stats(
+        self, test_client, test_db, admin_headers
+    ):
+        """An agent that streamed the statistics lines but reported none
+        (the build before the report carried them) still gets them parsed
+        from the tail of its log at completion; a report whose `stats` is
+        not a statistics block counts as none."""
+        agent, headers = self._register(test_client, test_db, admin_headers)
+        repository = Repository(
+            name="agent-compact-log", path="/agent-compact-log", borg_version=2
+        )
+        test_db.add(repository)
+        test_db.commit()
+        operation = self._running_compact_operation(test_db, repository)
+        job = self._compact_agent_job(test_db, agent, repository, operation)
+        for sequence in range(1, 80):
+            self._post_stats_line(
+                test_client, headers, job, sequence, f"line {sequence}"
+            )
+        # two lines flushed in one frame land in one row
+        frames = "\n".join(
+            json.dumps({"type": "log_message", "levelname": "INFO", "message": m})
+            for m in (
+                "Repository size is 502000 B in 6 objects.",
+                "Compaction saved 0 B.",
+            )
+        )
+        response = test_client.post(
+            f"/api/agents/jobs/{job.id}/logs",
+            json={"sequence": 80, "stream": "stderr", "message": frames},
+            headers=headers,
+        )
+        assert response.status_code == 200, response.text
+
+        response = test_client.post(
+            f"/api/agents/jobs/{job.id}/complete",
+            json={"result": {"return_code": 0, "stats": {"repository_size": "6"}}},
+            headers=headers,
+        )
+        assert response.status_code == 200
+        test_db.refresh(operation)
+        test_db.refresh(repository)
+        assert operation.status == "completed"
+        assert operation.result["stats"]["repository_size"] == 502_000
+        assert operation.result["stats"]["compaction_saved"] == 0
+        assert repository.total_size == "490.23 KB"
+        assert repository.total_size_source == "compact_stats"
+
+    def test_agent_compact_completion_without_stats_records_none(
+        self, test_client, test_db, admin_headers
+    ):
+        """Seen live: the agent's last log lines and its completion travel
+        on different paths, and the completion can win by 150 ms. With no
+        statistics in the report and none in the log yet, this compact
+        records none and the size stays as it was; nothing re-reads the
+        lines that arrive later."""
+        agent, headers = self._register(test_client, test_db, admin_headers)
+        repository = Repository(
+            name="agent-compact-late",
+            path="/agent-compact-late",
+            borg_version=2,
+            total_size="keep",
+            total_size_source="storage_used",
+        )
+        test_db.add(repository)
+        test_db.commit()
+        operation = self._running_compact_operation(test_db, repository)
+        job = self._compact_agent_job(test_db, agent, repository, operation)
+
+        response = test_client.post(
+            f"/api/agents/jobs/{job.id}/complete",
+            json={"result": {"return_code": 0}},
+            headers=headers,
+        )
+        assert response.status_code == 200
+        self._post_stats_line(
+            test_client, headers, job, 1, "Repository size is 502000 B in 6 objects."
+        )
+        test_db.refresh(operation)
+        test_db.refresh(repository)
+        assert operation.status == "completed"
+        assert (operation.result or {}).get("stats") is None
+        assert repository.total_size == "keep"
+        assert repository.total_size_source == "storage_used"
+
+    def test_agent_compact_report_for_a_borg1_repository_is_not_believed(
+        self, test_client, test_db, admin_headers
+    ):
+        """Borg 1 compact prints no statistics; a report that carries some
+        for a Borg 1 repository does not touch the size."""
+        agent, headers = self._register(test_client, test_db, admin_headers)
+        repository = Repository(
+            name="agent-compact-borg1", path="/agent-compact-borg1", borg_version=1
+        )
+        test_db.add(repository)
+        test_db.commit()
+        operation = self._running_compact_operation(test_db, repository)
+        job = self._compact_agent_job(test_db, agent, repository, operation)
+
+        response = test_client.post(
+            f"/api/agents/jobs/{job.id}/complete",
+            json={
+                "result": {
+                    "return_code": 0,
+                    "stats": {"repository_size": 5, "size_precision": "exact"},
+                }
+            },
+            headers=headers,
+        )
+        assert response.status_code == 200, response.text
+        test_db.refresh(operation)
+        test_db.refresh(repository)
+        assert operation.status == "completed"
+        assert (operation.result or {}).get("stats") is None
+        assert repository.total_size is None
+
+    def test_agent_compact_with_a_warning_exit_keeps_its_statistics(
+        self, test_client, test_db, admin_headers
+    ):
+        """A compact that warned ran through: the operation ends
+        `completed_with_warnings` and the statistics of its report are
+        stored and acted on like those of a clean run."""
+        agent, headers = self._register(test_client, test_db, admin_headers)
+        repository = Repository(
+            name="agent-compact-warn", path="/agent-compact-warn", borg_version=2
+        )
+        test_db.add(repository)
+        test_db.commit()
+        operation = self._running_compact_operation(test_db, repository)
+        job = self._compact_agent_job(test_db, agent, repository, operation)
+
+        response = test_client.post(
+            f"/api/agents/jobs/{job.id}/complete",
+            json={
+                "result": {
+                    "return_code": 1,
+                    "status": "completed_with_warnings",
+                    "stats": {"repository_size": 502_000, "size_precision": "exact"},
+                }
+            },
+            headers=headers,
+        )
+        assert response.status_code == 200, response.text
+        test_db.refresh(operation)
+        test_db.refresh(repository)
+        assert operation.status == "completed_with_warnings"
+        assert operation.result["stats"]["repository_size"] == 502_000
+        assert repository.total_size == "490.23 KB"
+        assert repository.last_compact is not None
+
+    def test_agent_compact_statistics_keep_a_measured_size(
+        self, test_client, test_db, admin_headers
+    ):
+        """The statistics always land on the operation; a size the chunk
+        index measured is not replaced by the compact's pack file figure
+        (the `stats` follow-up measures again after every compact)."""
+        agent, headers = self._register(test_client, test_db, admin_headers)
+        repository = Repository(
+            name="agent-compact-measured",
+            path="/agent-compact-measured",
+            borg_version=2,
+            total_size="7.00 GB",
+            total_size_source="borg2_index",
+        )
+        test_db.add(repository)
+        test_db.commit()
+        operation = self._running_compact_operation(test_db, repository)
+        job = self._compact_agent_job(test_db, agent, repository, operation)
+
+        response = test_client.post(
+            f"/api/agents/jobs/{job.id}/complete",
+            json={
+                "result": {
+                    "return_code": 0,
+                    "stats": {"repository_size": 5, "size_precision": "exact"},
+                }
+            },
+            headers=headers,
+        )
+        assert response.status_code == 200
+        test_db.refresh(operation)
+        test_db.refresh(repository)
+        assert operation.result["stats"]["repository_size"] == 5
+        assert repository.total_size == "7.00 GB"
+        assert repository.total_size_source == "borg2_index"
+
 
 @pytest.mark.unit
 class TestAgentTimezone:
@@ -1951,3 +2317,83 @@ class TestAgentTimezone:
         assert response.status_code == 200
         test_db.refresh(agent)
         assert agent.timezone == "America/New_York"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_waiter_returns_on_a_completion_with_warnings(
+    test_client, test_db, admin_headers
+):
+    """An agent that ran a Borg command through with a warning exit reports
+    a completion, which the server records as `completed_with_warnings`;
+    the waiter of a delegated maintenance operation must return on it,
+    not poll until the timeout."""
+    from app.services.repository_executor import (
+        wait_for_agent_repository_operation_job,
+    )
+
+    registered = _register_agent(
+        test_client, _create_enrollment_token(test_client, admin_headers)["token"]
+    )
+    agent = _get_agent(test_db, registered["agent_id"])
+    job = _create_agent_job(test_db, agent, status="completed_with_warnings")
+    job.result = {"return_code": 1, "stats": {"repository_size": 5}}
+    test_db.commit()
+
+    result = await wait_for_agent_repository_operation_job(
+        test_db, job.id, timeout_seconds=2, poll_interval_seconds=0.01
+    )
+    assert result["stats"] == {"repository_size": 5}
+
+    job.status = "failed"
+    job.error_message = "borg exited with code 2"
+    test_db.commit()
+    with pytest.raises(HTTPException) as excinfo:
+        await wait_for_agent_repository_operation_job(
+            test_db, job.id, timeout_seconds=2, poll_interval_seconds=0.01
+        )
+    assert excinfo.value.status_code == 502
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_script_and_backup_waiters_return_on_a_completion_with_warnings(
+    test_client, test_db, admin_headers
+):
+    """The other waiters share the terminal set: a hook script or a backup
+    whose agent job ended `completed_with_warnings` must not be polled
+    forever."""
+    from app.services.repository_executor import (
+        wait_for_agent_backup_job,
+        wait_for_agent_script_job,
+    )
+
+    registered = _register_agent(
+        test_client, _create_enrollment_token(test_client, admin_headers)["token"]
+    )
+    agent = _get_agent(test_db, registered["agent_id"])
+    script_job = _create_agent_job(test_db, agent, status="completed_with_warnings")
+    script_job.result = {"return_code": 1}
+    backup_job = BackupJob(repository="/repo", status="completed_with_warnings")
+    test_db.add(backup_job)
+    test_db.commit()
+    agent_backup_job = _create_agent_job(
+        test_db, agent, status="completed_with_warnings"
+    )
+    agent_backup_job.backup_job_id = backup_job.id
+    test_db.commit()
+
+    snapshot = await wait_for_agent_script_job(
+        test_db, script_job.id, timeout_seconds=2, poll_interval_seconds=0.01
+    )
+    assert snapshot["status"] == "completed_with_warnings"
+    assert snapshot["result"] == {"return_code": 1}
+
+    status_value = await wait_for_agent_backup_job(
+        test_db,
+        agent_backup_job.id,
+        backup_job.id,
+        lambda: False,
+        poll_interval_seconds=0.01,
+    )
+    assert status_value == "completed_with_warnings"

--- a/tests/unit/test_api_maintenance_jobs.py
+++ b/tests/unit/test_api_maintenance_jobs.py
@@ -7,7 +7,8 @@ from app.api.maintenance_jobs import (
     serialize_job_status,
     serialize_job_summary,
 )
-from app.database.models import CheckJob, Repository
+from app.database.models import CheckJob, Operation, Repository
+from app.services.operations.job_facade import MaintenanceJobFacade
 
 
 def _create_repo(test_db, name="Repo", path="/repos/main"):
@@ -116,3 +117,33 @@ class TestMaintenanceJobsHelpers:
 
         assert status_payload["logs"] == "live check output"
         assert status_payload["has_logs"] is True
+
+
+@pytest.mark.unit
+def test_status_serializes_stats_for_compact_only(test_db):
+    """`result["stats"]` is a compact's `--stats` output; the facade would
+    hand back a `stats` key of any kind's result, the payload does not."""
+    repo = _create_repo(test_db)
+    payloads = {}
+    for kind in ("compact", "check"):
+        operation = Operation(
+            repository_id=repo.id,
+            kind=kind,
+            category="maintenance",
+            status="completed",
+            trigger="manual",
+            priority=10,
+            run_id=f"run-{kind}",
+            result={"stats": {"repository_size": 5}},
+        )
+        test_db.add(operation)
+        test_db.commit()
+        payloads[kind] = serialize_job_status(
+            MaintenanceJobFacade(test_db, operation),
+            include_progress=True,
+            include_logs=False,
+            include_has_logs=False,
+            log_save_policy="all_jobs",
+        )
+    assert payloads["compact"]["stats"] == {"repository_size": 5}
+    assert "stats" not in payloads["check"]

--- a/tests/unit/test_borg2_compact_stats.py
+++ b/tests/unit/test_borg2_compact_stats.py
@@ -1,0 +1,293 @@
+import json
+
+import pytest
+
+from app.services.borg2_compact_stats import is_stats_line, parse_compact_stats
+
+# The logger Borg 2.0.0b24 emits the lines from; the parser does not depend
+# on it.
+COMPACT_LOGGER = "borg.archiver.compact_cmd"
+
+# Verbatim `borg compact --stats -v` output of 2.0.0b23 / b24 on a scratch
+# repository.
+PLAIN = """Starting compaction / garbage collection...
+Overall statistics, considering all 2 archives in this repository:
+Source data size was 1 MB in 6 files.
+Deduplicated size is 500 kB.
+Deduplication factor is 0.50.
+Repository size is 502 kB in 6 objects.
+Compression factor is 1.00.
+Compaction saved 0 B.
+Finished compaction / garbage collection...
+""".splitlines()
+
+EXPECTED = {
+    "archive_count": 2,
+    "source_size": 1_000_000,
+    "source_files": 6,
+    "deduplicated_size": 500_000,
+    "deduplication_factor": 0.5,
+    "repository_size": 502_000,
+    "object_count": 6,
+    "compression_factor": 1.0,
+    "compaction_saved": 0,
+    # the label follows the repository size token alone: "502 kB" is rounded
+    "size_precision": "rounded_to_printed_unit",
+}
+
+# The same repository under BORG_UNITS=raw (what every compact path here
+# sets): exact byte counts.
+RAW = """Overall statistics, considering all 2 archives in this repository:
+Source data size was 1048576 B in 6 files.
+Deduplicated size is 499712 B.
+Deduplication factor is 0.48.
+Repository size is 501913 B in 6 objects.
+Compression factor is 1.00.
+Compaction saved 0 B.
+""".splitlines()
+
+# BORG_UNITS=iec, inherited from a process environment: no decimals in the
+# printed unit either.
+IEC = """Source data size was 1 MiB in 6 files.
+Deduplicated size is 488 KiB.
+Repository size is 490 KiB in 6 objects.
+Compaction saved 0 B.
+""".splitlines()
+
+
+def _log_json(message, name=COMPACT_LOGGER):
+    return json.dumps(
+        {"type": "log_message", "levelname": "INFO", "name": name, "message": message}
+    )
+
+
+@pytest.mark.unit
+def test_parses_plain_lines():
+    assert parse_compact_stats(PLAIN) == EXPECTED
+
+
+@pytest.mark.unit
+def test_parses_log_json_entries_and_ignores_progress():
+    lines = [json.dumps({"type": "progress_percent", "current": 1, "total": 2})]
+    lines += [_log_json(line) for line in PLAIN]
+    assert parse_compact_stats(lines) == EXPECTED
+
+
+@pytest.mark.unit
+def test_accepts_any_logger_and_ignores_junk():
+    """The lines are matched by wording; the logger name is not a contract
+    (Borg has renamed loggers between betas)."""
+    lines = [
+        _log_json("Repository size is 9 GB in 1 objects.", name="borg.other"),
+        "{not json",
+        "",
+    ]
+    assert parse_compact_stats(lines) == {
+        "repository_size": 9_000_000_000,
+        "object_count": 1,
+        "size_precision": "rounded_to_printed_unit",
+    }
+    assert parse_compact_stats(["{not json", ""]) is None
+
+
+@pytest.mark.unit
+def test_returns_none_without_a_repository_size_line():
+    assert parse_compact_stats(["Source data size was 1 MB in 6 files."]) is None
+    assert parse_compact_stats([]) is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("Repository size is 2.39 TB in 1234 objects.", 2_390_000_000_000),
+        ("Repository size is 0 B in 0 objects.", 0),
+        ("Repository size is 12.5 GB in 7 objects.", 12_500_000_000),
+    ],
+)
+def test_decimal_units_as_borg_prints_them(text, expected):
+    stats = parse_compact_stats([text])
+    assert stats["repository_size"] == expected
+    assert "source_size" not in stats
+
+
+@pytest.mark.unit
+def test_raw_units_are_exact_integers():
+    stats = parse_compact_stats(RAW)
+    assert stats["source_size"] == 1_048_576
+    assert stats["deduplicated_size"] == 499_712
+    assert stats["repository_size"] == 501_913
+    assert stats["compaction_saved"] == 0
+    assert stats["deduplication_factor"] == 0.48
+    assert stats["size_precision"] == "exact"
+    # above 2**53, where a float detour would lose bytes
+    big = parse_compact_stats(["Repository size is 9007199254740993 B in 1 objects."])
+    assert big["repository_size"] == 9_007_199_254_740_993
+    assert big["size_precision"] == "exact"
+
+
+@pytest.mark.unit
+def test_iec_units_are_accepted_and_marked_rounded():
+    stats = parse_compact_stats(IEC)
+    assert stats["source_size"] == 1_048_576
+    assert stats["deduplicated_size"] == 488 * 1024
+    assert stats["repository_size"] == 490 * 1024
+    assert stats["size_precision"] == "rounded_to_printed_unit"
+    assert parse_compact_stats(["Repository size is 2.5 TiB in 1 objects."])[
+        "repository_size"
+    ] == int(2.5 * 2**40)
+
+
+@pytest.mark.unit
+def test_deeply_nested_json_is_not_a_statistics_line():
+    """Agent-supplied bytes: nesting past the interpreter's limit must not
+    raise out of the completion handler."""
+    assert parse_compact_stats(['{"a":' * 100_000 + "1" + "}" * 100_000]) is None
+    assert parse_compact_stats(["{" * 100_000]) is None
+
+
+@pytest.mark.unit
+def test_figures_beyond_borgs_range_are_not_statistics():
+    """A figure with 400 digits did not come from Borg; the line is skipped
+    so nothing downstream has to format it."""
+    huge = "9" * 400
+    assert parse_compact_stats([f"Repository size is {huge} B in 1 objects."]) is None
+    assert parse_compact_stats([f"Repository size is 1 B in {huge} objects."]) is None
+    stats = parse_compact_stats(
+        [
+            f"Compaction saved {huge} B.",
+            f"Deduplication factor is {huge}.",
+            "Compression factor is 1.50.",
+            "Repository size is 1 B in 1 objects.",
+        ]
+    )
+    assert stats == {
+        "compression_factor": 1.5,
+        "repository_size": 1,
+        "object_count": 1,
+        "size_precision": "exact",
+    }
+    # a digit run `int` refuses (sys.int_info.str_digits_check_threshold)
+    longer = "9" * 5000
+    assert parse_compact_stats([f"Repository size is {longer} B in 1 objects."]) is None
+    assert parse_compact_stats([f"Repository size is 1 B in {longer} objects."]) is None
+
+
+@pytest.mark.unit
+def test_size_precision_follows_the_repository_size_token():
+    """Only the repository size is acted on, so its token decides the
+    label: an exact repository figure next to a rounded source figure is
+    exact, a rounded repository figure next to exact ones is rounded."""
+    exact = parse_compact_stats(
+        [
+            "Source data size was 1 MB in 6 files.",
+            "Repository size is 900 B in 3 objects.",
+        ]
+    )
+    assert exact["size_precision"] == "exact"
+    assert exact["source_size"] == 1_000_000
+    rounded = parse_compact_stats(
+        [
+            "Source data size was 1000000 B in 6 files.",
+            "Repository size is 0.9 kB in 3 objects.",
+        ]
+    )
+    assert rounded["size_precision"] == "rounded_to_printed_unit"
+    assert rounded["repository_size"] == 900
+
+
+@pytest.mark.unit
+def test_agent_parser_is_the_same_parser():
+    """The agent ships its own copy of this parser (its wheel has no `app`);
+    a completion report and the server's fallback must read one transcript
+    the same way, so the two modules are identical below their docstrings."""
+    from pathlib import Path
+
+    from agent.borg_ui_agent import compact_stats as agent_parser
+    from app.services import borg2_compact_stats as server_parser
+
+    def body(module):
+        return Path(module.__file__).read_text().split('"""', 2)[2]
+
+    assert body(agent_parser) == body(server_parser)
+
+
+@pytest.mark.unit
+def test_is_stats_line_matches_by_wording_only():
+    assert is_stats_line("Repository size is 502 kB in 6 objects.")
+    assert is_stats_line(_log_json("Compaction saved 0 B.", name="borg.renamed"))
+    assert not is_stats_line("Starting compaction / garbage collection...")
+    assert not is_stats_line(_log_json("analyzing archive x", name=COMPACT_LOGGER))
+    assert not is_stats_line("{" * 100)
+    # a figure the parser would refuse does not make a statistics line
+    assert not is_stats_line(f"Repository size is {2**63} B in 1 objects.")
+    assert not is_stats_line("Deduplication factor is " + "9" * 400 + ".")
+
+
+@pytest.mark.unit
+def test_framed_lines_with_hostile_json_are_not_statistics():
+    """The transcript is agent-supplied: a framed line with an integer
+    literal past the interpreter's digit limit (a ValueError that is not a
+    JSONDecodeError), or a JSON value that is not an object, is skipped."""
+    huge = '{"type": "log_message", "message": "x", "n": ' + "9" * 5000 + "}"
+    assert parse_compact_stats([huge, "Repository size is 1 B in 1 objects."]) == {
+        "repository_size": 1,
+        "object_count": 1,
+        "size_precision": "exact",
+    }
+    for value in ("[]", '"text"', "null", "1"):
+        assert parse_compact_stats([value]) is None
+    assert not is_stats_line(huge)
+
+
+@pytest.mark.unit
+def test_lines_match_as_a_whole():
+    """A statistics line with anything appended is not one Borg printed."""
+    assert parse_compact_stats(["Repository size is 1 B in 1 objects. extra"]) is None
+    assert not is_stats_line("Compaction saved 0 B. and more")
+    assert parse_compact_stats(["Repository size is 1 B in 1 objects."]) is not None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "version, supported",
+    [
+        ("2.0.0b14", False),
+        ("2.0.0b15", True),
+        ("borg2 2.0.0b24", True),
+        ("2.0.0rc1", True),
+        ("2.0.0", True),
+        ("2.1.0", True),
+        ("borg 1.4.1", False),
+        ("Unknown", False),
+    ],
+)
+def test_has_compact_stats(version, supported):
+    from app.services.borg2_compact_stats import has_compact_stats
+
+    assert has_compact_stats(version) is supported
+
+
+@pytest.mark.unit
+def test_parse_borg_version_takes_the_first_version_token():
+    from app.services.borg2_compact_stats import parse_borg_version
+
+    assert parse_borg_version("borg2 2.0.0b24\n") == "2.0.0b24"
+    assert parse_borg_version("borg 1.4.1") == "1.4.1"
+    assert parse_borg_version("\nborg2 2.0.0\n") == "2.0.0"
+    assert parse_borg_version("no version here") is None
+    assert parse_borg_version("") is None
+    # a wrapper banner before Borg's own line: Borg's token wins
+    assert parse_borg_version("Python 3.11.2 -- borg2 2.0.0b24\n") == "2.0.0b24"
+    assert parse_borg_version("OpenSSL 3.2.1\nborg 1.4.1") == "1.4.1"
+    assert parse_borg_version("borg2 2.0.0rc1") == "2.0.0"
+    # digit runs `int` would refuse are not version tokens
+    assert parse_borg_version("borg2 " + "9" * 5000 + ".0.0") is None
+
+
+@pytest.mark.unit
+def test_is_stats_line_ignores_lines_without_a_statistics_prefix():
+    from app.services.borg2_compact_stats import is_stats_line
+
+    assert not is_stats_line(_log_json("analyzing archive foo (1/2)"))
+    assert is_stats_line(_log_json("Compression factor is 1.50."))

--- a/tests/unit/test_maintenance_state.py
+++ b/tests/unit/test_maintenance_state.py
@@ -3,7 +3,10 @@ from types import SimpleNamespace
 
 import pytest
 
-from app.services.maintenance_state import apply_compact_completion
+from app.services.maintenance_state import (
+    apply_compact_completion,
+    apply_compact_stats,
+)
 
 
 @pytest.mark.unit
@@ -69,3 +72,138 @@ def test_apply_compact_completion_marks_failure_without_repository_update():
     assert job.error_message == "Compact failed with exit code 2"
     assert job.completed_at == now
     assert repo.last_compact == previous_compact
+
+
+@pytest.mark.unit
+def test_apply_compact_completion_persists_stats_and_fills_an_unmeasured_size():
+    """`borg compact --stats` output lands on the job; where nothing has
+    measured the repository, it also fills total_size (#931)."""
+    job = SimpleNamespace(
+        status="running",
+        progress=0,
+        progress_message=None,
+        error_message=None,
+        completed_at=None,
+        stats=None,
+    )
+    repo = SimpleNamespace(last_compact=None, total_size=None, total_size_source=None)
+    stats = {"repository_size": 502_000, "object_count": 6, "size_precision": "exact"}
+
+    assert apply_compact_completion(job, repo, 0, stats=stats) is True
+
+    assert job.stats == stats
+    assert repo.total_size == "490.23 KB"
+    # value and provenance move together: the label names pack file bytes
+    assert repo.total_size_source == "compact_stats"
+
+    # An emptied repository measures 0 and replaces the older compact figure.
+    apply_compact_completion(
+        job, repo, 0, stats={"repository_size": 0, "size_precision": "exact"}
+    )
+    assert repo.total_size == "0.00 B"
+    assert repo.total_size_source == "compact_stats"
+
+    # the warning completion path writes them too
+    repo = SimpleNamespace(last_compact=None, total_size=None, total_size_source=None)
+    apply_compact_completion(job, repo, 100, stats=stats)
+    assert job.status == "completed_with_warnings"
+    assert repo.total_size == "490.23 KB"
+    assert repo.total_size_source == "compact_stats"
+
+
+@pytest.mark.unit
+def test_apply_compact_completion_keeps_size_without_stats_or_on_failure():
+    job = SimpleNamespace(
+        status="running",
+        progress=0,
+        progress_message=None,
+        error_message=None,
+        completed_at=None,
+        stats="untouched",
+    )
+    repo = SimpleNamespace(
+        last_compact=None, total_size="keep", total_size_source="storage_used"
+    )
+
+    assert apply_compact_completion(job, repo, 0, stats=None) is False
+    assert job.stats == "untouched" and repo.total_size == "keep"
+    assert repo.total_size_source == "storage_used"
+
+    assert apply_compact_completion(job, repo, 2, stats={"repository_size": 1}) is False
+    assert job.stats == "untouched" and repo.total_size == "keep"
+    assert repo.total_size_source == "storage_used"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "source",
+    ["borg2_index", "borg1_cache_stats", None],
+    ids=["index", "borg1-cache", "unlabelled"],
+)
+def test_apply_compact_stats_keeps_a_measured_size(source):
+    """Measurement first (#934): the statistics land on the job, a size the
+    index sum or the cache statistics wrote stays, as does one that
+    predates the source label. The stats follow-up measures again after
+    every compact."""
+    job = SimpleNamespace(stats=None)
+    repo = SimpleNamespace(total_size="7.00 GB", total_size_source=source)
+    stats = {"repository_size": 5, "size_precision": "exact"}
+
+    assert apply_compact_stats(job, repo, stats) is False
+
+    assert job.stats == stats
+    assert repo.total_size == "7.00 GB"
+    assert repo.total_size_source == source
+
+
+@pytest.mark.unit
+def test_apply_compact_stats_replaces_a_store_walk_and_an_older_compact():
+    """A store walk counts store file bytes and an older compact is older:
+    an exact compact figure is the better of the two."""
+    job = SimpleNamespace(stats=None)
+    for source in ("storage_used", "compact_stats"):
+        repo = SimpleNamespace(total_size="old", total_size_source=source)
+        assert (
+            apply_compact_stats(
+                job, repo, {"repository_size": 5, "size_precision": "exact"}
+            )
+            is True
+        )
+        assert repo.total_size == "5.00 B"
+        assert repo.total_size_source == "compact_stats"
+
+
+@pytest.mark.unit
+def test_apply_compact_stats_rounded_figure_replaces_only_an_older_compact():
+    """A compact that ran without BORG_UNITS=raw printed rounded sizes: the
+    statistics land on the job; the size replaces nothing measured, not
+    even a store walk, only no size or an older compact's figure."""
+    job = SimpleNamespace(stats=None)
+    rounded = {
+        "repository_size": 1_000_000,
+        "size_precision": "rounded_to_printed_unit",
+    }
+
+    for source in ("borg2_index", "storage_used", None):
+        repo = SimpleNamespace(total_size="1.43 MB", total_size_source=source)
+        apply_compact_stats(job, repo, rounded)
+        assert job.stats["repository_size"] == 1_000_000
+        assert repo.total_size == "1.43 MB"
+        assert repo.total_size_source == source
+
+    # a measured source with no size yet is a measurement too
+    repo = SimpleNamespace(total_size=None, total_size_source="borg2_index")
+    apply_compact_stats(job, repo, {"repository_size": 5, "size_precision": "exact"})
+    assert repo.total_size is None
+    assert repo.total_size_source == "borg2_index"
+
+    # an unlabelled figure is not trusted either
+    repo = SimpleNamespace(total_size="5.00 GB", total_size_source="storage_used")
+    apply_compact_stats(job, repo, {"repository_size": 1_000_000})
+    assert repo.total_size == "5.00 GB"
+
+    for total_size, source in ((None, None), ("old", "compact_stats")):
+        repo = SimpleNamespace(total_size=total_size, total_size_source=source)
+        apply_compact_stats(job, repo, rounded)
+        assert repo.total_size == "976.56 KB"
+        assert repo.total_size_source == "compact_stats"

--- a/tests/unit/test_operations_job_facade.py
+++ b/tests/unit/test_operations_job_facade.py
@@ -332,3 +332,26 @@ def test_claim_running_rejects_an_already_started_legacy_row(db, repository):
 
     second_started = datetime(2026, 9, 6, 12, 5, 0)
     assert claim_running(db, legacy.id, "check", second_started) == 0
+
+
+def test_stats_live_in_the_operation_result(db, repository):
+    """A service's `job.stats = ...` (a Borg 2 compact's statistics) lands
+    in `result["stats"]`, next to what the executor puts there, instead of
+    on the facade instance where a plain attribute write would leave it."""
+    op = _operation(db, repository, kind="compact")
+    job = MaintenanceJobFacade(db, op)
+    assert job.stats is None
+
+    job.stats = {"repository_size": 502_000}
+    db.commit()
+    db.refresh(op)
+    assert op.result == {"stats": {"repository_size": 502_000}}
+    assert job.stats == {"repository_size": 502_000}
+
+    op.result = {"logs": True, "stats": {"repository_size": 502_000}}
+    job.stats = {"repository_size": 1}
+    assert op.result == {"logs": True, "stats": {"repository_size": 1}}
+
+    job.stats = None
+    assert op.result == {"logs": True}
+    assert job.stats is None

--- a/tests/unit/test_operations_maintenance_executors.py
+++ b/tests/unit/test_operations_maintenance_executors.py
@@ -370,6 +370,73 @@ async def test_compact_stamps_last_compact_on_success(db, repository, monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_compact_returns_the_statistics_the_service_filed(
+    db, repository, monkeypatch
+):
+    """The runner writes the row's result from the outcome, so the `--stats`
+    output the service filed under `result["stats"]` has to come back
+    through it, or the runner's own write would drop it."""
+    from app.services.operations.executors import maintenance
+
+    op = _operation(db, repository, kind="compact")
+    ctx = FakeContext(db, op)
+    stats = {"repository_size": 502_000, "size_precision": "exact"}
+
+    async def fake_compact(self, job_id):
+        job = MaintenanceJobFacade(db, db.get(Operation, job_id))
+        job.stats = stats
+        job.status = "completed"
+        db.commit()
+
+    monkeypatch.setattr(
+        "app.core.borg_router.BorgRouter.compact", fake_compact, raising=True
+    )
+
+    outcome = await maintenance.run_compact(ctx)
+
+    assert outcome.status == "completed"
+    assert outcome.result == {"logs": False, "stats": stats}
+
+
+@pytest.mark.asyncio
+async def test_compact_reads_statistics_another_session_committed(
+    db, repository, monkeypatch
+):
+    """An agent compact is finished from the completion request's session,
+    not the runner's, whose identity map already holds the row: the
+    executor must read the row back after the service returns (the
+    in-memory SQLite engine shares one connection, so this exercises the
+    stale-copy half, not transaction isolation), or the statistics filed
+    there are missing from the outcome and the runner's result write drops
+    them."""
+    from app.services.operations.executors import maintenance
+
+    op = _operation(db, repository, kind="compact")
+    ctx = FakeContext(db, op)
+    stats = {"repository_size": 502_000, "size_precision": "exact"}
+
+    async def fake_compact(self, job_id):
+        # the runner's session already holds the row (FakeContext loaded it)
+        other = sessionmaker(bind=db.get_bind())()
+        try:
+            job = MaintenanceJobFacade(other, other.get(Operation, job_id))
+            job.stats = stats
+            job.status = "completed"
+            other.commit()
+        finally:
+            other.close()
+
+    monkeypatch.setattr(
+        "app.core.borg_router.BorgRouter.compact", fake_compact, raising=True
+    )
+
+    outcome = await maintenance.run_compact(ctx)
+
+    assert outcome.status == "completed"
+    assert outcome.result == {"logs": False, "stats": stats}
+
+
+@pytest.mark.asyncio
 async def test_delete_archive_passes_the_archive_name(db, repository, monkeypatch):
     from app.services.operations.executors import maintenance
 

--- a/tests/unit/test_repository_storage_usage.py
+++ b/tests/unit/test_repository_storage_usage.py
@@ -88,6 +88,10 @@ def _compact_env(monkeypatch, borg_version):
     monkeypatch.setattr(
         "agent.borg_ui_agent.repository_ops.subprocess.Popen", _FakePopen
     )
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.repository_ops.compact_stats_supported",
+        lambda binary: True,
+    )
     job = {
         "id": 7,
         "payload": {

--- a/tests/unit/test_v2_services.py
+++ b/tests/unit/test_v2_services.py
@@ -5,7 +5,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 from sqlalchemy.orm import sessionmaker
 
-from app.database.models import CheckJob, CompactJob, DeleteArchiveJob, Repository
+from app.database.models import (
+    CheckJob,
+    CompactJob,
+    DeleteArchiveJob,
+    Operation,
+    Repository,
+)
 from app.services.v2.check_service import CheckV2Service
 from app.services.v2.compact_service import CompactV2Service
 from app.services.v2.delete_archive_service import DeleteArchiveV2Service
@@ -527,6 +533,179 @@ class TestCompactV2Service:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
+    async def test_execute_compact_persists_stats_from_log_json(
+        self, db_session, testing_session_local, borg_v2_repo_for_services, tmp_path
+    ):
+        """The compact runs with --stats --info; the INFO statistics lines
+        are parsed from the --log-json stream and persisted on the operation
+        row the service drives through the facade (#931)."""
+        job = Operation(
+            repository_id=borg_v2_repo_for_services.id,
+            kind="compact",
+            category="maintenance",
+            status="running",
+            trigger="manual",
+            priority=10,
+            run_id="run-compact",
+        )
+        db_session.add(job)
+        db_session.commit()
+        db_session.refresh(job)
+        # what `BORG_UNITS=raw` prints: exact byte counts
+        messages = [
+            "Overall statistics, considering all 2 archives in this repository:",
+            "Source data size was 1000000 B in 6 files.",
+            "Deduplicated size is 500000 B.",
+            "Repository size is 502000 B in 6 objects.",
+            "Compression factor is 1.00.",
+            "Compaction saved 0 B.",
+        ]
+        lines = [
+            json.dumps(
+                {
+                    "type": "log_message",
+                    "levelname": "INFO",
+                    "name": "borg.archiver.compact_cmd",
+                    "message": m,
+                }
+            )
+            for m in messages
+        ]
+        service = CompactV2Service()
+        service.log_dir = tmp_path
+        with (
+            patch(
+                "app.services.v2.compact_service.SessionLocal", testing_session_local
+            ),
+            patch(
+                "app.services.v2.compact_service.resolve_repo_ssh_key_file",
+                return_value=None,
+            ),
+            patch(
+                "app.services.v2.compact_service.compact_stats_supported",
+                return_value=True,
+            ),
+            patch(
+                "app.services.v2.compact_service._get_borg2_binary",
+                return_value="borg2",
+            ),
+            patch(
+                "app.services.v2.compact_service._get_process_start_time",
+                return_value=123,
+            ),
+            patch(
+                "app.services.v2.compact_service.asyncio.create_subprocess_exec",
+                return_value=FakeProcess(returncode=0, stderr_lines=lines),
+            ) as spawn,
+        ):
+            await service.execute_compact(job.id, borg_v2_repo_for_services.id)
+
+        cmd = list(spawn.call_args.args)
+        assert cmd[cmd.index("compact") + 1 :][:2] == ["--stats", "--info"]
+        assert spawn.call_args.kwargs["env"]["BORG_UNITS"] == "raw"
+        verification = testing_session_local()
+        refreshed = verification.get(Operation, job.id)
+        refreshed_repo = (
+            verification.query(Repository)
+            .filter(Repository.id == borg_v2_repo_for_services.id)
+            .first()
+        )
+        assert refreshed.status == "completed"
+        assert refreshed.result["stats"]["repository_size"] == 502_000
+        assert refreshed.result["stats"]["source_files"] == 6
+        assert refreshed.result["stats"]["size_precision"] == "exact"
+        assert refreshed_repo.total_size == "490.23 KB"
+        assert refreshed_repo.total_size_source == "compact_stats"
+        verification.close()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_execute_compact_keeps_stats_when_finalize_commit_retries(
+        self, db_session, testing_session_local, borg_v2_repo_for_services, tmp_path
+    ):
+        """commit_with_retry rolls the session back before it reruns
+        prepare(); the finalize closure must restore stats and total_size
+        too, or a retried commit drops them (review finding on #931)."""
+        job = Operation(
+            repository_id=borg_v2_repo_for_services.id,
+            kind="compact",
+            category="maintenance",
+            status="running",
+            trigger="manual",
+            priority=10,
+            run_id="run-compact",
+        )
+        db_session.add(job)
+        db_session.commit()
+        db_session.refresh(job)
+        lines = [
+            json.dumps(
+                {
+                    "type": "log_message",
+                    "levelname": "INFO",
+                    "name": "borg.archiver.compact_cmd",
+                    "message": "Repository size is 502000 B in 6 objects.",
+                }
+            )
+        ]
+
+        from app.services.v2 import compact_service as compact_service_module
+
+        real_commit_with_retry = compact_service_module.commit_with_retry
+
+        async def rollback_then_commit(db, **kwargs):
+            if kwargs.get("action") == "borg2_compact_finalize":
+                db.rollback()  # what a SQLite lock error does before the retry
+            return await real_commit_with_retry(db, **kwargs)
+
+        service = CompactV2Service()
+        service.log_dir = tmp_path
+        with (
+            patch(
+                "app.services.v2.compact_service.SessionLocal", testing_session_local
+            ),
+            patch(
+                "app.services.v2.compact_service.commit_with_retry",
+                new=rollback_then_commit,
+            ),
+            patch(
+                "app.services.v2.compact_service.resolve_repo_ssh_key_file",
+                return_value=None,
+            ),
+            patch(
+                "app.services.v2.compact_service.compact_stats_supported",
+                return_value=True,
+            ),
+            patch(
+                "app.services.v2.compact_service._get_borg2_binary",
+                return_value="borg2",
+            ),
+            patch(
+                "app.services.v2.compact_service._get_process_start_time",
+                return_value=123,
+            ),
+            patch(
+                "app.services.v2.compact_service.asyncio.create_subprocess_exec",
+                return_value=FakeProcess(returncode=0, stderr_lines=lines),
+            ),
+        ):
+            await service.execute_compact(job.id, borg_v2_repo_for_services.id)
+
+        verification = testing_session_local()
+        refreshed = verification.get(Operation, job.id)
+        refreshed_repo = (
+            verification.query(Repository)
+            .filter(Repository.id == borg_v2_repo_for_services.id)
+            .first()
+        )
+        assert refreshed.status == "completed"
+        assert refreshed.result["stats"]["repository_size"] == 502_000
+        assert refreshed_repo.total_size == "490.23 KB"
+        assert refreshed_repo.total_size_source == "compact_stats"
+        verification.close()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
     async def test_execute_compact_sets_started_at_on_pending_scheduler_job(
         self, db_session, testing_session_local, borg_v2_repo_for_services, tmp_path
     ):
@@ -788,3 +967,124 @@ class TestDeleteArchiveV2Service:
         assert refreshed.status == "completed"
         assert refreshed.progress == 100
         verification.close()
+
+
+@pytest.mark.unit
+def test_compact_log_window_keeps_head_and_tail():
+    from app.services.v2.compact_service import _LogWindow
+
+    window = _LogWindow()
+    for i in range(_LogWindow.HEAD + _LogWindow.TAIL + 7):
+        window.append(f"line {i}")
+    lines = window.lines()
+    assert lines[0] == "line 0"
+    assert lines[_LogWindow.HEAD - 1] == f"line {_LogWindow.HEAD - 1}"
+    assert lines[_LogWindow.HEAD] == "... 7 lines omitted ..."
+    assert lines[_LogWindow.HEAD + 1] == f"line {_LogWindow.HEAD + 7}"
+    assert lines[-1] == f"line {_LogWindow.HEAD + _LogWindow.TAIL + 6}"
+    assert len(window) == _LogWindow.HEAD + _LogWindow.TAIL
+    # the statistics come last, wherever the newest lines sit
+    assert window.last(2) == lines[-2:]
+
+    short = _LogWindow()
+    short.append("only")
+    assert short.lines() == ["only"] and len(short) == 1
+    assert short.last(64) == ["only"]
+    assert short.last(0) == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_compact_without_stats_on_a_borg_before_b15(
+    db_session, testing_session_local, borg_v2_repo_for_services, tmp_path, monkeypatch
+):
+    """A configured Borg 2 binary may be any build; before 2.0.0b15 the
+    flag fails the whole compact, so it is left out with `--info` and
+    `BORG_UNITS=raw`, and no statistics are expected."""
+    monkeypatch.delenv("BORG_UNITS", raising=False)
+    job = Operation(
+        repository_id=borg_v2_repo_for_services.id,
+        kind="compact",
+        category="maintenance",
+        status="running",
+        trigger="manual",
+        priority=10,
+        run_id="run-compact-old",
+    )
+    db_session.add(job)
+    db_session.commit()
+    db_session.refresh(job)
+    service = CompactV2Service()
+    service.log_dir = tmp_path
+    with (
+        patch("app.services.v2.compact_service.SessionLocal", testing_session_local),
+        patch(
+            "app.services.v2.compact_service.resolve_repo_ssh_key_file",
+            return_value=None,
+        ),
+        patch(
+            "app.services.v2.compact_service._get_borg2_binary", return_value="borg2"
+        ),
+        patch(
+            "app.services.v2.compact_service.compact_stats_supported",
+            return_value=False,
+        ),
+        patch(
+            "app.services.v2.compact_service._get_process_start_time", return_value=1
+        ),
+        patch(
+            "app.services.v2.compact_service.asyncio.create_subprocess_exec",
+            return_value=FakeProcess(returncode=0, stderr_lines=[]),
+        ) as spawn,
+    ):
+        await service.execute_compact(job.id, borg_v2_repo_for_services.id)
+
+    cmd = list(spawn.call_args.args)
+    assert "--stats" not in cmd and "--info" not in cmd
+    assert "BORG_UNITS" not in spawn.call_args.kwargs["env"]
+    verification = testing_session_local()
+    refreshed = verification.get(Operation, job.id)
+    assert refreshed.status == "completed"
+    assert (refreshed.result or {}).get("stats") is None
+    verification.close()
+
+
+@pytest.mark.unit
+def test_server_compact_stats_support_is_probed_per_binary_file(monkeypatch):
+    from app.core import borg2 as borg2_core
+
+    calls = []
+
+    class _Probe:
+        stdout = "borg2 2.0.0b14\n"
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _Probe()
+
+    monkeypatch.setattr(borg2_core.subprocess, "run", fake_run)
+    monkeypatch.setattr(borg2_core, "_COMPACT_STATS_SUPPORT", {})
+    assert borg2_core.compact_stats_supported("/opt/borg2") is False
+    assert borg2_core.compact_stats_supported("/opt/borg2") is False
+    assert calls == [["/opt/borg2", "--version"]]
+
+    _Probe.stdout = "borg2 2.0.0b24\n"
+    monkeypatch.setattr(borg2_core, "_binary_key", lambda binary: (binary, 2, 2))
+    assert borg2_core.compact_stats_supported("/opt/borg2") is True
+
+    def failing_run(cmd, **kwargs):
+        raise OSError("no such binary")
+
+    monkeypatch.setattr(borg2_core.subprocess, "run", failing_run)
+    # unreadable: no flag this time (a wrong flag fails the whole compact)
+    assert borg2_core.compact_stats_supported("/opt/other") is False
+
+    # output without a version token: nothing known, no flag, and nothing
+    # is remembered, so the next probe decides afresh
+    _Probe.stdout = "some wrapper banner\n"
+    monkeypatch.setattr(borg2_core.subprocess, "run", fake_run)
+    monkeypatch.setattr(borg2_core, "_binary_key", lambda binary: (binary, 3, 3))
+    assert borg2_core.compact_stats_supported("/opt/borg2") is False
+    _Probe.stdout = "borg2 2.0.0b24\n"
+    assert borg2_core.compact_stats_supported("/opt/borg2") is True


### PR DESCRIPTION
## Description

Borg 2 reports repository-wide statistics in exactly one place: `borg compact --stats`, on INFO level (`info --help`: "for the repository-wide deduplicated size, use borg compact --stats"). The compact service never passed the flag, so the only size Borg 2 offers was discarded on every run and Borg 2 repositories kept showing `Total size: N/A`. Server half of #931; the agent half (agent 0.1.4 runs `compact --stats` under `BORG_UNITS=raw`) landed with #968. Built on the `operations` substrate of #947.

- **Parser** `app/services/borg2_compact_stats.py`: reads the statistics lines (verbatim 2.0.0b23 / b24 output, plain or wrapped as `--log-json` `log_message` entries of any logger) into `{archive_count, source_size, source_files, deduplicated_size, deduplication_factor, repository_size, object_count, compression_factor, compaction_saved, size_precision}`. Every compact path sets `BORG_UNITS=raw`, so sizes are exact byte counts; `size_precision` records when they are not. Agent-supplied bytes cannot raise out of it.
- **Command**: the server compact service runs `compact --stats --info` and warns when a successful compact printed no statistics. Borg's WARNING and ERROR frames stay at info in the server log; the `--info` chatter goes to debug.
- **Persistence**: the statistics live in the operation's `result["stats"]` (spec 6.1), reached through a `stats` property on `MaintenanceJobFacade`. No migration. The runner keeps the `stats` key the row holds when it writes its executor's result, read back from the table; nothing else on a row survives a requeue. `apply_compact_completion` stores the dict on success and warnings and refreshes `repositories.total_size` from `repository_size` with `total_size_source = compact_stats` (0 included: an emptied repository is a measurement). A rounded figure never replaces a measured size.
- **Agent path**: completion parses the collected job log. A line that arrives within ten minutes after the job's server-stamped completion (the agent's outbox drains after the completion report; seen live 150 ms apart) is appended to the operation's transcript, a failed run's error lines included; for a successful compact a closing statistics line triggers one parse of the transcript's tail. The size is refreshed only when no `stats` follow-up has measured the repository since (both `run_stats` branches now report `size_refreshed`) and no later compact reported one; the lookback is bounded below by the job's server-stamped claim, so the agent's clock cannot widen it.
- **API**: `serialize_job_status` includes `stats` for compact jobs; `/api/operations` carries it in `result` as before.
- `docs/architecture/job-system.md` describes the behaviour and its limits.

Not in this PR: the read-only size source order (#934) and the UI for the new fields (#935). A prune's late `--list` lines reach the transcript but are not fed back into the pruned-archive marking; a size refresh a user triggers by hand writes no operation row and is not seen by the guard.

## Related Issue

Fixes #931

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

New and changed tests:

- `test_borg2_compact_stats.py`: verbatim b23/b24 output from plain lines and `--log-json` entries; junk, other loggers and nesting past the recursion limit; `None` without a repository-size line; decimal, raw and IEC units; the closing-line classifier.
- `test_operations_job_facade.py`: `stats` round-trips through `result["stats"]` next to other keys.
- `test_operations_runner.py`: `_merged_result` keeps `stats` and nothing else; a merge with a key another session filed while the executor ran.
- `test_operations_index_executors.py`: both `run_stats` branches report `size_refreshed`.
- `test_maintenance_state.py`: stats persisted and `total_size` refreshed on success and warnings; untouched without stats, on failure, for a rounded or unlabelled figure over a measured size, and with `refresh_size=False`.
- `test_v2_services.py`: `execute_compact` on an `Operation` row spawns `compact --stats --info` under `BORG_UNITS=raw`, persists `result["stats"]` (exact) and `total_size`, and keeps both across a `commit_with_retry` rollback.
- `test_api_agents.py`: completion parses the job log, guarded against a `stats` follow-up that measured while the job was unreported; late lines over the HTTP route and the session handler (the whole block after completion, a two-line frame, a failed compact's error lines, the 9/11-minute window boundary, a resend, an absorb that raises, a missing transcript file, a legacy `compact_jobs` row); the size guard against a `stats` follow-up that measured, one that could not, a later compact, and a slow agent clock.

Runs (scratch venv, Python 3.12, ruff 0.16.5):

```
pytest tests/unit/test_borg2_compact_stats.py tests/unit/test_maintenance_state.py \
       tests/unit/test_v2_services.py tests/unit/test_api_agents.py \
       tests/unit/test_operations_runner.py tests/unit/test_operations_index_executors.py \
       tests/unit/test_operations_job_facade.py tests/unit/test_operations_maintenance_executors.py \
       tests/unit/test_api_maintenance_jobs.py tests/unit/test_api_repositories.py
387 passed

pytest tests/unit   (full suite, untouched export of this branch on main)
3670 passed, 13 skipped

ruff check .            All checks passed!
ruff format --check     clean
```

Measured on Borg 2.0.0b23 and 2.0.0b24 (identical): `compact --stats -v` prints the statistics block; `compact --dry-run` answers "Ignoring --stats"; `create --stats` reports store traffic only. The parsed `repository_size` equals the chunk-index sum within Borg's rounding.

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable.

## Additional Context

`--stats` makes compact somewhat slower (borgbackup/borg#8796), because Borg analyses the archives; the per-archive reference caches Borg keeps in the repository make unchanged archives cheap. A read-only `repo-info --stats` is requested upstream as borgbackup/borg#10329; until then this is the only Borg-native source. Part of the wave described in #917, #931, #933, #934, #935, #936.
