### PR TITLE
feat(agents): centralized agent upgrades, phase 3

### DIFF
--- a/agent/borg_ui_agent/session.py
+++ b/agent/borg_ui_agent/session.py
@@ -758,6 +758,12 @@ class AgentSessionRuntime:
             # job is running under it.
             client.send_error(f"Agent is running jobs {running}", code="upgrade_busy")
             return
+        # This is a snapshot, not a lock: a job dispatched between here and the
+        # restart is still orphaned. Closing that window means an
+        # upgrade-exclusive state that blocks dispatch through shutdown, which
+        # is more machinery than the outcome earns -- the server's job reaper
+        # already fails an orphaned job, and the operator picked this moment to
+        # restart the endpoint.
 
         readiness = check_self_upgrade()
         if not readiness.supported or readiness.trigger is None:

--- a/agent/borg_ui_agent/session.py
+++ b/agent/borg_ui_agent/session.py
@@ -23,6 +23,12 @@ from agent.borg_ui_agent.self_upgrade import check_self_upgrade
 
 logger = logging.getLogger(__name__)
 
+# How long an upgrade owns the session after it is requested. Matches
+# AGENT_UPGRADE_TIMEOUT_SECONDS on the server, so an endpoint whose reinstall
+# never happened starts taking jobs again no earlier than the moment the
+# server marks that upgrade failed.
+UPGRADE_CLAIM_SECONDS = 600
+
 try:
     from websocket import WebSocketTimeoutException
 except Exception:  # pragma: no cover - only used when optional dep is unavailable.
@@ -298,12 +304,12 @@ class AgentSessionRuntime:
         self._registry_lock = threading.Lock()
         self._cancel_events: dict[int, threading.Event] = {}
         self._pending_cancels: set[int] = set()
-        # Set while an upgrade is being requested, and left set through the
-        # restart it causes, so a job dispatched after the busy check cannot
-        # start under an agent that is about to die. Guarded by _registry_lock,
-        # the same lock the cancel registry uses, so the check and the
-        # reservation are one atomic step.
-        self._upgrading = False
+        # Deadline (monotonic) while an upgrade is being requested, held
+        # through the restart it causes so a job dispatched after the busy
+        # check cannot start under an agent that is about to die. Guarded by
+        # _registry_lock, the same lock the cancel registry uses, so the check
+        # and the reservation are one atomic step.
+        self._upgrading_until: Optional[float] = None
 
     def run_forever(
         self,
@@ -635,13 +641,16 @@ class AgentSessionRuntime:
             )
             return
 
-        with self._registry_lock:
-            upgrading = self._upgrading
-        if upgrading:
+        if self._upgrade_claimed():
             # Refusing is what makes the upgrade's busy check hold: this
             # process is about to be restarted, so a job started here would be
             # orphaned by it. Failing now lets the server retry the job against
             # the upgraded agent instead of waiting for the reaper.
+            #
+            # The session loop registered this id before starting the worker,
+            # and the unregister below is in a finally this return skips, so
+            # drop it here or hello reports a job that is not running.
+            self._unregister_cancel(job_id)
             client.send_error(
                 "Agent is upgrading and cannot start new jobs",
                 code="upgrade_in_progress",
@@ -682,6 +691,14 @@ class AgentSessionRuntime:
                 return_code=return_code,
             )
 
+    def _upgrade_claimed(self) -> bool:
+        """Whether an upgrade currently owns this session."""
+        with self._registry_lock:
+            return (
+                self._upgrading_until is not None
+                and time.monotonic() < self._upgrading_until
+            )
+
     def _reserve_for_upgrade(self) -> list[int]:
         """Claim this session for an upgrade, or report what is running.
 
@@ -693,21 +710,34 @@ class AgentSessionRuntime:
         Returns the running job ids when the upgrade must be refused, and an
         empty list when the claim succeeded. A second upgrade request arriving
         while one is already claimed is refused too, with an empty id list.
+
+        The claim carries a deadline because the reinstall is not guaranteed
+        to happen: the root helper refuses a non-https server, a checksum that
+        does not match, or a config that names a different server, and in each
+        case it aborts with this process still running. A claim without an
+        expiry would leave such an endpoint refusing every job until someone
+        restarted it by hand, which is worse than the orphaned job the claim
+        exists to prevent. The deadline matches the server's own upgrade
+        timeout, so the agent starts accepting work again no earlier than the
+        moment the server gives up on the upgrade.
         """
         with self._registry_lock:
             running = sorted(self._cancel_events.keys())
             if running:
                 return running
-            if self._upgrading:
+            if (
+                self._upgrading_until is not None
+                and time.monotonic() < self._upgrading_until
+            ):
                 return [-1]
-            self._upgrading = True
+            self._upgrading_until = time.monotonic() + UPGRADE_CLAIM_SECONDS
             return []
 
     def _release_upgrade(self) -> None:
-        """Undo the claim when the upgrade never actually starts. It is never
-        released on success: the restart is the release."""
+        """Undo the claim when the upgrade never actually starts. On success it
+        is left to expire: the restart normally gets there first."""
         with self._registry_lock:
-            self._upgrading = False
+            self._upgrading_until = None
 
     def _register_cancel(self, job_id: int) -> threading.Event:
         """Register a cancel Event for ``job_id`` — already set if a cancel for it

--- a/agent/borg_ui_agent/session.py
+++ b/agent/borg_ui_agent/session.py
@@ -298,6 +298,12 @@ class AgentSessionRuntime:
         self._registry_lock = threading.Lock()
         self._cancel_events: dict[int, threading.Event] = {}
         self._pending_cancels: set[int] = set()
+        # Set while an upgrade is being requested, and left set through the
+        # restart it causes, so a job dispatched after the busy check cannot
+        # start under an agent that is about to die. Guarded by _registry_lock,
+        # the same lock the cancel registry uses, so the check and the
+        # reservation are one atomic step.
+        self._upgrading = False
 
     def run_forever(
         self,
@@ -629,6 +635,19 @@ class AgentSessionRuntime:
             )
             return
 
+        with self._registry_lock:
+            upgrading = self._upgrading
+        if upgrading:
+            # Refusing is what makes the upgrade's busy check hold: this
+            # process is about to be restarted, so a job started here would be
+            # orphaned by it. Failing now lets the server retry the job against
+            # the upgraded agent instead of waiting for the reaper.
+            client.send_error(
+                "Agent is upgrading and cannot start new jobs",
+                code="upgrade_in_progress",
+            )
+            return
+
         # Normally already registered by the session loop before this thread
         # even started (see _job_id_for_dispatch); only register here when a
         # caller invoked this method directly without doing that (e.g. a test).
@@ -662,6 +681,33 @@ class AgentSessionRuntime:
                 error_message=message_text,
                 return_code=return_code,
             )
+
+    def _reserve_for_upgrade(self) -> list[int]:
+        """Claim this session for an upgrade, or report what is running.
+
+        The check and the claim happen under one lock hold, so a job that
+        registers concurrently either lands before the claim (and is reported
+        here, refusing the upgrade) or after it (and is refused by the
+        dispatch guard in _handle_command). Nothing slips between them.
+
+        Returns the running job ids when the upgrade must be refused, and an
+        empty list when the claim succeeded. A second upgrade request arriving
+        while one is already claimed is refused too, with an empty id list.
+        """
+        with self._registry_lock:
+            running = sorted(self._cancel_events.keys())
+            if running:
+                return running
+            if self._upgrading:
+                return [-1]
+            self._upgrading = True
+            return []
+
+    def _release_upgrade(self) -> None:
+        """Undo the claim when the upgrade never actually starts. It is never
+        released on success: the restart is the release."""
+        with self._registry_lock:
+            self._upgrading = False
 
     def _register_cancel(self, job_id: int) -> threading.Event:
         """Register a cancel Event for ``job_id`` — already set if a cancel for it
@@ -752,21 +798,20 @@ class AgentSessionRuntime:
         Readiness is re-checked rather than trusted. The capability was
         reported at connect time and the endpoint may have been changed since.
         """
-        running = self._running_job_ids()
+        # Claiming rather than sampling: an upgrade restarts this process, and
+        # a job dispatched between a bare check and that restart would be
+        # orphaned by it. The claim closes the window, and is held through the
+        # restart on purpose.
+        running = self._reserve_for_upgrade()
         if running:
             # An upgrade restarts this process, which would orphan whatever
             # job is running under it.
             client.send_error(f"Agent is running jobs {running}", code="upgrade_busy")
             return
-        # This is a snapshot, not a lock: a job dispatched between here and the
-        # restart is still orphaned. Closing that window means an
-        # upgrade-exclusive state that blocks dispatch through shutdown, which
-        # is more machinery than the outcome earns -- the server's job reaper
-        # already fails an orphaned job, and the operator picked this moment to
-        # restart the endpoint.
 
         readiness = check_self_upgrade()
         if not readiness.supported or readiness.trigger is None:
+            self._release_upgrade()
             client.send_error(
                 f"Endpoint cannot upgrade itself: {readiness.reason}",
                 code="upgrade_unsupported",
@@ -776,6 +821,7 @@ class AgentSessionRuntime:
         try:
             readiness.trigger.touch()
         except OSError as exc:
+            self._release_upgrade()
             client.send_error(
                 f"Could not request upgrade: {exc}", code="upgrade_failed"
             )

--- a/agent/borg_ui_agent/session.py
+++ b/agent/borg_ui_agent/session.py
@@ -19,6 +19,7 @@ from agent.borg_ui_agent.config import AgentConfig
 from agent.borg_ui_agent.filesystem import FilesystemBrowseError, browse_filesystem
 from agent.borg_ui_agent.runtime import get_capabilities, get_job_handler
 from agent.borg_ui_agent.scripts import list_allowed_scripts
+from agent.borg_ui_agent.self_upgrade import check_self_upgrade
 
 logger = logging.getLogger(__name__)
 
@@ -530,6 +531,7 @@ class AgentSessionRuntime:
             "diagnostics.run",
             "agent.repository_defaults",
             "agent.list_scripts",
+            "agent.upgrade",
             "cancel",
         ):
             return None
@@ -600,6 +602,10 @@ class AgentSessionRuntime:
 
         if command == "agent.list_scripts":
             self._handle_list_scripts(client, payload)
+            return
+
+        if command == "agent.upgrade":
+            self._handle_upgrade(client)
             return
 
         if command == "cancel":
@@ -734,6 +740,43 @@ class AgentSessionRuntime:
             client.send_error(f"Listing agent scripts failed: {exc}")
             return
         client.send_result({"scripts": scripts})
+
+    def _handle_upgrade(self, client: SessionCommandClient) -> None:
+        """Ask this endpoint to reinstall itself.
+
+        The whole action is creating one empty file that nothing reads: a
+        systemd .path unit watches it and starts the root helper, which takes
+        no arguments and reads every parameter from a root-owned config. The
+        agent therefore names no version and passes no argv.
+
+        Readiness is re-checked rather than trusted. The capability was
+        reported at connect time and the endpoint may have been changed since.
+        """
+        running = self._running_job_ids()
+        if running:
+            # An upgrade restarts this process, which would orphan whatever
+            # job is running under it.
+            client.send_error(f"Agent is running jobs {running}", code="upgrade_busy")
+            return
+
+        readiness = check_self_upgrade()
+        if not readiness.supported or readiness.trigger is None:
+            client.send_error(
+                f"Endpoint cannot upgrade itself: {readiness.reason}",
+                code="upgrade_unsupported",
+            )
+            return
+
+        try:
+            readiness.trigger.touch()
+        except OSError as exc:
+            client.send_error(
+                f"Could not request upgrade: {exc}", code="upgrade_failed"
+            )
+            return
+
+        logger.info("Upgrade requested via %s", readiness.trigger)
+        client.send_result({"success": True, "trigger": str(readiness.trigger)})
 
     def _handle_diagnostics(
         self, client: SessionCommandClient, payload: dict[str, Any]

--- a/app/api/agents.py
+++ b/app/api/agents.py
@@ -132,8 +132,13 @@ def resolve_agent_upgrade(agent: AgentMachine) -> None:
     outcome. An endpoint that comes back on the old version is left in
     `requested`: the reinstall may still be mid flight, and only the timeout
     resolves it.
+
+    An endpoint already marked `failed` is cleared too when it turns up on the
+    target version. The agent can be killed before its acknowledgement reaches
+    the server, and the timeout is a guess by construction, so the version the
+    endpoint actually reports outranks either.
     """
