### PR TITLE
fix(sshfs): mount the SSHFS cache under /tmp so AppArmor allows it

### DIFF
--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -22,6 +22,7 @@ from app.services.notification_service import notification_service
 from app.services.script_executor import execute_script
 from app.services.script_library_executor import ScriptLibraryExecutor
 from app.services.mqtt_service import mqtt_service
+from app.services.mount_service import stable_sshfs_temp_root
 from app.services.operations.backup_facade import (
     refresh_backup_job,
     resolve_backup_job,
@@ -64,16 +65,6 @@ def _uses_remote_execution(job: BackupJob) -> bool:
     return (job.execution_mode or "").strip().lower() in REMOTE_EXECUTION_MODES or (
         job.route_strategy or ""
     ).strip().lower() == "remote_direct"
-
-
-def _stable_sshfs_temp_root(repository_id: int | None) -> str | None:
-    if repository_id is None:
-        return None
-    return os.path.join(
-        settings.data_dir,
-        "sshfs-cache",
-        f"repository-{repository_id}",
-    )
 
 
 class BackupService:
@@ -1897,7 +1888,7 @@ class BackupService:
                 source_paths,
                 job_id,
                 source_connection_id=effective_source_ssh_connection_id,
-                stable_sshfs_temp_root=_stable_sshfs_temp_root(
+                stable_sshfs_temp_root=stable_sshfs_temp_root(
                     repo_record.id if repo_record else None
                 ),
             )

--- a/app/services/mount_service.py
+++ b/app/services/mount_service.py
@@ -54,6 +54,33 @@ def stable_sshfs_temp_root(repository_id: int | None) -> str | None:
     return os.path.join(SSHFS_CACHE_BASE, f"repository-{repository_id}")
 
 
+def _ensure_sshfs_cache_root(temp_root: str) -> None:
+    """Create the SSHFS cache root, rejecting hijacked path components.
+
+    /tmp is world-writable, so a local user could otherwise pre-create
+    /tmp/borg-ui as a symlink and redirect the mount elsewhere (CWE-59).
+    A residual TOCTOU race remains for an attacker already running inside
+    the container; closing it needs an O_NOFOLLOW dirfd walk.
+    """
+    path = Path(temp_root)
+    base = Path(SSHFS_CACHE_BASE)
+    if base not in path.parents:
+        os.makedirs(temp_root, exist_ok=True)
+        return
+
+    for component in (base.parent, base, path):
+        if component.is_symlink():
+            raise Exception(
+                f"Refusing to use SSHFS cache path reached via symlink: {component}"
+            )
+        component.mkdir(mode=0o700, exist_ok=True)
+        component.chmod(0o700)
+        if component.stat().st_uid != os.geteuid():
+            raise Exception(
+                f"Refusing to use SSHFS cache path owned by another user: {component}"
+            )
+
+
 NO_FUSE_SUPPORT_MARKERS = (
     "no fuse support",
     "borg mount not available",
@@ -645,7 +672,7 @@ class MountService:
             if temp_root is None:
                 temp_root = tempfile.mkdtemp(prefix=f"sshfs_mount_{job_id or 'user'}_")
             else:
-                os.makedirs(temp_root, exist_ok=True)
+                _ensure_sshfs_cache_root(temp_root)
 
             logger.info(
                 "Mounting multiple SSH paths under shared temp root",

--- a/app/services/mount_service.py
+++ b/app/services/mount_service.py
@@ -39,6 +39,21 @@ from app.utils.ssh_utils import ssh_key_auth_args, sshfs_key_auth_options
 
 logger = structlog.get_logger()
 
+# Ubuntu 25.04+ ships an enforced AppArmor profile on the setuid fusermount3
+# binary that only permits FUSE mount targets under a handful of roots (/tmp/**/
+# among them). Mounting under DATA_DIR is denied there with "failed mntpnt match",
+# so the SSHFS cache lives under /tmp. The path stays stable per repository, which
+# is what the borg files cache needs (see #681).
+SSHFS_CACHE_BASE = "/tmp/borg-ui/sshfs-cache"
+
+
+def stable_sshfs_temp_root(repository_id: int | None) -> str | None:
+    """Per-repository SSHFS mount root, stable across runs."""
+    if repository_id is None:
+        return None
+    return os.path.join(SSHFS_CACHE_BASE, f"repository-{repository_id}")
+
+
 NO_FUSE_SUPPORT_MARKERS = (
     "no fuse support",
     "borg mount not available",
@@ -214,16 +229,21 @@ class MountService:
         try:
             import glob
 
-            # Find all legacy /tmp roots and repository-stable cache roots.
+            # Legacy /tmp roots, the current cache root, and the DATA_DIR root
+            # used before the move to /tmp (kept so upgrades leave nothing behind).
+            stable_cache_parents = [
+                Path(SSHFS_CACHE_BASE),
+                Path(settings.data_dir) / "sshfs-cache",
+            ]
             temp_dirs = list(
                 dict.fromkeys(
                     [
                         *glob.glob("/tmp/sshfs_mount_*"),
-                        *glob.glob(
-                            str(
-                                Path(settings.data_dir) / "sshfs-cache" / "repository-*"
-                            )
-                        ),
+                        *[
+                            path
+                            for parent in stable_cache_parents
+                            for path in glob.glob(str(parent / "repository-*"))
+                        ],
                     ]
                 )
             )
@@ -235,12 +255,11 @@ class MountService:
                     tracked_temp_roots.add(mount_info.temp_root)
 
             active_mount_points = self._get_active_mount_points()
-            stable_cache_parent = Path(settings.data_dir) / "sshfs-cache"
 
             def is_stable_cache_root(temp_dir: str) -> bool:
                 temp_path = Path(temp_dir)
                 return (
-                    temp_path.parent == stable_cache_parent
+                    temp_path.parent in stable_cache_parents
                     and temp_path.name.startswith("repository-")
                 )
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -396,6 +396,26 @@ container's privileges noticeably - Remote Direct Backups need neither. See
 [Mounting Archives](mounting) and
 [Remote Machines](ssh-keys#remote-source-backups).
 
+On Ubuntu 25.04 and newer, `apparmor:unconfined` on the container is not the
+whole story: the host ships an enforced AppArmor profile attached to the setuid
+`fusermount3` binary itself, which only permits FUSE mount targets under a few
+roots (`/tmp`, `/mnt`, `/media`, the user's home). Borg UI mounts SSHFS sources
+under `/tmp/borg-ui/sshfs-cache/`, which is allowed. If you mount archives or
+SSHFS sources somewhere else and see
+`fusermount3: mount failed: Permission denied` with
+`apparmor="DENIED" ... info="failed mntpnt match"` in the host's kernel log, add
+a drop-in for your path instead of editing the shipped profile:
+
+```
+# /etc/apparmor.d/local/fusermount3
+mount fstype={fuse,fuse.*} options=(nosuid,nodev) options in (ro,rw,noatime,dirsync,nodiratime,noexec,sync) -> /your/mount/base/**/,
+umount /your/mount/base/**/,
+```
+
+Then reload it with `sudo apparmor_parser -r /etc/apparmor.d/fusermount3`. The
+drop-in survives package updates. `sudo aa-complain fusermount3` is the quicker
+alternative, at the cost of dropping enforcement for all FUSE mounts.
+
 ## Docker Run
 
 For a quick test:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -406,7 +406,7 @@ SSHFS sources somewhere else and see
 `apparmor="DENIED" ... info="failed mntpnt match"` in the host's kernel log, add
 a drop-in for your path instead of editing the shipped profile:
 
-```
+```text
 # /etc/apparmor.d/local/fusermount3
 mount fstype={fuse,fuse.*} options=(nosuid,nodev) options in (ro,rw,noatime,dirsync,nodiratime,noexec,sync) -> /your/mount/base/**/,
 umount /your/mount/base/**/,

--- a/docs/mounting.md
+++ b/docs/mounting.md
@@ -83,6 +83,15 @@ Mounts do not survive container restarts.
 
 FUSE is not available to the container. Check `/dev/fuse`, `SYS_ADMIN`, and AppArmor settings.
 
+### fusermount3: mount failed: Permission denied
+
+On Ubuntu 25.04 and newer, the host's own AppArmor profile for `fusermount3`
+restricts where FUSE filesystems may be mounted, and the container's
+`apparmor:unconfined` does not lift it. Confirm with
+`apparmor="DENIED" ... info="failed mntpnt match"` in `dmesg`, and see
+[Optional FUSE Access](installation#optional-fuse-access) for the host-side
+drop-in.
+
 ### Mount is busy
 
 Close shells, file browsers, or processes using the mounted path, then unmount again.

--- a/tests/unit/test_backup_service_mocks.py
+++ b/tests/unit/test_backup_service_mocks.py
@@ -299,7 +299,7 @@ async def test_execute_backup_passes_repository_stable_sshfs_root_to_source_prep
         port=22,
     )
     job = BackupJob(id=job_id, status="pending")
-    stable_root = "/tmp/borg-data/sshfs-cache/repository-7"
+    stable_root = "/tmp/borg-ui/sshfs-cache/repository-7"
 
     def query_side_effect(model):
         m = MagicMock()
@@ -1402,7 +1402,7 @@ async def test_execute_backup_resolves_grouped_source_locations(
     mock_process.returncode = 0
     mock_process.stdout = AsyncMock()
     mock_process.stdout.__aiter__.return_value = iter([])
-    stable_root = "/tmp/borg-data/sshfs-cache/repository-1"
+    stable_root = "/tmp/borg-ui/sshfs-cache/repository-1"
 
     with (
         patch("app.services.backup_service.SessionLocal", return_value=mock_db_session),

--- a/tests/unit/test_mount_service.py
+++ b/tests/unit/test_mount_service.py
@@ -8,7 +8,12 @@ import os
 from unittest.mock import Mock, patch, AsyncMock
 from datetime import datetime, timezone
 
-from app.services.mount_service import MountService, MountType, MountInfo
+from app.services.mount_service import (
+    MountService,
+    MountType,
+    MountInfo,
+    stable_sshfs_temp_root,
+)
 from app.database.models import SSHConnection, SSHKey, Repository
 
 
@@ -242,6 +247,34 @@ class TestMountService:
 
         assert not orphaned_root.exists()
         assert tracked_root.exists()
+
+    def test_stable_sshfs_temp_root_stays_under_tmp(self):
+        # Ubuntu 25.04+ AppArmor only allows FUSE mounts under /tmp/**/ and a few
+        # other roots; moving this off /tmp breaks SSHFS backups there (#760).
+        assert stable_sshfs_temp_root(3) == "/tmp/borg-ui/sshfs-cache/repository-3"
+        assert stable_sshfs_temp_root(None) is None
+
+    def test_cleanup_orphaned_temp_dirs_removes_roots_under_cache_base(
+        self, mount_service, tmp_path, monkeypatch
+    ):
+        cache_base = tmp_path / "borg-ui" / "sshfs-cache"
+        orphaned_root = cache_base / "repository-7"
+        orphaned_root.mkdir(parents=True)
+        monkeypatch.setattr(
+            "app.services.mount_service.SSHFS_CACHE_BASE", str(cache_base)
+        )
+
+        def glob_side_effect(pattern):
+            if pattern == "/tmp/sshfs_mount_*":
+                return []
+            if pattern.startswith(str(cache_base)):
+                return [str(orphaned_root)]
+            return []
+
+        with patch("glob.glob", side_effect=glob_side_effect):
+            mount_service._cleanup_orphaned_temp_dirs()
+
+        assert not orphaned_root.exists()
 
     def test_cleanup_orphaned_temp_dirs_preserves_mounted_stable_sshfs_cache_root(
         self, mount_service

--- a/tests/unit/test_mount_service.py
+++ b/tests/unit/test_mount_service.py
@@ -5,6 +5,7 @@ Unit tests for MountService
 import pytest
 import tempfile
 import os
+import stat
 from unittest.mock import Mock, patch, AsyncMock
 from datetime import datetime, timezone
 
@@ -13,6 +14,7 @@ from app.services.mount_service import (
     MountType,
     MountInfo,
     stable_sshfs_temp_root,
+    _ensure_sshfs_cache_root,
 )
 from app.database.models import SSHConnection, SSHKey, Repository
 
@@ -253,6 +255,37 @@ class TestMountService:
         # other roots; moving this off /tmp breaks SSHFS backups there (#760).
         assert stable_sshfs_temp_root(3) == "/tmp/borg-ui/sshfs-cache/repository-3"
         assert stable_sshfs_temp_root(None) is None
+
+    def test_ensure_sshfs_cache_root_rejects_symlinked_parent(
+        self, tmp_path, monkeypatch
+    ):
+        # /tmp is world-writable, so a hijacked parent must not be followed.
+        elsewhere = tmp_path / "attacker"
+        elsewhere.mkdir()
+        hijacked_parent = tmp_path / "borg-ui"
+        hijacked_parent.symlink_to(elsewhere)
+        cache_base = hijacked_parent / "sshfs-cache"
+        monkeypatch.setattr(
+            "app.services.mount_service.SSHFS_CACHE_BASE", str(cache_base)
+        )
+
+        with pytest.raises(Exception, match="symlink"):
+            _ensure_sshfs_cache_root(str(cache_base / "repository-3"))
+
+        assert not (elsewhere / "sshfs-cache").exists()
+
+    def test_ensure_sshfs_cache_root_creates_private_dirs(self, tmp_path, monkeypatch):
+        cache_base = tmp_path / "borg-ui" / "sshfs-cache"
+        monkeypatch.setattr(
+            "app.services.mount_service.SSHFS_CACHE_BASE", str(cache_base)
+        )
+        temp_root = cache_base / "repository-3"
+
+        _ensure_sshfs_cache_root(str(temp_root))
+
+        assert temp_root.is_dir()
+        assert stat.S_IMODE(temp_root.stat().st_mode) == 0o700
+        assert stat.S_IMODE(cache_base.parent.stat().st_mode) == 0o700
 
     def test_cleanup_orphaned_temp_dirs_removes_roots_under_cache_base(
         self, mount_service, tmp_path, monkeypatch


### PR DESCRIPTION
Fixes #760.

## Problem

Ubuntu 25.04+ ships an **enforced** AppArmor profile attached to the setuid `fusermount3` binary. It permits FUSE mount targets only under a handful of roots (`@{HOME}/**/`, `/mnt/`, `/media/`, `/tmp/**/`, `@{run}/user/@{uid}/**/`, ...). The container's `security_opt: apparmor:unconfined` does not lift it, because the profile follows the binary rather than the container.

#681 moved the SSHFS mount root from `/tmp/sshfs_mount_*` to `${DATA_DIR}/sshfs-cache/repository-N`. On those hosts every SSHFS backup now fails:

```
SSHFS mount failed: fusermount3: mount failed: Permission denied
apparmor="DENIED" operation="mount" profile="fusermount3" info="failed mntpnt match" name="/data/sshfs-cache/repository-3/..."
```

## Fix

#681 needed a path that is **stable per repository** (so the borg files cache keys match between runs), not one inside the data directory. So the default moves to `/tmp/borg-ui/sshfs-cache/repository-N`: still stable, and inside the profile's allowed patterns.

- `stable_sshfs_temp_root()` now lives in `mount_service` next to the constant, with the AppArmor reason in a comment.
- Orphan cleanup still sweeps the old `${DATA_DIR}/sshfs-cache/repository-*` root (and the legacy `/tmp/sshfs_mount_*` one), so upgrades leave nothing behind.
- Docs: the host-side `/etc/apparmor.d/local/fusermount3` drop-in, for anyone mounting archives or sources outside the allowed roots. That path is unavoidable there, and `aa-complain fusermount3` is noted as the blunter alternative.

Diagnosis credit to @ioanalytica in the issue thread.

## Tests

- New: `stable_sshfs_temp_root` stays under `/tmp` (regression guard on the AppArmor invariant), and orphan cleanup removes stale roots under the new base.
- Existing cleanup tests still cover the legacy `DATA_DIR` root.
- `pytest tests/unit -k "mount or backup or sshfs"` -> 601 passed, 8 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)