### PR TITLE
feat(backup-plans): skip a repository inside a plan without removing it

### DIFF
--- a/app/api/backup_plans.py
+++ b/app/api/backup_plans.py
@@ -1131,7 +1131,7 @@ def _validate_payload(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={"key": "backend.errors.backupPlans.sourceRequired"},
         )
-    if not payload.repositories:
+    if not any(link.enabled for link in payload.repositories):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={"key": "backend.errors.backupPlans.repositoriesRequired"},

--- a/app/api/backup_plans.py
+++ b/app/api/backup_plans.py
@@ -1854,6 +1854,40 @@ async def toggle_backup_plan_repository(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={"key": "backend.errors.backupPlans.repositoriesRequired"},
         )
+    if not link.enabled:
+        # Resuming must pass the same checks as attaching an enabled link on save.
+        repo = link.repository
+        if repo is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"key": "backend.errors.backupPlans.repositoryNotFound"},
+            )
+        if repo.mode == "observe":
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={"key": "backend.errors.backupPlans.observeRepositorySelected"},
+            )
+        source_locations = decode_source_locations(
+            plan.source_locations,
+            source_type=plan.source_type,
+            source_ssh_connection_id=plan.source_ssh_connection_id,
+            source_directories=_decode_json_list(plan.source_directories),
+        )
+        route = plan_repository_route(repo, source_locations)
+        if not route.supported:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={"key": route.reason_key, "params": route.display_params},
+            )
+        require_backup_plan_feature_access(
+            db,
+            enabled_repository_count=sum(
+                1 for item in plan.repositories if item.enabled
+            )
+            + 1,
+            repository_run_mode=plan.repository_run_mode,
+            source_locations=source_locations,
+        )
 
     link.enabled = not link.enabled
     plan.updated_at = datetime.utcnow()

--- a/app/api/backup_plans.py
+++ b/app/api/backup_plans.py
@@ -640,6 +640,10 @@ def _serialize_plan(plan: BackupPlan, *, detail: bool = False) -> dict[str, Any]
         "last_run": serialize_datetime(plan.last_run),
         "next_run": serialize_datetime(plan.next_run),
         "repository_count": len(enabled_links),
+        "repositories": [
+            _serialize_repository_link(link)
+            for link in sorted(plan.repositories, key=lambda item: item.execution_order)
+        ],
         "created_at": serialize_datetime(plan.created_at),
         "updated_at": serialize_datetime(plan.updated_at),
     }
@@ -663,9 +667,6 @@ def _serialize_plan(plan: BackupPlan, *, detail: bool = False) -> dict[str, Any]
                 "prune_keep_quarterly": plan.prune_keep_quarterly,
                 "prune_keep_yearly": plan.prune_keep_yearly,
                 "prune_keep_within": plan.prune_keep_within,
-                "repositories": [
-                    _serialize_repository_link(link) for link in plan.repositories
-                ],
             }
         )
     return payload
