### PR TITLE
docs(agents): mark phase 2 done

### DIFF
--- a/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
+++ b/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
@@ -548,7 +548,7 @@ Agents update this table and nothing else as work advances. Statuses:
 | Phase | Status | Plan file | Branch | Notes |
 | --- | --- | --- | --- | --- |
 | 1. Version model and visibility | done | `docs/engineering/plans/2026-09-07-agent-upgrades-phase-1.md` | `feat/agent-upgrades` | Pin UI moved to phase 3 |
-| 2. Privileged helper and capability | in review | `docs/engineering/plans/2026-09-09-agent-upgrades-phase-2.md` | `feat/agent-upgrades-phase-2` | https is a precondition; opt-out uses a marker file |
+| 2. Privileged helper and capability | done | `docs/engineering/plans/2026-09-09-agent-upgrades-phase-2.md` | `feat/agent-upgrades-phase-2` | https is a precondition; opt-out uses a marker file; the trigger is a `.path` unit, not sudoers |
 | 3. Single-agent remote upgrade | not started | | | |
 | 4. Fleet upgrade | not started | | | |
 | 5. Per-endpoint Borg version | not started | | | |


### PR DESCRIPTION
Phase 2 merged in #984. Flips the progress table and records that the trigger ended up as a systemd `.path` unit rather than the sudoers rule the spec originally described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)