### PR TITLE
feat(analytics): segment Umami visitors by plan

### DIFF
--- a/docs/trust.md
+++ b/docs/trust.md
@@ -129,7 +129,10 @@ Before anything is sent, your real hostname and URL are replaced with
 browser. The script tag is loaded with `referrerpolicy="no-referrer"` so the
 request that fetches it cannot carry the origin either. The identifier attached
 to a session is a hash of your install id and username, not the username
-itself. See `frontend/src/utils/analytics.ts` and [Analytics](analytics).
+itself. The session also carries your app version and your plan name
+(community, pro, or enterprise) so usage can be compared across plans. No
+licence key, customer, or other billing detail is sent. See
+`frontend/src/utils/analytics.ts` and [Analytics](analytics).
 
 Nothing else phones home. No crash reporting, no error telemetry, no update
 beacon.

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { hasConsentBeenGiven, loadUserPreference } from '../utils/analytics'
+import { hasConsentBeenGiven, loadUserPreference, setAnalyticsPlan } from '../utils/analytics'
 import AnalyticsConsentBanner from './AnalyticsConsentBanner'
 import AnnouncementModal from './AnnouncementModal'
 import AppHeader from './AppHeader'
 import AppSidebar from './AppSidebar'
 import { useAuth } from '../hooks/useAuth'
 import { useAnnouncementSurface } from '../hooks/useAnnouncementSurface'
+import { usePlan } from '../hooks/usePlan'
 import PasskeyEnrollmentPrompt from './PasskeyEnrollmentPrompt'
 import { useActiveBackendTarget } from '../services/remoteBackends/context'
 import {
@@ -34,6 +35,13 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   } = useAuth()
   const { announcement, acknowledgeAnnouncement, snoozeAnnouncement, trackAnnouncementCtaClick } =
     useAnnouncementSurface()
+  const { plan, isLoading: planLoading } = usePlan()
+
+  // Segment Umami visitors by plan. Skipped while loading so the 'community'
+  // fallback is never reported for a Pro or Enterprise install.
+  useEffect(() => {
+    if (!planLoading) setAnalyticsPlan(plan)
+  }, [plan, planLoading])
   const [mobileOpen, setMobileOpen] = useState(false)
   const [showConsentBanner, setShowConsentBanner] = useState(false)
   const [showPasskeyPrompt, setShowPasskeyPrompt] = useState(false)

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -38,9 +38,10 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   const { data: systemInfo } = useSystemInfo()
 
   // Segment Umami visitors by plan. Read straight from the query so a loading
-  // or failed system-info never reports a paid install as community.
+  // or failed system-info never reports a paid install as community, and so
+  // switching backend target (which clears the cache) drops the old plan.
   useEffect(() => {
-    if (systemInfo?.plan) setAnalyticsPlan(systemInfo.plan)
+    setAnalyticsPlan(systemInfo?.plan ?? null)
   }, [systemInfo?.plan])
   const [mobileOpen, setMobileOpen] = useState(false)
   const [showConsentBanner, setShowConsentBanner] = useState(false)

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -7,7 +7,7 @@ import AppHeader from './AppHeader'
 import AppSidebar from './AppSidebar'
 import { useAuth } from '../hooks/useAuth'
 import { useAnnouncementSurface } from '../hooks/useAnnouncementSurface'
-import { usePlan } from '../hooks/usePlan'
+import { useSystemInfo } from '../hooks/useSystemInfo'
 import PasskeyEnrollmentPrompt from './PasskeyEnrollmentPrompt'
 import { useActiveBackendTarget } from '../services/remoteBackends/context'
 import {
@@ -35,13 +35,13 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   } = useAuth()
   const { announcement, acknowledgeAnnouncement, snoozeAnnouncement, trackAnnouncementCtaClick } =
     useAnnouncementSurface()
-  const { plan, isLoading: planLoading } = usePlan()
+  const { data: systemInfo } = useSystemInfo()
 
-  // Segment Umami visitors by plan. Skipped while loading so the 'community'
-  // fallback is never reported for a Pro or Enterprise install.
+  // Segment Umami visitors by plan. Read straight from the query so a loading
+  // or failed system-info never reports a paid install as community.
   useEffect(() => {
-    if (!planLoading) setAnalyticsPlan(plan)
-  }, [plan, planLoading])
+    if (systemInfo?.plan) setAnalyticsPlan(systemInfo.plan)
+  }, [systemInfo?.plan])
   const [mobileOpen, setMobileOpen] = useState(false)
   const [showConsentBanner, setShowConsentBanner] = useState(false)
   const [showPasskeyPrompt, setShowPasskeyPrompt] = useState(false)

