### PR TITLE
fix(ci): unhang the integration suite and fix the shard 4 unit failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,7 @@ jobs:
   backend-unit-coverage:
     name: Backend / Unit Tests (${{ matrix.shard }}/${{ matrix.total_shards }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -214,6 +215,9 @@ jobs:
   backend-api-integration:
     name: Backend / Integration Tests
     runs-on: ubuntu-latest
+    # Without a cap a hung test holds the runner for GitHub's six hour
+    # default; the suite finishes in a couple of minutes.
+    timeout-minutes: 20
 
     services:
       redis:

--- a/tests/integration/test_api_schedule_integration.py
+++ b/tests/integration/test_api_schedule_integration.py
@@ -13,8 +13,8 @@ import time
 import pytest
 from fastapi.testclient import TestClient
 from app.database.models import (
-    BackupJob,
     CompactJob,
+    Operation,
     PruneJob,
     Repository,
     ScheduledJob,
@@ -654,10 +654,14 @@ class TestMultiRepositorySchedules:
         matching_jobs = []
         while datetime.now() < deadline:
             test_db.expire_all()
+            # Phase 8: a scheduled backup is an operations row.
             matching_jobs = (
-                test_db.query(BackupJob)
-                .filter(BackupJob.scheduled_job_id == schedule_id)
-                .order_by(BackupJob.id.asc())
+                test_db.query(Operation)
+                .filter(
+                    Operation.kind == "backup",
+                    Operation.scheduled_job_id == schedule_id,
+                )
+                .order_by(Operation.id.asc())
                 .all()
             )
             if len(matching_jobs) == 2 and all(

--- a/tests/integration/test_backup_workflows_integration.py
+++ b/tests/integration/test_backup_workflows_integration.py
@@ -14,7 +14,13 @@ import pytest
 from sqlalchemy.orm import Session
 
 from app.api.schedule import execute_multi_repo_schedule
-from app.database.models import BackupJob, ScheduledJob, ScheduledJobRepository
+from tests.utils.operations import operations_runner_for
+from app.database.models import (
+    BackupJob,
+    Operation,
+    ScheduledJob,
+    ScheduledJobRepository,
+)
 from app.services.backup_service import backup_service
 from tests.utils.borg import (
     create_registered_local_repository,
@@ -160,14 +166,23 @@ class TestMultiRepoScheduledBackupIntegration:
                     "app.services.backup_service.mqtt_service.sync_state_with_db"
                 ):
                     with patch.dict("os.environ", borg_env, clear=False):
-                        await execute_multi_repo_schedule(schedule, test_db)
+                        # Phase 8: the schedule enqueues and waits for the
+                        # runner, so a direct call needs one bound to this
+                        # test's database.
+                        async with operations_runner_for(test_db):
+                            await execute_multi_repo_schedule(schedule, test_db)
 
         test_db.refresh(schedule)
 
+        # Phase 8: a scheduled backup is an operations row, not a backup_jobs
+        # row, so the schedule's children are read from `operations`.
         backup_jobs = (
-            test_db.query(BackupJob)
-            .filter(BackupJob.scheduled_job_id == schedule.id)
-            .order_by(BackupJob.id.asc())
+            test_db.query(Operation)
+            .filter(
+                Operation.kind == "backup",
+                Operation.scheduled_job_id == schedule.id,
+            )
+            .order_by(Operation.id.asc())
             .all()
         )
         assert len(backup_jobs) == 2

--- a/tests/integration/test_multi_repo_schedule.py
+++ b/tests/integration/test_multi_repo_schedule.py
@@ -8,6 +8,7 @@ from app.database.models import ScheduledJob, ScheduledJobRepository
 from app.api.schedule import execute_multi_repo_schedule
 from app.utils.archive_names import sanitize_archive_component
 from tests.utils.borg import create_registered_local_repository, run_borg
+from tests.utils.operations import operations_runner_for
 
 try:
     from .test_helpers import make_borg_env
@@ -74,7 +75,10 @@ async def test_multi_repo_schedule_execution_real(
     print("\n[TEST] Starting execution...")
     try:
         with patch.dict(os.environ, borg_env, clear=False):
-            await execute_multi_repo_schedule(job, db_session)
+            # Phase 8: the schedule enqueues and waits for the runner, so a
+            # direct call needs one bound to this test's database.
+            async with operations_runner_for(db_session, patch_session_local=True):
+                await execute_multi_repo_schedule(job, db_session)
     except Exception as e:
         print(f"\n[TEST] Execution failed with exception: {e}")
         # Failure here is expected if the bug is present (detached instance)

--- a/tests/integration/test_scheduled_borg_router_integration.py
+++ b/tests/integration/test_scheduled_borg_router_integration.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from app.api.schedule import execute_scheduled_backup_with_maintenance
-from app.database.models import BackupJob, Repository, ScheduledJob
+from app.database.models import Operation, Repository, ScheduledJob
 
 
 @pytest.mark.integration
@@ -39,28 +39,29 @@ async def test_scheduled_maintenance_dispatches_v2_repo_through_borg_router(db_s
     db_session.commit()
     db_session.refresh(schedule)
 
-    backup_job = BackupJob(
-        repository=repo.path,
-        status="pending",
+    # Phase 8: a scheduled backup is an operations row that the runner drives,
+    # and this test is about what happens after it succeeds, so the row starts
+    # out completed and the wait in the function under test returns at once.
+    backup_job = Operation(
+        repository_id=repo.id,
+        kind="backup",
+        category="backup",
+        status="completed",
+        trigger="schedule",
+        priority=5,
+        run_id="scheduled-run-1",
         scheduled_job_id=schedule.id,
+        params={"executor": "server"},
         created_at=datetime.now(timezone.utc),
+        completed_at=datetime.now(timezone.utc),
     )
     db_session.add(backup_job)
     db_session.commit()
     db_session.refresh(backup_job)
 
-    async def mark_backup_complete(job_id, repository_path, db, archive_name=None):
-        job = db.query(BackupJob).filter(BackupJob.id == job_id).first()
-        job.status = "completed"
-        db.commit()
-
     fake_router = SimpleNamespace(prune=AsyncMock(), compact=AsyncMock())
 
     with (
-        patch(
-            "app.services.backup_service.backup_service.execute_backup",
-            new=mark_backup_complete,
-        ),
         patch("app.api.schedule.BorgRouter", return_value=fake_router),
         patch("app.api.schedule.get_db", return_value=iter([db_session])),
     ):

--- a/tests/integration/test_scheduled_jobs_bugfixes.py
+++ b/tests/integration/test_scheduled_jobs_bugfixes.py
@@ -30,6 +30,7 @@ from app.database.models import (
     ScheduledJobRepository,
 )
 from app.api.schedule import execute_multi_repo_schedule
+from tests.utils.operations import operations_runner_for
 
 
 @pytest.mark.integration
@@ -243,7 +244,9 @@ class TestRepositoryInlineScripts:
                 new=AsyncMock(),
             ):
                 # Execute the schedule
-                await execute_multi_repo_schedule(schedule, db_session)
+                # Phase 8: the schedule enqueues and waits for the runner.
+                async with operations_runner_for(db_session, patch_session_local=True):
+                    await execute_multi_repo_schedule(schedule, db_session)
 
         # Verify: Inline script was executed
         assert script_executed, "Repository inline pre-script should have been executed"
@@ -320,7 +323,9 @@ class TestRepositoryInlineScripts:
                 "app.services.backup_service.BackupService.execute_backup",
                 new=mock_backup,
             ):
-                await execute_multi_repo_schedule(schedule, db_session)
+                # Phase 8: the schedule enqueues and waits for the runner.
+                async with operations_runner_for(db_session, patch_session_local=True):
+                    await execute_multi_repo_schedule(schedule, db_session)
 
         # Verify: Post-script was executed
         assert post_script_executed, (
@@ -428,7 +433,9 @@ class TestRepositoryLibraryScripts:
                 "app.services.backup_service.BackupService.execute_backup",
                 new=AsyncMock(),
             ):
-                await execute_multi_repo_schedule(schedule, db_session)
+                # Phase 8: the schedule enqueues and waits for the runner.
+                async with operations_runner_for(db_session, patch_session_local=True):
+                    await execute_multi_repo_schedule(schedule, db_session)
 
         # Verify: Library script was executed
         assert library_script_executed, (
@@ -512,7 +519,11 @@ class TestRepositoryLibraryScripts:
                     "app.services.backup_service.BackupService.execute_backup",
                     new=AsyncMock(),
                 ):
-                    await execute_multi_repo_schedule(schedule, db_session)
+                    # Phase 8: the schedule enqueues and waits for the runner.
+                    async with operations_runner_for(
+                        db_session, patch_session_local=True
+                    ):
+                        await execute_multi_repo_schedule(schedule, db_session)
 
         # Verify: Only library script executed, inline ignored
         assert library_executed, "Library script should have been executed"
@@ -609,7 +620,9 @@ class TestScheduleLevelScripts:
                 "app.services.backup_service.BackupService.execute_backup",
                 new=AsyncMock(),
             ):
-                await execute_multi_repo_schedule(schedule, db_session)
+                # Phase 8: the schedule enqueues and waits for the runner.
+                async with operations_runner_for(db_session, patch_session_local=True):
+                    await execute_multi_repo_schedule(schedule, db_session)
 
         # Verify: Schedule script executed exactly ONCE, not per repository
         assert schedule_script_count == 1, (
@@ -754,7 +767,9 @@ class TestCombinedScenarios:
                 "app.services.backup_service.BackupService.execute_backup",
                 new=mock_backup,
             ):
-                await execute_multi_repo_schedule(schedule, db_session)
+                # Phase 8: the schedule enqueues and waits for the runner.
+                async with operations_runner_for(db_session, patch_session_local=True):
+                    await execute_multi_repo_schedule(schedule, db_session)
 
         # Verify: Execution order is correct
         # Expected: Schedule Pre -> Repo Library Script -> Backup -> Schedule Post

--- a/tests/unit/test_api_backup.py
+++ b/tests/unit/test_api_backup.py
@@ -63,6 +63,33 @@ def _wait_for_agent_job(test_db, operation_id: int, timeout: float = 5.0):
     raise AssertionError(f"no agent job queued for operation {operation_id}")
 
 
+def _wait_for_followups(test_db, repository_id: int, timeout: float = 5.0):
+    """The spec 7.4 chain, once the runner has enqueued it.
+
+    For an agent backup the chain comes from the runner when the executor
+    returns from waiting on the transport job, not from the completion report
+    (which sees the operation still running and stands down), so a caller has
+    to wait for the executor to wake rather than read straight after the
+    report.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        test_db.expire_all()
+        followups = (
+            test_db.query(Operation)
+            .filter(
+                Operation.repository_id == repository_id,
+                Operation.trigger == "followup",
+            )
+            .order_by(Operation.id)
+            .all()
+        )
+        if followups:
+            return followups
+        time.sleep(0.05)
+    raise AssertionError(f"no follow-up chain enqueued for repository {repository_id}")
+
+
 def _set_log_save_policy(test_db, policy: str) -> None:
     settings = test_db.query(SystemSettings).first()
     if settings is None:
@@ -881,13 +908,8 @@ class TestBackupStart:
         # last_backup now comes from the archive index: completion enqueues
         # the backup follow-up chain instead of writing the column (#933).
         assert repo.last_backup is None
-        followups = (
-            test_db.query(Operation)
-            .filter(Operation.repository_id == repo.id, Operation.trigger == "followup")
-            .order_by(Operation.id)
-            .all()
-        )
-        assert followups and followups[0].kind == "archive_sync"
+        followups = _wait_for_followups(test_db, repo.id)
+        assert followups[0].kind == "archive_sync"
 
         logs_response = test_client.get(
             f"/api/activity/backup/{backup_job_id}/logs", headers=admin_headers

--- a/tests/utils/operations.py
+++ b/tests/utils/operations.py
@@ -1,0 +1,71 @@
+"""Run the operations runner against a test's own database.
+
+Since phase 8 the schedule and plan entry points enqueue an operation and
+wait for the runner to dispatch it, instead of running the backup inline. A
+test that calls one of those functions directly therefore needs a runner
+bound to the session it wrote the row through.
+
+`OperationRunner` resolves its sessions through `_session_factory` when one
+is set, which is what this helper uses. Without it the runner reads the
+process-wide database that `tests/conftest.py` creates empty, never sees the
+queued row, and the caller's wait never ends.
+"""
+
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+from sqlalchemy.orm import sessionmaker
+
+# The `SessionLocal` aliases the backup path opens its own sessions through.
+# The `test_db` fixture already patches these; a test on a bare `db_session`
+# does not, and the executor would otherwise run against the empty
+# process-wide database and log "Job not found".
+_SESSION_LOCAL_ALIASES = (
+    "app.database.database.SessionLocal",
+    "app.services.backup_service.SessionLocal",
+    "app.services.remote_backup_service.SessionLocal",
+    "app.services.operations.reconcile.SessionLocal",
+    "app.api.schedule.SessionLocal",
+)
+
+
+@asynccontextmanager
+async def operations_runner_for(session, *, patch_session_local: bool = False):
+    """A live runner dispatching the operations `session` can see.
+
+    Set `patch_session_local` for a test that does not use the `test_db`
+    fixture, so the services the executor calls open their sessions on this
+    database too.
+    """
+    from app.services.operations.executors import load_default_executors
+    from app.services.operations.runner import operation_runner
+
+    load_default_executors()
+    factory = sessionmaker(autocommit=False, autoflush=False, bind=session.get_bind())
+    previous_factory = operation_runner._session_factory
+    operation_runner._session_factory = factory
+    patches = (
+        [patch(alias, factory) for alias in _SESSION_LOCAL_ALIASES]
+        if patch_session_local
+        else []
+    )
+    for started in patches:
+        started.start()
+    task = asyncio.create_task(operation_runner.start())
+    try:
+        yield operation_runner
+    finally:
+        for started in patches:
+            started.stop()
+        operation_runner.stop()
+        try:
+            await asyncio.wait_for(operation_runner.drain(), timeout=30)
+        except (asyncio.TimeoutError, Exception):
+            pass
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+        operation_runner._session_factory = previous_factory


### PR DESCRIPTION
CI has been broken on `main` since the phase 8 merge (`6587efba`); `b1a86121` just before it was green. Two separate problems.

(The phase 8 progress-table update that was #992 merged separately while this was in progress, so this PR is now purely the CI fixes.)

## 1. `Backend / Integration Tests` hangs forever

Phase 8 changed the schedule entry points from running a backup inline to enqueueing an operation and waiting for the runner. Several integration tests call `execute_multi_repo_schedule` and `execute_scheduled_backup_with_maintenance` **directly**, so no runner is up to dispatch the row and `wait_for_backup_operation` polls forever. The job has no `timeout-minutes`, so it held a runner until GitHub's six hour default.

Measured: `test_backup_workflows_integration.py` is **2 passed in 4.11s** at `b1a86121` and never returns on current `main`.

Starting a runner alone would not have fixed it. The runner resolves sessions through `SessionLocal`, which `tests/conftest.py` points at a process-wide database it deliberately leaves empty, while these tests write through their own session. `tests/utils/operations.py` starts a runner bound to the test's own engine through the `_session_factory` hook the runner already exposes, and optionally patches the `SessionLocal` aliases for tests that do not use the `test_db` fixture.

Assertions on `backup_jobs` rows that phase 8 no longer writes now read `operations`.

Files fixed, all of which passed before phase 8:
- `test_backup_workflows_integration.py` (in the CI list, was hanging)
- `test_multi_repo_schedule.py` (in the CI list)
- `test_api_schedule_integration.py` (in the CI list, was failing on the legacy table)
- `test_scheduled_borg_router_integration.py` (not in the CI list, was failing)
- `test_scheduled_jobs_bugfixes.py` (not in the CI list, was hanging; 10 passed in 5s now)

`timeout-minutes` added to the integration job (20) and the unit shards (30) so a future hang fails fast instead of holding a runner.

## 2. `Backend / Unit Tests (4/4)` fails

`test_agent_completion_updates_linked_backup_job` reads the spec 7.4 follow-up chain straight after the agent's completion report. Since phase 8 the report stands down while the operation is still running, because the executor is waiting on the transport job and the runner enqueues the chain when it returns. The read raced the executor: green when the module runs alone, red on shard 4, which runs `test_api_auth.py` first. `_wait_for_followups` polls for it the way the file's existing `_wait_for_agent_job` polls for the transport job.

## Not changed, deliberately

`wait_for_backup_operation` is unbounded, which looked like a hazard for the `/api/v2/backups` route. It is not a regression: before phase 8 all three call sites `await backup_service.execute_backup(...)` inline, which is equally unbounded, and a real backup legitimately runs for hours. Phase 8 actually improved that route by adding an admission check that answers 409 instead of blocking behind a wipe.

## Verification

- Integration, exactly the CI file list: 82 passed, 14 skipped, 2:20, no hang. The one failure, `test_create_repository_invalid_path`, is a pre-existing macOS-only `/root` permission case that fails at `b1a86121` too.
- `pytest tests/unit/test_api_auth.py tests/unit/test_api_backup.py`: 171 passed, run three times
- Full unit suite on this work: 3722 passed, 14 skipped, 0 failed
- ruff check and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vAyieGLZxL1NCZy3xpBgT