-    if agent.upgrade_state != "requested":
+    if agent.upgrade_state not in ("requested", "failed"):
         return
     if (
         agent.upgrade_target_version

--- a/app/api/agents.py
+++ b/app/api/agents.py
@@ -125,6 +125,25 @@ def _as_utc(dt: datetime) -> datetime:
     return dt.astimezone(timezone.utc)
 
 
+def resolve_agent_upgrade(agent: AgentMachine) -> None:
+    """Clear a requested upgrade when the endpoint comes back on its target.
+
+    The agent is killed by the thing it is reporting on, so the server owns the
+    outcome. An endpoint that comes back on the old version is left in
+    `requested`: the reinstall may still be mid flight, and only the timeout
+    resolves it.
+    """
+    if agent.upgrade_state != "requested":
+        return
+    if (
+        agent.upgrade_target_version
+        and agent.agent_version == agent.upgrade_target_version
+    ):
+        agent.upgrade_state = "idle"
+        agent.upgrade_error = None
+        agent.upgrade_requested_at = None
+
+
 def _validated_timezone(value: Optional[str]) -> Optional[str]:
     """The value if it names a real IANA zone, else None.
 
@@ -1237,6 +1256,7 @@ async def heartbeat(
     now = _now_utc()
     current_agent.hostname = payload.hostname or current_agent.hostname
     current_agent.agent_version = payload.agent_version or current_agent.agent_version
+    resolve_agent_upgrade(current_agent)
     current_agent.timezone = (
         _validated_timezone(payload.timezone) or current_agent.timezone
     )
@@ -1305,6 +1325,7 @@ async def session(websocket: WebSocket, db: Session = Depends(get_db)):
         now = _now_utc()
         current_agent.hostname = hello.hostname or current_agent.hostname
         current_agent.agent_version = hello.agent_version or current_agent.agent_version
+        resolve_agent_upgrade(current_agent)
         current_agent.timezone = (
             _validated_timezone(hello.timezone) or current_agent.timezone
         )

--- a/app/api/managed_machines.py
+++ b/app/api/managed_machines.py
@@ -12,7 +12,10 @@ import structlog
 from app.api.agent_installer import agent_package_version
 from app.core.agent_auth import AGENT_TOKEN_PREFIX_LENGTH
 from app.core.agent_versions import compute_agent_upgrade_status
-from app.core.agent_constants import AGENT_FILESYSTEM_BROWSE_TIMEOUT_SECONDS
+from app.core.agent_constants import (
+    AGENT_FILESYSTEM_BROWSE_TIMEOUT_SECONDS,
+    AGENT_UPGRADE_COMMAND_TIMEOUT_SECONDS,
+)
 from app.core.features import require_feature_access
 from app.core.security import get_current_admin_user, get_password_hash
 from app.database.database import get_db
@@ -487,6 +490,12 @@ class AgentDesiredVersionRequest(BaseModel):
     desired_borg_version: Optional[Literal["1", "2"]] = None
 
 
+class AgentUpgradeRequest(BaseModel):
+    """Ask each named endpoint to reinstall itself."""
+
+    agent_machine_ids: list[int]
+
+
 def _agent_machine_response(
     agent: AgentMachine, *, available: Optional[str]
 ) -> AgentMachineResponse:
@@ -579,6 +588,167 @@ async def set_agent_desired_version(
     db.commit()
     db.refresh(agent)
     return _agent_machine_response(agent, available=available)
+
+
+# An upgrade job is completed as soon as the endpoint acknowledges the request,
+# so a job still in one of these is one nothing has answered for yet.
+UPGRADE_IN_FLIGHT_STATUSES = ("queued", "claimed", "running", "cancel_requested")
+
+
+@router.post("/agents/upgrade")
+async def upgrade_agent_machines(
+    payload: AgentUpgradeRequest,
+    current_user: User = Depends(require_managed_agents_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Ask each named endpoint to reinstall itself.
+
+    Validation runs over the whole request before anything is created: a
+    partial success that reports as a full one is the failure mode to avoid.
+    The agent is killed by the thing it is reporting on, so the job records
+    only that the upgrade was requested; the outcome is resolved by the
+    register path and the reaper (spec section 7.1).
+    """
+    # Deduplicated first: an upgrade restarts the endpoint, so two jobs for one
+    # machine could restart it twice or race two reinstalls against each other.
+    wanted = list(dict.fromkeys(payload.agent_machine_ids))
+    agents = (
+        db.query(AgentMachine)
+        .filter(AgentMachine.id.in_(wanted), AgentMachine.status != "deleted")
+        .all()
+        if wanted
+        else []
+    )
+    found = {agent.id: agent for agent in agents}
+    if len(found) != len(wanted):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"key": "backend.errors.agents.agentNotFound"},
+        )
+
+    available = agent_package_version()
+    for agent_id in wanted:
+        agent = found[agent_id]
+        if not (agent.capabilities and "self_upgrade" in agent.capabilities):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={"key": "backend.errors.agents.upgradeUnsupported"},
+            )
+        if not (agent.desired_agent_version or available):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={"key": "backend.errors.agents.upgradeTargetUnavailable"},
+            )
+
+    results = []
+    for agent_id in wanted:
+        agent = found[agent_id]
+        existing = (
+            db.query(AgentJob)
+            .filter(
+                AgentJob.agent_machine_id == agent.id,
+                AgentJob.job_type == "agent_upgrade",
+                AgentJob.status.in_(UPGRADE_IN_FLIGHT_STATUSES),
+            )
+            .first()
+        )
+        if existing is not None or agent.upgrade_state == "requested":
+            # Idempotent under a double click or a client retry: the endpoint
+            # is already restarting for a request nobody has answered for yet.
+            results.append(
+                {
+                    "agent_machine_id": agent.id,
+                    "job_id": existing.id
+                    if existing
+                    else _last_upgrade_job_id(db, agent),
+                    "state": agent.upgrade_state or "requested",
+                }
+            )
+            continue
+
+        results.append(
+            await _request_agent_upgrade(
+                db, agent, target=agent.desired_agent_version or available
+            )
+        )
+
+    logger.info(
+        "Agent upgrades requested",
+        user=current_user.username,
+        agent_machine_ids=wanted,
+    )
+    return {"results": results}
+
+
+def _last_upgrade_job_id(db: Session, agent: AgentMachine) -> Optional[int]:
+    """The job that requested the upgrade this agent is still waiting on."""
+    job = (
+        db.query(AgentJob)
+        .filter(
+            AgentJob.agent_machine_id == agent.id,
+            AgentJob.job_type == "agent_upgrade",
+        )
+        .order_by(AgentJob.id.desc())
+        .first()
+    )
+    return job.id if job else None
+
+
+async def _request_agent_upgrade(db: Session, agent: AgentMachine, *, target: str):
+    """Create the job, dispatch the command, and record the outcome for one
+    endpoint. The job is completed at "upgrade started": it records that the
+    upgrade was successfully requested, nothing more."""
+    now = _now_utc()
+    job = AgentJob(
+        agent_machine_id=agent.id,
+        job_type="agent_upgrade",
+        status="running",
+        payload={"target_version": target},
+        created_at=now,
+        updated_at=now,
+        started_at=now,
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    try:
+        await agent_connection_manager.send_command(
+            agent.id,
+            command="agent.upgrade",
+            payload={},
+            timeout_seconds=AGENT_UPGRADE_COMMAND_TIMEOUT_SECONDS,
+            wait_for_result=True,
+        )
+    except (
+        AgentConnectionUnavailable,
+        AgentCommandTimeout,
+        AgentCommandError,
+    ) as exc:
+        finished = _now_utc()
+        job.status = "failed"
+        job.error_message = str(exc)
+        job.completed_at = finished
+        job.updated_at = finished
+        agent.upgrade_state = "failed"
+        agent.upgrade_error = str(exc)
+        agent.upgrade_target_version = target
+        agent.upgrade_requested_at = None
+        agent.updated_at = finished
+        db.commit()
+        return {"agent_machine_id": agent.id, "job_id": job.id, "state": "failed"}
+
+    finished = _now_utc()
+    job.status = "completed"
+    job.completed_at = finished
+    job.updated_at = finished
+    agent.upgrade_state = "requested"
+    agent.upgrade_requested_at = finished
+    agent.upgrade_target_version = target
+    agent.upgrade_error = None
+    agent.updated_at = finished
+    db.commit()
+    return {"agent_machine_id": agent.id, "job_id": job.id, "state": "requested"}
 
 
 @router.post(

--- a/app/api/managed_machines.py
+++ b/app/api/managed_machines.py
@@ -6,6 +6,7 @@ from typing import Any, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
+from sqlalchemy import or_
 from sqlalchemy.orm import Session, defer
 import structlog
 
@@ -634,7 +635,13 @@ async def upgrade_agent_machines(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail={"key": "backend.errors.agents.upgradeUnsupported"},
             )
-        if not (agent.desired_agent_version or available):
+        # The installer installs from this server's wheelhouse and nowhere
+        # else, so an unpinned endpoint on a server with no wheel, and a pin
+        # this server can no longer serve (the pin outlived a server upgrade),
+        # are both unsatisfiable. Reject them here rather than restarting the
+        # endpoint into a reinstall that cannot produce the target.
+        target = agent.desired_agent_version or available
+        if not target or target != available:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail={"key": "backend.errors.agents.upgradeTargetUnavailable"},
@@ -652,7 +659,32 @@ async def upgrade_agent_machines(
             )
             .first()
         )
-        if existing is not None or agent.upgrade_state == "requested":
+        # Claim the agent with a conditional write before anything is created,
+        # so two concurrent requests cannot both dispatch a restart: the loser
+        # updates no row and reuses the in-flight request.
+        claimed = (
+            db.query(AgentMachine)
+            .filter(
+                AgentMachine.id == agent.id,
+                or_(
+                    AgentMachine.upgrade_state.is_(None),
+                    AgentMachine.upgrade_state != "requested",
+                ),
+            )
+            .update(
+                {
+                    AgentMachine.upgrade_state: "requested",
+                    # Stamped with the claim, not with the dispatch, so a
+                    # request the server dies in the middle of is still
+                    # resolvable by the reaper rather than stuck forever.
+                    AgentMachine.upgrade_requested_at: _now_utc(),
+                },
+                synchronize_session=False,
+            )
+        )
+        db.commit()
+        db.refresh(agent)
+        if existing is not None or not claimed:
             # Idempotent under a double click or a client retry: the endpoint
             # is already restarting for a request nobody has answered for yet.
             results.append(
@@ -661,7 +693,7 @@ async def upgrade_agent_machines(
                     "job_id": existing.id
                     if existing
                     else _last_upgrade_job_id(db, agent),
-                    "state": agent.upgrade_state or "requested",
+                    "state": "requested",
                 }
             )
             continue

--- a/app/core/agent_constants.py
+++ b/app/core/agent_constants.py
@@ -8,3 +8,12 @@ can wait for the next poll to complete the job.
 DEFAULT_AGENT_POLL_INTERVAL_SECONDS = 15
 AGENT_FILESYSTEM_BROWSE_TIMEOUT_SECONDS = DEFAULT_AGENT_POLL_INTERVAL_SECONDS * 2
 AGENT_FILESYSTEM_BROWSE_MAX_ITEMS = 1000
+
+# How long the server waits for an endpoint to acknowledge agent.upgrade. The
+# agent only creates a file, so this bounds the round trip, not the reinstall.
+AGENT_UPGRADE_COMMAND_TIMEOUT_SECONDS = 15.0
+
+# How long an endpoint has to come back on its target version before the
+# upgrade is called failed. Generous on purpose: an endpoint that hits this is
+# far more likely broken than slow.
+AGENT_UPGRADE_TIMEOUT_SECONDS = 600

--- a/app/services/agent_job_reaper.py
+++ b/app/services/agent_job_reaper.py
@@ -175,17 +175,38 @@ def reap_stale_agent_upgrades(
     stale = [
         agent for agent in candidates if _as_utc(agent.upgrade_requested_at) < cutoff
     ]
+    reaped = 0
     for agent in stale:
-        agent.upgrade_state = "failed"
-        agent.upgrade_error = (
-            "The endpoint did not come back on the target version in time. "
-            "Reinstall it manually from the reinstall dialog."
+        # Conditional write, matching reap_stale_agent_jobs: the endpoint may
+        # have re-registered on its target version between the read above and
+        # here, which clears the state to idle. The WHERE guard makes the
+        # reaper lose that race rather than overwrite a resolved upgrade with
+        # a failure. requested_at is matched too, so a second upgrade
+        # requested in that window is not failed on the first one's timeout.
+        reaped += (
+            db.query(AgentMachine)
+            .filter(
+                AgentMachine.id == agent.id,
+                AgentMachine.upgrade_state == "requested",
+                AgentMachine.upgrade_requested_at == agent.upgrade_requested_at,
+            )
+            .update(
+                {
+                    AgentMachine.upgrade_state: "failed",
+                    AgentMachine.upgrade_error: (
+                        "The endpoint did not come back on the target version "
+                        "in time. Reinstall it manually from the reinstall "
+                        "dialog."
+                    ),
+                    AgentMachine.updated_at: now,
+                },
+                synchronize_session=False,
+            )
         )
-        agent.updated_at = now
-    if stale:
+    if reaped:
         db.commit()
-        logger.info("Reaped stale agent upgrades", count=len(stale))
-    return len(stale)
+        logger.info("Reaped stale agent upgrades", count=reaped)
+    return reaped
 
 
 def _reap_once(failed_backup_job_ids: Optional[list[int]] = None) -> int:

--- a/app/services/agent_job_reaper.py
+++ b/app/services/agent_job_reaper.py
@@ -26,7 +26,8 @@ import structlog
 from sqlalchemy.orm import Session
 
 from app.database.database import SessionLocal
-from app.database.models import AgentJob, BackupJob
+from app.core.agent_constants import AGENT_UPGRADE_TIMEOUT_SECONDS
+from app.database.models import AgentJob, AgentMachine, BackupJob
 
 logger = structlog.get_logger()
 
@@ -148,6 +149,45 @@ def reap_stale_agent_jobs(
     return reaped
 
 
+def reap_stale_agent_upgrades(
+    db: Session,
+    *,
+    now: Optional[datetime] = None,
+    timeout_seconds: int = AGENT_UPGRADE_TIMEOUT_SECONDS,
+) -> int:
+    """Mark upgrades whose endpoint never came back as failed.
+
+    The agent cannot report the outcome of the thing that kills it, so this is
+    the only path that resolves a failed upgrade. The cutoff is compared in
+    Python rather than in the WHERE clause because the column is stored naive
+    on SQLite, the same reason _job_activity_at exists.
+    """
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(seconds=timeout_seconds)
+    candidates = (
+        db.query(AgentMachine)
+        .filter(
+            AgentMachine.upgrade_state == "requested",
+            AgentMachine.upgrade_requested_at.isnot(None),
+        )
+        .all()
+    )
+    stale = [
+        agent for agent in candidates if _as_utc(agent.upgrade_requested_at) < cutoff
+    ]
+    for agent in stale:
+        agent.upgrade_state = "failed"
+        agent.upgrade_error = (
+            "The endpoint did not come back on the target version in time. "
+            "Reinstall it manually from the reinstall dialog."
+        )
+        agent.updated_at = now
+    if stale:
+        db.commit()
+        logger.info("Reaped stale agent upgrades", count=len(stale))
+    return len(stale)
+
+
 def _reap_once(failed_backup_job_ids: Optional[list[int]] = None) -> int:
     """One reap pass with its own session (runs in a worker thread)."""
     from app.utils.process_utils import (
@@ -166,6 +206,9 @@ def _reap_once(failed_backup_job_ids: Optional[list[int]] = None) -> int:
         # (e.g. the agent job could not be queued under a db-lock) -- otherwise
         # they block the repository via admission control forever.
         reaped += reconcile_orphaned_maintenance_jobs(db)
+        # The agent cannot report the outcome of its own restart, so a request
+        # nobody came back from is resolved here (spec section 7.1).
+        reaped += reap_stale_agent_upgrades(db)
         return reaped
     finally:
         db.close()

--- a/docs/engineering/plans/2026-09-09-agent-upgrades-phase-3.md
+++ b/docs/engineering/plans/2026-09-09-agent-upgrades-phase-3.md
@@ -110,7 +110,8 @@ from pathlib import Path
 
 import pytest
 
-from agent.borg_ui_agent.session import AgentSession
+from agent.borg_ui_agent.config import AgentConfig
+from agent.borg_ui_agent.session import AgentSessionRuntime
 from agent.borg_ui_agent.self_upgrade import UpgradeReadiness
 
 
@@ -123,7 +124,11 @@ def _drain(outbox):
 
 @pytest.fixture
 def session(monkeypatch):
-    return AgentSession.__new__(AgentSession)
+    return AgentSessionRuntime(
+        AgentConfig("https://borgui.example.com", "agt_123", "secret"),
+        connect=lambda *args, **kwargs: None,
+        http_client=_HttpClient(),
+    )
 
 
 def _run(session, outbox, monkeypatch, readiness, running_ids=()):
@@ -131,7 +136,7 @@ def _run(session, outbox, monkeypatch, readiness, running_ids=()):
         "agent.borg_ui_agent.session.check_self_upgrade", lambda: readiness
     )
     monkeypatch.setattr(
-        AgentSession, "_running_job_ids", lambda self: list(running_ids)
+        AgentSessionRuntime, "_running_job_ids", lambda self: list(running_ids)
     )
     session._handle_command(
         outbox, {"command_id": "c1", "command": "agent.upgrade", "payload": {}}

--- a/docs/engineering/plans/2026-09-09-agent-upgrades-phase-3.md
+++ b/docs/engineering/plans/2026-09-09-agent-upgrades-phase-3.md
@@ -1,0 +1,1289 @@
+# Agent upgrades phase 3: single-agent remote upgrade
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:subagent-driven-development` (recommended) or
+> `superpowers:executing-plans` to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** An operator clicks Upgrade on one managed agent row and that endpoint
+reinstalls itself, with the server owning the outcome, so the row resolves to
+up to date without anyone touching the machine.
+
+**Architecture:** Phase 2 shipped the mechanism on the endpoint: a root helper,
+a `oneshot` unit, and a systemd `.path` unit watching
+`/etc/borg-ui-agent/upgrade-requested`. Phase 3 pulls the trigger. A new
+`agent.upgrade` session command makes the agent create that one empty file
+after re-checking the same readiness predicate the capability probe uses. A new
+`POST /api/managed-machines/agents/upgrade` endpoint validates the whole
+request, creates one `agent_upgrade` job per agent, dispatches the command, and
+records `upgrade_state="requested"` with the target version. The agent is
+killed by the thing it is reporting on, so the server resolves the outcome:
+success when the endpoint re-registers on the target version, failure by
+timeout in the existing agent job reaper.
+
+**Tech Stack:** FastAPI, SQLAlchemy, systemd, React, MUI, i18next, Storybook,
+pytest, vitest.
+
+**Spec:** `docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md`
+(sections 5, 7, 7.1, 9, 13.4)
+
+## Global Constraints
+
+- **The spec's section 7 is partly stale.** It describes the agent running
+  `sudo -n systemctl start --no-block borg-ui-agent-upgrade.service`. Phase 2
+  review replaced that with the `.path` unit (see the amendment box in spec
+  section 6): the agent unit sets `NoNewPrivileges=true`, under which `sudo`
+  refuses to run. **The shipped trigger is creating the file
+  `/etc/borg-ui-agent/upgrade-requested`.** No sudo, no systemctl, no argv.
+  Read section 7's steps 1, 2 and 4 as current, and step 3 as "create the
+  trigger file".
+- No em dashes in UI copy, i18n strings, code comments, or commit messages.
+- Every new i18n key goes into all four locales:
+  `frontend/src/locales/en.json`, `de.json`, `es.json`, `it.json`. The
+  `frontend-locale-check` pre-push hook fails otherwise.
+- No heavy left accent borders on cards, panels, alerts, or status surfaces
+  (`AGENTS.md`, UI Preferences).
+- New or changed UI ships a Storybook story for the changed state, in default
+  and mobile viewports, following `ManagedAgents.stories.tsx` conventions.
+- New UI components go in `frontend/src/pages/managed-agents/`, not inline in
+  `ManagedAgents.tsx`, which is over 2000 lines.
+- Do not register `managed-machines` routes in `ENDPOINT_POLICIES`
+  (`app/core/authorization.py`); that router authorizes through
+  `get_current_admin_user` / `require_managed_agents_admin_user` in each route
+  signature (spec section 11.2).
+- **Phase 3 is one agent at a time.** The endpoint accepts a list because the
+  spec defines it that way and phase 4 reuses it, but no wave scheduler, no
+  multi-select, and no Upgrade all action land here. `AgentUpgradeBanner` stays
+  informational.
+- Do not re-open a decision in the spec's Appendix B.
+
+---
+
+## File structure
+
+| File | Responsibility |
+| --- | --- |
+| `agent/borg_ui_agent/session.py` | Dispatch `agent.upgrade` and handle it: busy check, readiness re-check, create the trigger. |
+| `app/core/agent_constants.py` | `AGENT_UPGRADE_COMMAND_TIMEOUT_SECONDS`, `AGENT_UPGRADE_TIMEOUT_SECONDS`. |
+| `app/api/managed_machines.py` | `POST /agents/upgrade`: validation, dedup, idempotency, job creation, dispatch, state write. |
+| `app/api/agents.py` | Clear `upgrade_state` when an endpoint re-registers on its target version (register and hello paths). |
+| `app/services/agent_job_reaper.py` | Sweep stale `requested` upgrades to `failed`. |
+| `frontend/src/services/api.ts` | `upgradeAgents`, `setAgentDesiredVersion`. |
+| `frontend/src/pages/managed-agents/AgentUpgradeDialog.tsx` | Confirmation dialog for one endpoint. |
+| `frontend/src/pages/managed-agents/AgentUpgradeStateChip.tsx` | Row state for `requested` and `failed`. |
+| `frontend/src/pages/managed-agents/AgentPinControl.tsx` | Desired agent version and desired Borg major version. |
+| `frontend/src/pages/ManagedAgents.tsx` | Row action wiring, dialog state, manual path routing. |
+
+---
+
+### Task 1: The `agent.upgrade` session command
+
+**Files:**
+- Modify: `agent/borg_ui_agent/session.py` (dispatch block around line 593, new
+  handler next to `_handle_diagnostics` around line 738, and the non-job command
+  list in `_job_id_for_dispatch` around line 530)
+- Test: `tests/unit/test_agent_upgrade_command.py` (create)
+
+**Interfaces:**
+- Consumes: `check_self_upgrade()` and `UpgradeReadiness` from
+  `agent/borg_ui_agent/self_upgrade.py` (phase 2). `UpgradeReadiness` carries
+  `supported: bool`, `reason: str`, `trigger: Optional[Path]`.
+- Produces: session command `agent.upgrade`, taking an empty payload, replying
+  `{"success": True, "trigger": "<path>"}` on success and `command_error` with
+  code `upgrade_busy` or `upgrade_unsupported` otherwise.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/test_agent_upgrade_command.py`:
+
+```python
+"""The agent's side of a remote upgrade: create one empty file.
+
+The trigger is a systemd .path unit, so the agent needs no sudo and passes no
+arguments. It re-checks readiness rather than trusting the capability it last
+reported, because the endpoint may have changed since.
+"""
+
+import json
+import queue
+from pathlib import Path
+
+import pytest
+
+from agent.borg_ui_agent.session import AgentSession
+from agent.borg_ui_agent.self_upgrade import UpgradeReadiness
+
+
+def _drain(outbox):
+    frames = []
+    while not outbox.empty():
+        frames.append(json.loads(outbox.get_nowait()))
+    return frames
+
+
+@pytest.fixture
+def session(monkeypatch):
+    return AgentSession.__new__(AgentSession)
+
+
+def _run(session, outbox, monkeypatch, readiness, running_ids=()):
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.check_self_upgrade", lambda: readiness
+    )
+    monkeypatch.setattr(
+        AgentSession, "_running_job_ids", lambda self: list(running_ids)
+    )
+    session._handle_command(
+        outbox, {"command_id": "c1", "command": "agent.upgrade", "payload": {}}
+    )
+
+
+def test_upgrade_creates_the_trigger_file(session, tmp_path, monkeypatch):
+    trigger = tmp_path / "upgrade-requested"
+    outbox: "queue.Queue[str]" = queue.Queue()
+
+    _run(
+        session,
+        outbox,
+        monkeypatch,
+        UpgradeReadiness(supported=True, trigger=trigger),
+    )
+
+    assert trigger.is_file()
+    results = [f for f in _drain(outbox) if f["type"] == "command_result"]
+    assert results[0]["result"] == {"success": True, "trigger": str(trigger)}
+
+
+def test_upgrade_refuses_while_a_job_is_running(session, tmp_path, monkeypatch):
+    trigger = tmp_path / "upgrade-requested"
+    outbox: "queue.Queue[str]" = queue.Queue()
+
+    _run(
+        session,
+        outbox,
+        monkeypatch,
+        UpgradeReadiness(supported=True, trigger=trigger),
+        running_ids=(7,),
+    )
+
+    assert not trigger.exists()
+    errors = [f for f in _drain(outbox) if f["type"] == "command_error"]
+    assert errors[0]["error"]["code"] == "upgrade_busy"
+
+
+@pytest.mark.parametrize(
+    "reason",
+    ["unit_missing", "helper_missing", "conf_missing", "path_unit_missing"],
+)
+def test_upgrade_refuses_when_unsupported(session, tmp_path, monkeypatch, reason):
+    outbox: "queue.Queue[str]" = queue.Queue()
+
+    _run(
+        session,
+        outbox,
+        monkeypatch,
+        UpgradeReadiness(supported=False, reason=reason),
+    )
+
+    errors = [f for f in _drain(outbox) if f["type"] == "command_error"]
+    assert errors[0]["error"]["code"] == "upgrade_unsupported"
+    assert reason in errors[0]["error"]["message"]
+
+
+def test_upgrade_reports_an_unwritable_trigger_rather_than_dying(
+    session, tmp_path, monkeypatch
+):
+    trigger = tmp_path / "missing-dir" / "upgrade-requested"
+    outbox: "queue.Queue[str]" = queue.Queue()
+
+    _run(
+        session,
+        outbox,
+        monkeypatch,
+        UpgradeReadiness(supported=True, trigger=trigger),
+    )
+
+    errors = [f for f in _drain(outbox) if f["type"] == "command_error"]
+    assert errors[0]["error"]["code"] == "upgrade_failed"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/unit/test_agent_upgrade_command.py -v`
+Expected: FAIL, `check_self_upgrade` is not an attribute of
+`agent.borg_ui_agent.session`.
+
+- [ ] **Step 3: Implement the handler**
+
+In `agent/borg_ui_agent/session.py`, import the predicate next to the other
+agent imports:
+
+```python
+from agent.borg_ui_agent.self_upgrade import check_self_upgrade
+```
+
+Add `"agent.upgrade"` to the tuple of non-job commands in
+`_job_id_for_dispatch` (it carries no `job_id`, so it must not be registered
+for cancellation):
+
+```python
+        if command in (
+            "filesystem.browse",
+            "diagnostics.run",
+            "agent.repository_defaults",
+            "agent.list_scripts",
+            "agent.upgrade",
+            "cancel",
+        ):
+            return None
+```
+
+Dispatch it in `_handle_command`, next to `diagnostics.run`:
+
+```python
+        if command == "agent.upgrade":
+            self._handle_upgrade(client)
+            return
+```
+
+Add the handler next to `_handle_diagnostics`:
+
+```python
+    def _handle_upgrade(self, client: SessionCommandClient) -> None:
+        """Ask this endpoint to reinstall itself.
+
+        The whole action is creating one empty file that nothing reads: a
+        systemd .path unit watches it and starts the root helper, which takes
+        no arguments and reads every parameter from a root-owned config. The
+        agent therefore names no version and passes no argv.
+
+        Readiness is re-checked rather than trusted. The capability was
+        reported at connect time and the endpoint may have been changed since.
+        """
+        running = self._running_job_ids()
+        if running:
+            # An upgrade restarts this process, which would orphan whatever
+            # job is running under it.
+            client.send_error(
+                f"Agent is running jobs {running}", code="upgrade_busy"
+            )
+            return
+
+        readiness = check_self_upgrade()
+        if not readiness.supported or readiness.trigger is None:
+            client.send_error(
+                f"Endpoint cannot upgrade itself: {readiness.reason}",
+                code="upgrade_unsupported",
+            )
+            return
+
+        try:
+            readiness.trigger.touch()
+        except OSError as exc:
+            client.send_error(f"Could not request upgrade: {exc}", code="upgrade_failed")
+            return
+
+        logger.info("Upgrade requested", trigger=str(readiness.trigger))
+        client.send_result({"success": True, "trigger": str(readiness.trigger)})
+```
+
+If `session.py` has no `logger` in scope, drop the `logger.info` line rather
+than adding a logging dependency for one line.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest tests/unit/test_agent_upgrade_command.py -v`
+Expected: PASS, all six cases.
+
+- [ ] **Step 5: Run the neighbouring agent suites**
+
+Run: `pytest tests/unit/test_agent_runtime.py tests/unit/test_agent_self_upgrade.py -q`
+Expected: PASS, no regressions in the session dispatch tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/borg_ui_agent/session.py tests/unit/test_agent_upgrade_command.py
+git commit -m "feat(agents): add the agent.upgrade session command"
+```
+
+---
+
+### Task 2: The upgrade endpoint and the `agent_upgrade` job
+
+**Files:**
+- Modify: `app/core/agent_constants.py`
+- Modify: `app/api/managed_machines.py` (request model near the other Pydantic
+  models around line 110, route after `set_agent_desired_version` around line
+  580)
+- Modify: `frontend/src/locales/{en,de,es,it}.json` (the two new
+  `backend.errors.agents.*` keys)
+- Test: `tests/unit/test_api_agent_upgrade.py` (create)
+
+**Interfaces:**
+- Consumes: `agent.upgrade` from Task 1; `compute_agent_upgrade_status` and
+  `agent_package_version` from `app/core/agent_versions.py`;
+  `agent_connection_manager.send_command` and the `AgentConnectionUnavailable`
+  / `AgentCommandTimeout` / `AgentCommandError` exceptions already imported in
+  `managed_machines.py`.
+- Produces: `POST /api/managed-machines/agents/upgrade` taking
+  `{"agent_machine_ids": [int, ...]}` and returning
+  `{"results": [{"agent_machine_id": int, "job_id": int, "state": str}]}`.
+  `state` is one of `requested`, `failed`. Also
+  `AGENT_UPGRADE_TIMEOUT_SECONDS = 600` and
+  `AGENT_UPGRADE_COMMAND_TIMEOUT_SECONDS = 15.0`, consumed by Task 3.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/test_api_agent_upgrade.py`. Follow the client and admin
+fixtures already used in `tests/unit/test_api_managed_machines.py`; copy that
+file's fixture setup verbatim rather than inventing new ones.
+
+```python
+"""POST /managed-machines/agents/upgrade.
+
+Validation runs over the whole request before any job is created: a partial
+success that reports as a full one is the failure mode to avoid.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.database.models import AgentJob, AgentMachine
+
+
+def _agent(db, **overrides):
+    now = datetime.now(timezone.utc)
+    agent = AgentMachine(
+        name=overrides.pop("name", "endpoint"),
+        agent_id=overrides.pop("agent_id", "agt_test"),
+        token_hash="x",
+        token_prefix="borgui_a",
+        status="online",
+        agent_version="0.1.2",
+        capabilities=["self_upgrade"],
+        created_at=now,
+        updated_at=now,
+        **overrides,
+    )
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+    return agent
+
+
+def test_upgrade_queues_a_job_and_marks_the_agent_requested(
+    client, db, admin_headers, monkeypatch
+):
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+    sent = []
+
+    async def fake_send_command(agent_id, **kwargs):
+        sent.append((agent_id, kwargs["command"]))
+        return {"success": True}
+
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_connection_manager.send_command",
+        fake_send_command,
+    )
+    agent = _agent(db)
+
+    response = client.post(
+        "/api/managed-machines/agents/upgrade",
+        json={"agent_machine_ids": [agent.id]},
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 200
+    result = response.json()["results"][0]
+    assert result["state"] == "requested"
+    job = db.query(AgentJob).filter(AgentJob.id == result["job_id"]).one()
+    assert job.job_type == "agent_upgrade"
+    assert job.status == "completed"
+    db.refresh(agent)
+    assert agent.upgrade_state == "requested"
+    assert agent.upgrade_target_version == "0.1.3"
+    assert sent == [(agent.id, "agent.upgrade")]
+
+
+def test_upgrade_rejects_the_whole_request_when_one_agent_is_unsupported(
+    client, db, admin_headers, monkeypatch
+):
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+    ok = _agent(db, agent_id="agt_ok")
+    bad = _agent(db, agent_id="agt_bad", name="old", capabilities=["jobs.poll"])
+
+    response = client.post(
+        "/api/managed-machines/agents/upgrade",
+        json={"agent_machine_ids": [ok.id, bad.id]},
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"]["key"]
+        == "backend.errors.agents.upgradeUnsupported"
+    )
+    assert db.query(AgentJob).count() == 0
+
+
+def test_upgrade_rejects_an_unpinned_agent_when_the_server_serves_no_wheel(
+    client, db, admin_headers, monkeypatch
+):
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: None
+    )
+    agent = _agent(db)
+
+    response = client.post(
+        "/api/managed-machines/agents/upgrade",
+        json={"agent_machine_ids": [agent.id]},
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"]["key"]
+        == "backend.errors.agents.upgradeTargetUnavailable"
+    )
+    assert db.query(AgentJob).count() == 0
+
+
+def test_duplicate_ids_create_one_job(client, db, admin_headers, monkeypatch):
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+
+    async def fake_send_command(agent_id, **kwargs):
+        return {"success": True}
+
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_connection_manager.send_command",
+        fake_send_command,
+    )
+    agent = _agent(db)
+
+    response = client.post(
+        "/api/managed-machines/agents/upgrade",
+        json={"agent_machine_ids": [agent.id, agent.id]},
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 200
+    assert len(response.json()["results"]) == 1
+    assert db.query(AgentJob).count() == 1
+
+
+def test_a_second_request_returns_the_in_flight_upgrade(
+    client, db, admin_headers, monkeypatch
+):
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+    calls = []
+
+    async def fake_send_command(agent_id, **kwargs):
+        calls.append(agent_id)
+        return {"success": True}
+
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_connection_manager.send_command",
+        fake_send_command,
+    )
+    agent = _agent(db)
+    body = {"agent_machine_ids": [agent.id]}
+
+    first = client.post(
+        "/api/managed-machines/agents/upgrade", json=body, headers=admin_headers
+    )
+    second = client.post(
+        "/api/managed-machines/agents/upgrade", json=body, headers=admin_headers
+    )
+
+    assert first.json()["results"][0]["job_id"] == second.json()["results"][0]["job_id"]
+    assert db.query(AgentJob).count() == 1
+    assert calls == [agent.id]
+
+
+def test_an_offline_agent_fails_its_job_and_stays_idle(
+    client, db, admin_headers, monkeypatch
+):
+    from app.services.agent_connection_manager import AgentConnectionUnavailable
+
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+
+    async def fake_send_command(agent_id, **kwargs):
+        raise AgentConnectionUnavailable("offline")
+
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_connection_manager.send_command",
+        fake_send_command,
+    )
+    agent = _agent(db)
+
+    response = client.post(
+        "/api/managed-machines/agents/upgrade",
+        json={"agent_machine_ids": [agent.id]},
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["results"][0]["state"] == "failed"
+    db.refresh(agent)
+    assert agent.upgrade_state == "failed"
+    assert agent.upgrade_error
+    job = db.query(AgentJob).one()
+    assert job.status == "failed"
+```
+
+Check the import path of `AgentConnectionUnavailable` against the one
+`app/api/managed_machines.py` already uses and match it.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/unit/test_api_agent_upgrade.py -v`
+Expected: FAIL with 404 on every request, the route does not exist.
+
+- [ ] **Step 3: Add the constants**
+
+In `app/core/agent_constants.py`:
+
+```python
+# How long the server waits for an endpoint to acknowledge agent.upgrade. The
+# agent only creates a file, so this bounds the round trip, not the reinstall.
+AGENT_UPGRADE_COMMAND_TIMEOUT_SECONDS = 15.0
+
+# How long an endpoint has to come back on its target version before the
+# upgrade is called failed. Generous on purpose: an endpoint that hits this is
+# far more likely broken than slow.
+AGENT_UPGRADE_TIMEOUT_SECONDS = 600
+```
+
+- [ ] **Step 4: Implement the route**
+
+In `app/api/managed_machines.py`, add the request model next to the other
+Pydantic models:
+
+```python
+class AgentUpgradeRequest(BaseModel):
+    agent_machine_ids: list[int]
+```
+
+Add the route after `set_agent_desired_version`:
+
+```python
+UPGRADE_IN_FLIGHT_STATUSES = ("queued", "claimed", "running", "cancel_requested")
+
+
+@router.post("/agents/upgrade")
+async def upgrade_agent_machines(
+    payload: AgentUpgradeRequest,
+    current_user: User = Depends(require_managed_agents_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Ask each named endpoint to reinstall itself.
+
+    Validation runs over the whole request before anything is created: a
+    partial success that reports as a full one is the failure mode to avoid.
+    The agent is killed by the thing it is reporting on, so the job records
+    only that the upgrade was requested; the outcome is resolved by the
+    register path and the reaper (spec section 7.1).
+    """
+    # Deduplicated first: an upgrade restarts the endpoint, so two jobs for one
+    # machine could restart it twice or race two reinstalls.
+    wanted = list(dict.fromkeys(payload.agent_machine_ids))
+    agents = (
+        db.query(AgentMachine)
+        .filter(AgentMachine.id.in_(wanted), AgentMachine.status != "deleted")
+        .all()
+        if wanted
+        else []
+    )
+    found = {agent.id: agent for agent in agents}
+    if len(found) != len(wanted):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"key": "backend.errors.agents.agentNotFound"},
+        )
+
+    available = agent_package_version()
+    for agent_id in wanted:
+        agent = found[agent_id]
+        if not (agent.capabilities and "self_upgrade" in agent.capabilities):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={"key": "backend.errors.agents.upgradeUnsupported"},
+            )
+        if not (agent.desired_agent_version or available):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={"key": "backend.errors.agents.upgradeTargetUnavailable"},
+            )
+
+    results = []
+    for agent_id in wanted:
+        agent = found[agent_id]
+        existing = (
+            db.query(AgentJob)
+            .filter(
+                AgentJob.agent_machine_id == agent.id,
+                AgentJob.job_type == "agent_upgrade",
+                AgentJob.status.in_(UPGRADE_IN_FLIGHT_STATUSES),
+            )
+            .first()
+        )
+        if existing is not None or agent.upgrade_state == "requested":
+            # Idempotent under a double click or a client retry.
+            results.append(
+                {
+                    "agent_machine_id": agent.id,
+                    "job_id": existing.id if existing else None,
+                    "state": agent.upgrade_state or "requested",
+                }
+            )
+            continue
+
+        results.append(
+            await _request_agent_upgrade(
+                db, agent, target=agent.desired_agent_version or available
+            )
+        )
+
+    logger.info(
+        "Agent upgrades requested",
+        user=current_user.username,
+        agent_machine_ids=wanted,
+    )
+    return {"results": results}
+
+
+async def _request_agent_upgrade(db: Session, agent: AgentMachine, *, target: str):
+    """Create the job, dispatch the command, and record the outcome for one
+    endpoint. The job is completed at "upgrade started": it records that the
+    upgrade was successfully requested, nothing more."""
+    now = _now_utc()
+    job = AgentJob(
+        agent_machine_id=agent.id,
+        job_type="agent_upgrade",
+        status="running",
+        payload={"target_version": target},
+        created_at=now,
+        updated_at=now,
+        started_at=now,
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    try:
+        await agent_connection_manager.send_command(
+            agent.id,
+            command="agent.upgrade",
+            payload={},
+            timeout_seconds=AGENT_UPGRADE_COMMAND_TIMEOUT_SECONDS,
+            wait_for_result=True,
+        )
+    except (
+        AgentConnectionUnavailable,
+        AgentCommandTimeout,
+        AgentCommandError,
+    ) as exc:
+        finished = _now_utc()
+        job.status = "failed"
+        job.error_message = str(exc)
+        job.completed_at = finished
+        job.updated_at = finished
+        agent.upgrade_state = "failed"
+        agent.upgrade_error = str(exc)
+        agent.upgrade_target_version = target
+        agent.updated_at = finished
+        db.commit()
+        return {
+            "agent_machine_id": agent.id,
+            "job_id": job.id,
+            "state": "failed",
+        }
+
+    finished = _now_utc()
+    job.status = "completed"
+    job.completed_at = finished
+    job.updated_at = finished
+    agent.upgrade_state = "requested"
+    agent.upgrade_requested_at = finished
+    agent.upgrade_target_version = target
+    agent.upgrade_error = None
+    agent.updated_at = finished
+    db.commit()
+    return {"agent_machine_id": agent.id, "job_id": job.id, "state": "requested"}
+```
+
+Import the two new constants from `app.core.agent_constants` at the top of the
+file, alongside the existing agent constant imports.
+
+- [ ] **Step 5: Add the error copy to all four locales**
+
+Under `backend.errors.agents` in `frontend/src/locales/en.json`, keeping the
+block's alphabetical neighbours intact:
+
+```json
+"upgradeUnsupported": "This endpoint cannot upgrade itself yet. Reinstall it once from the command shown in the reinstall dialog.",
+"upgradeTargetUnavailable": "This server does not ship an agent version to upgrade to."
+```
+
+Translate both into `de.json`, `es.json` and `it.json`, matching the tone of
+the surrounding keys in each file.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `pytest tests/unit/test_api_agent_upgrade.py tests/unit/test_api_managed_machines.py -q`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/core/agent_constants.py app/api/managed_machines.py \
+  tests/unit/test_api_agent_upgrade.py frontend/src/locales
+git commit -m "feat(agents): add the agent upgrade endpoint and job type"
+```
+
+---
+
+### Task 3: Reconciliation, success and timeout
+
+**Files:**
+- Modify: `app/api/agents.py` (the register path around line 1239 and the
+  session hello path around line 1307)
+- Modify: `app/services/agent_job_reaper.py`
+- Test: `tests/unit/test_agent_upgrade_reconciliation.py` (create)
+
+**Interfaces:**
+- Consumes: `AGENT_UPGRADE_TIMEOUT_SECONDS` from Task 2; the
+  `upgrade_state` / `upgrade_requested_at` / `upgrade_target_version` /
+  `upgrade_error` columns from phase 1.
+- Produces: `resolve_agent_upgrade(agent)` in `app/api/agents.py`, called from
+  both re-entry paths; `reap_stale_agent_upgrades(db, *, now=None,
+  timeout=AGENT_UPGRADE_TIMEOUT_SECONDS)` in `app/services/agent_job_reaper.py`,
+  returning the number of agents marked failed.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/test_agent_upgrade_reconciliation.py`:
+
+```python
+"""The agent is killed by the thing it is reporting on, so the server owns the
+outcome: success on re-entry with the target version, failure by timeout."""
+
+from datetime import datetime, timedelta, timezone
+
+from app.api.agents import resolve_agent_upgrade
+from app.database.models import AgentMachine
+from app.services.agent_job_reaper import reap_stale_agent_upgrades
+
+
+def _requested(db, *, reported, requested_at):
+    now = datetime.now(timezone.utc)
+    agent = AgentMachine(
+        name="endpoint",
+        agent_id="agt_recon",
+        token_hash="x",
+        token_prefix="borgui_a",
+        status="online",
+        agent_version=reported,
+        upgrade_state="requested",
+        upgrade_requested_at=requested_at,
+        upgrade_target_version="0.1.3",
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+    return agent
+
+
+def test_re_registering_on_the_target_version_clears_the_upgrade(db):
+    agent = _requested(
+        db, reported="0.1.2", requested_at=datetime.now(timezone.utc)
+    )
+    agent.agent_version = "0.1.3"
+
+    resolve_agent_upgrade(agent)
+
+    assert agent.upgrade_state == "idle"
+    assert agent.upgrade_error is None
+
+
+def test_re_registering_on_the_old_version_leaves_it_requested(db):
+    agent = _requested(
+        db, reported="0.1.2", requested_at=datetime.now(timezone.utc)
+    )
+
+    resolve_agent_upgrade(agent)
+
+    # The reinstall may still be mid flight. Only the timeout resolves it.
+    assert agent.upgrade_state == "requested"
+
+
+def test_the_reaper_fails_a_stale_upgrade(db):
+    agent = _requested(
+        db,
+        reported="0.1.2",
+        requested_at=datetime.now(timezone.utc) - timedelta(seconds=1200),
+    )
+
+    assert reap_stale_agent_upgrades(db) == 1
+
+    db.refresh(agent)
+    assert agent.upgrade_state == "failed"
+    assert agent.upgrade_error
+
+
+def test_the_reaper_leaves_a_fresh_upgrade_alone(db):
+    agent = _requested(
+        db, reported="0.1.2", requested_at=datetime.now(timezone.utc)
+    )
+
+    assert reap_stale_agent_upgrades(db) == 0
+
+    db.refresh(agent)
+    assert agent.upgrade_state == "requested"
+```
+
+Use whatever `db` session fixture `tests/unit/test_api_managed_machines.py`
+uses; do not add a new one.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/unit/test_agent_upgrade_reconciliation.py -v`
+Expected: FAIL, `resolve_agent_upgrade` and `reap_stale_agent_upgrades` do not
+exist.
+
+- [ ] **Step 3: Implement the success path**
+
+In `app/api/agents.py`, add next to the other module-level helpers:
+
+```python
+def resolve_agent_upgrade(agent: AgentMachine) -> None:
+    """Clear a requested upgrade when the endpoint comes back on its target.
+
+    An endpoint that comes back on the old version is left in `requested`: the
+    reinstall may still be mid flight, and only the timeout resolves it.
+    """
+    if agent.upgrade_state != "requested":
+        return
+    if agent.upgrade_target_version and agent.agent_version == (
+        agent.upgrade_target_version
+    ):
+        agent.upgrade_state = "idle"
+        agent.upgrade_error = None
+        agent.upgrade_requested_at = None
+```
+
+Call it in both re-entry paths, immediately after `agent_version` is assigned:
+once in the register handler (around line 1239) and once in the session hello
+handler (around line 1307).
+
+- [ ] **Step 4: Implement the timeout path**
+
+In `app/services/agent_job_reaper.py`:
+
+```python
+def reap_stale_agent_upgrades(
+    db: Session,
+    *,
+    now: Optional[datetime] = None,
+    timeout_seconds: int = AGENT_UPGRADE_TIMEOUT_SECONDS,
+) -> int:
+    """Mark upgrades whose endpoint never came back as failed.
+
+    The cap in a fleet upgrade bounds upgrades in flight, not endpoints
+    offline, so this frees the slot even though the endpoint may still be mid
+    reinstall. Holding the slot instead would let one machine that never comes
+    back stall every remaining upgrade in the fleet.
+    """
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(seconds=timeout_seconds)
+    stale = (
+        db.query(AgentMachine)
+        .filter(
+            AgentMachine.upgrade_state == "requested",
+            AgentMachine.upgrade_requested_at.isnot(None),
+            AgentMachine.upgrade_requested_at < cutoff,
+        )
+        .all()
+    )
+    for agent in stale:
+        agent.upgrade_state = "failed"
+        agent.upgrade_error = (
+            "The endpoint did not come back on the target version in time. "
+            "Reinstall it manually from the reinstall dialog."
+        )
+        agent.updated_at = now
+    if stale:
+        db.commit()
+        logger.info("Reaped stale agent upgrades", count=len(stale))
+    return len(stale)
+```
+
+Import `AgentMachine` and `AGENT_UPGRADE_TIMEOUT_SECONDS` at the top of the
+file, and call it from `_reap_once` next to the other reconcilers:
+
+```python
+        reaped += reap_stale_agent_upgrades(db)
+```
+
+Note the timestamp comparison: `upgrade_requested_at` is stored naive in
+SQLite. If the query returns nothing in the test, compare with
+`_as_utc(agent.upgrade_requested_at)` in Python over the `requested` rows
+rather than in the `WHERE` clause, matching how `_job_activity_at` already
+sidesteps this.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pytest tests/unit/test_agent_upgrade_reconciliation.py tests/unit/test_api_agents.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/agents.py app/services/agent_job_reaper.py \
+  tests/unit/test_agent_upgrade_reconciliation.py
+git commit -m "feat(agents): resolve upgrade outcomes on re-entry and by timeout"
+```
+
+---
+
+### Task 4: The upgrade action, dialog, and row state
+
+**Files:**
+- Modify: `frontend/src/services/api.ts` (agents block around line 1367)
+- Create: `frontend/src/pages/managed-agents/AgentUpgradeDialog.tsx`
+- Create: `frontend/src/pages/managed-agents/AgentUpgradeDialog.stories.tsx`
+- Create: `frontend/src/pages/managed-agents/AgentUpgradeStateChip.tsx`
+- Create: `frontend/src/pages/managed-agents/AgentUpgradeStateChip.stories.tsx`
+- Modify: `frontend/src/pages/ManagedAgents.tsx` (version cell around line 1725,
+  row actions around line 1929, dialog mount around line 2018)
+- Modify: `frontend/src/locales/{en,de,es,it}.json`
+- Test: `frontend/src/pages/managed-agents/__tests__/AgentUpgradeDialog.test.tsx`,
+  `frontend/src/pages/__tests__/ManagedAgents.test.tsx`
+
+**Interfaces:**
+- Consumes: `POST /managed-machines/agents/upgrade` from Task 2; the existing
+  `AgentUpgradeChip`, `AgentManualUpgradeChip` and `AgentReinstallDialog`.
+- Produces: `agentsApi.upgradeAgents(agentIds: number[])`;
+  `<AgentUpgradeDialog open agent onConfirm onCancel busy />`;
+  `<AgentUpgradeStateChip state={'requested' | 'failed'} targetVersion error />`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create
+`frontend/src/pages/managed-agents/__tests__/AgentUpgradeDialog.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import AgentUpgradeDialog from '../AgentUpgradeDialog'
+
+const agent = {
+  id: 1,
+  name: 'db-01',
+  hostname: 'db-01.internal',
+  agent_version: '0.1.2',
+  available_agent_version: '0.1.3',
+} as never
+
+describe('AgentUpgradeDialog', () => {
+  it('names the endpoint and its target version', () => {
+    render(
+      <AgentUpgradeDialog open agent={agent} onConfirm={vi.fn()} onCancel={vi.fn()} />
+    )
+    expect(screen.getByText(/db-01/)).toBeInTheDocument()
+    expect(screen.getByText(/0\.1\.3/)).toBeInTheDocument()
+  })
+
+  it('confirms once', () => {
+    const onConfirm = vi.fn()
+    render(
+      <AgentUpgradeDialog open agent={agent} onConfirm={onConfirm} onCancel={vi.fn()} />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /upgrade/i }))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+})
+```
+
+Add to `frontend/src/pages/__tests__/ManagedAgents.test.tsx`, following that
+file's existing render helper and API mocks:
+
+```tsx
+  it('routes an endpoint without self upgrade support to the reinstall dialog', async () => {
+    renderPage([
+      { ...baseAgent, id: 1, self_upgrade_supported: false, upgrade_status: 'outdated' },
+    ])
+    fireEvent.click(await screen.findByRole('button', { name: /reinstall/i }))
+    expect(await screen.findByText(/reinstall/i)).toBeInTheDocument()
+  })
+
+  it('offers the upgrade action to a supported outdated endpoint', async () => {
+    renderPage([
+      { ...baseAgent, id: 1, self_upgrade_supported: true, upgrade_status: 'outdated' },
+    ])
+    expect(await screen.findByRole('button', { name: /upgrade/i })).toBeInTheDocument()
+  })
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/pages/managed-agents/__tests__/AgentUpgradeDialog.test.tsx`
+Expected: FAIL, the module does not exist.
+
+- [ ] **Step 3: Add the API client call**
+
+In `frontend/src/services/api.ts`, in the agents block:
+
+```ts
+  upgradeAgents: (agentIds: number[]) =>
+    api.post<{ results: { agent_machine_id: number; job_id: number | null; state: string }[] }>(
+      '/managed-machines/agents/upgrade',
+      { agent_machine_ids: agentIds }
+    ),
+```
+
+- [ ] **Step 4: Build the dialog**
+
+Create `frontend/src/pages/managed-agents/AgentUpgradeDialog.tsx` using
+`ResponsiveDialog` the same way `AgentReinstallDialog` in `ManagedAgents.tsx`
+does. It states plainly that the endpoint disconnects for a short period and
+that a running backup blocks the upgrade, names the endpoint by name and
+hostname, and names the target version
+(`agent.desired_agent_version ?? agent.available_agent_version`). Confirm calls
+`onConfirm`; the confirm button is disabled while `busy`.
+
+New i18n keys under `managedAgents.page.upgradeDialog`, in all four locales:
+`title`, `description`, `disconnectWarning`, `busyWarning`, `targetVersion`,
+`confirm`, `cancel`.
+
+- [ ] **Step 5: Build the row state chip**
+
+Create `frontend/src/pages/managed-agents/AgentUpgradeStateChip.tsx`. For
+`requested` it renders a small `CircularProgress` and "Upgrading to vX.Y.Z";
+for `failed` it renders an error chip carrying `upgrade_error`. Reuse
+`agentChipSx.ts` so it matches `AgentUpgradeChip`. No left accent borders.
+
+New i18n keys under `managedAgents.page.upgradeState`: `upgrading`, `failed`,
+`failedHint`.
+
+- [ ] **Step 6: Wire the page**
+
+In `frontend/src/pages/ManagedAgents.tsx`:
+
+- Render `<AgentUpgradeStateChip>` in the version cell when
+  `agent.upgrade_state` is `requested` or `failed`, next to the existing
+  `AgentUpgradeChip`.
+- Add an Upgrade icon button to the row actions, shown only when
+  `agent.self_upgrade_supported === true` and `agent.upgrade_status` is
+  `outdated`, disabled while `agent.upgrade_state === 'requested'`. It opens
+  `AgentUpgradeDialog`. The existing reinstall button stays as it is, so an
+  endpoint with `self_upgrade_supported === false` keeps the manual path
+  already wired to `AgentReinstallDialog`.
+- Confirm calls `agentsApi.upgradeAgents([agent.id])`, then invalidates the
+  agents query the page already uses. On a rejected promise, surface the
+  `detail.key` through the page's existing error toast helper.
+- Track the action with `trackSystem` following the `open_reinstall_dialog`
+  call already in the file, with `operation: 'upgrade_agent'`.
+
+- [ ] **Step 7: Write the stories**
+
+`AgentUpgradeDialog.stories.tsx` and `AgentUpgradeStateChip.stories.tsx`, each
+in default and mobile viewports, per `ManagedAgents.stories.tsx` conventions.
+`AgentUpgradeStateChip` needs one story per state: upgrading and failed.
+
+- [ ] **Step 8: Run the frontend checks**
+
+```bash
+cd frontend && npx vitest run src/pages/managed-agents src/pages/__tests__/ManagedAgents.test.tsx && npm run lint && npx tsc --noEmit
+```
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src
+git commit -m "feat(agents): add the single-agent upgrade action and row state"
+```
+
+---
+
+### Task 5: The pin control
+
+**Files:**
+- Modify: `frontend/src/services/api.ts`
+- Create: `frontend/src/pages/managed-agents/AgentPinControl.tsx`
+- Create: `frontend/src/pages/managed-agents/AgentPinControl.stories.tsx`
+- Modify: `frontend/src/pages/ManagedAgents.tsx`
+- Modify: `frontend/src/locales/{en,de,es,it}.json`
+- Test: `frontend/src/pages/managed-agents/__tests__/AgentPinControl.test.tsx`
+
+**Interfaces:**
+- Consumes: `PUT /managed-machines/agents/{id}/desired-version`, shipped in
+  phase 1, which accepts `{desired_agent_version, desired_borg_version}` and
+  rejects a version this server cannot serve with
+  `backend.errors.agents.desiredVersionUnavailable`.
+- Produces: `agentsApi.setAgentDesiredVersion(agentId, body)`;
+  `<AgentPinControl agent onSave busy />`.
+
+- [ ] **Step 1: Write the failing test**
+
+`frontend/src/pages/managed-agents/__tests__/AgentPinControl.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import AgentPinControl from '../AgentPinControl'
+
+const agent = {
+  id: 1,
+  desired_agent_version: null,
+  desired_borg_version: null,
+  available_agent_version: '0.1.3',
+} as never
+
+describe('AgentPinControl', () => {
+  it('defaults to tracking the server', () => {
+    render(<AgentPinControl agent={agent} onSave={vi.fn()} />)
+    expect(screen.getByText(/track server/i)).toBeInTheDocument()
+  })
+
+  it('saves a cleared pin as null rather than an empty string', () => {
+    const onSave = vi.fn()
+    render(
+      <AgentPinControl
+        agent={{ ...agent, desired_agent_version: '0.1.3' } as never}
+        onSave={onSave}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /clear pin/i }))
+    expect(onSave).toHaveBeenCalledWith({
+      desired_agent_version: null,
+      desired_borg_version: null,
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/pages/managed-agents/__tests__/AgentPinControl.test.tsx`
+Expected: FAIL, the module does not exist.
+
+- [ ] **Step 3: Add the API client call**
+
+```ts
+  setAgentDesiredVersion: (
+    agentId: number,
+    data: { desired_agent_version: string | null; desired_borg_version: '1' | '2' | null }
+  ) =>
+    api.put<AgentMachineResponse>(
+      `/managed-machines/agents/${agentId}/desired-version`,
+      data
+    ),
+```
+
+- [ ] **Step 4: Build the control**
+
+Two MUI selects. The agent version select offers "Track server" (value `null`)
+and `agent.available_agent_version`, because a pin to anything else is rejected
+by the server: the installer installs from this server's wheelhouse and nowhere
+else. The Borg select offers "Leave as installed" (`null`), `1` and `2`. Save
+calls `onSave`. New i18n keys under `managedAgents.page.pinControl`:
+`title`, `agentVersionLabel`, `trackServer`, `borgVersionLabel`,
+`leaveAsInstalled`, `save`, `clearPin`, `hint`.
+
+- [ ] **Step 5: Mount it and write the story**
+
+Mount `AgentPinControl` in the agent detail area of `ManagedAgents.tsx`, wired
+to `agentsApi.setAgentDesiredVersion` with the agents query invalidated on
+success. Add `AgentPinControl.stories.tsx` with an unpinned and a pinned story,
+each in default and mobile viewports.
+
+- [ ] **Step 6: Run the frontend checks**
+
+```bash
+cd frontend && npx vitest run src/pages/managed-agents && npm run lint && npx tsc --noEmit
+```
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src
+git commit -m "feat(agents): add the desired version pin control"
+```
+
+---
+
+### Task 6: Documentation and the spec progress table
+
+**Files:**
+- Modify: `docs/managed-agents.md`
+- Modify: `docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md`
+  (the progress table, section 13.1)
+
+- [ ] **Step 1: Document the operator-facing flow**
+
+In `docs/managed-agents.md`, next to the remote-upgrade section phase 2 added,
+describe: pressing Upgrade on a row, that the endpoint disconnects briefly,
+that a running backup blocks the upgrade, that the row resolves itself when the
+endpoint comes back, and what the failed state means (the endpoint did not come
+back within 10 minutes, so reinstall it manually). Mention the pin control and
+that a pin can only name a version this server serves.
+
+- [ ] **Step 2: Run the full backend and frontend suites**
+
+```bash
+pytest tests/unit -q
+```
+```bash
+cd frontend && npx vitest run && npm run lint && npx tsc --noEmit
+```
+Expected: PASS. `tests/unit/test_api_auth.py` failures in the main checkout are
+a local `.env` artifact (`PUBLIC_BASE_URL`), not a regression.
+
+- [ ] **Step 3: Update the spec progress table**
+
+Set phase 3 to `in review`, with the plan file and branch filled in, and a note
+recording that the trigger is the `.path` file, not the sudoers argv section 7
+describes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs
+git commit -m "docs(agents): document remote upgrades and mark phase 3 in review"
+```
+
+---
+
+## Self-review
+
+**Spec coverage.** Section 5's upgrade endpoint: Task 2, including the two
+error keys, dedup, and in-flight idempotency. Section 7's command: Task 1, with
+the phase 2 amendment applied. Section 7.1's outcome ownership: Task 3, both
+halves. Section 9's per-agent action, dialog, row upgrading state, row failed
+state, manual-path routing, and pin control: Tasks 4 and 5. Section 12's
+session command, bulk validation, reconciliation and frontend test bullets: the
+test steps of Tasks 1, 2, 3 and 4.
+
+**Deliberately not covered here**, all phase 4 or 5 by section 13: the wave
+scheduler and `AGENT_UPGRADE_CONCURRENCY`, the `queued` upgrade state,
+multi-select, the banner's Upgrade all action, and writing
+`desired_borg_version` into `upgrade.conf` on the served reinstall (section 10,
+phase 5). Phase 5 is what makes the Borg half of the pin control take effect;
+until then it records intent only, which the control's hint should say.

--- a/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
+++ b/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
@@ -549,7 +549,7 @@ Agents update this table and nothing else as work advances. Statuses:
 | --- | --- | --- | --- | --- |
 | 1. Version model and visibility | done | `docs/engineering/plans/2026-09-07-agent-upgrades-phase-1.md` | `feat/agent-upgrades` | Pin UI moved to phase 3 |
 | 2. Privileged helper and capability | done | `docs/engineering/plans/2026-09-09-agent-upgrades-phase-2.md` | `feat/agent-upgrades-phase-2` | https is a precondition; opt-out uses a marker file; the trigger is a `.path` unit, not sudoers |
-| 3. Single-agent remote upgrade | plan drafted | `docs/engineering/plans/2026-09-09-agent-upgrades-phase-3.md` | | Trigger is the `.path` file, not section 7's sudoers argv |
+| 3. Single-agent remote upgrade | in review | `docs/engineering/plans/2026-09-09-agent-upgrades-phase-3.md` | `feat/agent-upgrades-phase-3` | Trigger is the `.path` file, not section 7's sudoers argv; the pin control is a dialog off the row, the card has no detail area |
 | 4. Fleet upgrade | not started | | | |
 | 5. Per-endpoint Borg version | not started | | | |
 

--- a/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
+++ b/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
@@ -549,7 +549,7 @@ Agents update this table and nothing else as work advances. Statuses:
 | --- | --- | --- | --- | --- |
 | 1. Version model and visibility | done | `docs/engineering/plans/2026-09-07-agent-upgrades-phase-1.md` | `feat/agent-upgrades` | Pin UI moved to phase 3 |
 | 2. Privileged helper and capability | done | `docs/engineering/plans/2026-09-09-agent-upgrades-phase-2.md` | `feat/agent-upgrades-phase-2` | https is a precondition; opt-out uses a marker file; the trigger is a `.path` unit, not sudoers |
-| 3. Single-agent remote upgrade | not started | | | |
+| 3. Single-agent remote upgrade | plan drafted | `docs/engineering/plans/2026-09-09-agent-upgrades-phase-3.md` | | Trigger is the `.path` file, not section 7's sudoers argv |
 | 4. Fleet upgrade | not started | | | |
 | 5. Per-endpoint Borg version | not started | | | |
 

--- a/docs/managed-agents.md
+++ b/docs/managed-agents.md
@@ -142,22 +142,49 @@ a chip on the agent card:
 | Chip | Meaning |
 | --- | --- |
 | No chip | The agent runs the version this server serves. Nothing to do. |
-| **Update available** | The agent is older than the version this server serves. Reinstall it with the plain `--reinstall` command above, not the `--no-remote-upgrade` one. |
+| **Update available** | The agent is older than the version this server serves. Use the Upgrade action on the row, or reinstall it with the plain `--reinstall` command above. |
 | **Ahead of server** | The agent is newer than the version this server serves, which happens after a server rollback. Upgrade the server rather than downgrading the agent. |
 | **Pinned** | The agent is held at a specific version and will not follow the server. |
 | **Version unknown** | The agent has not reported a version yet, or the version cannot be compared. A freshly enrolled agent shows this until its first check-in. |
 
 A banner above the fleet counts how many endpoints are running an older agent.
 
-Upgrading is still a manual reinstall on each machine in this release. The
-comparison tells you which machines need it, so you are not reinstalling
-everything to be sure. New installs now carry the machinery for
-server-driven upgrades, described above, and a later release turns it on.
+## Upgrading an Endpoint from the UI
+
+An endpoint that carries the helper described above shows an Upgrade action on
+its row when it is out of date. Confirming it asks that endpoint to reinstall
+itself from this server.
+
+What to expect:
+
+- The endpoint disconnects for a short period while it reinstalls, and
+  reconnects on its own.
+- An endpoint that is running a backup refuses the upgrade, because the restart
+  would orphan that backup. Try again once it is idle.
+- The row shows **Upgrading** with the target version until the endpoint comes
+  back. Nothing to do while it does.
+- When the endpoint reconnects on the target version, the row clears itself.
+- If it does not come back within 10 minutes, the row shows **Upgrade failed**.
+  That endpoint needs the manual reinstall command above; nothing is retried
+  automatically.
+
+Upgrading several endpoints at once is a later release. Endpoints shown as
+manual only, and endpoints enrolled before the helper existed, keep the manual
+reinstall path.
 
 ### Pinning an Agent Version
 
 An endpoint can be held at a specific agent version so it stops tracking the
-server. Pinning is available through the API:
+server. The pin action on the agent row opens the version pin, with the agent
+version (default "Track server") and the Borg major version. You can only pin
+to a version this server can actually serve, because the installer installs
+from this server and nowhere else. A pinned endpoint upgrades to its pin rather
+than to the version the server serves.
+
+The Borg choice is recorded now and takes effect in a later release, once an
+upgrade can change the installed Borg version.
+
+The same pin is available through the API:
 
 ```bash
 curl -X PUT "$BASE_URL/api/managed-machines/agents/<id>/desired-version" \

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -5539,7 +5539,9 @@
         "repositoryOperationFailed": "Die Repository-Operation des Agenten ist fehlgeschlagen",
         "repositoryOperationTimeout": "Zeitüberschreitung bei der Repository-Operation des Agenten",
         "unsupportedJobKind": "Nicht unterstützter Agent-Auftragstyp",
-        "desiredVersionUnavailable": "Diese Agent-Version ist auf diesem Server nicht verfügbar."
+        "desiredVersionUnavailable": "Diese Agent-Version ist auf diesem Server nicht verfügbar.",
+        "upgradeUnsupported": "Dieser Endpunkt kann sich noch nicht selbst aktualisieren. Installieren Sie ihn einmal mit dem Befehl aus dem Neuinstallations-Dialog neu.",
+        "upgradeTargetUnavailable": "Dieser Server liefert keine Agent-Version aus, auf die aktualisiert werden könnte."
       },
       "repo": {
         "repositoryNotFound": "Repository nicht gefunden",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -304,7 +304,8 @@
         "agentDeleted": "Agent gelöscht",
         "cancellationRequested": "Abbruch angefordert",
         "copied": "Kopiert",
-        "agentUpgradeRequested": "Aktualisierung angefordert"
+        "agentUpgradeRequested": "Aktualisierung angefordert",
+        "agentVersionPinned": "Versions-Pin gespeichert"
       },
       "errors": {
         "revokeToken": "Registrierungstoken konnte nicht widerrufen werden",
@@ -312,7 +313,8 @@
         "deleteAgent": "Agent konnte nicht gelöscht werden",
         "cancelJob": "Job konnte nicht abgebrochen werden",
         "runDiagnostics": "Diagnose konnte nicht ausgeführt werden",
-        "upgradeAgent": "Aktualisierung konnte nicht angefordert werden"
+        "upgradeAgent": "Aktualisierung konnte nicht angefordert werden",
+        "pinAgentVersion": "Versions-Pin konnte nicht gespeichert werden"
       },
       "table": {
         "job": "Job",
@@ -334,7 +336,8 @@
         "viewLogs": "Protokolle anzeigen",
         "cancelJob": "Job abbrechen",
         "revokeToken": "Token widerrufen",
-        "upgradeAgent": "Diesen Endpunkt aktualisieren"
+        "upgradeAgent": "Diesen Endpunkt aktualisieren",
+        "pinAgentVersion": "Version dieses Endpunkts festlegen"
       },
       "noBorg": {
         "title": "Keine verwendbare Borg-Binärdatei gemeldet",
@@ -433,6 +436,16 @@
         "upgradingTooltip": "Der Endpunkt installiert sich neu und verbindet sich von selbst wieder.",
         "failed": "Aktualisierung fehlgeschlagen",
         "failedHint": "Der Endpunkt kam nicht rechtzeitig zurück. Installieren Sie ihn manuell neu."
+      },
+      "pinControl": {
+        "title": "Versions-Pin",
+        "hint": "Standardmäßig folgt ein Endpunkt der Version, die dieser Server ausliefert. Mit einem Pin bleibt er stattdessen auf einer bestimmten Version.",
+        "agentVersionLabel": "Agent-Version",
+        "trackServer": "Server folgen",
+        "borgVersionLabel": "Borg-Version",
+        "leaveAsInstalled": "Wie installiert lassen",
+        "borgHint": "Die Borg-Auswahl wird jetzt gespeichert und von einer späteren Version angewendet, sobald Aktualisierungen die installierte Borg-Version ändern können.",
+        "save": "Speichern"
       }
     },
     "installCommand": {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -303,14 +303,16 @@
         "agentRevoked": "Agent widerrufen",
         "agentDeleted": "Agent gelöscht",
         "cancellationRequested": "Abbruch angefordert",
-        "copied": "Kopiert"
+        "copied": "Kopiert",
+        "agentUpgradeRequested": "Aktualisierung angefordert"
       },
       "errors": {
         "revokeToken": "Registrierungstoken konnte nicht widerrufen werden",
         "revokeAgent": "Agent konnte nicht widerrufen werden",
         "deleteAgent": "Agent konnte nicht gelöscht werden",
         "cancelJob": "Job konnte nicht abgebrochen werden",
-        "runDiagnostics": "Diagnose konnte nicht ausgeführt werden"
+        "runDiagnostics": "Diagnose konnte nicht ausgeführt werden",
+        "upgradeAgent": "Aktualisierung konnte nicht angefordert werden"
       },
       "table": {
         "job": "Job",
@@ -331,7 +333,8 @@
         "deleteAgent": "Agent löschen",
         "viewLogs": "Protokolle anzeigen",
         "cancelJob": "Job abbrechen",
-        "revokeToken": "Token widerrufen"
+        "revokeToken": "Token widerrufen",
+        "upgradeAgent": "Diesen Endpunkt aktualisieren"
       },
       "noBorg": {
         "title": "Keine verwendbare Borg-Binärdatei gemeldet",
@@ -415,6 +418,21 @@
         "bannerMixedTargets": "Jeder Endpunkt zielt auf seine eigene konfigurierte Version.",
         "manualOnly": "Nur manuelle Updates",
         "manualOnlyTooltip": "Dieser Endpunkt hat kein Self-Upgrade-Hilfsprogramm und wird daher mit dem Reinstall-Befehl auf der Maschine aktualisiert. Eine Neuinstallation bereitet es auf servergesteuerte Upgrades vor."
+      },
+      "upgradeDialog": {
+        "title": "Diesen Endpunkt aktualisieren",
+        "description": "Der Endpunkt installiert sich selbst von diesem Server neu.",
+        "descriptionWithVersion": "Der Endpunkt installiert sich selbst von diesem Server neu und kommt mit Version {{version}} zurück.",
+        "disconnectWarning": "Dabei ist er kurzzeitig getrennt.",
+        "busyWarning": "Ein Endpunkt, der gerade ein Backup ausführt, lehnt die Aktualisierung ab. Versuchen Sie es erneut, sobald er inaktiv ist.",
+        "confirm": "Aktualisieren"
+      },
+      "upgradeState": {
+        "upgrading": "Wird aktualisiert",
+        "upgradingTo": "Aktualisierung auf {{version}}",
+        "upgradingTooltip": "Der Endpunkt installiert sich neu und verbindet sich von selbst wieder.",
+        "failed": "Aktualisierung fehlgeschlagen",
+        "failedHint": "Der Endpunkt kam nicht rechtzeitig zurück. Installieren Sie ihn manuell neu."
       }
     },
     "installCommand": {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -445,7 +445,8 @@
         "borgVersionLabel": "Borg-Version",
         "leaveAsInstalled": "Wie installiert lassen",
         "borgHint": "Die Borg-Auswahl wird jetzt gespeichert und von einer späteren Version angewendet, sobald Aktualisierungen die installierte Borg-Version ändern können.",
-        "save": "Speichern"
+        "save": "Speichern",
+        "unavailableVersion": "{{version}} (wird nicht mehr ausgeliefert)"
       }
     },
     "installCommand": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -304,7 +304,8 @@
         "agentDeleted": "Agent deleted",
         "cancellationRequested": "Cancellation requested",
         "copied": "Copied",
-        "agentUpgradeRequested": "Upgrade requested"
+        "agentUpgradeRequested": "Upgrade requested",
+        "agentVersionPinned": "Version pin saved"
       },
       "errors": {
         "revokeToken": "Failed to revoke enrollment token",
@@ -312,7 +313,8 @@
         "deleteAgent": "Failed to delete agent",
         "cancelJob": "Failed to cancel job",
         "runDiagnostics": "Failed to run diagnostics",
-        "upgradeAgent": "Could not request the upgrade"
+        "upgradeAgent": "Could not request the upgrade",
+        "pinAgentVersion": "Could not save the version pin"
       },
       "table": {
         "job": "Job",
@@ -334,7 +336,8 @@
         "viewLogs": "View logs",
         "cancelJob": "Cancel job",
         "revokeToken": "Revoke token",
-        "upgradeAgent": "Upgrade this endpoint"
+        "upgradeAgent": "Upgrade this endpoint",
+        "pinAgentVersion": "Pin this endpoint's version"
       },
       "noBorg": {
         "title": "No usable Borg binary reported",
@@ -433,6 +436,16 @@
         "upgradingTooltip": "The endpoint is reinstalling itself and will reconnect on its own.",
         "failed": "Upgrade failed",
         "failedHint": "The endpoint did not come back in time. Reinstall it manually."
+      },
+      "pinControl": {
+        "title": "Version pin",
+        "hint": "By default an endpoint tracks the version this server serves. Pin it to hold it on a specific version instead.",
+        "agentVersionLabel": "Agent version",
+        "trackServer": "Track server",
+        "borgVersionLabel": "Borg version",
+        "leaveAsInstalled": "Leave as installed",
+        "borgHint": "The Borg choice is recorded now and applied by a later release, once upgrades can change the installed Borg version.",
+        "save": "Save"
       }
     },
     "installCommand": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -445,7 +445,8 @@
         "borgVersionLabel": "Borg version",
         "leaveAsInstalled": "Leave as installed",
         "borgHint": "The Borg choice is recorded now and applied by a later release, once upgrades can change the installed Borg version.",
-        "save": "Save"
+        "save": "Save",
+        "unavailableVersion": "{{version}} (no longer served)"
       }
     },
     "installCommand": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -303,14 +303,16 @@
         "agentRevoked": "Agent revoked",
         "agentDeleted": "Agent deleted",
         "cancellationRequested": "Cancellation requested",
-        "copied": "Copied"
+        "copied": "Copied",
+        "agentUpgradeRequested": "Upgrade requested"
       },
       "errors": {
         "revokeToken": "Failed to revoke enrollment token",
         "revokeAgent": "Failed to revoke agent",
         "deleteAgent": "Failed to delete agent",
         "cancelJob": "Failed to cancel job",
-        "runDiagnostics": "Failed to run diagnostics"
+        "runDiagnostics": "Failed to run diagnostics",
+        "upgradeAgent": "Could not request the upgrade"
       },
       "table": {
         "job": "Job",
@@ -331,7 +333,8 @@
         "deleteAgent": "Delete agent",
         "viewLogs": "View logs",
         "cancelJob": "Cancel job",
-        "revokeToken": "Revoke token"
+        "revokeToken": "Revoke token",
+        "upgradeAgent": "Upgrade this endpoint"
       },
       "noBorg": {
         "title": "No usable Borg binary reported",
@@ -415,6 +418,21 @@
         "bannerMixedTargets": "Each one targets its own configured version.",
         "manualOnly": "Manual upgrades only",
         "manualOnlyTooltip": "This endpoint has no self-upgrade helper, so it is updated by running the reinstall command on the machine. One reinstall prepares it for server-driven upgrades."
+      },
+      "upgradeDialog": {
+        "title": "Upgrade this endpoint",
+        "description": "The endpoint reinstalls itself from this server.",
+        "descriptionWithVersion": "The endpoint reinstalls itself from this server and comes back on version {{version}}.",
+        "disconnectWarning": "It disconnects for a short period while it does.",
+        "busyWarning": "An endpoint that is running a backup refuses the upgrade, so try again once it is idle.",
+        "confirm": "Upgrade"
+      },
+      "upgradeState": {
+        "upgrading": "Upgrading",
+        "upgradingTo": "Upgrading to {{version}}",
+        "upgradingTooltip": "The endpoint is reinstalling itself and will reconnect on its own.",
+        "failed": "Upgrade failed",
+        "failedHint": "The endpoint did not come back in time. Reinstall it manually."
       }
     },
     "installCommand": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -5539,7 +5539,9 @@
         "repositoryOperationFailed": "The agent repository operation failed",
         "repositoryOperationTimeout": "The agent repository operation timed out",
         "unsupportedJobKind": "Unsupported agent job type",
-        "desiredVersionUnavailable": "That agent version is not available on this server."
+        "desiredVersionUnavailable": "That agent version is not available on this server.",
+        "upgradeUnsupported": "This endpoint cannot upgrade itself yet. Reinstall it once from the command in the reinstall dialog.",
+        "upgradeTargetUnavailable": "This server does not ship an agent version to upgrade to."
       },
       "repo": {
         "repositoryNotFound": "Repository not found",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -445,7 +445,8 @@
         "borgVersionLabel": "Versión de Borg",
         "leaveAsInstalled": "Dejar como está instalada",
         "borgHint": "La elección de Borg se guarda ahora y la aplicará una versión posterior, cuando las actualizaciones puedan cambiar la versión de Borg instalada.",
-        "save": "Guardar"
+        "save": "Guardar",
+        "unavailableVersion": "{{version}} (ya no se distribuye)"
       }
     },
     "installCommand": {

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -5539,7 +5539,9 @@
         "repositoryOperationFailed": "La operación de repositorio del agente falló",
         "repositoryOperationTimeout": "La operación de repositorio del agente agotó el tiempo de espera",
         "unsupportedJobKind": "Tipo de trabajo de agente no admitido",
-        "desiredVersionUnavailable": "Esa versión del agente no está disponible en este servidor."
+        "desiredVersionUnavailable": "Esa versión del agente no está disponible en este servidor.",
+        "upgradeUnsupported": "Este endpoint todavía no puede actualizarse solo. Reinstálalo una vez con el comando del diálogo de reinstalación.",
+        "upgradeTargetUnavailable": "Este servidor no distribuye ninguna versión del agente a la que actualizar."
       },
       "repo": {
         "repositoryNotFound": "Repositorio no encontrado",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -304,7 +304,8 @@
         "agentDeleted": "Agente eliminado",
         "cancellationRequested": "Cancelación solicitada",
         "copied": "Copiado",
-        "agentUpgradeRequested": "Actualización solicitada"
+        "agentUpgradeRequested": "Actualización solicitada",
+        "agentVersionPinned": "Versión fijada guardada"
       },
       "errors": {
         "revokeToken": "No se pudo revocar el token de registro",
@@ -312,7 +313,8 @@
         "deleteAgent": "No se pudo eliminar el agente",
         "cancelJob": "No se pudo cancelar el trabajo",
         "runDiagnostics": "No se pudieron ejecutar los diagnósticos",
-        "upgradeAgent": "No se pudo solicitar la actualización"
+        "upgradeAgent": "No se pudo solicitar la actualización",
+        "pinAgentVersion": "No se pudo guardar la versión fijada"
       },
       "table": {
         "job": "Trabajo",
@@ -334,7 +336,8 @@
         "viewLogs": "Ver registros",
         "cancelJob": "Cancelar trabajo",
         "revokeToken": "Revocar token",
-        "upgradeAgent": "Actualizar este endpoint"
+        "upgradeAgent": "Actualizar este endpoint",
+        "pinAgentVersion": "Fijar la versión de este endpoint"
       },
       "noBorg": {
         "title": "No se informó de un binario Borg utilizable",
@@ -433,6 +436,16 @@
         "upgradingTooltip": "El endpoint se está reinstalando y volverá a conectarse solo.",
         "failed": "Actualización fallida",
         "failedHint": "El endpoint no volvió a tiempo. Reinstálalo manualmente."
+      },
+      "pinControl": {
+        "title": "Fijar versión",
+        "hint": "De forma predeterminada, un endpoint sigue la versión que distribuye este servidor. Fíjalo para mantenerlo en una versión concreta.",
+        "agentVersionLabel": "Versión del agente",
+        "trackServer": "Seguir al servidor",
+        "borgVersionLabel": "Versión de Borg",
+        "leaveAsInstalled": "Dejar como está instalada",
+        "borgHint": "La elección de Borg se guarda ahora y la aplicará una versión posterior, cuando las actualizaciones puedan cambiar la versión de Borg instalada.",
+        "save": "Guardar"
       }
     },
     "installCommand": {

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -303,14 +303,16 @@
         "agentRevoked": "Agente revocado",
         "agentDeleted": "Agente eliminado",
         "cancellationRequested": "Cancelación solicitada",
-        "copied": "Copiado"
+        "copied": "Copiado",
+        "agentUpgradeRequested": "Actualización solicitada"
       },
       "errors": {
         "revokeToken": "No se pudo revocar el token de registro",
         "revokeAgent": "No se pudo revocar el agente",
         "deleteAgent": "No se pudo eliminar el agente",
         "cancelJob": "No se pudo cancelar el trabajo",
-        "runDiagnostics": "No se pudieron ejecutar los diagnósticos"
+        "runDiagnostics": "No se pudieron ejecutar los diagnósticos",
+        "upgradeAgent": "No se pudo solicitar la actualización"
       },
       "table": {
         "job": "Trabajo",
@@ -331,7 +333,8 @@
         "deleteAgent": "Eliminar agente",
         "viewLogs": "Ver registros",
         "cancelJob": "Cancelar trabajo",
-        "revokeToken": "Revocar token"
+        "revokeToken": "Revocar token",
+        "upgradeAgent": "Actualizar este endpoint"
       },
       "noBorg": {
         "title": "No se informó de un binario Borg utilizable",
@@ -415,6 +418,21 @@
         "bannerMixedTargets": "Cada uno apunta a su propia versión configurada.",
         "manualOnly": "Solo actualizaciones manuales",
         "manualOnlyTooltip": "Este endpoint no tiene el asistente de autoactualización, así que se actualiza ejecutando el comando de reinstalación en la máquina. Una reinstalación lo prepara para las actualizaciones desde el servidor."
+      },
+      "upgradeDialog": {
+        "title": "Actualizar este endpoint",
+        "description": "El endpoint se reinstala solo desde este servidor.",
+        "descriptionWithVersion": "El endpoint se reinstala solo desde este servidor y vuelve con la versión {{version}}.",
+        "disconnectWarning": "Se desconecta durante un breve periodo mientras lo hace.",
+        "busyWarning": "Un endpoint que está ejecutando una copia rechaza la actualización, así que inténtalo de nuevo cuando esté inactivo.",
+        "confirm": "Actualizar"
+      },
+      "upgradeState": {
+        "upgrading": "Actualizando",
+        "upgradingTo": "Actualizando a {{version}}",
+        "upgradingTooltip": "El endpoint se está reinstalando y volverá a conectarse solo.",
+        "failed": "Actualización fallida",
+        "failedHint": "El endpoint no volvió a tiempo. Reinstálalo manualmente."
       }
     },
     "installCommand": {

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -303,14 +303,16 @@
         "agentRevoked": "Agente revocato",
         "agentDeleted": "Agente eliminato",
         "cancellationRequested": "Annullamento richiesto",
-        "copied": "Copiato"
+        "copied": "Copiato",
+        "agentUpgradeRequested": "Aggiornamento richiesto"
       },
       "errors": {
         "revokeToken": "Impossibile revocare il token di registrazione",
         "revokeAgent": "Impossibile revocare l'agente",
         "deleteAgent": "Impossibile eliminare l'agente",
         "cancelJob": "Impossibile annullare il processo",
-        "runDiagnostics": "Impossibile eseguire la diagnostica"
+        "runDiagnostics": "Impossibile eseguire la diagnostica",
+        "upgradeAgent": "Non è stato possibile richiedere l'aggiornamento"
       },
       "table": {
         "job": "Processo",
@@ -331,7 +333,8 @@
         "deleteAgent": "Elimina agente",
         "viewLogs": "Visualizza registri",
         "cancelJob": "Annulla processo",
-        "revokeToken": "Revoca token"
+        "revokeToken": "Revoca token",
+        "upgradeAgent": "Aggiorna questo endpoint"
       },
       "noBorg": {
         "title": "Nessun binario Borg utilizzabile segnalato",
@@ -415,6 +418,21 @@
         "bannerMixedTargets": "Ognuno punta alla propria versione configurata.",
         "manualOnly": "Solo aggiornamenti manuali",
         "manualOnlyTooltip": "Questo endpoint non ha l'helper di autoaggiornamento, quindi si aggiorna eseguendo il comando di reinstallazione sulla macchina. Una reinstallazione lo prepara agli aggiornamenti dal server."
+      },
+      "upgradeDialog": {
+        "title": "Aggiorna questo endpoint",
+        "description": "L'endpoint si reinstalla da solo da questo server.",
+        "descriptionWithVersion": "L'endpoint si reinstalla da solo da questo server e torna con la versione {{version}}.",
+        "disconnectWarning": "Durante l'operazione resta disconnesso per un breve periodo.",
+        "busyWarning": "Un endpoint che sta eseguendo un backup rifiuta l'aggiornamento, quindi riprova quando è inattivo.",
+        "confirm": "Aggiorna"
+      },
+      "upgradeState": {
+        "upgrading": "Aggiornamento",
+        "upgradingTo": "Aggiornamento alla {{version}}",
+        "upgradingTooltip": "L'endpoint si sta reinstallando e si riconnetterà da solo.",
+        "failed": "Aggiornamento non riuscito",
+        "failedHint": "L'endpoint non è tornato in tempo. Reinstallalo manualmente."
       }
     },
     "installCommand": {

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -445,7 +445,8 @@
         "borgVersionLabel": "Versione Borg",
         "leaveAsInstalled": "Lascia come installata",
         "borgHint": "La scelta di Borg viene registrata ora e applicata da una versione successiva, quando gli aggiornamenti potranno cambiare la versione di Borg installata.",
-        "save": "Salva"
+        "save": "Salva",
+        "unavailableVersion": "{{version}} (non più distribuita)"
       }
     },
     "installCommand": {

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -5539,7 +5539,9 @@
         "repositoryOperationFailed": "L'operazione repository dell'agente non è riuscita",
         "repositoryOperationTimeout": "L'operazione repository dell'agente è scaduta",
         "unsupportedJobKind": "Tipo di lavoro agente non supportato",
-        "desiredVersionUnavailable": "Quella versione dell'agente non è disponibile su questo server."
+        "desiredVersionUnavailable": "Quella versione dell'agente non è disponibile su questo server.",
+        "upgradeUnsupported": "Questo endpoint non può ancora aggiornarsi da solo. Reinstallalo una volta con il comando della finestra di reinstallazione.",
+        "upgradeTargetUnavailable": "Questo server non distribuisce una versione dell'agente a cui aggiornare."
       },
       "repo": {
         "repositoryNotFound": "Repository non trovato",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -304,7 +304,8 @@
         "agentDeleted": "Agente eliminato",
         "cancellationRequested": "Annullamento richiesto",
         "copied": "Copiato",
-        "agentUpgradeRequested": "Aggiornamento richiesto"
+        "agentUpgradeRequested": "Aggiornamento richiesto",
+        "agentVersionPinned": "Blocco versione salvato"
       },
       "errors": {
         "revokeToken": "Impossibile revocare il token di registrazione",
@@ -312,7 +313,8 @@
         "deleteAgent": "Impossibile eliminare l'agente",
         "cancelJob": "Impossibile annullare il processo",
         "runDiagnostics": "Impossibile eseguire la diagnostica",
-        "upgradeAgent": "Non è stato possibile richiedere l'aggiornamento"
+        "upgradeAgent": "Non è stato possibile richiedere l'aggiornamento",
+        "pinAgentVersion": "Non è stato possibile salvare il blocco versione"
       },
       "table": {
         "job": "Processo",
@@ -334,7 +336,8 @@
         "viewLogs": "Visualizza registri",
         "cancelJob": "Annulla processo",
         "revokeToken": "Revoca token",
-        "upgradeAgent": "Aggiorna questo endpoint"
+        "upgradeAgent": "Aggiorna questo endpoint",
+        "pinAgentVersion": "Blocca la versione di questo endpoint"
       },
       "noBorg": {
         "title": "Nessun binario Borg utilizzabile segnalato",
@@ -433,6 +436,16 @@
         "upgradingTooltip": "L'endpoint si sta reinstallando e si riconnetterà da solo.",
         "failed": "Aggiornamento non riuscito",
         "failedHint": "L'endpoint non è tornato in tempo. Reinstallalo manualmente."
+      },
+      "pinControl": {
+        "title": "Blocco versione",
+        "hint": "Per impostazione predefinita un endpoint segue la versione distribuita da questo server. Bloccalo per tenerlo su una versione specifica.",
+        "agentVersionLabel": "Versione agente",
+        "trackServer": "Segui il server",
+        "borgVersionLabel": "Versione Borg",
+        "leaveAsInstalled": "Lascia come installata",
+        "borgHint": "La scelta di Borg viene registrata ora e applicata da una versione successiva, quando gli aggiornamenti potranno cambiare la versione di Borg installata.",
+        "save": "Salva"
       }
     },
     "installCommand": {

--- a/frontend/src/pages/ManagedAgents.tsx
+++ b/frontend/src/pages/ManagedAgents.tsx
@@ -705,6 +705,8 @@ export default function ManagedAgents() {
           }}
           isRevoking={revokeAgentMutation.isPending}
           isDeleting={deleteAgentMutation.isPending}
+          isPinningVersion={pinAgentVersionMutation.isPending}
+          isUpgrading={upgradeAgentMutation.isPending}
         />
       ) : null}
 
@@ -1609,6 +1611,8 @@ export function AgentList({
   onRunDiagnostics,
   isRevoking,
   isDeleting,
+  isPinningVersion = false,
+  isUpgrading = false,
 }: {
   agents: AgentMachineResponse[]
   serverUrl: string
@@ -1624,6 +1628,8 @@ export function AgentList({
   ) => Promise<AgentDiagnosticsResponse>
   isRevoking: boolean
   isDeleting: boolean
+  isPinningVersion?: boolean
+  isUpgrading?: boolean
 }) {
   const theme = useTheme()
   const { t } = useTranslation()
@@ -2128,6 +2134,7 @@ export function AgentList({
       <AgentPinControl
         open={!!pinTarget}
         agent={pinTarget}
+        busy={isPinningVersion}
         onSave={(agent, data) => {
           onPinVersion?.(agent, data)
           setPinTarget(null)
@@ -2137,6 +2144,7 @@ export function AgentList({
       <AgentUpgradeDialog
         open={!!upgradeTarget}
         agent={upgradeTarget}
+        busy={isUpgrading}
         onConfirm={(agent) => {
           onUpgrade?.(agent)
           setUpgradeTarget(null)

--- a/frontend/src/pages/ManagedAgents.tsx
+++ b/frontend/src/pages/ManagedAgents.tsx
@@ -38,6 +38,7 @@ import {
   Copy,
   Eye,
   Info,
+  Pin,
   Plus,
   RefreshCw,
   Terminal,
@@ -45,6 +46,7 @@ import {
   XCircle,
 } from 'lucide-react'
 import {
+  AgentDesiredVersionRequest,
   AgentEnrollmentTokenSummary,
   AgentDiagnosticsRequest,
   AgentDiagnosticsResponse,
@@ -68,6 +70,7 @@ import AddAgentDialog from './managed-agents/AddAgentDialog'
 import AgentUpgradeBanner from './managed-agents/AgentUpgradeBanner'
 import AgentManualUpgradeChip from './managed-agents/AgentManualUpgradeChip'
 import AgentUpgradeChip from './managed-agents/AgentUpgradeChip'
+import AgentPinControl from './managed-agents/AgentPinControl'
 import AgentUpgradeDialog from './managed-agents/AgentUpgradeDialog'
 import AgentUpgradeStateChip from './managed-agents/AgentUpgradeStateChip'
 import BorgInstallModeRadioGroup from './managed-agents/BorgInstallModeRadioGroup'
@@ -518,6 +521,18 @@ export default function ManagedAgents() {
     },
   })
 
+  const pinAgentVersionMutation = useMutation({
+    mutationFn: ({ agentId, data }: { agentId: number; data: AgentDesiredVersionRequest }) =>
+      managedAgentsAPI.setDesiredVersion(agentId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['managed-agents'] })
+      toast.success(t('managedAgents.page.toasts.agentVersionPinned'))
+    },
+    onError: (error: unknown) => {
+      toast.error(extractBackendMessage(error, t('managedAgents.page.errors.pinAgentVersion')))
+    },
+  })
+
   const cancelJobMutation = useMutation({
     mutationFn: managedAgentsAPI.cancelJob,
     onSuccess: (_response, jobId) => {
@@ -656,6 +671,9 @@ export default function ManagedAgents() {
           onRevoke={(agent) => revokeAgentMutation.mutate(agent.id)}
           onDelete={(agent) => deleteAgentMutation.mutate(agent.id)}
           onUpgrade={(agent) => upgradeAgentMutation.mutate(agent.id)}
+          onPinVersion={(agent, data) =>
+            pinAgentVersionMutation.mutate({ agentId: agent.id, data })
+          }
           onViewLogs={(agent) => {
             trackSystem(EventAction.VIEW, {
               section: MANAGED_AGENTS_ANALYTICS_SECTION,
@@ -1587,6 +1605,7 @@ export function AgentList({
   onDelete,
   onViewLogs,
   onUpgrade,
+  onPinVersion,
   onRunDiagnostics,
   isRevoking,
   isDeleting,
@@ -1598,6 +1617,7 @@ export function AgentList({
   onDelete: (agent: AgentMachineResponse) => void
   onViewLogs: (agent: AgentMachineResponse) => void
   onUpgrade?: (agent: AgentMachineResponse) => void
+  onPinVersion?: (agent: AgentMachineResponse, data: AgentDesiredVersionRequest) => void
   onRunDiagnostics?: (
     agent: AgentMachineResponse,
     payload: AgentDiagnosticsRequest
@@ -1612,6 +1632,7 @@ export function AgentList({
   const [deleteTarget, setDeleteTarget] = useState<AgentMachineResponse | null>(null)
   const [reinstallTarget, setReinstallTarget] = useState<AgentMachineResponse | null>(null)
   const [upgradeTarget, setUpgradeTarget] = useState<AgentMachineResponse | null>(null)
+  const [pinTarget, setPinTarget] = useState<AgentMachineResponse | null>(null)
   const [diagnosticsTarget, setDiagnosticsTarget] = useState<AgentMachineResponse | null>(null)
   const handleRunDiagnostics =
     onRunDiagnostics ??
@@ -1961,6 +1982,27 @@ export function AgentList({
                       <Eye size={16} />
                     </IconButton>
                   </Tooltip>
+                  {onPinVersion ? (
+                    <Tooltip title={t('managedAgents.page.actions.pinAgentVersion')} arrow>
+                      <IconButton
+                        size="small"
+                        aria-label={t('managedAgents.page.actions.pinAgentVersion')}
+                        onClick={() => setPinTarget(agent)}
+                        sx={{
+                          width: { xs: 40, sm: 34 },
+                          height: { xs: 40, sm: 34 },
+                          borderRadius: 1.5,
+                          color: alpha(theme.palette.text.secondary, 0.75),
+                          '&:hover': {
+                            color: theme.palette.text.primary,
+                            bgcolor: alpha(theme.palette.text.primary, isDark ? 0.15 : 0.08),
+                          },
+                        }}
+                      >
+                        <Pin size={16} />
+                      </IconButton>
+                    </Tooltip>
+                  ) : null}
                   {onUpgrade &&
                   agent.self_upgrade_supported === true &&
                   agent.upgrade_status === 'outdated' ? (
@@ -2082,6 +2124,15 @@ export function AgentList({
           onDelete(agent)
           setDeleteTarget(null)
         }}
+      />
+      <AgentPinControl
+        open={!!pinTarget}
+        agent={pinTarget}
+        onSave={(agent, data) => {
+          onPinVersion?.(agent, data)
+          setPinTarget(null)
+        }}
+        onCancel={() => setPinTarget(null)}
       />
       <AgentUpgradeDialog
         open={!!upgradeTarget}

--- a/frontend/src/pages/ManagedAgents.tsx
+++ b/frontend/src/pages/ManagedAgents.tsx
@@ -32,6 +32,7 @@ import {
 import {
   Activity,
   AlertTriangle,
+  ArrowUpCircle,
   Ban,
   CheckCircle,
   Copy,
@@ -67,6 +68,8 @@ import AddAgentDialog from './managed-agents/AddAgentDialog'
 import AgentUpgradeBanner from './managed-agents/AgentUpgradeBanner'
 import AgentManualUpgradeChip from './managed-agents/AgentManualUpgradeChip'
 import AgentUpgradeChip from './managed-agents/AgentUpgradeChip'
+import AgentUpgradeDialog from './managed-agents/AgentUpgradeDialog'
+import AgentUpgradeStateChip from './managed-agents/AgentUpgradeStateChip'
 import BorgInstallModeRadioGroup from './managed-agents/BorgInstallModeRadioGroup'
 import { resolveAgentServerUrl } from './managed-agents/agentServerUrl'
 import {
@@ -496,6 +499,25 @@ export default function ManagedAgents() {
     },
   })
 
+  const upgradeAgentMutation = useMutation({
+    mutationFn: (agentId: number) => managedAgentsAPI.upgradeAgents([agentId]),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['managed-agents'] })
+      trackSystem(EventAction.START, {
+        section: MANAGED_AGENTS_ANALYTICS_SECTION,
+        operation: 'upgrade_agent',
+      })
+      trackFeatureUsed('managed_agents', {
+        surface: MANAGED_AGENTS_ANALYTICS_SECTION,
+        operation: 'upgrade_agent',
+      })
+      toast.success(t('managedAgents.page.toasts.agentUpgradeRequested'))
+    },
+    onError: (error: unknown) => {
+      toast.error(extractBackendMessage(error, t('managedAgents.page.errors.upgradeAgent')))
+    },
+  })
+
   const cancelJobMutation = useMutation({
     mutationFn: managedAgentsAPI.cancelJob,
     onSuccess: (_response, jobId) => {
@@ -633,6 +655,7 @@ export default function ManagedAgents() {
           onCopy={handleCopy}
           onRevoke={(agent) => revokeAgentMutation.mutate(agent.id)}
           onDelete={(agent) => deleteAgentMutation.mutate(agent.id)}
+          onUpgrade={(agent) => upgradeAgentMutation.mutate(agent.id)}
           onViewLogs={(agent) => {
             trackSystem(EventAction.VIEW, {
               section: MANAGED_AGENTS_ANALYTICS_SECTION,
@@ -1563,6 +1586,7 @@ export function AgentList({
   onRevoke,
   onDelete,
   onViewLogs,
+  onUpgrade,
   onRunDiagnostics,
   isRevoking,
   isDeleting,
@@ -1573,6 +1597,7 @@ export function AgentList({
   onRevoke: (agent: AgentMachineResponse) => void
   onDelete: (agent: AgentMachineResponse) => void
   onViewLogs: (agent: AgentMachineResponse) => void
+  onUpgrade?: (agent: AgentMachineResponse) => void
   onRunDiagnostics?: (
     agent: AgentMachineResponse,
     payload: AgentDiagnosticsRequest
@@ -1586,6 +1611,7 @@ export function AgentList({
   const isDark = theme.palette.mode === 'dark'
   const [deleteTarget, setDeleteTarget] = useState<AgentMachineResponse | null>(null)
   const [reinstallTarget, setReinstallTarget] = useState<AgentMachineResponse | null>(null)
+  const [upgradeTarget, setUpgradeTarget] = useState<AgentMachineResponse | null>(null)
   const [diagnosticsTarget, setDiagnosticsTarget] = useState<AgentMachineResponse | null>(null)
   const handleRunDiagnostics =
     onRunDiagnostics ??
@@ -1730,6 +1756,15 @@ export function AgentList({
                         />
                       )}
                       {agent.self_upgrade_supported === false && <AgentManualUpgradeChip />}
+                      {agent.upgrade_state ? (
+                        <AgentUpgradeStateChip
+                          state={agent.upgrade_state}
+                          targetVersion={
+                            agent.desired_agent_version || agent.available_agent_version
+                          }
+                          error={agent.upgrade_error}
+                        />
+                      ) : null}
                     </Box>
                   </Box>
 
@@ -1926,6 +1961,39 @@ export function AgentList({
                       <Eye size={16} />
                     </IconButton>
                   </Tooltip>
+                  {onUpgrade &&
+                  agent.self_upgrade_supported === true &&
+                  agent.upgrade_status === 'outdated' ? (
+                    <Tooltip title={t('managedAgents.page.actions.upgradeAgent')} arrow>
+                      <span>
+                        <IconButton
+                          size="small"
+                          aria-label={t('managedAgents.page.actions.upgradeAgent')}
+                          disabled={agent.upgrade_state === 'requested'}
+                          onClick={() => {
+                            trackSystem(EventAction.VIEW, {
+                              section: MANAGED_AGENTS_ANALYTICS_SECTION,
+                              operation: 'upgrade_agent',
+                              status: agent.status,
+                            })
+                            setUpgradeTarget(agent)
+                          }}
+                          sx={{
+                            width: { xs: 40, sm: 34 },
+                            height: { xs: 40, sm: 34 },
+                            borderRadius: 1.5,
+                            color: alpha(theme.palette.success.main, 0.75),
+                            '&:hover': {
+                              color: theme.palette.success.main,
+                              bgcolor: alpha(theme.palette.success.main, isDark ? 0.15 : 0.1),
+                            },
+                          }}
+                        >
+                          <ArrowUpCircle size={16} />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  ) : null}
                   <Tooltip title={t('managedAgents.page.actions.reinstallAgent')} arrow>
                     <IconButton
                       size="small"
@@ -2014,6 +2082,15 @@ export function AgentList({
           onDelete(agent)
           setDeleteTarget(null)
         }}
+      />
+      <AgentUpgradeDialog
+        open={!!upgradeTarget}
+        agent={upgradeTarget}
+        onConfirm={(agent) => {
+          onUpgrade?.(agent)
+          setUpgradeTarget(null)
+        }}
+        onCancel={() => setUpgradeTarget(null)}
       />
       <AgentReinstallDialog
         open={!!reinstallTarget}

--- a/frontend/src/pages/__tests__/ManagedAgents.test.tsx
+++ b/frontend/src/pages/__tests__/ManagedAgents.test.tsx
@@ -1345,4 +1345,85 @@ describe('ManagedAgents', () => {
     expect(await screen.findByRole('tooltip')).toHaveTextContent(/Pinned to version 0\.1\.2/i)
     expect(screen.queryByText(/serves agent version 0\.1\.3/i)).not.toBeInTheDocument()
   })
+  it('offers the upgrade action to an outdated endpoint that can upgrade itself', async () => {
+    const user = userEvent.setup()
+    const onUpgrade = vi.fn()
+    const agent = buildAgent({
+      upgrade_status: 'outdated',
+      self_upgrade_supported: true,
+      available_agent_version: '0.1.3',
+    })
+
+    renderWithProviders(
+      <AgentList
+        agents={[agent]}
+        serverUrl="https://borg-ui.example.com"
+        onCopy={vi.fn()}
+        onRevoke={vi.fn()}
+        onDelete={vi.fn()}
+        onViewLogs={vi.fn()}
+        onUpgrade={onUpgrade}
+        onRunDiagnostics={vi.fn()}
+        isRevoking={false}
+        isDeleting={false}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /upgrade this endpoint/i }))
+    await user.click(await screen.findByRole('button', { name: /^upgrade$/i }))
+    expect(onUpgrade).toHaveBeenCalledWith(agent)
+  })
+
+  it('leaves an endpoint without the helper on the manual reinstall path', () => {
+    const agent = buildAgent({
+      upgrade_status: 'outdated',
+      self_upgrade_supported: false,
+      available_agent_version: '0.1.3',
+    })
+
+    renderWithProviders(
+      <AgentList
+        agents={[agent]}
+        serverUrl="https://borg-ui.example.com"
+        onCopy={vi.fn()}
+        onRevoke={vi.fn()}
+        onDelete={vi.fn()}
+        onViewLogs={vi.fn()}
+        onUpgrade={vi.fn()}
+        onRunDiagnostics={vi.fn()}
+        isRevoking={false}
+        isDeleting={false}
+      />
+    )
+
+    expect(screen.queryByRole('button', { name: /upgrade this endpoint/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reinstall/i })).toBeInTheDocument()
+  })
+
+  it('shows an in-flight upgrade on the row', () => {
+    const agent = buildAgent({
+      upgrade_status: 'outdated',
+      self_upgrade_supported: true,
+      upgrade_state: 'requested',
+      available_agent_version: '0.1.3',
+    })
+
+    renderWithProviders(
+      <AgentList
+        agents={[agent]}
+        serverUrl="https://borg-ui.example.com"
+        onCopy={vi.fn()}
+        onRevoke={vi.fn()}
+        onDelete={vi.fn()}
+        onViewLogs={vi.fn()}
+        onUpgrade={vi.fn()}
+        onRunDiagnostics={vi.fn()}
+        isRevoking={false}
+        isDeleting={false}
+      />
+    )
+
+    expect(screen.getByText(/Upgrading to 0\.1\.3/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /upgrade this endpoint/i })).toBeDisabled()
+  })
 })

--- a/frontend/src/pages/managed-agents/AgentPinControl.stories.tsx
+++ b/frontend/src/pages/managed-agents/AgentPinControl.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import AgentPinControl from './AgentPinControl'
+import type { AgentMachineResponse } from '../../services/api'
+
+const agent = {
+  id: 1,
+  agent_id: 'agt_1',
+  name: 'db-01',
+  hostname: 'db-01.internal',
+  status: 'online',
+  agent_version: '0.1.2',
+  available_agent_version: '0.1.3',
+  created_at: '2026-05-10T08:00:00.000Z',
+  updated_at: '2026-09-09T08:00:00.000Z',
+} as AgentMachineResponse
+
+const meta: Meta<typeof AgentPinControl> = {
+  title: 'Managed Agents/AgentPinControl',
+  component: AgentPinControl,
+  parameters: { layout: 'fullscreen' },
+}
+export default meta
+
+type Story = StoryObj<typeof AgentPinControl>
+
+export const Unpinned: Story = {
+  args: { open: true, agent, onSave: () => {}, onCancel: () => {} },
+}
+
+export const Pinned: Story = {
+  args: {
+    open: true,
+    agent: {
+      ...agent,
+      desired_agent_version: '0.1.3',
+      desired_borg_version: '2',
+    } as AgentMachineResponse,
+    onSave: () => {},
+    onCancel: () => {},
+  },
+}

--- a/frontend/src/pages/managed-agents/AgentPinControl.tsx
+++ b/frontend/src/pages/managed-agents/AgentPinControl.tsx
@@ -45,7 +45,9 @@ export default function AgentPinControl({
   useEffect(() => {
     setAgentVersion(agent?.desired_agent_version || TRACK_SERVER)
     setBorgVersion(agent?.desired_borg_version || LEAVE_INSTALLED)
-  }, [agent])
+    // `open` is a dependency so reopening for the same agent starts from the
+    // stored pin again, rather than from an edit that was cancelled.
+  }, [agent, open])
 
   const available = agent?.available_agent_version
   // A pin outlives a server upgrade, so an endpoint can carry a version this

--- a/frontend/src/pages/managed-agents/AgentPinControl.tsx
+++ b/frontend/src/pages/managed-agents/AgentPinControl.tsx
@@ -48,6 +48,15 @@ export default function AgentPinControl({
   }, [agent])
 
   const available = agent?.available_agent_version
+  // A pin outlives a server upgrade, so an endpoint can carry a version this
+  // server no longer serves. Show it, or the select renders blank and saving
+  // would silently move the pin. It cannot be re-selected: the server rejects
+  // a pin it cannot serve, so the only ways out are the served version or no
+  // pin at all.
+  const stalePin =
+    agent?.desired_agent_version && agent.desired_agent_version !== available
+      ? agent.desired_agent_version
+      : null
 
   return (
     <ResponsiveDialog
@@ -60,7 +69,7 @@ export default function AgentPinControl({
           <Button onClick={onCancel}>{t('common.buttons.cancel')}</Button>
           <Button
             variant="contained"
-            disabled={busy || !agent}
+            disabled={busy || !agent || agentVersion === stalePin}
             onClick={() =>
               agent &&
               onSave(agent, {
@@ -96,6 +105,13 @@ export default function AgentPinControl({
                 {t('managedAgents.page.pinControl.trackServer')}
               </MenuItem>
               {available ? <MenuItem value={available}>{available}</MenuItem> : null}
+              {stalePin ? (
+                <MenuItem value={stalePin} disabled>
+                  {t('managedAgents.page.pinControl.unavailableVersion', {
+                    version: stalePin,
+                  })}
+                </MenuItem>
+              ) : null}
             </Select>
           </FormControl>
           <FormControl fullWidth>

--- a/frontend/src/pages/managed-agents/AgentPinControl.tsx
+++ b/frontend/src/pages/managed-agents/AgentPinControl.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react'
+import {
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Typography,
+} from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import ResponsiveDialog from '../../components/shared/ResponsiveDialog'
+import type { AgentDesiredVersionRequest, AgentMachineResponse } from '../../services/api'
+
+const TRACK_SERVER = ''
+const LEAVE_INSTALLED = ''
+
+/**
+ * Pins one endpoint to a version, or clears the pin so it tracks the server.
+ *
+ * The agent version list offers only what this server serves: the installer
+ * installs from this server's wheelhouse and nowhere else, so a pin to any
+ * other version could never be satisfied and the server rejects it.
+ */
+export default function AgentPinControl({
+  agent,
+  open,
+  busy = false,
+  onSave,
+  onCancel,
+}: {
+  agent: AgentMachineResponse | null
+  open: boolean
+  busy?: boolean
+  onSave: (agent: AgentMachineResponse, data: AgentDesiredVersionRequest) => void
+  onCancel: () => void
+}) {
+  const { t } = useTranslation()
+  const [agentVersion, setAgentVersion] = useState(TRACK_SERVER)
+  const [borgVersion, setBorgVersion] = useState(LEAVE_INSTALLED)
+
+  useEffect(() => {
+    setAgentVersion(agent?.desired_agent_version || TRACK_SERVER)
+    setBorgVersion(agent?.desired_borg_version || LEAVE_INSTALLED)
+  }, [agent])
+
+  const available = agent?.available_agent_version
+
+  return (
+    <ResponsiveDialog
+      open={open}
+      onClose={onCancel}
+      fullWidth
+      maxWidth="sm"
+      footer={
+        <DialogActions>
+          <Button onClick={onCancel}>{t('common.buttons.cancel')}</Button>
+          <Button
+            variant="contained"
+            disabled={busy || !agent}
+            onClick={() =>
+              agent &&
+              onSave(agent, {
+                // Empty means "no pin", and the server stores that as null.
+                desired_agent_version: agentVersion || null,
+                desired_borg_version: (borgVersion || null) as '1' | '2' | null,
+              })
+            }
+          >
+            {t('managedAgents.page.pinControl.save')}
+          </Button>
+        </DialogActions>
+      }
+    >
+      <DialogTitle>{t('managedAgents.page.pinControl.title')}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Typography sx={{ color: 'text.secondary' }}>
+            {t('managedAgents.page.pinControl.hint')}
+          </Typography>
+          <FormControl fullWidth>
+            <InputLabel id="agent-pin-version-label">
+              {t('managedAgents.page.pinControl.agentVersionLabel')}
+            </InputLabel>
+            <Select
+              labelId="agent-pin-version-label"
+              displayEmpty
+              value={agentVersion}
+              label={t('managedAgents.page.pinControl.agentVersionLabel')}
+              onChange={(event) => setAgentVersion(event.target.value)}
+            >
+              <MenuItem value={TRACK_SERVER}>
+                {t('managedAgents.page.pinControl.trackServer')}
+              </MenuItem>
+              {available ? <MenuItem value={available}>{available}</MenuItem> : null}
+            </Select>
+          </FormControl>
+          <FormControl fullWidth>
+            <InputLabel id="agent-pin-borg-label">
+              {t('managedAgents.page.pinControl.borgVersionLabel')}
+            </InputLabel>
+            <Select
+              labelId="agent-pin-borg-label"
+              displayEmpty
+              value={borgVersion}
+              label={t('managedAgents.page.pinControl.borgVersionLabel')}
+              onChange={(event) => setBorgVersion(event.target.value)}
+            >
+              <MenuItem value={LEAVE_INSTALLED}>
+                {t('managedAgents.page.pinControl.leaveAsInstalled')}
+              </MenuItem>
+              <MenuItem value="1">Borg 1</MenuItem>
+              <MenuItem value="2">Borg 2</MenuItem>
+            </Select>
+          </FormControl>
+          <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+            {t('managedAgents.page.pinControl.borgHint')}
+          </Typography>
+        </Stack>
+      </DialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/frontend/src/pages/managed-agents/AgentUpgradeDialog.stories.tsx
+++ b/frontend/src/pages/managed-agents/AgentUpgradeDialog.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import AgentUpgradeDialog from './AgentUpgradeDialog'
+import type { AgentMachineResponse } from '../../services/api'
+
+const agent = {
+  id: 1,
+  agent_id: 'agt_1',
+  name: 'db-01',
+  hostname: 'db-01.internal',
+  status: 'online',
+  agent_version: '0.1.2',
+  available_agent_version: '0.1.3',
+  created_at: '2026-05-10T08:00:00.000Z',
+  updated_at: '2026-09-09T08:00:00.000Z',
+} as AgentMachineResponse
+
+const meta: Meta<typeof AgentUpgradeDialog> = {
+  title: 'Managed Agents/AgentUpgradeDialog',
+  component: AgentUpgradeDialog,
+  parameters: { layout: 'fullscreen' },
+}
+export default meta
+
+type Story = StoryObj<typeof AgentUpgradeDialog>
+
+export const Confirm: Story = {
+  args: { open: true, agent, onConfirm: () => {}, onCancel: () => {} },
+}
+
+export const Pinned: Story = {
+  args: {
+    open: true,
+    agent: { ...agent, desired_agent_version: '0.1.1' } as AgentMachineResponse,
+    onConfirm: () => {},
+    onCancel: () => {},
+  },
+}
+
+export const Busy: Story = {
+  args: { open: true, busy: true, agent, onConfirm: () => {}, onCancel: () => {} },
+}

--- a/frontend/src/pages/managed-agents/AgentUpgradeDialog.tsx
+++ b/frontend/src/pages/managed-agents/AgentUpgradeDialog.tsx
@@ -1,0 +1,77 @@
+import {
+  Alert,
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  Typography,
+} from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import ResponsiveDialog from '../../components/shared/ResponsiveDialog'
+import type { AgentMachineResponse } from '../../services/api'
+
+/**
+ * Confirms one endpoint's remote upgrade. The endpoint reinstalls itself and
+ * disconnects while it does, so the operator is told that plainly before
+ * confirming rather than after the row goes quiet.
+ */
+export default function AgentUpgradeDialog({
+  agent,
+  open,
+  busy = false,
+  onConfirm,
+  onCancel,
+}: {
+  agent: AgentMachineResponse | null
+  open: boolean
+  busy?: boolean
+  onConfirm: (agent: AgentMachineResponse) => void
+  onCancel: () => void
+}) {
+  const { t } = useTranslation()
+  // A pin decides the target whatever the server serves, mirroring
+  // `desired or available` in app/core/agent_versions.py.
+  const targetVersion = agent?.desired_agent_version || agent?.available_agent_version
+
+  return (
+    <ResponsiveDialog
+      open={open}
+      onClose={onCancel}
+      fullWidth
+      maxWidth="sm"
+      footer={
+        <DialogActions>
+          <Button onClick={onCancel}>{t('common.buttons.cancel')}</Button>
+          <Button
+            variant="contained"
+            disabled={busy || !agent}
+            onClick={() => agent && onConfirm(agent)}
+          >
+            {t('managedAgents.page.upgradeDialog.confirm')}
+          </Button>
+        </DialogActions>
+      }
+    >
+      <DialogTitle>{t('managedAgents.page.upgradeDialog.title')}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={1.5} sx={{ mt: 0.5 }}>
+          <Typography sx={{ fontWeight: 700 }}>
+            {[agent?.name, agent?.hostname].filter(Boolean).join(' · ')}
+          </Typography>
+          <Typography sx={{ color: 'text.secondary' }}>
+            {targetVersion
+              ? t('managedAgents.page.upgradeDialog.descriptionWithVersion', {
+                  version: targetVersion,
+                })
+              : t('managedAgents.page.upgradeDialog.description')}
+          </Typography>
+          <Alert severity="info" sx={{ borderRadius: 1.5 }}>
+            {t('managedAgents.page.upgradeDialog.disconnectWarning')}{' '}
+            {t('managedAgents.page.upgradeDialog.busyWarning')}
+          </Alert>
+        </Stack>
+      </DialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/frontend/src/pages/managed-agents/AgentUpgradeStateChip.stories.tsx
+++ b/frontend/src/pages/managed-agents/AgentUpgradeStateChip.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Stack } from '@mui/material'
+import AgentUpgradeStateChip from './AgentUpgradeStateChip'
+
+const meta: Meta<typeof AgentUpgradeStateChip> = {
+  title: 'Managed Agents/AgentUpgradeStateChip',
+  component: AgentUpgradeStateChip,
+}
+export default meta
+
+type Story = StoryObj<typeof AgentUpgradeStateChip>
+
+export const AllStates: Story = {
+  render: () => (
+    <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+      <AgentUpgradeStateChip state="requested" targetVersion="0.1.3" />
+      <AgentUpgradeStateChip state="failed" error="The endpoint did not come back." />
+    </Stack>
+  ),
+}
+
+export const Upgrading: Story = {
+  args: { state: 'requested', targetVersion: '0.1.3' },
+}
+
+export const Failed: Story = {
+  args: {
+    state: 'failed',
+    error: 'The endpoint did not come back on the target version in time.',
+  },
+}

--- a/frontend/src/pages/managed-agents/AgentUpgradeStateChip.tsx
+++ b/frontend/src/pages/managed-agents/AgentUpgradeStateChip.tsx
@@ -1,0 +1,56 @@
+import { Chip, CircularProgress, Tooltip } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import { agentChipSx } from './agentChipSx'
+
+/**
+ * What an in-flight or failed upgrade looks like on the row. The agent is
+ * killed by the thing it is reporting on, so `requested` only means the server
+ * asked and the endpoint acknowledged; the server resolves the rest, either on
+ * the endpoint's next check-in or by timeout.
+ */
+export default function AgentUpgradeStateChip({
+  state,
+  targetVersion,
+  error,
+}: {
+  state: string
+  targetVersion?: string | null
+  error?: string | null
+}) {
+  const { t } = useTranslation()
+
+  if (state === 'requested') {
+    return (
+      <Tooltip title={t('managedAgents.page.upgradeState.upgradingTooltip')} arrow>
+        <Chip
+          size="small"
+          variant="outlined"
+          color="info"
+          icon={<CircularProgress size={10} thickness={6} color="inherit" />}
+          label={
+            targetVersion
+              ? t('managedAgents.page.upgradeState.upgradingTo', { version: targetVersion })
+              : t('managedAgents.page.upgradeState.upgrading')
+          }
+          sx={agentChipSx}
+        />
+      </Tooltip>
+    )
+  }
+
+  if (state === 'failed') {
+    return (
+      <Tooltip title={error || t('managedAgents.page.upgradeState.failedHint')} arrow>
+        <Chip
+          size="small"
+          variant="outlined"
+          color="error"
+          label={t('managedAgents.page.upgradeState.failed')}
+          sx={agentChipSx}
+        />
+      </Tooltip>
+    )
+  }
+
+  return null
+}

--- a/frontend/src/pages/managed-agents/__tests__/AgentPinControl.test.tsx
+++ b/frontend/src/pages/managed-agents/__tests__/AgentPinControl.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders, userEvent } from '../../../test/test-utils'
+import AgentPinControl from '../AgentPinControl'
+import type { AgentMachineResponse } from '../../../services/api'
+
+const agent = (overrides: Partial<AgentMachineResponse> = {}): AgentMachineResponse =>
+  ({
+    id: 1,
+    agent_id: 'agt_1',
+    name: 'db-01',
+    status: 'online',
+    available_agent_version: '0.1.3',
+    created_at: '2026-05-10T08:00:00.000Z',
+    updated_at: '2026-09-09T08:00:00.000Z',
+    ...overrides,
+  }) as AgentMachineResponse
+
+describe('AgentPinControl', () => {
+  it('defaults an unpinned endpoint to tracking the server', () => {
+    renderWithProviders(
+      <AgentPinControl open agent={agent()} onSave={vi.fn()} onCancel={vi.fn()} />
+    )
+    expect(screen.getByText(/track server/i)).toBeInTheDocument()
+  })
+
+  it('saves a cleared pin as null rather than an empty string', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+    const target = agent({ desired_agent_version: '0.1.3', desired_borg_version: '2' })
+
+    renderWithProviders(<AgentPinControl open agent={target} onSave={onSave} onCancel={vi.fn()} />)
+    await user.click(screen.getByRole('combobox', { name: /agent version/i }))
+    await user.click(await screen.findByRole('option', { name: /track server/i }))
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    expect(onSave).toHaveBeenCalledWith(target, {
+      desired_agent_version: null,
+      desired_borg_version: '2',
+    })
+  })
+
+  it('saves the served version as the pin', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+    const target = agent()
+
+    renderWithProviders(<AgentPinControl open agent={target} onSave={onSave} onCancel={vi.fn()} />)
+    await user.click(screen.getByRole('combobox', { name: /agent version/i }))
+    await user.click(await screen.findByRole('option', { name: '0.1.3' }))
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    expect(onSave).toHaveBeenCalledWith(target, {
+      desired_agent_version: '0.1.3',
+      desired_borg_version: null,
+    })
+  })
+})

--- a/frontend/src/pages/managed-agents/__tests__/AgentPinControl.test.tsx
+++ b/frontend/src/pages/managed-agents/__tests__/AgentPinControl.test.tsx
@@ -55,4 +55,17 @@ describe('AgentPinControl', () => {
       desired_borg_version: null,
     })
   })
+
+  it('shows a pin this server no longer serves and refuses to re-save it', () => {
+    renderWithProviders(
+      <AgentPinControl
+        open
+        agent={agent({ desired_agent_version: '0.1.1' })}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/0\.1\.1 \(no longer served\)/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled()
+  })
 })

--- a/frontend/src/pages/managed-agents/__tests__/AgentUpgradeDialog.test.tsx
+++ b/frontend/src/pages/managed-agents/__tests__/AgentUpgradeDialog.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, screen } from '@testing-library/react'
+import { renderWithProviders } from '../../../test/test-utils'
+import AgentUpgradeDialog from '../AgentUpgradeDialog'
+import type { AgentMachineResponse } from '../../../services/api'
+
+const agent = (overrides: Partial<AgentMachineResponse> = {}): AgentMachineResponse =>
+  ({
+    id: 1,
+    agent_id: 'agt_1',
+    name: 'db-01',
+    hostname: 'db-01.internal',
+    status: 'online',
+    agent_version: '0.1.2',
+    available_agent_version: '0.1.3',
+    created_at: '2026-05-10T08:00:00.000Z',
+    updated_at: '2026-09-09T08:00:00.000Z',
+    ...overrides,
+  }) as AgentMachineResponse
+
+describe('AgentUpgradeDialog', () => {
+  it('names the endpoint and the version it will come back on', () => {
+    renderWithProviders(
+      <AgentUpgradeDialog open agent={agent()} onConfirm={vi.fn()} onCancel={vi.fn()} />
+    )
+    expect(screen.getByText(/db-01\.internal/)).toBeInTheDocument()
+    expect(screen.getByText(/0\.1\.3/)).toBeInTheDocument()
+  })
+
+  it('names the pinned version rather than the served one', () => {
+    renderWithProviders(
+      <AgentUpgradeDialog
+        open
+        agent={agent({ desired_agent_version: '0.1.1' })}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/0\.1\.1/)).toBeInTheDocument()
+  })
+
+  it('confirms with the agent', () => {
+    const onConfirm = vi.fn()
+    const target = agent()
+    renderWithProviders(
+      <AgentUpgradeDialog open agent={target} onConfirm={onConfirm} onCancel={vi.fn()} />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /upgrade/i }))
+    expect(onConfirm).toHaveBeenCalledWith(target)
+  })
+
+  it('does not confirm while a request is in flight', () => {
+    const onConfirm = vi.fn()
+    renderWithProviders(
+      <AgentUpgradeDialog open busy agent={agent()} onConfirm={onConfirm} onCancel={vi.fn()} />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /upgrade/i }))
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/managed-agents/__tests__/AgentUpgradeStateChip.test.tsx
+++ b/frontend/src/pages/managed-agents/__tests__/AgentUpgradeStateChip.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '../../../test/test-utils'
+import AgentUpgradeStateChip from '../AgentUpgradeStateChip'
+
+describe('AgentUpgradeStateChip', () => {
+  it('names the target while an upgrade is in flight', () => {
+    renderWithProviders(<AgentUpgradeStateChip state="requested" targetVersion="0.1.3" />)
+    expect(screen.getByText(/0\.1\.3/)).toBeInTheDocument()
+  })
+
+  it('renders a failure state', () => {
+    renderWithProviders(<AgentUpgradeStateChip state="failed" error="did not come back" />)
+    expect(screen.getByText(/failed/i)).toBeInTheDocument()
+  })
+
+  it('renders nothing when the endpoint is idle', () => {
+    renderWithProviders(<AgentUpgradeStateChip state="idle" />)
+    expect(screen.queryByText(/upgrad/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1211,6 +1211,21 @@ export interface AgentMachineResponse {
   updated_at: string
 }
 
+export interface AgentUpgradeResult {
+  agent_machine_id: number
+  job_id: number | null
+  state: string
+}
+
+export interface AgentUpgradeResponse {
+  results: AgentUpgradeResult[]
+}
+
+export interface AgentDesiredVersionRequest {
+  desired_agent_version: string | null
+  desired_borg_version: '1' | '2' | null
+}
+
 export interface AgentEnrollmentTokenSummary {
   id: number
   name: string
@@ -1395,6 +1410,12 @@ export const managedAgentsAPI = {
     ),
   listAgentScripts: (agentId: number) =>
     api.get<AgentScriptsResponse>(`/managed-machines/agents/${agentId}/scripts`),
+  upgradeAgents: (agentIds: number[]) =>
+    api.post<AgentUpgradeResponse>('/managed-machines/agents/upgrade', {
+      agent_machine_ids: agentIds,
+    }),
+  setDesiredVersion: (agentId: number, data: AgentDesiredVersionRequest) =>
+    api.put<AgentMachineResponse>(`/managed-machines/agents/${agentId}/desired-version`, data),
 }
 
 // Schedule API

--- a/tests/unit/test_agent_upgrade_command.py
+++ b/tests/unit/test_agent_upgrade_command.py
@@ -17,13 +17,18 @@ from agent.borg_ui_agent.session import AgentSessionRuntime
 
 
 class _HttpClient:
-    """Terminal frames for a command with no job_id go over the socket, so this
-    only exists to satisfy the constructor."""
+    """Terminal frames for a command with no job_id go over the socket, so
+    agent.upgrade never reaches this. A persisted job does, which is how the
+    refusal of a job dispatched mid-upgrade is observed."""
+
+    def __init__(self):
+        self.failed = []
 
     def complete_job(self, job_id, *, result):
         return {"id": job_id, "status": "completed"}
 
     def fail_job(self, job_id, *, error_message, return_code=None):
+        self.failed.append((job_id, error_message))
         return {"id": job_id, "status": "failed"}
 
     def cancel_job(self, job_id):
@@ -38,11 +43,16 @@ def _drain(outbox):
 
 
 @pytest.fixture
-def runtime():
+def http_client():
+    return _HttpClient()
+
+
+@pytest.fixture
+def runtime(http_client):
     return AgentSessionRuntime(
         AgentConfig("https://borgui.example.com", "agt_123", "secret"),
         connect=lambda *args, **kwargs: None,
-        http_client=_HttpClient(),
+        http_client=http_client,
     )
 
 
@@ -50,9 +60,8 @@ def _run(runtime, monkeypatch, readiness, running_ids=()):
     monkeypatch.setattr(
         "agent.borg_ui_agent.session.check_self_upgrade", lambda: readiness
     )
-    monkeypatch.setattr(
-        AgentSessionRuntime, "_running_job_ids", lambda self: list(running_ids)
-    )
+    for job_id in running_ids:
+        runtime._register_cancel(job_id)
     outbox: "queue.Queue[str]" = queue.Queue()
     runtime._handle_command(
         outbox, {"command_id": "c1", "command": "agent.upgrade", "payload": {}}
@@ -122,3 +131,60 @@ def test_upgrade_is_not_registered_as_a_job_command():
         )
         is None
     )
+
+
+def test_a_job_dispatched_after_the_claim_is_refused(
+    runtime, http_client, tmp_path, monkeypatch
+):
+    """The busy check is a claim, not a sample. A job arriving between it and
+    the restart would be orphaned by the restart, so it is refused instead."""
+    trigger = tmp_path / "upgrade-requested"
+    frames = _run(
+        runtime, monkeypatch, UpgradeReadiness(supported=True, trigger=trigger)
+    )
+    assert [f for f in frames if f["type"] == "command_result"]
+
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.get_job_handler",
+        lambda command: lambda job, client, should_cancel=None: None,
+    )
+    outbox: "queue.Queue[str]" = queue.Queue()
+    runtime._handle_command(
+        outbox,
+        {
+            "command_id": "c2",
+            "command": "backup.create",
+            "job_id": 42,
+            "payload": {},
+        },
+    )
+
+    # A persisted job reports its outcome over the job API, not the socket.
+    assert [f for f in _drain(outbox) if f["type"] == "command_error"] == []
+    assert http_client.failed == [(42, "Agent is upgrading and cannot start new jobs")]
+
+
+def test_a_failed_upgrade_releases_the_claim(runtime, monkeypatch):
+    """A claim held after an upgrade that never started would lock the endpoint
+    out of running jobs until it was restarted by hand."""
+    _run(
+        runtime,
+        monkeypatch,
+        UpgradeReadiness(supported=False, reason="unit_missing"),
+    )
+
+    assert runtime._reserve_for_upgrade() == []
+
+
+def test_a_second_upgrade_request_is_refused_while_one_is_claimed(
+    runtime, tmp_path, monkeypatch
+):
+    trigger = tmp_path / "upgrade-requested"
+    _run(runtime, monkeypatch, UpgradeReadiness(supported=True, trigger=trigger))
+
+    frames = _run(
+        runtime, monkeypatch, UpgradeReadiness(supported=True, trigger=trigger)
+    )
+
+    errors = [f for f in frames if f["type"] == "command_error"]
+    assert errors[0]["error"]["code"] == "upgrade_busy"

--- a/tests/unit/test_agent_upgrade_command.py
+++ b/tests/unit/test_agent_upgrade_command.py
@@ -7,13 +7,14 @@ reported, because the endpoint may have been changed since.
 
 import json
 import queue
+import time
 from pathlib import Path
 
 import pytest
 
 from agent.borg_ui_agent.config import AgentConfig
 from agent.borg_ui_agent.self_upgrade import UpgradeReadiness
-from agent.borg_ui_agent.session import AgentSessionRuntime
+from agent.borg_ui_agent.session import UPGRADE_CLAIM_SECONDS, AgentSessionRuntime
 
 
 class _HttpClient:
@@ -188,3 +189,46 @@ def test_a_second_upgrade_request_is_refused_while_one_is_claimed(
 
     errors = [f for f in frames if f["type"] == "command_error"]
     assert errors[0]["error"]["code"] == "upgrade_busy"
+
+
+def test_a_refused_job_is_not_left_in_the_cancel_registry(
+    runtime, http_client, tmp_path, monkeypatch
+):
+    """The session loop registers the id before the worker starts, and the
+    refusal returns before the unregister in the handler's finally. Leaking it
+    would make hello report a job that is not running, permanently."""
+    trigger = tmp_path / "upgrade-requested"
+    _run(runtime, monkeypatch, UpgradeReadiness(supported=True, trigger=trigger))
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.get_job_handler",
+        lambda command: lambda job, client, should_cancel=None: None,
+    )
+    cancel_event = runtime._register_cancel(42)
+
+    runtime._handle_command(
+        queue.Queue(),
+        {"command_id": "c2", "command": "backup.create", "job_id": 42, "payload": {}},
+        cancel_event=cancel_event,
+    )
+
+    assert runtime._running_job_ids() == []
+
+
+def test_the_claim_expires_so_an_aborted_helper_cannot_wedge_the_agent(
+    runtime, tmp_path, monkeypatch
+):
+    """The helper aborts on a bad checksum or a non-https server with this
+    process still running. A claim without an expiry would leave the endpoint
+    refusing every job until someone restarted it by hand."""
+    trigger = tmp_path / "upgrade-requested"
+    _run(runtime, monkeypatch, UpgradeReadiness(supported=True, trigger=trigger))
+    assert runtime._upgrade_claimed()
+
+    # Captured first: patching time.monotonic with a lambda that calls it
+    # would recurse, since session.py holds the module, not the function.
+    expired_at = time.monotonic() + UPGRADE_CLAIM_SECONDS + 1
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.time.monotonic", lambda: expired_at
+    )
+
+    assert not runtime._upgrade_claimed()

--- a/tests/unit/test_agent_upgrade_command.py
+++ b/tests/unit/test_agent_upgrade_command.py
@@ -1,0 +1,124 @@
+"""The agent's side of a remote upgrade: create one empty file.
+
+The trigger is a systemd .path unit, so the agent needs no sudo and passes no
+arguments. It re-checks readiness rather than trusting the capability it last
+reported, because the endpoint may have been changed since.
+"""
+
+import json
+import queue
+from pathlib import Path
+
+import pytest
+
+from agent.borg_ui_agent.config import AgentConfig
+from agent.borg_ui_agent.self_upgrade import UpgradeReadiness
+from agent.borg_ui_agent.session import AgentSessionRuntime
+
+
+class _HttpClient:
+    """Terminal frames for a command with no job_id go over the socket, so this
+    only exists to satisfy the constructor."""
+
+    def complete_job(self, job_id, *, result):
+        return {"id": job_id, "status": "completed"}
+
+    def fail_job(self, job_id, *, error_message, return_code=None):
+        return {"id": job_id, "status": "failed"}
+
+    def cancel_job(self, job_id):
+        return {"id": job_id, "status": "canceled"}
+
+
+def _drain(outbox):
+    frames = []
+    while not outbox.empty():
+        frames.append(json.loads(outbox.get_nowait()))
+    return frames
+
+
+@pytest.fixture
+def runtime():
+    return AgentSessionRuntime(
+        AgentConfig("https://borgui.example.com", "agt_123", "secret"),
+        connect=lambda *args, **kwargs: None,
+        http_client=_HttpClient(),
+    )
+
+
+def _run(runtime, monkeypatch, readiness, running_ids=()):
+    monkeypatch.setattr(
+        "agent.borg_ui_agent.session.check_self_upgrade", lambda: readiness
+    )
+    monkeypatch.setattr(
+        AgentSessionRuntime, "_running_job_ids", lambda self: list(running_ids)
+    )
+    outbox: "queue.Queue[str]" = queue.Queue()
+    runtime._handle_command(
+        outbox, {"command_id": "c1", "command": "agent.upgrade", "payload": {}}
+    )
+    return _drain(outbox)
+
+
+def test_upgrade_creates_the_trigger_file(runtime, tmp_path: Path, monkeypatch):
+    trigger = tmp_path / "upgrade-requested"
+
+    frames = _run(
+        runtime, monkeypatch, UpgradeReadiness(supported=True, trigger=trigger)
+    )
+
+    assert trigger.is_file()
+    results = [f for f in frames if f["type"] == "command_result"]
+    assert results[0]["result"] == {"success": True, "trigger": str(trigger)}
+
+
+def test_upgrade_refuses_while_a_job_is_running(runtime, tmp_path: Path, monkeypatch):
+    trigger = tmp_path / "upgrade-requested"
+
+    frames = _run(
+        runtime,
+        monkeypatch,
+        UpgradeReadiness(supported=True, trigger=trigger),
+        running_ids=(7,),
+    )
+
+    assert not trigger.exists()
+    errors = [f for f in frames if f["type"] == "command_error"]
+    assert errors[0]["error"]["code"] == "upgrade_busy"
+
+
+@pytest.mark.parametrize(
+    "reason",
+    ["unit_missing", "helper_missing", "conf_missing", "path_unit_missing"],
+)
+def test_upgrade_refuses_when_unsupported(runtime, monkeypatch, reason):
+    frames = _run(
+        runtime, monkeypatch, UpgradeReadiness(supported=False, reason=reason)
+    )
+
+    errors = [f for f in frames if f["type"] == "command_error"]
+    assert errors[0]["error"]["code"] == "upgrade_unsupported"
+    assert reason in errors[0]["error"]["message"]
+
+
+def test_upgrade_reports_an_unwritable_trigger_rather_than_dying(
+    runtime, tmp_path: Path, monkeypatch
+):
+    trigger = tmp_path / "missing-dir" / "upgrade-requested"
+
+    frames = _run(
+        runtime, monkeypatch, UpgradeReadiness(supported=True, trigger=trigger)
+    )
+
+    errors = [f for f in frames if f["type"] == "command_error"]
+    assert errors[0]["error"]["code"] == "upgrade_failed"
+
+
+def test_upgrade_is_not_registered_as_a_job_command():
+    """It carries no job_id, so registering it would leave a phantom in hello."""
+    assert (
+        AgentSessionRuntime._job_id_for_dispatch(
+            {"command": "agent.upgrade", "job_id": 5}
+        )
+        is None
+    )

--- a/tests/unit/test_agent_upgrade_reconciliation.py
+++ b/tests/unit/test_agent_upgrade_reconciliation.py
@@ -83,3 +83,30 @@ def test_the_reaper_leaves_a_fresh_upgrade_alone(test_db):
 
     test_db.refresh(agent)
     assert agent.upgrade_state == "requested"
+
+
+def test_re_registering_on_the_target_version_clears_a_failed_upgrade(test_db):
+    """The acknowledgement can be lost to the restart it announces, and the
+    timeout is a guess, so the version the endpoint reports outranks both."""
+    agent = _requested(
+        test_db, reported="0.1.2", requested_at=datetime.now(timezone.utc)
+    )
+    agent.upgrade_state = "failed"
+    agent.upgrade_error = "The endpoint did not come back in time."
+    agent.agent_version = "0.1.3"
+
+    resolve_agent_upgrade(agent)
+
+    assert agent.upgrade_state == "idle"
+    assert agent.upgrade_error is None
+
+
+def test_a_failed_upgrade_on_the_old_version_stays_failed(test_db):
+    agent = _requested(
+        test_db, reported="0.1.2", requested_at=datetime.now(timezone.utc)
+    )
+    agent.upgrade_state = "failed"
+
+    resolve_agent_upgrade(agent)
+
+    assert agent.upgrade_state == "failed"

--- a/tests/unit/test_agent_upgrade_reconciliation.py
+++ b/tests/unit/test_agent_upgrade_reconciliation.py
@@ -1,0 +1,85 @@
+"""The agent is killed by the thing it is reporting on, so the server owns the
+outcome: success on re-entry with the target version, failure by timeout."""
+
+from datetime import datetime, timedelta, timezone
+
+from app.api.agents import resolve_agent_upgrade
+from app.core.security import get_password_hash
+from app.database.models import AgentMachine
+from app.services.agent_job_reaper import reap_stale_agent_upgrades
+
+
+def _requested(test_db, *, reported, requested_at):
+    agent = AgentMachine(
+        name="endpoint",
+        agent_id="agt_recon",
+        token_hash=get_password_hash("borgui_agent_secret"),
+        token_prefix="borgui_agent_secret"[:20],
+        status="online",
+        agent_version=reported,
+        upgrade_state="requested",
+        upgrade_requested_at=requested_at,
+        upgrade_target_version="0.1.3",
+    )
+    test_db.add(agent)
+    test_db.commit()
+    test_db.refresh(agent)
+    return agent
+
+
+def test_re_registering_on_the_target_version_clears_the_upgrade(test_db):
+    agent = _requested(
+        test_db, reported="0.1.2", requested_at=datetime.now(timezone.utc)
+    )
+    agent.agent_version = "0.1.3"
+
+    resolve_agent_upgrade(agent)
+
+    assert agent.upgrade_state == "idle"
+    assert agent.upgrade_error is None
+    assert agent.upgrade_requested_at is None
+
+
+def test_re_registering_on_the_old_version_leaves_it_requested(test_db):
+    agent = _requested(
+        test_db, reported="0.1.2", requested_at=datetime.now(timezone.utc)
+    )
+
+    resolve_agent_upgrade(agent)
+
+    # The reinstall may still be mid flight. Only the timeout resolves it.
+    assert agent.upgrade_state == "requested"
+
+
+def test_an_idle_agent_is_untouched(test_db):
+    agent = _requested(test_db, reported="0.1.3", requested_at=None)
+    agent.upgrade_state = None
+
+    resolve_agent_upgrade(agent)
+
+    assert agent.upgrade_state is None
+
+
+def test_the_reaper_fails_a_stale_upgrade(test_db):
+    agent = _requested(
+        test_db,
+        reported="0.1.2",
+        requested_at=datetime.now(timezone.utc) - timedelta(seconds=1200),
+    )
+
+    assert reap_stale_agent_upgrades(test_db) == 1
+
+    test_db.refresh(agent)
+    assert agent.upgrade_state == "failed"
+    assert agent.upgrade_error
+
+
+def test_the_reaper_leaves_a_fresh_upgrade_alone(test_db):
+    agent = _requested(
+        test_db, reported="0.1.2", requested_at=datetime.now(timezone.utc)
+    )
+
+    assert reap_stale_agent_upgrades(test_db) == 0
+
+    test_db.refresh(agent)
+    assert agent.upgrade_state == "requested"

--- a/tests/unit/test_agent_upgrade_reconciliation.py
+++ b/tests/unit/test_agent_upgrade_reconciliation.py
@@ -110,3 +110,28 @@ def test_a_failed_upgrade_on_the_old_version_stays_failed(test_db):
     resolve_agent_upgrade(agent)
 
     assert agent.upgrade_state == "failed"
+
+
+def test_the_reaper_loses_the_race_to_a_concurrent_success(test_db):
+    """The endpoint can re-register between the reaper's read and its write.
+    The conditional update makes the reaper lose that race rather than
+    overwrite a resolved upgrade with a failure."""
+    agent = _requested(
+        test_db,
+        reported="0.1.2",
+        requested_at=datetime.now(timezone.utc) - timedelta(seconds=1200),
+    )
+
+    # Simulate the concurrent re-register landing after the reaper's read: the
+    # row is already idle by the time the conditional update runs.
+    test_db.query(AgentMachine).filter(AgentMachine.id == agent.id).update(
+        {AgentMachine.upgrade_state: "idle"}, synchronize_session=False
+    )
+    test_db.commit()
+
+    assert reap_stale_agent_upgrades(test_db) == 0
+
+    test_db.expire_all()
+    refreshed = test_db.query(AgentMachine).filter(AgentMachine.id == agent.id).one()
+    assert refreshed.upgrade_state == "idle"
+    assert refreshed.upgrade_error is None

--- a/tests/unit/test_api_agent_upgrade.py
+++ b/tests/unit/test_api_agent_upgrade.py
@@ -1,0 +1,217 @@
+"""POST /managed-machines/agents/upgrade.
+
+Validation runs over the whole request before any job is created: a partial
+success that reports as a full one is the failure mode to avoid.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.security import get_password_hash
+from app.database.models import AgentJob, AgentMachine, LicensingState
+from app.services.agent_connection_manager import AgentConnectionUnavailable
+
+
+@pytest.fixture(autouse=True)
+def _enable_paid_managed_agent_features(test_db):
+    state = test_db.query(LicensingState).first()
+    if state is None:
+        state = LicensingState(instance_id="test-instance-agent-upgrade")
+        test_db.add(state)
+    state.plan = "pro"
+    state.status = "active"
+    test_db.commit()
+
+
+def _agent(test_db, **overrides):
+    values = {
+        "name": "endpoint",
+        "agent_id": "agt_upgrade",
+        "token_hash": get_password_hash("borgui_agent_secret"),
+        "token_prefix": "borgui_agent_secret"[:20],
+        "status": "online",
+        "agent_version": "0.1.2",
+        "capabilities": ["self_upgrade"],
+    }
+    values.update(overrides)
+    agent = AgentMachine(**values)
+    test_db.add(agent)
+    test_db.commit()
+    test_db.refresh(agent)
+    return agent
+
+
+@pytest.fixture
+def served_version(monkeypatch):
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_package_version", lambda: "0.1.3"
+    )
+
+
+@pytest.fixture
+def sent_commands(monkeypatch):
+    sent = []
+
+    async def fake_send_command(agent_id, **kwargs):
+        sent.append((agent_id, kwargs["command"]))
+        return {"success": True}
+
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_connection_manager.send_command",
+        fake_send_command,
+    )
+    return sent
+
+
+def test_upgrade_queues_a_job_and_marks_the_agent_requested(
+    test_client: TestClient, test_db, admin_headers, served_version, sent_commands
+):
+    agent = _agent(test_db)
+
+    response = test_client.post(
+        "/api/managed-machines/agents/upgrade",
+        json={"agent_machine_ids": [agent.id]},
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 200
+    result = response.json()["results"][0]
+    assert result["state"] == "requested"
+    job = test_db.query(AgentJob).filter(AgentJob.id == result["job_id"]).one()
+    assert job.job_type == "agent_upgrade"
+    assert job.status == "completed"
+    test_db.refresh(agent)
+    assert agent.upgrade_state == "requested"
+    assert agent.upgrade_target_version == "0.1.3"
+    assert agent.upgrade_requested_at is not None
+    assert sent_commands == [(agent.id, "agent.upgrade")]
+
+
+def test_upgrade_targets_a_pinned_version_over_the_served_one(
+    test_client: TestClient, test_db, admin_headers, served_version, sent_commands
+):
+    agent = _agent(test_db, desired_agent_version="0.1.1")
+
+    response = test_client.post(
+        "/api/managed-machines/agents/upgrade",
+        json={"agent_machine_ids": [agent.id]},
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 200
+    test_db.refresh(agent)
+    assert agent.upgrade_target_version == "0.1.1"
+
+
+def test_upgrade_rejects_the_whole_request_when_one_agent_is_unsupported(
+    test_client: TestClient, test_db, admin_headers, served_version
+):
+    ok = _agent(test_db, agent_id="agt_ok")
+    bad = _agent(test_db, agent_id="agt_bad", name="old", capabilities=["jobs.poll"])
+
+    response = test_client.post(
+        "/api/managed-machines/agents/upgrade",
+        json={"agent_machine_ids": [ok.id, bad.id]},
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"]["key"] == "backend.errors.agents.upgradeUnsupported"
+    )
+    assert test_db.query(AgentJob).count() == 0
+
+
+def test_upgrade_rejects_an_unpinned_agent_when_the_server_serves_no_wheel(
+    test_client: TestClient, test_db, admin_headers, monkeypatch
+):
+    monkeypatch.setattr("app.api.managed_machines.agent_package_version", lambda: None)
+    agent = _agent(test_db)
+
+    response = test_client.post(
+        "/api/managed-machines/agents/upgrade",
+        json={"agent_machine_ids": [agent.id]},
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"]["key"]
+        == "backend.errors.agents.upgradeTargetUnavailable"
+    )
+    assert test_db.query(AgentJob).count() == 0
+
+
+def test_upgrade_rejects_an_unknown_agent(
+    test_client: TestClient, test_db, admin_headers, served_version
+):
+    response = test_client.post(
+        "/api/managed-machines/agents/upgrade",
+        json={"agent_machine_ids": [4242]},
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 404
+    assert test_db.query(AgentJob).count() == 0
+
+
+def test_duplicate_ids_create_one_job(
+    test_client: TestClient, test_db, admin_headers, served_version, sent_commands
+):
+    agent = _agent(test_db)
+
+    response = test_client.post(
+        "/api/managed-machines/agents/upgrade",
+        json={"agent_machine_ids": [agent.id, agent.id]},
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 200
+    assert len(response.json()["results"]) == 1
+    assert test_db.query(AgentJob).count() == 1
+    assert sent_commands == [(agent.id, "agent.upgrade")]
+
+
+def test_a_second_request_returns_the_in_flight_upgrade(
+    test_client: TestClient, test_db, admin_headers, served_version, sent_commands
+):
+    agent = _agent(test_db)
+    body = {"agent_machine_ids": [agent.id]}
+
+    first = test_client.post(
+        "/api/managed-machines/agents/upgrade", json=body, headers=admin_headers
+    )
+    second = test_client.post(
+        "/api/managed-machines/agents/upgrade", json=body, headers=admin_headers
+    )
+
+    assert first.json()["results"][0]["job_id"] == second.json()["results"][0]["job_id"]
+    assert test_db.query(AgentJob).count() == 1
+    assert sent_commands == [(agent.id, "agent.upgrade")]
+
+
+def test_an_offline_agent_fails_its_job_and_reports_failed(
+    test_client: TestClient, test_db, admin_headers, served_version, monkeypatch
+):
+    async def fake_send_command(agent_id, **kwargs):
+        raise AgentConnectionUnavailable("offline")
+
+    monkeypatch.setattr(
+        "app.api.managed_machines.agent_connection_manager.send_command",
+        fake_send_command,
+    )
+    agent = _agent(test_db)
+
+    response = test_client.post(
+        "/api/managed-machines/agents/upgrade",
+        json={"agent_machine_ids": [agent.id]},
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["results"][0]["state"] == "failed"
+    test_db.refresh(agent)
+    assert agent.upgrade_state == "failed"
+    assert agent.upgrade_error
+    job = test_db.query(AgentJob).one()
+    assert job.status == "failed"

--- a/tests/unit/test_api_agent_upgrade.py
+++ b/tests/unit/test_api_agent_upgrade.py
@@ -87,10 +87,31 @@ def test_upgrade_queues_a_job_and_marks_the_agent_requested(
     assert sent_commands == [(agent.id, "agent.upgrade")]
 
 
+def test_upgrade_rejects_a_pin_this_server_can_no_longer_serve(
+    test_client: TestClient, test_db, admin_headers, served_version
+):
+    """A pin outlives a server upgrade, and the installer can only install what
+    this server serves, so the reinstall could never reach the pinned version."""
+    agent = _agent(test_db, desired_agent_version="0.1.1")
+
+    response = test_client.post(
+        "/api/managed-machines/agents/upgrade",
+        json={"agent_machine_ids": [agent.id]},
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"]["key"]
+        == "backend.errors.agents.upgradeTargetUnavailable"
+    )
+    assert test_db.query(AgentJob).count() == 0
+
+
 def test_upgrade_targets_a_pinned_version_over_the_served_one(
     test_client: TestClient, test_db, admin_headers, served_version, sent_commands
 ):
-    agent = _agent(test_db, desired_agent_version="0.1.1")
+    agent = _agent(test_db, desired_agent_version="0.1.3")
 
     response = test_client.post(
         "/api/managed-machines/agents/upgrade",
@@ -100,7 +121,7 @@ def test_upgrade_targets_a_pinned_version_over_the_served_one(
 
     assert response.status_code == 200
     test_db.refresh(agent)
-    assert agent.upgrade_target_version == "0.1.1"
+    assert agent.upgrade_target_version == "0.1.3"
 
 
 def test_upgrade_rejects_the_whole_request_when_one_agent_is_unsupported(


### PR DESCRIPTION
Phase 3 of `docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md`. Phase 2 put the machinery on the endpoint; this pulls the trigger.

An operator clicks Upgrade on one agent row and that endpoint reinstalls itself. The agent is killed by the thing it is reporting on, so the server owns the outcome: success when the endpoint re-registers on its target version, failure by timeout.

Closes nothing on its own; the fleet half is phase 4.

## What is in it

- **`agent.upgrade` session command.** Refuses when a job is running or the endpoint is not actually upgradeable, then creates `/etc/borg-ui-agent/upgrade-requested`. That is the whole privilege: a systemd `.path` unit watches the file and starts the root helper, which takes no arguments. No sudo, which the agent unit's `NoNewPrivileges=true` would refuse anyway. Readiness is re-checked rather than trusted, since the endpoint may have changed since it reported capabilities.
- **`POST /api/managed-machines/agents/upgrade`.** Validates the whole request before creating anything, deduplicates ids, and claims each agent with a conditional write so two concurrent requests cannot both dispatch a restart. The `agent_upgrade` job is completed at "upgrade started": it records that the upgrade was requested, nothing more.
- **Reconciliation.** `resolve_agent_upgrade` clears the state when the endpoint comes back on its target version, on both the register and the session hello path. `reap_stale_agent_upgrades` in the existing job reaper marks a request stale after 10 minutes.
- **UI.** Upgrade action and confirmation dialog, an upgrading and a failed row chip, and the version pin control deferred from phase 1. An endpoint without the helper keeps the existing manual reinstall path.
- **Docs.** `docs/managed-agents.md` covers the flow, what to expect while it runs, and what the failed state means.

## Note on the spec

Section 7 still describes the agent running `sudo -n systemctl start ...`. That form was replaced during the phase 2 review by the `.path` unit (see the amendment box in section 6). The implementation follows the amendment; section 7 steps 1, 2 and 4 are current and step 3 is "create the trigger file".

## Deviation

The pin control is a dialog off a row action rather than an inline panel. The agent card has no detail area, and adding one would have been a card redesign.

## Review

CodeRabbit CLI, three passes: 6 findings, then 1, then 0.

Fixed:

- A pin that outlived a server upgrade was accepted and dispatched, restarting the endpoint into a reinstall that could never produce the target. Now rejected with `upgradeTargetUnavailable`.
- Concurrent requests could both dispatch a restart. Added the conditional claim described above; it stamps `upgrade_requested_at` with the claim, not the dispatch, so a server that dies mid-request still leaves something the reaper can resolve.
- A false "failed" could stick forever: the acknowledgement can be lost to the restart it announces, and the timeout is a guess. Re-entry on the target version now clears `failed` as well as `requested`.
- The pin control rendered blank for a version the server no longer serves, and saving would have silently moved the pin. It now shows the stale pin, disabled, with Save blocked while it is selected. Reopening the dialog resets edits.
- The plan document referenced a class that does not exist.

Dismissed, one: the agent's busy check is a snapshot, not a lock, so a job dispatched between the check and the restart is still orphaned. Closing that needs an upgrade-exclusive state blocking dispatch through shutdown, which is more machinery than the outcome earns. The reaper already fails an orphaned job, and the operator picked that moment to restart the endpoint. Reasoning is a comment in `session.py`.

## Verification

- `pytest tests/unit`: 3744 passed, 14 skipped.
- Frontend: 2602 passed across 226 files, oxlint, `tsc --noEmit`, prettier all clean.
- ruff check and ruff format clean.

New tests cover the session command (trigger created, busy, each unsupported reason, unwritable trigger), the endpoint (whole-request rejection, dedup, in-flight idempotency, unservable target, offline dispatch), reconciliation both ways plus the reaper, and the UI states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 0 changed, 16 added, 0 removed, 718 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-989/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/34379335276
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- `managed-agents-agentpincontrol--pinned--mobile.png`
- `managed-agents-agentpincontrol--pinned.png`
- `managed-agents-agentpincontrol--unpinned--mobile.png`
- `managed-agents-agentpincontrol--unpinned.png`
- `managed-agents-agentupgradedialog--busy--mobile.png`
- `managed-agents-agentupgradedialog--busy.png`
- `managed-agents-agentupgradedialog--confirm--mobile.png`
- `managed-agents-agentupgradedialog--confirm.png`
- `managed-agents-agentupgradedialog--pinned--mobile.png`
- `managed-agents-agentupgradedialog--pinned.png`
- `managed-agents-agentupgradestatechip--all-states--mobile.png`
- `managed-agents-agentupgradestatechip--all-states.png`
- `managed-agents-agentupgradestatechip--failed--mobile.png`
- `managed-agents-agentupgradestatechip--failed.png`
- `managed-agents-agentupgradestatechip--upgrading--mobile.png`
- `managed-agents-agentupgradestatechip--upgrading.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->