--- a/frontend/src/utils/__tests__/analytics.test.ts
+++ b/frontend/src/utils/__tests__/analytics.test.ts
@@ -242,7 +242,9 @@ describe('analytics (umami)', () => {
       expect(window.umami?.identify).toHaveBeenLastCalledWith(
         expect.objectContaining({ app_version: '1.2.3', plan: 'pro' })
       )
+
       setAnalyticsPlan(null)
+      expect(window.umami?.identify).toHaveBeenLastCalledWith({ app_version: '1.2.3' })
     })
 
     it('setUserId does not throw', () => {

--- a/frontend/src/utils/__tests__/analytics.test.ts
+++ b/frontend/src/utils/__tests__/analytics.test.ts
@@ -9,6 +9,7 @@ import {
   trackSiteSearch,
   setCustomDimension,
   setAppVersion,
+  setAnalyticsPlan,
   setUserId,
   resetUserId,
   trackOptOut,
@@ -233,6 +234,15 @@ describe('analytics (umami)', () => {
     it('setAppVersion identifies the current app version when umami is available', () => {
       expect(() => setAppVersion('1.2.3')).not.toThrow()
       expect(window.umami?.identify).toHaveBeenCalledWith({ app_version: '1.2.3' })
+    })
+
+    it('setAnalyticsPlan adds the plan to the identity payload', () => {
+      setAppVersion('1.2.3')
+      setAnalyticsPlan('pro')
+      expect(window.umami?.identify).toHaveBeenLastCalledWith(
+        expect.objectContaining({ app_version: '1.2.3', plan: 'pro' })
+      )
+      setAnalyticsPlan(null)
     })
 
     it('setUserId does not throw', () => {

--- a/frontend/src/utils/__tests__/analytics.test.ts
+++ b/frontend/src/utils/__tests__/analytics.test.ts
@@ -247,6 +247,13 @@ describe('analytics (umami)', () => {
       expect(window.umami?.identify).toHaveBeenLastCalledWith({ app_version: '1.2.3' })
     })
 
+    it('setAnalyticsPlan does not re-identify when the plan has not changed', () => {
+      setAnalyticsPlan(null)
+      const calls = window.umami?.identify?.mock.calls.length
+      setAnalyticsPlan(null)
+      expect(window.umami?.identify?.mock.calls.length).toBe(calls)
+    })
+
     it('setUserId does not throw', () => {
       expect(() => setUserId('user123')).not.toThrow()
     })

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -43,12 +43,14 @@ const withAppVersion = (data?: Record<string, unknown>): Record<string, unknown>
 }
 
 let currentUserId: string | null = null
+let currentPlan: string | null = null
 
 const identifySession = (): void => {
   if (!window.umami?.identify) return
   const data: Record<string, unknown> = {}
   if (currentUserId) data.user_id = currentUserId
   if (currentAppVersion) data.app_version = currentAppVersion
+  if (currentPlan) data.plan = currentPlan
   if (Object.keys(data).length) window.umami.identify(data)
 }
 
@@ -225,6 +227,15 @@ export const setCustomDimension = (_dimensionId: number, _value: string): void =
 
 export const setAppVersion = (version: string): void => {
   currentAppVersion = version || null
+  identifySession()
+}
+
+/**
+ * Set the effective subscription plan so Umami can segment visitors by plan.
+ * Only the plan name is sent, never licence keys or customer details.
+ */
+export const setAnalyticsPlan = (plan: string | null): void => {
+  currentPlan = plan || null
   identifySession()
 }
 

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -235,7 +235,11 @@ export const setAppVersion = (version: string): void => {
  * Only the plan name is sent, never licence keys or customer details.
  */
 export const setAnalyticsPlan = (plan: string | null): void => {
-  currentPlan = plan || null
+  const next = plan || null
+  // The plan starts unknown, so the first render would otherwise re-identify
+  // the session with nothing new to say.
+  if (next === currentPlan) return
+  currentPlan = next
   identifySession()
 }
 


### PR DESCRIPTION
Closes #880

Umami received an anonymous identity and app version, but not the plan, so DAU could not be compared across Community, Pro, and Enterprise. Feature-gate events carried `current_plan`, page views did not.

## Change

- `setAnalyticsPlan()` in `analytics.ts` adds a `plan` property to the Umami identity payload, alongside the existing `user_id` and `app_version`.
- `Layout` sets it from the existing `usePlan()` / `system-info` query, so it refreshes whenever an entitlement change invalidates that query (licence activation already does).
- Skipped while the query loads, so the `community` fallback is never reported for a paid install.
- Only the plan name is sent. No licence key, customer, or billing detail.
- `docs/trust.md` updated to say the session carries app version and plan name.

## Test

New case in `analytics.test.ts` asserting `identify` receives `{ app_version, plan }`. Existing analytics, UmamiTracker, and Layout suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- visual-regression:start -->
## Visual regression report
No visual changes detected: 0 changed, 0 added, 0 removed, 734 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-993/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/34439325403
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- None
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->