### PR TITLE
docs(agents): mark phase 3 done

### DIFF
--- a/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
+++ b/docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md
@@ -549,7 +549,7 @@ Agents update this table and nothing else as work advances. Statuses:
 | --- | --- | --- | --- | --- |
 | 1. Version model and visibility | done | `docs/engineering/plans/2026-09-07-agent-upgrades-phase-1.md` | `feat/agent-upgrades` | Pin UI moved to phase 3 |
 | 2. Privileged helper and capability | done | `docs/engineering/plans/2026-09-09-agent-upgrades-phase-2.md` | `feat/agent-upgrades-phase-2` | https is a precondition; opt-out uses a marker file; the trigger is a `.path` unit, not sudoers |
-| 3. Single-agent remote upgrade | in review | `docs/engineering/plans/2026-09-09-agent-upgrades-phase-3.md` | `feat/agent-upgrades-phase-3` | Trigger is the `.path` file, not section 7's sudoers argv; the pin control is a dialog off the row, the card has no detail area |
+| 3. Single-agent remote upgrade | done | `docs/engineering/plans/2026-09-09-agent-upgrades-phase-3.md` | `feat/agent-upgrades-phase-3` | Trigger is the `.path` file, not section 7's sudoers argv; the pin control is a dialog off the row, the card has no detail area; the agent holds an expiring upgrade claim so a helper that aborts cannot wedge it |
 | 4. Fleet upgrade | not started | | | |
 | 5. Per-endpoint Borg version | not started | | | |
 


### PR DESCRIPTION
Phase 3 merged in #989, so the progress table in `docs/engineering/specs/2026-09-07-centralized-agent-upgrades.md` moves from `in review` to `done`.

The notes column also records the last thing that changed during review: the agent holds an expiring claim while an upgrade is in flight, so a root helper that aborts (non-https server, checksum mismatch, config naming a different host) cannot leave the endpoint refusing jobs until someone restarts it by hand.

Phase 4 (fleet upgrade) is next and not started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)