### PR TITLE
test(backup): wait for the follow-up chain after agent completion

### DIFF
--- a/tests/unit/test_api_backup.py
+++ b/tests/unit/test_api_backup.py
@@ -63,6 +63,34 @@ def _wait_for_agent_job(test_db, operation_id: int, timeout: float = 5.0):
     raise AssertionError(f"no agent job queued for operation {operation_id}")
 
 
+def _wait_for_followups(test_db, repository_id: int, timeout: float = 5.0):
+    """The follow-up chain of a runner-driven backup.
+
+    The runner commits the operation's terminal status before it enqueues the
+    chain, so a completion observed from the request thread can briefly
+    precede the follow-ups.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        test_db.expire_all()
+        rows = (
+            test_db.query(Operation)
+            .filter(
+                Operation.repository_id == repository_id,
+                Operation.trigger == "followup",
+            )
+            .order_by(Operation.id)
+            .all()
+        )
+        if rows:
+            return rows
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                f"no follow-ups enqueued for repository {repository_id}"
+            )
+        time.sleep(0.05)
+
+
 def _set_log_save_policy(test_db, policy: str) -> None:
     settings = test_db.query(SystemSettings).first()
     if settings is None:
@@ -869,6 +897,8 @@ class TestBackupStart:
             == 200
         )
 
+        followups = _wait_for_followups(test_db, repo.id)
+
         test_db.expire_all()
         backup_job = BackupJobFacade(test_db, test_db.get(Operation, backup_job_id))
         test_db.refresh(repo)
@@ -881,13 +911,7 @@ class TestBackupStart:
         # last_backup now comes from the archive index: completion enqueues
         # the backup follow-up chain instead of writing the column (#933).
         assert repo.last_backup is None
-        followups = (
-            test_db.query(Operation)
-            .filter(Operation.repository_id == repo.id, Operation.trigger == "followup")
-            .order_by(Operation.id)
-            .all()
-        )
-        assert followups and followups[0].kind == "archive_sync"
+        assert followups[0].kind == "archive_sync"
 
         logs_response = test_client.get(
             f"/api/activity/backup/{backup_job_id}/logs", headers=admin_headers


### PR DESCRIPTION
`Backend / Unit Tests (4/4)` has been failing on main since phase 8 (#988):

```
FAILED tests/unit/test_api_backup.py::TestBackupStart::test_agent_completion_updates_linked_backup_job - assert ([])
```

## Cause

A backup now runs through the operations runner, so agent completion returns early (`app/api/agents.py`, operation still in `running_tasks`) and the runner owns the follow-up chain. On the success path the runner commits the terminal status, awaits the broadcast, and only then enqueues the chain, so the request thread can observe a completed backup a beat before `archive_sync` exists.

The test asserted on the first read after `/complete`. Locally it wins the race, on the CI runner it loses it every time.

## Change

Poll for the follow-ups, the same way the test already polls for the agent job with `_wait_for_agent_job`. No product change.

## Test

`pytest tests/unit/test_api_backup.py` — 67 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)