### PR TITLE
chore(restore): drop the dead dry_run field from RestoreRequest

### DIFF
--- a/app/api/restore.py
+++ b/app/api/restore.py
@@ -78,7 +78,6 @@ class RestoreRequest(BaseModel):
     archive: str
     paths: List[str]
     destination: str
-    dry_run: bool = False
     repository_id: int  # Repository ID for fetching repository details
     destination_type: str = "local"  # 'local' or 'ssh'
     destination_connection_id: Optional[int] = (

--- a/tests/unit/test_api_restore.py
+++ b/tests/unit/test_api_restore.py
@@ -1183,17 +1183,41 @@ class TestRestoreRequestShape:
     def test_start_ignores_a_dry_run_field_a_client_still_sends(
         self, test_client: TestClient, admin_headers, test_db
     ):
-        """Pydantic ignores unknown fields, so an old client that still sends
-        dry_run gets exactly the behaviour it got before: a real restore."""
-        from app.api.restore import RestoreRequest
-
-        request = RestoreRequest(
-            repository="/test/repo",
-            archive="a",
-            paths=["etc"],
-            destination="/dest",
-            repository_id=1,
-            dry_run=True,
+        """Pydantic ignores unknown fields, so a client still sending dry_run
+        gets exactly the behaviour it got before the field was removed: a real
+        restore, enqueued the same way, with nothing recorded about dry run."""
+        repo = Repository(
+            name="Dry Run Repo",
+            path="/test/dry-run-repo",
+            encryption="none",
+            repository_type="local",
         )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
 
-        assert not hasattr(request, "dry_run")
+        with patch(
+            "app.services.restore_service.restore_service.execute_restore",
+            new=AsyncMock(return_value=None),
+        ):
+            response = test_client.post(
+                "/api/restore/start",
+                json={
+                    "repository": repo.path,
+                    "repository_id": repo.id,
+                    "archive": "test-archive",
+                    "paths": ["docs/"],
+                    "destination": "/restore/target",
+                    "dry_run": True,
+                },
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "pending"
+
+        operation = test_db.get(Operation, body["job_id"])
+        assert operation.kind == "restore"
+        assert operation.repository_id == repo.id
+        assert "dry_run" not in operation.params

--- a/tests/unit/test_api_restore.py
+++ b/tests/unit/test_api_restore.py
@@ -1168,3 +1168,32 @@ Restore completed successfully"""
         # Verify line breaks are preserved
         assert "\n" in data["logs"]
         assert data["logs"].count("\n") == multiline_logs.count("\n")
+
+
+@pytest.mark.unit
+class TestRestoreRequestShape:
+    """The restore request model carries no dry-run switch. Dry-run restore is
+    the dedicated preview route, which runs borg extract with --dry-run."""
+
+    def test_restore_request_has_no_dry_run_field(self):
+        from app.api.restore import RestoreRequest
+
+        assert "dry_run" not in RestoreRequest.model_fields
+
+    def test_start_ignores_a_dry_run_field_a_client_still_sends(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """Pydantic ignores unknown fields, so an old client that still sends
+        dry_run gets exactly the behaviour it got before: a real restore."""
+        from app.api.restore import RestoreRequest
+
+        request = RestoreRequest(
+            repository="/test/repo",
+            archive="a",
+            paths=["etc"],
+            destination="/dest",
+            repository_id=1,
+            dry_run=True,
+        )
+
+        assert not hasattr(request, "dry_run")


### PR DESCRIPTION
Follow-up from PR #976, where CodeRabbit flagged that a restore started with `dry_run: true` performs a real extraction.

That is true, but the framing was wrong. `dry_run` is not a broken feature, it is a field nothing has ever read.

## What it actually was

`RestoreRequest` has declared `dry_run: bool = False` since the initial commit. Nothing reads it: not the start route, not the restore service, not the executor, not any command builder. The frontend does not send it, and it is not in the API docs, so it was only reachable by hand-crafting a request.

## Why removing it is the right fix rather than wiring it up

Dry-run restore already exists as its own endpoint. `POST /restore/preview` runs `borg extract` with `--dry-run`, on both the Borg 1 and Borg 2 paths. Wiring the field up would give the API two ways to preview a restore, one of which is a flag on the endpoint that performs the real thing. Removing it leaves one.

## Compatibility

Pydantic ignores unknown fields, so a client still sending `dry_run` keeps exactly the behaviour it has today: the field is dropped and a real restore runs. The added test posts that legacy payload through the route and asserts the restore is enqueued normally with no `dry_run` in the operation params.

## Verification

- `pytest tests/unit/test_api_restore.py`: 42 passed.
- Restore suites together (v1 API, v1 service, v2 service, operations facade, operations executor): 83 passed.
- `ruff check app tests` and `ruff format --check` clean.
- Two local CodeRabbit passes. The first asked that the compatibility test go through the endpoint rather than construct the model, which it now does. The second returned zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vAyieGLZxL1NCZy3xpBgT