@@ -1821,6 +1822,48 @@ async def toggle_backup_plan(
         "Backup plan toggled",
         backup_plan_id=plan.id,
         enabled=plan.enabled,
+        user=current_user.username,
+    )
+    return _serialize_plan(plan, detail=True)
+
+
+@router.post("/{plan_id}/repositories/{repository_id}/toggle")
+async def toggle_backup_plan_repository(
+    plan_id: int,
+    repository_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Skip or resume one repository inside a plan without touching its config."""
+    plan = _load_plan_or_404(db, plan_id)
+    _require_plan_operator_access(db, current_user, plan)
+
+    link = next(
+        (item for item in plan.repositories if item.repository_id == repository_id),
+        None,
+    )
+    if link is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"key": "backend.errors.backupPlans.repositoryNotFound"},
+        )
+    if link.enabled and not any(
+        item.enabled for item in plan.repositories if item.id != link.id
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"key": "backend.errors.backupPlans.repositoriesRequired"},
+        )
+
+    link.enabled = not link.enabled
+    plan.updated_at = datetime.utcnow()
+    db.commit()
+    plan = _load_plan_or_404(db, plan_id)
+    logger.info(
+        "Backup plan repository toggled",
+        backup_plan_id=plan.id,
+        repository_id=repository_id,
+        enabled=link.enabled,
         user=current_user.username,
     )
     return _serialize_plan(plan, detail=True)

--- a/frontend/src/components/MultiRepositorySelector.stories.tsx
+++ b/frontend/src/components/MultiRepositorySelector.stories.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box } from '@mui/material'
+import MultiRepositorySelector from './MultiRepositorySelector'
+import type { Repository } from '../types'
+
+const repositories = [
+  { id: 1, name: 'NAS', path: '/mnt/nas/borg', borg_version: 1, mode: 'full' },
+  { id: 2, name: 'rsync.net', path: 'ssh://rsync.net/borg', borg_version: 1, mode: 'full' },
+  { id: 3, name: 'USB Drive', path: '/Volumes/usb/borg', borg_version: 2, mode: 'full' },
+] as Repository[]
+
+function SkipToggleSelector() {
+  const [ids, setIds] = useState([1, 2, 3])
+  const [disabledIds, setDisabledIds] = useState([2])
+  return (
+    <Box sx={{ p: 3, maxWidth: 640 }}>
+      <MultiRepositorySelector
+        repositories={repositories}
+        selectedIds={ids}
+        onChange={setIds}
+        allowReorder
+        disabledIds={disabledIds}
+        onToggleEnabled={(id) =>
+          setDisabledIds((prev) =>
+            prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id]
+          )
+        }
+        label="Repositories"
+        helperText="Select one or more repositories. Execution order is used in series mode."
+      />
+    </Box>
+  )
+}
+
+const meta = {
+  title: 'Components/MultiRepositorySelector',
+} satisfies Meta
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const SkipToggle: Story = {
+  render: () => <SkipToggleSelector />,
+}

--- a/frontend/src/components/MultiRepositorySelector.tsx
+++ b/frontend/src/components/MultiRepositorySelector.tsx
@@ -1,7 +1,16 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Autocomplete, TextField, Box, Typography, Stack, IconButton, Tooltip } from '@mui/material'
-import { ChevronUp, ChevronDown, X } from 'lucide-react'
+import {
+  Autocomplete,
+  TextField,
+  Box,
+  Typography,
+  Stack,
+  IconButton,
+  Tooltip,
+  Chip,
+} from '@mui/material'
+import { ChevronUp, ChevronDown, X, Pause, Play } from 'lucide-react'
 import { Repository } from '../types'
 import RepoMenuItem from './RepoMenuItem'
 import { getRepoCapabilities } from '../utils/repoCapabilities'
@@ -20,6 +29,9 @@ interface MultiRepositorySelectorProps {
   error?: boolean
   filterMode?: 'observe' | null // Exclude repositories with this mode
   getOptionDisabled?: (repo: Repository) => boolean
+  // Selected repositories that stay attached but are skipped during runs.
+  disabledIds?: number[]
+  onToggleEnabled?: (repoId: number) => void
 }
 
 /**
@@ -43,6 +55,8 @@ export const MultiRepositorySelector: React.FC<MultiRepositorySelectorProps> = (
   error = false,
   filterMode = null,
   getOptionDisabled,
+  disabledIds = [],
+  onToggleEnabled,
 }) => {
   const { t } = useTranslation()
   // Track whether user has interacted with the field
@@ -160,88 +174,129 @@ export const MultiRepositorySelector: React.FC<MultiRepositorySelectorProps> = (
               : t('multiRepositorySelector.selectedCount', { count: selectedRepos.length })}
           </Typography>
           <Stack spacing={1}>
-            {selectedRepos.map((repo, index) => (
-              <Box
-                key={repo.id}
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1,
-                  p: 1.5,
-                  border: 1,
-                  borderColor: 'divider',
-                  borderRadius: 1,
-                  bgcolor: 'background.paper',
-                  '&:hover': {
-                    bgcolor: 'action.hover',
-                  },
-                }}
-              >
-                {allowReorder && selectedRepos.length > 1 && (
-                  <Typography
-                    variant="body2"
-                    sx={{
-                      minWidth: 24,
-                      fontWeight: 600,
-                      color: 'text.secondary',
-                    }}
-                  >
-                    {index + 1}.
-                  </Typography>
-                )}
-
-                <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-                  <RepoMenuItem
-                    name={repo.name}
-                    path={repo.path}
-                    borgVersion={repo.borg_version}
-                    mode={repo.mode as 'full' | 'observe' | undefined}
-                    hasRunningMaintenance={repo.has_running_maintenance}
-                  />
-                </Box>
-
-                <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
+            {selectedRepos.map((repo, index) => {
+              const skipped = disabledIds.includes(repo.id)
+              return (
+                <Box
+                  key={repo.id}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    p: 1.5,
+                    border: 1,
+                    borderColor: 'divider',
+                    borderStyle: skipped ? 'dashed' : 'solid',
+                    borderRadius: 1,
+                    bgcolor: 'background.paper',
+                    opacity: skipped ? 0.6 : 1,
+                    transition: 'opacity 150ms ease',
+                    '&:hover': {
+                      bgcolor: 'action.hover',
+                    },
+                  }}
+                >
                   {allowReorder && selectedRepos.length > 1 && (
-                    <>
-                      <Tooltip title={t('multiRepositorySelector.moveUp')} arrow>
-                        <span>
-                          <IconButton
-                            size="small"
-                            disabled={index === 0 || disabled}
-                            onClick={() => handleMoveUp(index)}
-                          >
-                            <ChevronUp size={18} />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                      <Tooltip title={t('multiRepositorySelector.moveDown')} arrow>
-                        <span>
-                          <IconButton
-                            size="small"
-                            disabled={index === selectedRepos.length - 1 || disabled}
-                            onClick={() => handleMoveDown(index)}
-                          >
-                            <ChevronDown size={18} />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                    </>
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        minWidth: 24,
+                        fontWeight: 600,
+                        color: 'text.secondary',
+                      }}
+                    >
+                      {index + 1}.
+                    </Typography>
                   )}
-                  <Tooltip title={t('multiRepositorySelector.remove')} arrow>
-                    <span>
-                      <IconButton
+
+                  <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                    <RepoMenuItem
+                      name={repo.name}
+                      path={repo.path}
+                      borgVersion={repo.borg_version}
+                      mode={repo.mode as 'full' | 'observe' | undefined}
+                      hasRunningMaintenance={repo.has_running_maintenance}
+                    />
+                  </Box>
+
+                  <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
+                    {skipped && (
+                      <Chip
                         size="small"
-                        disabled={disabled}
-                        onClick={() => handleRemove(repo.id)}
-                        sx={{ color: 'error.main' }}
+                        label={t('multiRepositorySelector.skipped')}
+                        color="warning"
+                        variant="outlined"
+                        sx={{ height: 20, fontSize: '0.65rem', '& .MuiChip-label': { px: 0.75 } }}
+                      />
+                    )}
+                    {onToggleEnabled && (
+                      <Tooltip
+                        title={
+                          skipped
+                            ? t('multiRepositorySelector.resume')
+                            : t('multiRepositorySelector.skip')
+                        }
+                        arrow
                       >
-                        <X size={18} />
-                      </IconButton>
-                    </span>
-                  </Tooltip>
+                        <span>
+                          <IconButton
+                            size="small"
+                            disabled={disabled}
+                            onClick={() => onToggleEnabled(repo.id)}
+                            aria-label={
+                              skipped
+                                ? t('multiRepositorySelector.resume')
+                                : t('multiRepositorySelector.skip')
+                            }
+                            sx={{ color: skipped ? 'success.main' : 'text.secondary' }}
+                          >
+                            {skipped ? <Play size={16} /> : <Pause size={16} />}
+                          </IconButton>
+                        </span>
+                      </Tooltip>
+                    )}
+                    {allowReorder && selectedRepos.length > 1 && (
+                      <>
+                        <Tooltip title={t('multiRepositorySelector.moveUp')} arrow>
+                          <span>
+                            <IconButton
+                              size="small"
+                              disabled={index === 0 || disabled}
+                              onClick={() => handleMoveUp(index)}
+                            >
+                              <ChevronUp size={18} />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                        <Tooltip title={t('multiRepositorySelector.moveDown')} arrow>
+                          <span>
+                            <IconButton
+                              size="small"
+                              disabled={index === selectedRepos.length - 1 || disabled}
+                              onClick={() => handleMoveDown(index)}
+                            >
+                              <ChevronDown size={18} />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      </>
+                    )}
+                    <Tooltip title={t('multiRepositorySelector.remove')} arrow>
+                      <span>
+                        <IconButton
+                          size="small"
+                          disabled={disabled}
+                          onClick={() => handleRemove(repo.id)}
+                          sx={{ color: 'error.main' }}
+                        >
+                          <X size={18} />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  </Box>
                 </Box>
-              </Box>
-            ))}
+              )
+            })}
           </Stack>
         </Box>
       )}

--- a/frontend/src/components/MultiRepositorySelector.tsx
+++ b/frontend/src/components/MultiRepositorySelector.tsx
@@ -89,6 +89,8 @@ export const MultiRepositorySelector: React.FC<MultiRepositorySelectorProps> = (
     onChange(newIds)
   }
 
+  const enabledCount = selectedRepos.filter((repo) => !disabledIds.includes(repo.id)).length
+
   const handleRemove = (repoId: number) => {
     onChange(selectedIds.filter((id) => id !== repoId))
   }
@@ -176,6 +178,8 @@ export const MultiRepositorySelector: React.FC<MultiRepositorySelectorProps> = (
           <Stack spacing={1}>
             {selectedRepos.map((repo, index) => {
               const skipped = disabledIds.includes(repo.id)
+              // Mirrors the backend rule: a plan must keep one enabled repository.
+              const isLastEnabled = !skipped && enabledCount <= 1
               return (
                 <Box
                   key={repo.id}
@@ -234,14 +238,16 @@ export const MultiRepositorySelector: React.FC<MultiRepositorySelectorProps> = (
                         title={
                           skipped
                             ? t('multiRepositorySelector.resume')
-                            : t('multiRepositorySelector.skip')
+                            : isLastEnabled
+                              ? t('multiRepositorySelector.lastEnabled')
+                              : t('multiRepositorySelector.skip')
                         }
                         arrow
                       >
                         <span>
                           <IconButton
                             size="small"
-                            disabled={disabled}
+                            disabled={disabled || isLastEnabled}
                             onClick={() => onToggleEnabled(repo.id)}
                             aria-label={
                               skipped

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1411,7 +1411,11 @@
       "nextRun": "Nächster Lauf: {{date}}",
       "repositoryFallback": "Repository",
       "moreRepositories": "+{{count}} weitere",
-      "runningNow": "Läuft"
+      "runningNow": "Läuft",
+      "repositoryCountPartial": "{{enabled}} von {{total}} Repositories",
+      "skippedRepositoriesTooltip": "Bei Läufen übersprungen: {{names}}",
+      "skippedLabel": "Übersprungen",
+      "clickToResumeRepository": "Backups nach {{name}} fortsetzen"
     },
     "statuses": {
       "unknown": "Unbekannt",
@@ -1443,7 +1447,9 @@
       "repositoryCreateFailed": "Repository konnte nicht erstellt werden",
       "multiRepositoryRequiresPro": "Mehrere Repositories in einem Backup-Plan erfordern Pro",
       "selectSourceConnection": "Wähle einen Remote-Client aus, bevor du Quellpfade durchsuchst",
-      "scriptCreateFailed": "Failed to create generated script"
+      "scriptCreateFailed": "Failed to create generated script",
+      "repositoryToggled": "Repository aktualisiert",
+      "repositoryToggleFailed": "Repository konnte nicht aktualisiert werden"
     },
     "sourceChooser": {
       "summaryTitle": "Backup source",
@@ -4409,7 +4415,10 @@
     "moveUp": "Nach oben",
     "moveDown": "Nach unten",
     "remove": "Entfernen",
-    "searchOrAddMore": "Suchen oder weitere hinzufügen..."
+    "searchOrAddMore": "Suchen oder weitere hinzufügen...",
+    "skipped": "Übersprungen",
+    "skip": "Bei Läufen überspringen",
+    "resume": "Backups fortsetzen"
   },
   "wizard": {
     "steps": {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -4418,7 +4418,8 @@
     "searchOrAddMore": "Suchen oder weitere hinzufügen...",
     "skipped": "Übersprungen",
     "skip": "Bei Läufen überspringen",
-    "resume": "Backups fortsetzen"
+    "resume": "Backups fortsetzen",
+    "lastEnabled": "Mindestens ein Repository muss aktiviert bleiben"
   },
   "wizard": {
     "steps": {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1447,7 +1447,7 @@
       "repositoryCreateFailed": "Repository konnte nicht erstellt werden",
       "multiRepositoryRequiresPro": "Mehrere Repositories in einem Backup-Plan erfordern Pro",
       "selectSourceConnection": "Wähle einen Remote-Client aus, bevor du Quellpfade durchsuchst",
-      "scriptCreateFailed": "Failed to create generated script",
+      "scriptCreateFailed": "Generiertes Skript konnte nicht erstellt werden",
       "repositoryToggled": "Repository aktualisiert",
       "repositoryToggleFailed": "Repository konnte nicht aktualisiert werden"
     },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1411,7 +1411,11 @@
       "nextRun": "Next run: {{date}}",
       "repositoryFallback": "Repository",
       "moreRepositories": "+{{count}} more",
-      "runningNow": "Running"
+      "runningNow": "Running",
+      "repositoryCountPartial": "{{enabled}} of {{total}} repositories",
+      "skippedRepositoriesTooltip": "Skipped during runs: {{names}}",
+      "skippedLabel": "Skipped",
+      "clickToResumeRepository": "Resume backups to {{name}}"
     },
     "statuses": {
       "unknown": "Unknown",
@@ -1443,7 +1447,9 @@
       "repositoryCreateFailed": "Failed to create repository",
       "multiRepositoryRequiresPro": "Multiple repositories in one backup plan require Pro",
       "selectSourceConnection": "Select a remote client before browsing source paths",
-      "scriptCreateFailed": "Failed to create generated script"
+      "scriptCreateFailed": "Failed to create generated script",
+      "repositoryToggled": "Repository updated",
+      "repositoryToggleFailed": "Failed to update repository"
     },
     "sourceChooser": {
       "summaryTitle": "Backup source",
@@ -4409,7 +4415,10 @@
     "moveUp": "Move up",
     "moveDown": "Move down",
     "remove": "Remove",
-    "searchOrAddMore": "Search or add more..."
+    "searchOrAddMore": "Search or add more...",
+    "skipped": "Skipped",
+    "skip": "Skip during runs",
+    "resume": "Resume backups"
   },
   "wizard": {
     "steps": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -4418,7 +4418,8 @@
     "searchOrAddMore": "Search or add more...",
     "skipped": "Skipped",
     "skip": "Skip during runs",
-    "resume": "Resume backups"
+    "resume": "Resume backups",
+    "lastEnabled": "At least one repository must stay enabled"
   },
   "wizard": {
     "steps": {

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -4418,7 +4418,8 @@
     "searchOrAddMore": "Buscar o agregar más...",
     "skipped": "Omitido",
     "skip": "Omitir en las ejecuciones",
-    "resume": "Reanudar copias"
+    "resume": "Reanudar copias",
+    "lastEnabled": "Al menos un repositorio debe permanecer activado"
   },
   "wizard": {
     "steps": {

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -1447,7 +1447,7 @@
       "repositoryCreateFailed": "No se pudo crear el repositorio",
       "multiRepositoryRequiresPro": "Varios repositorios en un plan de copia requieren Pro",
       "selectSourceConnection": "Selecciona un cliente remoto antes de explorar rutas de origen",
-      "scriptCreateFailed": "Failed to create generated script",
+      "scriptCreateFailed": "No se pudo crear el script generado",
       "repositoryToggled": "Repositorio actualizado",
       "repositoryToggleFailed": "No se pudo actualizar el repositorio"
     },

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -1411,7 +1411,11 @@
       "nextRun": "Próxima ejecución: {{date}}",
       "repositoryFallback": "Repositorio",
       "moreRepositories": "+{{count}} más",
-      "runningNow": "En curso"
+      "runningNow": "En curso",
+      "repositoryCountPartial": "{{enabled}} de {{total}} repositorios",
+      "skippedRepositoriesTooltip": "Omitidos en las ejecuciones: {{names}}",
+      "skippedLabel": "Omitidos",
+      "clickToResumeRepository": "Reanudar copias en {{name}}"
     },
     "statuses": {
       "unknown": "Desconocido",
@@ -1443,7 +1447,9 @@
       "repositoryCreateFailed": "No se pudo crear el repositorio",
       "multiRepositoryRequiresPro": "Varios repositorios en un plan de copia requieren Pro",
       "selectSourceConnection": "Selecciona un cliente remoto antes de explorar rutas de origen",
-      "scriptCreateFailed": "Failed to create generated script"
+      "scriptCreateFailed": "Failed to create generated script",
+      "repositoryToggled": "Repositorio actualizado",
+      "repositoryToggleFailed": "No se pudo actualizar el repositorio"
     },
     "sourceChooser": {
       "summaryTitle": "Backup source",
@@ -4409,7 +4415,10 @@
     "moveUp": "Subir",
     "moveDown": "Bajar",
     "remove": "Eliminar",
-    "searchOrAddMore": "Buscar o agregar más..."
+    "searchOrAddMore": "Buscar o agregar más...",
+    "skipped": "Omitido",
+    "skip": "Omitir en las ejecuciones",
+    "resume": "Reanudar copias"
   },
   "wizard": {
     "steps": {

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -1411,7 +1411,11 @@
       "nextRun": "Prossima esecuzione: {{date}}",
       "repositoryFallback": "Repository",
       "moreRepositories": "+{{count}} altri",
-      "runningNow": "In corso"
+      "runningNow": "In corso",
+      "repositoryCountPartial": "{{enabled}} di {{total}} repository",
+      "skippedRepositoriesTooltip": "Saltati durante le esecuzioni: {{names}}",
+      "skippedLabel": "Saltati",
+      "clickToResumeRepository": "Riprendi i backup su {{name}}"
     },
     "statuses": {
       "unknown": "Sconosciuto",
@@ -1443,7 +1447,9 @@
       "repositoryCreateFailed": "Impossibile creare il repository",
       "multiRepositoryRequiresPro": "Più repository in un piano di backup richiedono Pro",
       "selectSourceConnection": "Seleziona un client remoto prima di sfogliare i percorsi sorgente",
-      "scriptCreateFailed": "Creazione dello script generato fallita"
+      "scriptCreateFailed": "Creazione dello script generato fallita",
+      "repositoryToggled": "Repository aggiornato",
+      "repositoryToggleFailed": "Impossibile aggiornare il repository"
     },
     "sourceChooser": {
       "summaryTitle": "Sorgente di backup",
@@ -4409,7 +4415,10 @@
     "moveUp": "Sposta su",
     "moveDown": "Sposta giù",
     "remove": "Rimuovi",
-    "searchOrAddMore": "Cerca o aggiungi altri..."
+    "searchOrAddMore": "Cerca o aggiungi altri...",
+    "skipped": "Saltato",
+    "skip": "Salta durante le esecuzioni",
+    "resume": "Riprendi i backup"
   },
   "wizard": {
     "steps": {

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -4418,7 +4418,8 @@
     "searchOrAddMore": "Cerca o aggiungi altri...",
     "skipped": "Saltato",
     "skip": "Salta durante le esecuzioni",
-    "resume": "Riprendi i backup"
+    "resume": "Riprendi i backup",
+    "lastEnabled": "Almeno un repository deve restare attivo"
   },
   "wizard": {
     "steps": {

--- a/frontend/src/pages/BackupPlans.tsx
+++ b/frontend/src/pages/BackupPlans.tsx
@@ -644,13 +644,16 @@ export default function BackupPlans() {
       })
     }
 
-    setWizardState((prev) => ({
-      ...prev,
-      repositoryIds: nextSelection.ids,
-      disabledRepositoryIds: (prev.disabledRepositoryIds || []).filter((id) =>
+    setWizardState((prev) => {
+      let disabled = (prev.disabledRepositoryIds || []).filter((id) =>
         nextSelection.ids.includes(id)
-      ),
-    }))
+      )
+      // Removing the last enabled repository must not leave only skipped ones.
+      if (nextSelection.ids.length > 0 && disabled.length === nextSelection.ids.length) {
+        disabled = disabled.filter((id) => id !== nextSelection.ids[0])
+      }
+      return { ...prev, repositoryIds: nextSelection.ids, disabledRepositoryIds: disabled }
+    })
   }
 
   const handleRepositoryEnabledToggle = (repositoryId: number) => {
@@ -907,6 +910,9 @@ export default function BackupPlans() {
         onViewLogs={setLogJob}
         onTogglePlan={handleTogglePlan}
         onToggleRepository={handleToggleRepository}
+        togglingRepository={
+          toggleRepositoryMutation.isPending ? (toggleRepositoryMutation.variables ?? null) : null
+        }
         onEditPlan={openEditWizard}
         onDeletePlan={handleDeletePlan}
         onViewHistory={setHistoryPlanId}

--- a/frontend/src/pages/BackupPlans.tsx
+++ b/frontend/src/pages/BackupPlans.tsx
@@ -475,6 +475,19 @@ export default function BackupPlans() {
     },
   })
 
+  const toggleRepositoryMutation = useMutation({
+    mutationFn: ({ planId, repositoryId }: { planId: number; repositoryId: number }) =>
+      backupPlansAPI.toggleRepository(planId, repositoryId),
+    onSuccess: () => {
+      toast.success(t('backupPlans.toasts.repositoryToggled'))
+      queryClient.invalidateQueries({ queryKey: ['backup-plans'] })
+      queryClient.invalidateQueries({ queryKey: ['backup-plan'] })
+    },
+    onError: (error: unknown) => {
+      toast.error(errorMessage(error, t('backupPlans.toasts.repositoryToggleFailed')))
+    },
+  })
+
   const repositoryCreateMutation = useMutation({
     mutationFn: (data: RepositoryData) => BorgApiClient.createRepository(data),
     onSuccess: (response) => {
@@ -634,7 +647,22 @@ export default function BackupPlans() {
     setWizardState((prev) => ({
       ...prev,
       repositoryIds: nextSelection.ids,
+      disabledRepositoryIds: (prev.disabledRepositoryIds || []).filter((id) =>
+        nextSelection.ids.includes(id)
+      ),
     }))
+  }
+
+  const handleRepositoryEnabledToggle = (repositoryId: number) => {
+    setWizardState((prev) => {
+      const disabled = prev.disabledRepositoryIds || []
+      return {
+        ...prev,
+        disabledRepositoryIds: disabled.includes(repositoryId)
+          ? disabled.filter((id) => id !== repositoryId)
+          : [...disabled, repositoryId],
+      }
+    })
   }
 
   const handlePruneSettingsChange = (values: PruneSettings) => {
@@ -800,6 +828,7 @@ export default function BackupPlans() {
       onCreateScript={createSourceScript}
       updateBasicRepositoryState={updateBasicRepositoryState}
       handleRepositoryIdsChange={handleRepositoryIdsChange}
+      handleRepositoryEnabledToggle={handleRepositoryEnabledToggle}
       handlePruneSettingsChange={handlePruneSettingsChange}
       createBasicRepository={createBasicRepository}
       openSourceExplorer={openSourceExplorer}
@@ -828,6 +857,11 @@ export default function BackupPlans() {
   const handleCancelRun = useCallback((runId: number) => cancelRunMutate(runId), [cancelRunMutate])
   const handleRetryRun = useCallback((runId: number) => retryRunMutate(runId), [retryRunMutate])
   const handleTogglePlan = useCallback((planId: number) => toggleMutate(planId), [toggleMutate])
+  const toggleRepositoryMutate = toggleRepositoryMutation.mutate
+  const handleToggleRepository = useCallback(
+    (planId: number, repositoryId: number) => toggleRepositoryMutate({ planId, repositoryId }),
+    [toggleRepositoryMutate]
+  )
   const handleDeletePlan = useCallback((planId: number) => deleteMutate(planId), [deleteMutate])
   const handleViewRepositories = useCallback(
     (planId: number) => navigate(`/repositories?backupPlanId=${planId}`),
@@ -872,6 +906,7 @@ export default function BackupPlans() {
         onCancelRun={handleCancelRun}
         onViewLogs={setLogJob}
         onTogglePlan={handleTogglePlan}
+        onToggleRepository={handleToggleRepository}
         onEditPlan={openEditWizard}
         onDeletePlan={handleDeletePlan}
         onViewHistory={setHistoryPlanId}

--- a/frontend/src/pages/backup-plans/BackupPlanWizardStep.tsx
+++ b/frontend/src/pages/backup-plans/BackupPlanWizardStep.tsx
@@ -31,6 +31,7 @@ export function BackupPlanWizardStep({
   onCreateScript,
   updateBasicRepositoryState,
   handleRepositoryIdsChange,
+  handleRepositoryEnabledToggle,
   handlePruneSettingsChange,
   createBasicRepository,
   openExcludeExplorer,
@@ -75,6 +76,7 @@ export function BackupPlanWizardStep({
         repositoryCreatePending={repositoryCreatePending}
         updateBasicRepositoryState={updateBasicRepositoryState}
         handleRepositoryIdsChange={handleRepositoryIdsChange}
+        handleRepositoryEnabledToggle={handleRepositoryEnabledToggle}
         createBasicRepository={createBasicRepository}
         setBasicRepositoryOpen={setBasicRepositoryOpen}
         setRepositoryWizardOpen={setRepositoryWizardOpen}

--- a/frontend/src/pages/backup-plans/BackupPlansContent.stories.tsx
+++ b/frontend/src/pages/backup-plans/BackupPlansContent.stories.tsx
@@ -208,6 +208,7 @@ function SkippedRepositoryBackupPlans() {
         onViewLogs={noop}
         onTogglePlan={noop}
         onToggleRepository={noop}
+        togglingRepository={null}
         onEditPlan={noop}
         onDeletePlan={noop}
         onViewHistory={noop}
@@ -256,6 +257,7 @@ function CommunityLockedBackupPlans() {
         onViewLogs={noop}
         onTogglePlan={noop}
         onToggleRepository={noop}
+        togglingRepository={null}
         onEditPlan={noop}
         onDeletePlan={noop}
         onViewHistory={noop}

--- a/frontend/src/pages/backup-plans/BackupPlansContent.stories.tsx
+++ b/frontend/src/pages/backup-plans/BackupPlansContent.stories.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { Box } from '@mui/material'
+import { Box, CssBaseline, ThemeProvider } from '@mui/material'
+
+import { getTheme } from '../../theme'
 import i18next from 'i18next'
 import type { TFunction } from 'i18next'
 
@@ -127,6 +129,96 @@ const managedAgentPlan: BackupPlan = {
 
 const lockedPlans = [databasePlan, containerPlan, multiRepositoryPlan, managedAgentPlan]
 
+// Issue #879: a plan keeps a repository attached but skips it during runs.
+const skippedRepositoryPlan: BackupPlan = {
+  id: 105,
+  name: 'Home Media',
+  description: 'Local NAS plus an off-site copy that is down for maintenance.',
+  enabled: true,
+  source_type: 'local',
+  source_directories: ['/srv/media', '/srv/photos'],
+  exclude_patterns: [],
+  archive_name_template: '{plan_name}-{repo_name}-{now}',
+  compression: 'zstd,3',
+  repository_run_mode: 'series',
+  max_parallel_repositories: 1,
+  failure_behavior: 'continue',
+  schedule_enabled: true,
+  cron_expression: '0 2 * * *',
+  timezone: 'UTC',
+  next_run: '2026-06-09T02:00:00.000Z',
+  repository_count: 2,
+  repositories: [
+    {
+      repository_id: 1,
+      enabled: true,
+      execution_order: 1,
+      repository: { id: 1, name: 'NAS', path: '/mnt/nas/borg' } as never,
+    },
+    {
+      repository_id: 2,
+      enabled: false,
+      execution_order: 2,
+      repository: { id: 2, name: 'rsync.net', path: 'ssh://rsync.net/borg' } as never,
+    },
+    {
+      repository_id: 3,
+      enabled: true,
+      execution_order: 3,
+      repository: { id: 3, name: 'USB Drive', path: '/Volumes/usb/borg' } as never,
+    },
+  ],
+}
+
+function SkippedRepositoryBackupPlans() {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [sortBy, setSortBy] = useState('name-asc')
+  const [groupBy, setGroupBy] = useState('none')
+  const plans = [skippedRepositoryPlan, managedAgentPlan]
+
+  return (
+    <Box sx={{ p: 3, maxWidth: 1120, mx: 'auto' }}>
+      <BackupPlansContent
+        loadingPlans={false}
+        backupPlans={plans}
+        processedPlans={{ groups: [{ name: null, plans }] }}
+        latestRunByPlan={new Map()}
+        backupPlanRuns={[]}
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        sortBy={sortBy}
+        setSortBy={setSortBy}
+        groupBy={groupBy}
+        setGroupBy={setGroupBy}
+        repositoryFilter={null}
+        onClearRepositoryFilter={noop}
+        startingPlanId={null}
+        highlightedPlanId={null}
+        canUseMultiRepository
+        canUseManagedAgents
+        canUseDatabaseDiscovery
+        canUseContainerBackups
+        cancellingRunId={null}
+        runPending={false}
+        togglePending={false}
+        toggleVariables={undefined}
+        openCreateWizard={noop}
+        onRunPlan={noop}
+        onCancelRun={noop}
+        onViewLogs={noop}
+        onTogglePlan={noop}
+        onToggleRepository={noop}
+        onEditPlan={noop}
+        onDeletePlan={noop}
+        onViewHistory={noop}
+        onViewRepositories={noop}
+        formatStatusLabel={(status) => status ?? t('backupPlans.statuses.unknown')}
+        t={t}
+      />
+    </Box>
+  )
+}
+
 function CommunityLockedBackupPlans() {
   const [searchQuery, setSearchQuery] = useState('')
   const [sortBy, setSortBy] = useState('name-asc')
@@ -163,6 +255,7 @@ function CommunityLockedBackupPlans() {
         onCancelRun={noop}
         onViewLogs={noop}
         onTogglePlan={noop}
+        onToggleRepository={noop}
         onEditPlan={noop}
         onDeletePlan={noop}
         onViewHistory={noop}
@@ -187,4 +280,17 @@ type Story = StoryObj<typeof meta>
 
 export const CommunityLockedRuns: Story = {
   render: () => <CommunityLockedBackupPlans />,
+}
+
+export const SkippedRepository: Story = {
+  render: () => <SkippedRepositoryBackupPlans />,
+}
+
+export const SkippedRepositoryDark: Story = {
+  render: () => (
+    <ThemeProvider theme={getTheme('dark')}>
+      <CssBaseline />
+      <SkippedRepositoryBackupPlans />
+    </ThemeProvider>
+  ),
 }

--- a/frontend/src/pages/backup-plans/BackupPlansContent.tsx
+++ b/frontend/src/pages/backup-plans/BackupPlansContent.tsx
@@ -50,6 +50,7 @@ interface BackupPlansContentProps {
   onCancelRun: (runId: number) => void
   onViewLogs: (job: BackupPlanRunLogJob) => void
   onTogglePlan: (planId: number) => void
+  onToggleRepository: (planId: number, repositoryId: number) => void
   onEditPlan: (plan: BackupPlan) => void
   onDeletePlan: (planId: number) => void
   onViewHistory: (planId: number) => void
@@ -167,6 +168,7 @@ function BackupPlansContentImpl({
   onCancelRun,
   onViewLogs,
   onTogglePlan,
+  onToggleRepository,
   onEditPlan,
   onDeletePlan,
   onViewHistory,
@@ -609,6 +611,13 @@ function BackupPlansContentImpl({
                           enabled_before: plan.enabled,
                         })
                         onTogglePlan(plan.id)
+                      }}
+                      onToggleRepository={(repositoryId) => {
+                        trackBackupPlan(EventAction.EDIT, {
+                          operation: 'enable_plan_repository',
+                          repository_count: plan.repository_count,
+                        })
+                        onToggleRepository(plan.id, repositoryId)
                       }}
                       onEdit={() => {
                         trackBackupPlan(EventAction.VIEW, {

--- a/frontend/src/pages/backup-plans/BackupPlansContent.tsx
+++ b/frontend/src/pages/backup-plans/BackupPlansContent.tsx
@@ -51,6 +51,7 @@ interface BackupPlansContentProps {
   onViewLogs: (job: BackupPlanRunLogJob) => void
   onTogglePlan: (planId: number) => void
   onToggleRepository: (planId: number, repositoryId: number) => void
+  togglingRepository: { planId: number; repositoryId: number } | null
   onEditPlan: (plan: BackupPlan) => void
   onDeletePlan: (planId: number) => void
   onViewHistory: (planId: number) => void
@@ -169,6 +170,7 @@ function BackupPlansContentImpl({
   onViewLogs,
   onTogglePlan,
   onToggleRepository,
+  togglingRepository,
   onEditPlan,
   onDeletePlan,
   onViewHistory,
@@ -612,6 +614,11 @@ function BackupPlansContentImpl({
                         })
                         onTogglePlan(plan.id)
                       }}
+                      togglingRepositoryId={
+                        togglingRepository?.planId === plan.id
+                          ? togglingRepository.repositoryId
+                          : null
+                      }
                       onToggleRepository={(repositoryId) => {
                         trackBackupPlan(EventAction.EDIT, {
                           operation: 'enable_plan_repository',

--- a/frontend/src/pages/backup-plans/__tests__/BackupPlansContent.test.tsx
+++ b/frontend/src/pages/backup-plans/__tests__/BackupPlansContent.test.tsx
@@ -192,6 +192,7 @@ function renderContent(overrides: Partial<React.ComponentProps<typeof BackupPlan
     onViewLogs: vi.fn(),
     onTogglePlan: vi.fn(),
     onToggleRepository: vi.fn(),
+    togglingRepository: null,
     onEditPlan: vi.fn(),
     onDeletePlan: vi.fn(),
     onViewHistory: vi.fn(),
@@ -277,6 +278,33 @@ describe('BackupPlansContent', () => {
     fireEvent.click(screen.getByText('Offsite Repo'))
 
     expect(onToggleRepository).toHaveBeenCalledWith(plan.id, 12)
+  })
+
+  it('ignores clicks on a skipped repository chip while its toggle is pending', () => {
+    const onToggleRepository = vi.fn()
+    const plan: BackupPlan = {
+      ...basePlan,
+      repositories: [
+        { repository_id: 11, enabled: true, execution_order: 1 },
+        {
+          repository_id: 12,
+          enabled: false,
+          execution_order: 2,
+          repository: { id: 12, name: 'Offsite Repo', path: '/backups/offsite' } as never,
+        },
+      ],
+    }
+
+    renderContent({
+      onToggleRepository,
+      togglingRepository: { planId: plan.id, repositoryId: 12 },
+      backupPlans: [plan],
+      processedPlans: { groups: [{ name: null, plans: [plan] }] },
+    })
+
+    fireEvent.click(screen.getByText('Offsite Repo'))
+
+    expect(onToggleRepository).not.toHaveBeenCalled()
   })
 
   it('calls the repository navigation action from a backup plan card', async () => {

--- a/frontend/src/pages/backup-plans/__tests__/BackupPlansContent.test.tsx
+++ b/frontend/src/pages/backup-plans/__tests__/BackupPlansContent.test.tsx
@@ -38,6 +38,8 @@ const t = ((
     name?: string
     feature?: string
     features?: string
+    enabled?: number
+    total?: number
   }
 ) => {
   const translations: Record<string, string> = {
@@ -63,6 +65,9 @@ const t = ((
     'backupPlans.wizard.review.compression': 'Compression',
     'backupPlans.status.sourcePathCount': `${options?.count ?? 0} sources`,
     'backupPlans.status.repositoryCount': `${options?.count ?? 0} repositories`,
+    'backupPlans.status.repositoryCountPartial': `${options?.enabled} of ${options?.total} repositories`,
+    'backupPlans.status.skippedLabel': 'Skipped',
+    'backupPlans.status.clickToResumeRepository': `Resume backups to ${options?.name}`,
     'backupPlans.status.lastRunLabel': 'Last run',
     'backupPlans.status.nextRunLabel': 'Next run',
     'backupPlans.status.manualOnly': 'Manual only',
@@ -186,6 +191,7 @@ function renderContent(overrides: Partial<React.ComponentProps<typeof BackupPlan
     onCancelRun: vi.fn(),
     onViewLogs: vi.fn(),
     onTogglePlan: vi.fn(),
+    onToggleRepository: vi.fn(),
     onEditPlan: vi.fn(),
     onDeletePlan: vi.fn(),
     onViewHistory: vi.fn(),
@@ -238,6 +244,39 @@ describe('BackupPlansContent', () => {
 
     expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Cancel Run' })).toBeInTheDocument()
+  })
+
+  it('shows skipped repositories on the card and re-enables one in a single click', () => {
+    const onToggleRepository = vi.fn()
+    const plan: BackupPlan = {
+      ...basePlan,
+      repository_count: 1,
+      repositories: [
+        {
+          repository_id: 11,
+          enabled: true,
+          execution_order: 1,
+          repository: { id: 11, name: 'Primary Repo', path: '/backups/primary' } as never,
+        },
+        {
+          repository_id: 12,
+          enabled: false,
+          execution_order: 2,
+          repository: { id: 12, name: 'Offsite Repo', path: '/backups/offsite' } as never,
+        },
+      ],
+    }
+
+    renderContent({
+      onToggleRepository,
+      backupPlans: [plan],
+      processedPlans: { groups: [{ name: null, plans: [plan] }] },
+    })
+
+    expect(screen.getByText('1 of 2 repositories')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Offsite Repo'))
+
+    expect(onToggleRepository).toHaveBeenCalledWith(plan.id, 12)
   })
 
   it('calls the repository navigation action from a backup plan card', async () => {

--- a/frontend/src/pages/backup-plans/plan-runs/BackupPlanIdleCard.tsx
+++ b/frontend/src/pages/backup-plans/plan-runs/BackupPlanIdleCard.tsx
@@ -10,7 +10,16 @@ import {
   Typography,
   useTheme,
 } from '@mui/material'
-import { CalendarClock, Database, Folder, History, Play, SquarePen, Trash2 } from 'lucide-react'
+import {
+  CalendarClock,
+  Database,
+  Folder,
+  History,
+  Pause,
+  Play,
+  SquarePen,
+  Trash2,
+} from 'lucide-react'
 import type { TFunction } from 'i18next'
 
 import BackupPlanScheduleBadge from '../../../components/BackupPlanScheduleBadge'
@@ -44,6 +53,7 @@ interface BackupPlanIdleCardProps {
   onDelete: () => void
   onViewHistory: () => void
   onViewRepositories: () => void
+  onToggleRepository: (repositoryId: number) => void
   planIsToggling: boolean
   t: TFunction
   formatStatusLabel: (status?: string) => string
@@ -66,6 +76,7 @@ export function BackupPlanIdleCard({
   onDelete,
   onViewHistory,
   onViewRepositories,
+  onToggleRepository,
   planIsToggling,
   t,
   formatStatusLabel,
@@ -119,6 +130,14 @@ export function BackupPlanIdleCard({
       : t('backupPlans.status.scheduledBadge', { defaultValue: 'Scheduled' })
     : t('backupPlans.status.manualOnly')
 
+  // Links the plan keeps but skips at run time (issue #879). The list payload
+  // always carries `repositories`, so this needs no extra fetch.
+  const skippedLinks = (plan.repositories || []).filter((link) => !link.enabled)
+  const totalRepositoryCount = plan.repository_count + skippedLinks.length
+  const skippedNames = skippedLinks
+    .map((link) => link.repository?.name)
+    .filter((name): name is string => Boolean(name))
+
   const keyStats = [
     {
       label: t('backupPlans.wizard.review.sources'),
@@ -130,11 +149,23 @@ export function BackupPlanIdleCard({
     },
     {
       label: t('backupPlans.wizard.review.repositories'),
-      value: t('backupPlans.status.repositoryCount', {
-        count: plan.repository_count,
-      }),
+      value:
+        skippedLinks.length > 0
+          ? t('backupPlans.status.repositoryCountPartial', {
+              enabled: plan.repository_count,
+              total: totalRepositoryCount,
+            })
+          : t('backupPlans.status.repositoryCount', {
+              count: plan.repository_count,
+            }),
       icon: <Database size={11} />,
-      tooltip: '',
+      valueColor: skippedLinks.length > 0 ? theme.palette.warning.main : undefined,
+      tooltip:
+        skippedLinks.length > 0
+          ? t('backupPlans.status.skippedRepositoriesTooltip', {
+              names: skippedNames.join(', '),
+            })
+          : '',
     },
     {
       label: t('backupPlans.status.lastRunLabel', { defaultValue: 'Last run' }),
@@ -402,6 +433,7 @@ export function BackupPlanIdleCard({
                       fontWeight: 600,
                       fontVariantNumeric: 'tabular-nums',
                       fontSize: '0.85rem',
+                      color: stat.valueColor,
                     }}
                   >
                     {stat.value}
@@ -411,6 +443,65 @@ export function BackupPlanIdleCard({
             )
           })}
         </Box>
+
+        {skippedLinks.length > 0 && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+              gap: 0.75,
+              mb: 1.5,
+              px: 0.25,
+            }}
+          >
+            <Typography
+              sx={{
+                fontSize: '0.58rem',
+                fontWeight: 700,
+                textTransform: 'uppercase',
+                letterSpacing: '0.07em',
+                color: alpha(theme.palette.warning.main, 0.85),
+                lineHeight: 1,
+              }}
+            >
+              {t('backupPlans.status.skippedLabel')}
+            </Typography>
+            {skippedLinks.map((link) => {
+              const name =
+                link.repository?.name ||
+                t('backupPlans.status.repositoryFallback', { id: link.repository_id })
+              return (
+                <Tooltip
+                  key={link.repository_id}
+                  title={t('backupPlans.status.clickToResumeRepository', { name })}
+                  arrow
+                >
+                  <Chip
+                    size="small"
+                    icon={<Pause size={11} />}
+                    label={name}
+                    onClick={() => onToggleRepository(link.repository_id)}
+                    sx={{
+                      height: 22,
+                      fontSize: '0.68rem',
+                      fontWeight: 600,
+                      color: isDark ? theme.palette.warning.light : theme.palette.warning.dark,
+                      bgcolor: alpha(theme.palette.warning.main, isDark ? 0.14 : 0.08),
+                      border: `1px dashed ${alpha(theme.palette.warning.main, isDark ? 0.5 : 0.4)}`,
+                      '& .MuiChip-icon': { color: 'inherit', ml: '6px' },
+                      '& .MuiChip-label': { px: 0.75 },
+                      '&:hover': {
+                        bgcolor: alpha(theme.palette.warning.main, isDark ? 0.24 : 0.16),
+                        borderStyle: 'solid',
+                      },
+                    }}
+                  />
+                </Tooltip>
+              )
+            })}
+          </Box>
+        )}
 
         <Box
           sx={{

--- a/frontend/src/pages/backup-plans/plan-runs/BackupPlanIdleCard.tsx
+++ b/frontend/src/pages/backup-plans/plan-runs/BackupPlanIdleCard.tsx
@@ -54,6 +54,7 @@ interface BackupPlanIdleCardProps {
   onViewHistory: () => void
   onViewRepositories: () => void
   onToggleRepository: (repositoryId: number) => void
+  togglingRepositoryId: number | null
   planIsToggling: boolean
   t: TFunction
   formatStatusLabel: (status?: string) => string
@@ -77,6 +78,7 @@ export function BackupPlanIdleCard({
   onViewHistory,
   onViewRepositories,
   onToggleRepository,
+  togglingRepositoryId,
   planIsToggling,
   t,
   formatStatusLabel,
@@ -482,6 +484,7 @@ export function BackupPlanIdleCard({
                     icon={<Pause size={11} />}
                     label={name}
                     onClick={() => onToggleRepository(link.repository_id)}
+                    disabled={togglingRepositoryId === link.repository_id}
                     sx={{
                       height: 22,
                       fontSize: '0.68rem',

--- a/frontend/src/pages/backup-plans/state.ts
+++ b/frontend/src/pages/backup-plans/state.ts
@@ -21,6 +21,7 @@ export const createInitialState = (): WizardState => ({
   sourceLocations: [],
   excludePatterns: [],
   repositoryIds: [],
+  disabledRepositoryIds: [],
   compression: 'lz4',
   archiveNameTemplate: '{plan_name}-{repo_name}-{now}',
   customFlags: '',
@@ -316,9 +317,9 @@ function normalizePlanScriptHooks(plan: BackupPlan): BackupPlanScriptHook[] {
 }
 
 export function planToState(plan: BackupPlan): WizardState {
-  const repositoryLinks = (plan.repositories || [])
-    .filter((link) => link.enabled)
-    .sort((a, b) => a.execution_order - b.execution_order)
+  const repositoryLinks = [...(plan.repositories || [])].sort(
+    (a, b) => a.execution_order - b.execution_order
+  )
   const sourceLocations = normalizePlanSourceLocations(plan)
   const sourceDirectories = sourceLocations.length
     ? sourceLocations.flatMap((location) => location.paths)
@@ -342,6 +343,9 @@ export function planToState(plan: BackupPlan): WizardState {
     sourceLocations,
     excludePatterns: plan.exclude_patterns || [],
     repositoryIds: repositoryLinks.map((link) => link.repository_id),
+    disabledRepositoryIds: repositoryLinks
+      .filter((link) => !link.enabled)
+      .map((link) => link.repository_id),
     compression: plan.compression || 'lz4',
     archiveNameTemplate: plan.archive_name_template || '{plan_name}-{repo_name}-{now}',
     customFlags: plan.custom_flags || '',

--- a/frontend/src/pages/backup-plans/wizard-step/RepositoriesStep.tsx
+++ b/frontend/src/pages/backup-plans/wizard-step/RepositoriesStep.tsx
@@ -32,6 +32,7 @@ type RepositoriesStepProps = Pick<
   | 'repositoryCreatePending'
   | 'updateBasicRepositoryState'
   | 'handleRepositoryIdsChange'
+  | 'handleRepositoryEnabledToggle'
   | 'createBasicRepository'
   | 'setBasicRepositoryOpen'
   | 'setRepositoryWizardOpen'
@@ -50,6 +51,7 @@ export function RepositoriesStep({
   repositoryCreatePending,
   updateBasicRepositoryState,
   handleRepositoryIdsChange,
+  handleRepositoryEnabledToggle,
   createBasicRepository,
   setBasicRepositoryOpen,
   setRepositoryWizardOpen,
@@ -74,6 +76,8 @@ export function RepositoriesStep({
           repositories={fullRepositories}
           selectedIds={wizardState.repositoryIds}
           onChange={handleRepositoryIdsChange}
+          disabledIds={wizardState.disabledRepositoryIds}
+          onToggleEnabled={handleRepositoryEnabledToggle}
           label={t('backupPlans.wizard.fields.repositories')}
           helperText={
             canUseMultiRepository

--- a/frontend/src/pages/backup-plans/wizard-step/ReviewStep.tsx
+++ b/frontend/src/pages/backup-plans/wizard-step/ReviewStep.tsx
@@ -1,4 +1,4 @@
-import { Alert, Box, Stack, Typography } from '@mui/material'
+import { Alert, Box, Chip, Stack, Typography } from '@mui/material'
 import {
   CalendarClock,
   Code,
@@ -340,6 +340,7 @@ export function ReviewStep({
           >
             {selectedRepositories.map((repository) => {
               const routePreview = routePreviewByRepositoryId.get(repository.id)
+              const skipped = (wizardState.disabledRepositoryIds || []).includes(repository.id)
               return (
                 <Box
                   key={repository.id}
@@ -364,6 +365,21 @@ export function ReviewStep({
                     title={repository.name}
                   >
                     {repository.name}
+                    {skipped && (
+                      <Chip
+                        size="small"
+                        label={t('multiRepositorySelector.skipped')}
+                        color="warning"
+                        variant="outlined"
+                        sx={{
+                          ml: 0.75,
+                          height: 18,
+                          fontSize: '0.62rem',
+                          verticalAlign: 'middle',
+                          '& .MuiChip-label': { px: 0.6 },
+                        }}
+                      />
+                    )}
                   </Typography>
                   <Typography
                     variant="caption"

--- a/frontend/src/pages/backup-plans/wizard-step/ReviewStep.tsx
+++ b/frontend/src/pages/backup-plans/wizard-step/ReviewStep.tsx
@@ -367,6 +367,7 @@ export function ReviewStep({
                     {repository.name}
                     {skipped && (
                       <Chip
+                        component="span"
                         size="small"
                         label={t('multiRepositorySelector.skipped')}
                         color="warning"

--- a/frontend/src/pages/backup-plans/wizard-step/types.ts
+++ b/frontend/src/pages/backup-plans/wizard-step/types.ts
@@ -31,6 +31,7 @@ export interface BackupPlanWizardStepProps {
   onCreateScript: (input: SourceScriptCreateInput) => Promise<{ id: number }>
   updateBasicRepositoryState: (updates: Partial<BasicRepositoryState>) => void
   handleRepositoryIdsChange: (ids: number[]) => void
+  handleRepositoryEnabledToggle: (id: number) => void
   handlePruneSettingsChange: (values: PruneSettings) => void
   createBasicRepository: () => void
   openSourceExplorer: () => void

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1062,6 +1062,8 @@ export const backupPlansAPI = {
   update: (id: number, data: BackupPlanData) => api.put(`/backup-plans/${id}`, data),
   delete: (id: number) => api.delete(`/backup-plans/${id}`),
   toggle: (id: number) => api.post(`/backup-plans/${id}/toggle`),
+  toggleRepository: (id: number, repositoryId: number) =>
+    api.post(`/backup-plans/${id}/repositories/${repositoryId}/toggle`),
   run: (id: number) => api.post(`/backup-plans/${id}/run`),
   listRuns: () => api.get('/backup-plans/runs'),
   getRun: (id: number) => api.get(`/backup-plans/runs/${id}`),

--- a/frontend/src/utils/backupPlanPayload.ts
+++ b/frontend/src/utils/backupPlanPayload.ts
@@ -26,6 +26,8 @@ export interface BackupPlanPayloadState {
   sourceLocations?: SourceLocation[]
   excludePatterns: string[]
   repositoryIds: number[]
+  // Repositories kept on the plan but skipped during runs (issue #879).
+  disabledRepositoryIds?: number[]
   compression: string
   archiveNameTemplate: string
   customFlags: string
@@ -432,7 +434,7 @@ export function buildBackupPlanPayload(
     prune_keep_within: normalizeOptionalString(state.pruneKeepWithin),
     repositories: state.repositoryIds.map((repositoryId, index) => ({
       repository_id: repositoryId,
-      enabled: true,
+      enabled: !(state.disabledRepositoryIds || []).includes(repositoryId),
       execution_order: index + 1,
       compression_source: 'plan',
       compression_override: null,

--- a/tests/unit/test_api_backup_plans.py
+++ b/tests/unit/test_api_backup_plans.py
@@ -2518,6 +2518,74 @@ class TestBackupPlanRoutes:
         assert plan.enabled is True
         assert plan.next_run is not None
 
+    def test_toggle_plan_repository_disables_link_and_list_reports_it(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        _set_plan(test_db, "pro")
+        repo_a = _create_repo(test_db, "Primary", "/repos/primary")
+        repo_b = _create_repo(test_db, "Offsite", "/repos/offsite")
+        plan = _create_scheduled_plan(test_db, [repo_a, repo_b])
+
+        response = test_client.post(
+            f"/api/backup-plans/{plan.id}/repositories/{repo_b.id}/toggle",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["repository_count"] == 1
+        assert {
+            link["repository_id"]: link["enabled"] for link in body["repositories"]
+        } == {repo_a.id: True, repo_b.id: False}
+
+        listed = test_client.get("/api/backup-plans/", headers=admin_headers).json()
+        listed_plan = next(p for p in listed["backup_plans"] if p["id"] == plan.id)
+        assert listed_plan["repository_count"] == 1
+        assert [
+            (link["repository_id"], link["enabled"], link["repository"]["name"])
+            for link in listed_plan["repositories"]
+        ] == [(repo_a.id, True, "Primary"), (repo_b.id, False, "Offsite")]
+
+        # Toggle again re-enables in one action.
+        response = test_client.post(
+            f"/api/backup-plans/{plan.id}/repositories/{repo_b.id}/toggle",
+            headers=admin_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["repository_count"] == 2
+
+    def test_toggle_plan_repository_refuses_to_disable_last_enabled_link(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        repo = _create_repo(test_db, "Primary", "/repos/primary")
+        plan = _create_scheduled_plan(test_db, [repo])
+
+        response = test_client.post(
+            f"/api/backup-plans/{plan.id}/repositories/{repo.id}/toggle",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == {
+            "key": "backend.errors.backupPlans.repositoriesRequired"
+        }
+        test_db.refresh(plan)
+        assert plan.repositories[0].enabled is True
+
+    def test_toggle_plan_repository_unknown_link_returns_404(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        repo = _create_repo(test_db, "Primary", "/repos/primary")
+        other = _create_repo(test_db, "Other", "/repos/other")
+        plan = _create_scheduled_plan(test_db, [repo])
+
+        response = test_client.post(
+            f"/api/backup-plans/{plan.id}/repositories/{other.id}/toggle",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 404
+
     def test_community_cannot_enable_existing_multi_repository_plan_after_downgrade(
         self, test_client: TestClient, admin_headers, test_db
     ):

--- a/tests/unit/test_api_backup_plans.py
+++ b/tests/unit/test_api_backup_plans.py
@@ -2588,6 +2588,27 @@ class TestBackupPlanRoutes:
             "key": "backend.errors.backupPlans.repositoriesRequired"
         }
 
+    def test_toggle_plan_repository_refuses_to_resume_observe_repository(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        _set_plan(test_db, "pro")
+        repo_a = _create_repo(test_db, "Primary", "/repos/primary")
+        repo_b = _create_repo(test_db, "Watch only", "/repos/watch")
+        plan = _create_scheduled_plan(test_db, [repo_a, repo_b])
+        plan.repositories[1].enabled = False
+        repo_b.mode = "observe"
+        test_db.commit()
+
+        response = test_client.post(
+            f"/api/backup-plans/{plan.id}/repositories/{repo_b.id}/toggle",
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == {
+            "key": "backend.errors.backupPlans.observeRepositorySelected"
+        }
+
     def test_toggle_plan_repository_unknown_link_returns_404(
         self, test_client: TestClient, admin_headers, test_db
     ):

--- a/tests/unit/test_api_backup_plans.py
+++ b/tests/unit/test_api_backup_plans.py
@@ -2572,6 +2572,22 @@ class TestBackupPlanRoutes:
         test_db.refresh(plan)
         assert plan.repositories[0].enabled is True
 
+    def test_create_plan_rejects_all_repositories_disabled(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        repo = _create_repo(test_db, "Primary", "/repos/primary")
+        payload = _payload([repo.id])
+        payload["repositories"][0]["enabled"] = False
+
+        response = test_client.post(
+            "/api/backup-plans/", json=payload, headers=admin_headers
+        )
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == {
+            "key": "backend.errors.backupPlans.repositoriesRequired"
+        }
+
     def test_toggle_plan_repository_unknown_link_returns_404(
         self, test_client: TestClient, admin_headers, test_db
     ):


### PR DESCRIPTION
Closes #879

## What

A repository attached to a backup plan can now be paused and resumed without losing its configuration. The runner already skipped links with `enabled = false`; this PR wires that flag through the UI and adds a one-action toggle.

- `POST /backup-plans/{id}/repositories/{repo_id}/toggle` flips one link. It refuses to disable the last enabled repository (422 with the existing `repositoriesRequired` key).
- The plan list payload now carries `repositories`, so the card can show state without a detail fetch. `repository_count` still means enabled repositories, so license gating is unchanged.
- Wizard: editing a plan no longer silently drops disabled links. Each selected repository has a skip/resume control. The control is greyed out on the last enabled repository, and the save path rejects a payload with no enabled link.
- Plan card: the repositories stat reads "2 of 3 repositories" in amber when something is skipped, with a tooltip naming the skipped repositories. A dashed "Skipped" chip per repository sits under the stats. Clicking it resumes that repository. Plans with nothing skipped look exactly as before.
- Locale keys in en, de, es, it. Storybook stories for the card (light and dark) and the selector.

## Tests

- Backend: toggle endpoint round trip and list payload, last-enabled refusal, unknown link 404, all-disabled payload rejected on create.
- Frontend: card renders the partial count and the skipped chip, and clicking the chip calls the toggle with the right ids.

## CodeRabbit review

Four findings from a local `coderabbit review --base main`.

- Major, `BackupPlans.tsx`: the wizard could skip every repository. Real. Fixed on both sides (backend save guard plus a disabled control in the selector).
- Major, `backup_plans.py`: race between two concurrent toggles disabling different repositories. Dismissed. SQLite serializes writes, the plan-level toggle has the same shape today, and the runner already refuses to start a plan with no enabled repositories, so the worst case is a clear error rather than data loss.
- Minor x2, `de.json` and `es.json`: `scriptCreateFailed` is untranslated. Dismissed as pre-existing on main. This PR only added a trailing comma to that line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 0 changed, 6 added, 0 removed, 734 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-1000/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/34448659252
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- `components-multirepositoryselector--skip-toggle--mobile.png`
- `components-multirepositoryselector--skip-toggle.png`
- `pages-backup-plans-content--skipped-repository--mobile.png`
- `pages-backup-plans-content--skipped-repository-dark--mobile.png`
- `pages-backup-plans-content--skipped-repository-dark.png`
- `pages-backup-plans-content--skipped-repository.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->