### PR TITLE
fix(dashboard): read maintenance operations in the activity timeline

### DIFF
--- a/app/api/dashboard.py
+++ b/app/api/dashboard.py
@@ -1,12 +1,11 @@
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import func
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
 import psutil
 import structlog
 from dataclasses import dataclass, fields
 from datetime import datetime, timedelta
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Union
 
 from app.database.database import get_db
 from app.database.models import (
@@ -16,9 +15,6 @@ from app.database.models import (
     Repository,
     ScheduledJob,
     ScheduledJobRepository,
-    CheckJob,
-    CompactJob,
-    PruneJob,
     RestoreCheckJob,
     SSHConnection,
     SystemSettings,
@@ -28,6 +24,12 @@ from app.services.log_policy import get_log_save_policy, job_has_logs_by_policy
 from app.services.operations.backup_facade import (
     backup_jobs_started_since,
     recent_backup_jobs,
+)
+from app.services.operations.job_facade import (
+    UNSETTLED_STATUSES,
+    MaintenanceJobFacade,
+    latest_maintenance_jobs_by_repository,
+    maintenance_jobs_started_since,
 )
 from app.utils.datetime_utils import serialize_datetime
 from app.utils.schedule_time import (
@@ -177,13 +179,24 @@ def classify_day_age(days: int, warning_days: int, critical_days: int) -> str:
     return "healthy"
 
 
+# A restore check row from either table (spec section 14): the legacy model
+# until phase 9, the facade over an `operations` row since phase 5.
+LatestRestoreCheck = Union[RestoreCheckJob, MaintenanceJobFacade]
+
+
 def build_restore_check_health(
     repo: Repository,
     now: datetime,
-    latest_restore_check: Optional[RestoreCheckJob] = None,
+    latest_restore_check: Optional[LatestRestoreCheck] = None,
     thresholds: Optional[DashboardHealthThresholds] = None,
+    last_verdict: Optional[LatestRestoreCheck] = None,
 ) -> Dict[str, Any]:
-    """Build restore-verification health without penalizing unconfigured repos."""
+    """Build restore-verification health without penalizing unconfigured repos.
+
+    `latest_restore_check` is the newest row and drives the live status;
+    `last_verdict` is the newest row that finished and drives the severity,
+    so a run still queued or running does not hide the failure before it.
+    Without it the newest row is the verdict when it has one."""
     thresholds = thresholds or DashboardHealthThresholds()
     # "Configured" requires both a cron expression AND the user-facing toggle
     # being on. Pausing via the toggle should not penalize dashboard health.
@@ -192,20 +205,36 @@ def build_restore_check_health(
         schedule_enabled = True
     configured = bool(repo.restore_check_cron_expression) and bool(schedule_enabled)
     latest_status = latest_restore_check.status if latest_restore_check else None
-    latest_error = latest_restore_check.error_message if latest_restore_check else None
+    if last_verdict is None and latest_status not in UNSETTLED_STATUSES:
+        last_verdict = latest_restore_check
+    verdict_status = last_verdict.status if last_verdict else None
+    verdict_error = last_verdict.error_message if last_verdict else None
+    # An operation that did not run says why in its reason (spec 6.3); the
+    # facade already reads the restore check's `needs_backup` back as such.
+    verdict_reason = getattr(last_verdict, "skip_reason", None)
+    # The live row rarely carries a message; the verdict's is what the
+    # tooltip should show while a critical or warning reading stands.
+    latest_error = (
+        latest_restore_check.error_message if latest_restore_check else None
+    ) or verdict_error
     last_success = repo.last_restore_check
+    # The repository column is what the service stamps on success; the verdict
+    # row is the same fact, so whichever is newer is the last success.
+    if verdict_status == "completed" and last_verdict and last_verdict.completed_at:
+        if not last_success or last_verdict.completed_at > last_success:
+            last_success = last_verdict.completed_at
 
-    if latest_status == "failed":
+    if verdict_status == "failed":
         return {
             "dimension": "critical",
             "severity": "critical",
-            "warning": f"Restore check failed: {latest_error or 'unknown error'}",
+            "warning": f"Restore check failed: {verdict_error or 'unknown error'}",
             "configured": configured,
             "latest_status": latest_status,
             "latest_error": latest_error,
         }
 
-    if latest_status == "completed_with_warnings":
+    if verdict_status == "completed_with_warnings":
         return {
             "dimension": "warning",
             "severity": "warning",
@@ -215,21 +244,32 @@ def build_restore_check_health(
             "latest_error": latest_error,
         }
 
-    if latest_status == "needs_backup":
+    if verdict_status == "needs_backup":
         return {
             "dimension": "warning",
             "severity": "warning",
-            "warning": latest_error or "Restore check needs a backup first",
+            "warning": verdict_error or "Restore check needs a backup first",
             "configured": configured,
             "latest_status": latest_status,
             "latest_error": latest_error,
         }
 
-    if latest_status == "cancelled":
+    if verdict_status == "cancelled":
         return {
             "dimension": "warning",
             "severity": "warning",
-            "warning": "Latest restore check was cancelled",
+            "warning": "Last restore check run was cancelled",
+            "configured": configured,
+            "latest_status": latest_status,
+            "latest_error": latest_error,
+        }
+
+    if verdict_status == "skipped":
+        return {
+            "dimension": "warning",
+            "severity": "warning",
+            "warning": "Restore check skipped"
+            + (f": {verdict_reason.replace('_', ' ')}" if verdict_reason else ""),
             "configured": configured,
             "latest_status": latest_status,
             "latest_error": latest_error,
@@ -244,9 +284,6 @@ def build_restore_check_health(
             "latest_status": latest_status,
             "latest_error": latest_error,
         }
-
-    if latest_status == "completed" and not last_success and latest_restore_check:
-        last_success = latest_restore_check.completed_at
 
     if last_success:
         days_since_restore_check = (now - last_success).days
@@ -305,8 +342,9 @@ def build_restore_check_health(
 def build_full_repository_health(
     repo: Repository,
     now: datetime,
-    latest_restore_check: Optional[RestoreCheckJob] = None,
+    latest_restore_check: Optional[LatestRestoreCheck] = None,
     thresholds: Optional[DashboardHealthThresholds] = None,
+    last_verdict: Optional[LatestRestoreCheck] = None,
 ) -> Dict[str, Any]:
     """Build health signals for repositories managed directly by Borg UI."""
     thresholds = thresholds or DashboardHealthThresholds()
@@ -356,7 +394,7 @@ def build_full_repository_health(
         compact_dim = "critical"
 
     restore_check_health = build_restore_check_health(
-        repo, now, latest_restore_check, thresholds
+        repo, now, latest_restore_check, thresholds, last_verdict=last_verdict
     )
     if restore_check_health["severity"]:
         health_status, health_color = promote_repository_health(
@@ -384,8 +422,9 @@ def build_full_repository_health(
 def build_observe_repository_health(
     repo: Repository,
     now: datetime,
-    latest_restore_check: Optional[RestoreCheckJob] = None,
+    latest_restore_check: Optional[LatestRestoreCheck] = None,
     thresholds: Optional[DashboardHealthThresholds] = None,
+    last_verdict: Optional[LatestRestoreCheck] = None,
 ) -> Dict[str, Any]:
     """Build monitoring-oriented health signals for observe-only repositories."""
     thresholds = thresholds or DashboardHealthThresholds()
@@ -439,7 +478,7 @@ def build_observe_repository_health(
             health_color = "warning"
 
     restore_check_health = build_restore_check_health(
-        repo, now, latest_restore_check, thresholds
+        repo, now, latest_restore_check, thresholds, last_verdict=last_verdict
     )
     if restore_check_health["severity"]:
         health_status, health_color = promote_repository_health(
@@ -686,6 +725,22 @@ async def get_dashboard_schedule(
         )
 
 
+def _maintenance_repository_name(job, repo_name_map: dict, repo_id_map: dict) -> str:
+    """The repository name for a feed entry, in the order the timeline always
+    used: the path the row captured, exact or without the trailing slash;
+    then the repository id; then the path's last segment. An operations row
+    captures no path, its facade resolves it from the repository."""
+    path = job.repository_path
+    if path in repo_name_map:
+        return repo_name_map[path]
+    if path and path.rstrip("/") in repo_name_map:
+        return repo_name_map[path.rstrip("/")]
+    repository_id = getattr(job, "repository_id", None)
+    if repository_id and repository_id in repo_id_map:
+        return repo_id_map[repository_id]
+    return path.rstrip("/").split("/")[-1] if path else "Unknown"
+
+
 @router.get("/overview")
 async def get_dashboard_overview(
     current_user: User = Depends(get_current_user), db: Session = Depends(get_db)
@@ -729,27 +784,13 @@ async def get_dashboard_overview(
         # Get SSH connections
         ssh_connections = db.query(SSHConnection).all()
 
-        latest_restore_checks = {}
         repository_ids = [repo.id for repo in repositories]
-        if repository_ids:
-            latest_restore_check_ids = (
-                db.query(func.max(RestoreCheckJob.id).label("id"))
-                .filter(RestoreCheckJob.repository_id.in_(repository_ids))
-                .group_by(RestoreCheckJob.repository_id)
-                .subquery()
-            )
-            restore_check_jobs = (
-                db.query(RestoreCheckJob)
-                .join(
-                    latest_restore_check_ids,
-                    RestoreCheckJob.id == latest_restore_check_ids.c.id,
-                )
-                .all()
-            )
-            for restore_check_job in restore_check_jobs:
-                latest_restore_checks[restore_check_job.repository_id] = (
-                    restore_check_job
-                )
+        latest_restore_checks = latest_maintenance_jobs_by_repository(
+            db, "restore_check", repository_ids
+        )
+        restore_check_verdicts = latest_maintenance_jobs_by_repository(
+            db, "restore_check", repository_ids, settled=True
+        )
 
         # Calculate repository health (only for full-mode repos that do backups)
         repo_health = []
@@ -768,7 +809,11 @@ async def get_dashboard_overview(
             size_bytes = parse_size_to_bytes(repo.total_size)
             latest_restore_check = latest_restore_checks.get(repo.id)
             health = build_full_repository_health(
-                repo, now, latest_restore_check, health_thresholds
+                repo,
+                now,
+                latest_restore_check,
+                health_thresholds,
+                last_verdict=restore_check_verdicts.get(repo.id),
             )
 
             # Get associated schedule — prefer enabled over disabled when multiple match
@@ -855,7 +900,11 @@ async def get_dashboard_overview(
             size_bytes = parse_size_to_bytes(repo.total_size)
             latest_restore_check = latest_restore_checks.get(repo.id)
             health = build_observe_repository_health(
-                repo, now, latest_restore_check, health_thresholds
+                repo,
+                now,
+                latest_restore_check,
+                health_thresholds,
+                last_verdict=restore_check_verdicts.get(repo.id),
             )
             repo_backup_plans = backup_plans_by_repo.get(repo.id, [])
 
@@ -1034,22 +1083,17 @@ async def get_dashboard_overview(
         # Get activity for the last 14 days — matches the timeline window exactly
         fourteen_days_ago = now - timedelta(days=14)
         recent_backups = backup_jobs_started_since(db, fourteen_days_ago)
-        recent_checks = (
-            db.query(CheckJob).filter(CheckJob.started_at >= fourteen_days_ago).all()
-        )
-        recent_compacts = (
-            db.query(CompactJob)
-            .filter(CompactJob.started_at >= fourteen_days_ago)
-            .all()
-        )
-        recent_prunes = (
-            db.query(PruneJob).filter(PruneJob.started_at >= fourteen_days_ago).all()
-        )
-        recent_restore_checks = (
-            db.query(RestoreCheckJob)
-            .filter(RestoreCheckJob.started_at >= fourteen_days_ago)
-            .all()
-        )
+        # Maintenance kinds live in `operations` since phase 5 and in their
+        # legacy tables before it; the timeline reads both (spec section 14).
+        recent_maintenance = [
+            (kind, label, maintenance_jobs_started_since(db, kind, fourteen_days_ago))
+            for kind, label in (
+                ("check", "Check"),
+                ("compact", "Compact"),
+                ("prune", "Prune"),
+                ("restore_check", "Restore check"),
+            )
+        ]
 
         # Create a lookup map for repository paths to names (with normalized paths)
         repo_name_map = {}
@@ -1099,140 +1143,29 @@ async def get_dashboard_overview(
                 }
             )
 
-        for job in recent_checks:
-            # Try multiple ways to get repo name
-            repo_name = None
-            if job.repository_path in repo_name_map:
-                repo_name = repo_name_map[job.repository_path]
-            elif (
-                job.repository_path and job.repository_path.rstrip("/") in repo_name_map
-            ):
-                repo_name = repo_name_map[job.repository_path.rstrip("/")]
-            elif (
-                hasattr(job, "repository_id")
-                and job.repository_id
-                and job.repository_id in repo_id_map
-            ):
-                repo_name = repo_id_map[job.repository_id]
-            else:
-                repo_name = (
-                    job.repository_path.rstrip("/").split("/")[-1]
-                    if job.repository_path
-                    else "Unknown"
+        for kind, label, jobs in recent_maintenance:
+            for job in jobs:
+                # a legacy status column is nullable; the feed still names the row
+                status = job.status or "unknown"
+                activity_feed.append(
+                    {
+                        "id": job.id,
+                        "type": kind,
+                        "status": status,
+                        "repository": _maintenance_repository_name(
+                            job, repo_name_map, repo_id_map
+                        ),
+                        "timestamp": serialize_datetime(job.started_at),
+                        "message": f"{label} {status.replace('_', ' ')}",
+                        # a run that did not happen says why in its message too
+                        "error": (
+                            job.error_message
+                            if status in ("failed", "skipped", "needs_backup")
+                            else None
+                        ),
+                        "archive_pruned_at": None,
+                    }
                 )
-
-            activity_feed.append(
-                {
-                    "id": job.id,
-                    "type": "check",
-                    "status": job.status,
-                    "repository": repo_name,
-                    "timestamp": serialize_datetime(job.started_at),
-                    "message": f"Check {job.status}",
-                    "error": job.error_message if job.status == "failed" else None,
-                    "archive_pruned_at": None,
-                }
-            )
-
-        for job in recent_compacts:
-            # Try multiple ways to get repo name
-            repo_name = None
-            if job.repository_path in repo_name_map:
-                repo_name = repo_name_map[job.repository_path]
-            elif (
-                job.repository_path and job.repository_path.rstrip("/") in repo_name_map
-            ):
-                repo_name = repo_name_map[job.repository_path.rstrip("/")]
-            elif (
-                hasattr(job, "repository_id")
-                and job.repository_id
-                and job.repository_id in repo_id_map
-            ):
-                repo_name = repo_id_map[job.repository_id]
-            else:
-                repo_name = (
-                    job.repository_path.rstrip("/").split("/")[-1]
-                    if job.repository_path
-                    else "Unknown"
-                )
-
-            activity_feed.append(
-                {
-                    "id": job.id,
-                    "type": "compact",
-                    "status": job.status,
-                    "repository": repo_name,
-                    "timestamp": serialize_datetime(job.started_at),
-                    "message": f"Compact {job.status}",
-                    "error": job.error_message if job.status == "failed" else None,
-                    "archive_pruned_at": None,
-                }
-            )
-
-        for job in recent_prunes:
-            # Try multiple ways to get repo name
-            repo_name = None
-            if job.repository_path in repo_name_map:
-                repo_name = repo_name_map[job.repository_path]
-            elif (
-                job.repository_path and job.repository_path.rstrip("/") in repo_name_map
-            ):
-                repo_name = repo_name_map[job.repository_path.rstrip("/")]
-            elif (
-                hasattr(job, "repository_id")
-                and job.repository_id
-                and job.repository_id in repo_id_map
-            ):
-                repo_name = repo_id_map[job.repository_id]
-            else:
-                repo_name = (
-                    job.repository_path.rstrip("/").split("/")[-1]
-                    if job.repository_path
-                    else "Unknown"
-                )
-
-            activity_feed.append(
-                {
-                    "id": job.id,
-                    "type": "prune",
-                    "status": job.status,
-                    "repository": repo_name,
-                    "timestamp": serialize_datetime(job.started_at),
-                    "message": f"Prune {job.status}",
-                    "error": job.error_message if job.status == "failed" else None,
-                    "archive_pruned_at": None,
-                }
-            )
-
-        for job in recent_restore_checks:
-            repo_name = None
-            if job.repository_path in repo_name_map:
-                repo_name = repo_name_map[job.repository_path]
-            elif (
-                job.repository_path and job.repository_path.rstrip("/") in repo_name_map
-            ):
-                repo_name = repo_name_map[job.repository_path.rstrip("/")]
-            elif job.repository_id and job.repository_id in repo_id_map:
-                repo_name = repo_id_map[job.repository_id]
-            else:
-                repo_name = (
-                    job.repository_path.rstrip("/").split("/")[-1]
-                    if job.repository_path
-                    else "Unknown"
-                )
-
-            activity_feed.append(
-                {
-                    "id": job.id,
-                    "type": "restore_check",
-                    "status": job.status,
-                    "repository": repo_name,
-                    "timestamp": serialize_datetime(job.started_at),
-                    "message": f"Restore check {job.status}",
-                    "error": job.error_message if job.status == "failed" else None,
-                    "archive_pruned_at": None,
-                }
-            )
 
         activity_feed.sort(key=lambda x: x["timestamp"] or "", reverse=True)
 

--- a/app/services/operations/backup_facade.py
+++ b/app/services/operations/backup_facade.py
@@ -608,7 +608,7 @@ def backup_jobs_for_archive_names(db: Session, repository: Repository, names) ->
     return jobs
 
 
-def _newest_per_group(db: Session, model, group_column, order_column, filters) -> list:
+def newest_per_group(db: Session, model, group_column, order_column, filters) -> list:
     """The newest row of each group, ranked in SQL. Only the winners are
     loaded, so a caller reading one row per repository does not materialize
     every backup ever taken (the window query the legacy path used)."""
@@ -651,8 +651,8 @@ def latest_backup_jobs_by_repository(db: Session, *, running: bool = False) -> d
     # owns one path, so the two rankings meet on the same key below.
     candidates = _facades(
         db,
-        _newest_per_group(db, Operation, Operation.repository_id, op_order, op_filters),
-    ) + _newest_per_group(
+        newest_per_group(db, Operation, Operation.repository_id, op_order, op_filters),
+    ) + newest_per_group(
         db, BackupJob, BackupJob.repository, legacy_order, legacy_filters
     )
     result: dict = {}

--- a/app/services/operations/executors/maintenance.py
+++ b/app/services/operations/executors/maintenance.py
@@ -25,7 +25,9 @@ logger = structlog.get_logger()
 # the way the legacy services did from inside their own bodies.
 _LAST_DONE_COLUMN = {"check": "last_check", "compact": "last_compact"}
 
-_TERMINAL = ("completed", "completed_with_warnings", "failed", "cancelled")
+# The row's words once a service is done. The facade writes the restore
+# check's legacy `needs_backup` as `skipped` with that reason (spec 6.3).
+_TERMINAL = ("completed", "completed_with_warnings", "failed", "cancelled", "skipped")
 _CANCEL_POLL_SECONDS = 1.0
 
 
@@ -113,6 +115,12 @@ async def _run(
         # cancelled itself when it sees its own flag set. Report the failure
         # shape and let the runner have the last word.
         return Outcome(status="failed", error_message=job.error_message or "cancelled")
+    if status == "skipped":
+        return Outcome(
+            status="skipped",
+            skip_reason=operation.skip_reason,
+            error_message=job.error_message,
+        )
     return Outcome(status="failed", error_message=job.error_message)
 
 

--- a/app/services/operations/job_facade.py
+++ b/app/services/operations/job_facade.py
@@ -15,7 +15,7 @@ read `Operation` directly.
 from datetime import datetime
 from typing import Any, Iterable, Optional
 
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import Session
 
 from app.database.models import (
@@ -27,6 +27,7 @@ from app.database.models import (
     Repository,
     RestoreCheckJob,
 )
+from app.services.operations.backup_facade import newest_per_group
 
 MAINTENANCE_KINDS: tuple[str, ...] = (
     "check",
@@ -83,10 +84,12 @@ _BOOLEAN_PARAMS = frozenset(
     }
 )
 
-# Only "pending" differs between the two vocabularies (spec 6.3); every other
-# legacy word is already an operations word.
-_LEGACY_TO_OPERATION = {"pending": "queued"}
+# The words that differ between the two vocabularies (spec 6.3). The restore
+# check's `needs_backup` is `skipped` with that reason on an operation; the
+# facade's status property carries the reason both ways.
+_LEGACY_TO_OPERATION = {"pending": "queued", "needs_backup": "skipped"}
 _OPERATION_TO_LEGACY = {"queued": "pending"}
+NEEDS_BACKUP = "needs_backup"
 
 
 def operation_status(status: str) -> str:
@@ -155,11 +158,18 @@ class MaintenanceJobFacade:
 
     @property
     def status(self) -> str:
+        if (
+            self.operation.status == "skipped"
+            and self.operation.skip_reason == NEEDS_BACKUP
+        ):
+            return NEEDS_BACKUP
         return legacy_status(self.operation.status)
 
     @status.setter
     def status(self, value: str) -> None:
         self.operation.status = operation_status(value)
+        if value == NEEDS_BACKUP:
+            self.operation.skip_reason = NEEDS_BACKUP
 
     @property
     def started_at(self):
@@ -184,6 +194,16 @@ class MaintenanceJobFacade:
     @error_message.setter
     def error_message(self, value) -> None:
         self.operation.error_message = value
+
+    @property
+    def skip_reason(self):
+        """Why a `skipped` operation did not run (spec 6.3); a legacy row has
+        no such column, its `needs_backup` status carries the reason."""
+        return self.operation.skip_reason
+
+    @skip_reason.setter
+    def skip_reason(self, value) -> None:
+        self.operation.skip_reason = value
 
     # -- progress ----------------------------------------------------------
 
@@ -460,3 +480,74 @@ def claim_running(db: Session, job_id: int, kind: str, started_at: datetime) -> 
             synchronize_session=False,
         )
     )
+
+
+def maintenance_jobs_started_since(db: Session, kind: str, since: datetime) -> list:
+    """Every `kind` job started at or after `since`, from both tables, newest
+    first. A reader of recent history (the dashboard timeline) sees the
+    operations rows this phase writes and the legacy rows written before it,
+    until phase 9 drops the legacy table (spec section 14)."""
+    model = _legacy_model(kind)
+    operations = (
+        db.query(Operation)
+        .filter(Operation.kind == kind, Operation.started_at >= since)
+        .all()
+    )
+    jobs = [MaintenanceJobFacade(db, operation) for operation in operations]
+    jobs.extend(db.query(model).filter(model.started_at >= since).all())
+    jobs.sort(key=lambda job: (job.started_at, job.id), reverse=True)
+    return jobs
+
+
+# A row still waiting for its verdict. `pending` is the legacy word for
+# `queued` (spec 6.3); every other status is an outcome, `skipped` included,
+# since its reason says what kept the run from happening.
+UNSETTLED_STATUSES: frozenset[str] = frozenset({"pending", "queued", "running"})
+
+
+def _legacy_model(kind: str):
+    model = LEGACY_MODELS.get(kind)
+    if model is None:
+        raise ValueError(f"Not a maintenance kind: {kind!r}")
+    return model
+
+
+def latest_maintenance_jobs_by_repository(
+    db: Session, kind: str, repository_ids: list[int], *, settled: bool = False
+) -> dict[int, Any]:
+    """The newest `kind` row of each repository, from both tables. Newest by
+    creation, as the legacy max-id lookup was; an operation wins a tie, since
+    it is the row still being written.
+
+    With `settled`, only rows that reached a verdict count: a queued run can
+    wait hours for a runner slot and must not hide the failure before it, so
+    a health reading asks for the verdict separately from the live row."""
+    if not repository_ids:
+        return {}
+    model = _legacy_model(kind)
+    legacy_filters = [model.repository_id.in_(repository_ids)]
+    op_filters = [Operation.kind == kind, Operation.repository_id.in_(repository_ids)]
+    if settled:
+        # a legacy status column is nullable; NULL is not "still waiting"
+        legacy_filters.append(
+            or_(model.status.is_(None), model.status.notin_(UNSETTLED_STATUSES))
+        )
+        op_filters.append(Operation.status.notin_(UNSETTLED_STATUSES))
+    result: dict[int, Any] = {}
+    for job in newest_per_group(
+        db,
+        model,
+        model.repository_id,
+        func.coalesce(model.created_at, datetime.min),
+        legacy_filters,
+    ):
+        result[job.repository_id] = job
+    for operation in newest_per_group(
+        db, Operation, Operation.repository_id, Operation.created_at, op_filters
+    ):
+        current = result.get(operation.repository_id)
+        if current is None or operation.created_at >= (
+            current.created_at or datetime.min
+        ):
+            result[operation.repository_id] = MaintenanceJobFacade(db, operation)
+    return result

--- a/tests/unit/test_api_dashboard.py
+++ b/tests/unit/test_api_dashboard.py
@@ -13,11 +13,13 @@ from app.api.dashboard import (
     SystemMetrics,
     build_full_repository_health,
     build_observe_repository_health,
+    build_restore_check_health,
     format_bytes,
     get_recent_jobs,
     parse_size_to_bytes,
 )
 from app.database.models import (
+    Operation,
     BackupJob,
     BackupPlan,
     BackupPlanRepository,
@@ -306,6 +308,27 @@ class TestDashboardHelpers:
     def test_parse_size_to_bytes(self, size_string, expected):
         assert parse_size_to_bytes(size_string) == expected
 
+    def test_maintenance_repository_name_falls_back_from_id_to_path(self):
+        from types import SimpleNamespace
+
+        from app.api.dashboard import _maintenance_repository_name
+
+        names = {"/srv/backups/full": "Full Repo"}
+        ids = {7: "Full Repo"}
+
+        def name(repository_id, path):
+            return _maintenance_repository_name(
+                SimpleNamespace(repository_id=repository_id, repository_path=path),
+                names,
+                ids,
+            )
+
+        assert name(7, "/elsewhere") == "Full Repo"
+        assert name(None, "/srv/backups/full") == "Full Repo"
+        assert name(99, "/srv/backups/full/") == "Full Repo"
+        assert name(None, "/mnt/orphan/") == "orphan"
+        assert name(None, None) == "Unknown"
+
     @pytest.mark.parametrize(
         "size_value, expected",
         [
@@ -439,6 +462,142 @@ class TestDashboardHelpers:
         assert health["dimension_health"]["restore"] == "warning"
         assert health["latest_restore_check_status"] == "needs_backup"
         assert any("Run a backup" in warning for warning in health["warnings"])
+
+    def test_full_repository_health_keeps_the_verdict_while_a_run_is_live(self):
+        now = datetime.utcnow()
+        repo = Repository(
+            id=7,
+            name="Restore Running Repo",
+            path="/srv/backups/restore-running",
+            last_backup=now - timedelta(hours=1),
+            last_check=now - timedelta(hours=1),
+            last_compact=now - timedelta(hours=1),
+            last_restore_check=now - timedelta(days=5),
+            restore_check_cron_expression="0 4 * * *",
+        )
+        failed = RestoreCheckJob(
+            repository_id=7,
+            repository_path=repo.path,
+            status="failed",
+            error_message="Canary manifest not found",
+            started_at=now - timedelta(days=1),
+        )
+        running = RestoreCheckJob(
+            repository_id=7,
+            repository_path=repo.path,
+            status="running",
+            started_at=now - timedelta(minutes=10),
+        )
+
+        health = build_full_repository_health(repo, now, running, last_verdict=failed)
+
+        assert health["latest_restore_check_status"] == "running"
+        assert health["dimension_health"]["restore"] == "critical"
+        assert health["health_status"] == "critical"
+        assert "Restore check failed: Canary manifest not found" in health["warnings"]
+
+    def test_restore_check_health_takes_the_newer_of_column_and_verdict(self):
+        now = datetime.utcnow()
+        repo = Repository(
+            id=7,
+            name="Stale Column Repo",
+            path="/srv/backups/stale-column",
+            last_restore_check=now - timedelta(days=40),
+            restore_check_cron_expression="0 4 * * *",
+        )
+        completed = RestoreCheckJob(
+            repository_id=7,
+            repository_path=repo.path,
+            status="completed",
+            completed_at=now - timedelta(days=1),
+        )
+
+        health = build_restore_check_health(repo, now, completed)
+
+        assert health["dimension"] == "healthy"
+        assert health["warning"] is None
+
+    def test_restore_check_health_names_the_reason_of_another_skip(self):
+        from types import SimpleNamespace
+
+        now = datetime.utcnow()
+        repo = Repository(
+            id=7,
+            name="Dependent Repo",
+            path="/srv/backups/dependent",
+            last_restore_check=now - timedelta(days=1),
+            restore_check_cron_expression="0 4 * * *",
+        )
+        verdict = SimpleNamespace(
+            status="skipped",
+            skip_reason="dependency_failed",
+            error_message=None,
+            completed_at=now - timedelta(hours=1),
+        )
+
+        health = build_restore_check_health(repo, now, verdict)
+
+        assert health["dimension"] == "warning"
+        assert health["warning"] == "Restore check skipped: dependency failed"
+
+    def test_restore_check_health_ignores_a_live_run_behind_a_completed_verdict(
+        self,
+    ):
+        now = datetime.utcnow()
+        repo = Repository(
+            id=7,
+            name="Quiet Repo",
+            path="/srv/backups/quiet",
+            last_restore_check=None,
+            restore_check_cron_expression="0 4 * * *",
+        )
+        completed = RestoreCheckJob(
+            repository_id=7,
+            repository_path=repo.path,
+            status="completed",
+            completed_at=now - timedelta(days=2),
+        )
+        running = RestoreCheckJob(
+            repository_id=7, repository_path=repo.path, status="running"
+        )
+
+        health = build_restore_check_health(repo, now, running, last_verdict=completed)
+
+        assert health["dimension"] == "healthy"
+        assert health["latest_status"] == "running"
+
+    def test_observe_repository_health_keeps_the_verdict_while_a_run_is_live(self):
+        now = datetime.utcnow()
+        repo = Repository(
+            id=9,
+            name="Observe Running Repo",
+            path="/srv/backups/observe-running",
+            mode="observe",
+            archive_count=4,
+            last_backup=now - timedelta(hours=1),
+            last_check=now - timedelta(hours=1),
+            last_restore_check=now - timedelta(days=3),
+            restore_check_cron_expression="0 4 * * *",
+        )
+        failed = RestoreCheckJob(
+            repository_id=9,
+            repository_path=repo.path,
+            status="failed",
+            error_message="Probe path missing",
+            started_at=now - timedelta(days=1),
+        )
+        pending = RestoreCheckJob(
+            repository_id=9, repository_path=repo.path, status="pending"
+        )
+
+        health = build_observe_repository_health(
+            repo, now, pending, last_verdict=failed
+        )
+
+        assert health["health_status"] == "critical"
+        assert health["latest_restore_check_status"] == "pending"
+        assert health["latest_restore_check_error"] == "Probe path missing"
+        assert "Restore check failed: Probe path missing" in health["warnings"]
 
     def test_observe_repository_health_includes_restore_check_signal(self):
         now = datetime.utcnow()
@@ -921,6 +1080,190 @@ class TestDashboardScheduleAndOverview:
         )
         assert data["system_metrics"]["cpu_usage"] == 12.5
         assert data["last_updated"].endswith("+00:00")
+
+    def test_dashboard_overview_reads_maintenance_operations(
+        self,
+        test_client: TestClient,
+        admin_headers,
+        test_db,
+    ):
+        """Check, prune, compact and restore check are `operations` rows since
+        phase 5; the timeline and the restore health signal read them next
+        to the rows the legacy tables still hold."""
+        now = datetime.now(timezone.utc)
+        repo = Repository(
+            name="Ops Repo",
+            path="/srv/backups/ops",
+            repository_type="local",
+            mode="full",
+        )
+        empty = Repository(
+            name="Empty Repo",
+            path="/srv/backups/empty",
+            repository_type="local",
+            mode="full",
+            restore_check_cron_expression="0 4 * * *",
+        )
+        test_db.add_all([repo, empty])
+        test_db.commit()
+
+        def operation(kind, *, status, started, error=None):
+            return Operation(
+                repository_id=repo.id,
+                kind=kind,
+                category="restore" if kind == "restore_check" else "maintenance",
+                status=status,
+                trigger="manual",
+                priority=0,
+                run_id="run-ops",
+                created_at=started,
+                started_at=started,
+                completed_at=started + timedelta(minutes=5),
+                error_message=error,
+            )
+
+        test_db.add_all(
+            [
+                operation("check", status="completed", started=now - timedelta(days=1)),
+                operation(
+                    "compact", status="completed", started=now - timedelta(days=2)
+                ),
+                operation(
+                    "prune",
+                    status="failed",
+                    started=now - timedelta(days=3),
+                    error="prune failed",
+                ),
+                operation(
+                    "restore_check",
+                    status="failed",
+                    started=now - timedelta(hours=1),
+                    error="Canary manifest not found",
+                ),
+                # newer, but still waiting for a slot (shown as the legacy word
+                # "pending"): in the feed, not the latest verdict
+                operation(
+                    "restore_check", status="queued", started=now - timedelta(minutes=5)
+                ),
+                # outside the timeline window
+                operation(
+                    "prune", status="completed", started=now - timedelta(days=20)
+                ),
+                # the restore check's "run a backup first" verdict, as the
+                # facade writes it (spec 6.3)
+                Operation(
+                    repository_id=empty.id,
+                    kind="restore_check",
+                    category="restore",
+                    status="skipped",
+                    skip_reason="needs_backup",
+                    trigger="manual",
+                    priority=0,
+                    run_id="run-empty",
+                    created_at=now - timedelta(days=13),
+                    started_at=now - timedelta(days=13),
+                    completed_at=now - timedelta(days=13) + timedelta(minutes=1),
+                    error_message="Run a backup, then run this restore check again",
+                ),
+                # no repository left to name it after
+                Operation(
+                    repository_id=None,
+                    kind="check",
+                    category="maintenance",
+                    status="completed",
+                    trigger="manual",
+                    priority=0,
+                    run_id="run-orphan",
+                    created_at=now - timedelta(days=6),
+                    started_at=now - timedelta(days=6),
+                    completed_at=now - timedelta(days=6) + timedelta(minutes=5),
+                ),
+                # a legacy row without a status (nullable column) is still named
+                CheckJob(
+                    repository_id=repo.id,
+                    repository_path=repo.path,
+                    started_at=now - timedelta(days=12),
+                    completed_at=now - timedelta(days=12) + timedelta(minutes=5),
+                ),
+                # a legacy row from before the migration is still read
+                PruneJob(
+                    repository_id=repo.id,
+                    repository_path=repo.path,
+                    status="completed",
+                    started_at=now - timedelta(days=4),
+                    completed_at=now - timedelta(days=4) + timedelta(minutes=5),
+                ),
+                # older than the restore check operation, so it is not the latest
+                RestoreCheckJob(
+                    repository_id=repo.id,
+                    repository_path=repo.path,
+                    status="completed",
+                    created_at=now - timedelta(days=2, hours=6),
+                    started_at=now - timedelta(days=2, hours=6),
+                    completed_at=now - timedelta(days=2, hours=5),
+                ),
+            ]
+        )
+        test_db.commit()
+        test_db.query(CheckJob).filter(
+            CheckJob.started_at == now - timedelta(days=12)
+        ).update({"status": None})
+        test_db.commit()
+
+        metrics = SystemMetrics(
+            cpu_usage=1.0,
+            cpu_count=1,
+            memory_usage=1.0,
+            memory_total=1,
+            memory_available=1,
+            disk_usage=1.0,
+            disk_total=1,
+            disk_free=1,
+            uptime=1,
+        )
+        with patch("app.api.dashboard.get_system_metrics", return_value=metrics):
+            response = test_client.get("/api/dashboard/overview", headers=admin_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [
+            (item["type"], item["status"], item["repository"])
+            for item in data["activity_feed"]
+        ] == [
+            ("restore_check", "pending", "Ops Repo"),
+            ("restore_check", "failed", "Ops Repo"),
+            ("check", "completed", "Ops Repo"),
+            ("compact", "completed", "Ops Repo"),
+            ("restore_check", "completed", "Ops Repo"),
+            ("prune", "failed", "Ops Repo"),
+            ("prune", "completed", "Ops Repo"),
+            ("check", "completed", "Unknown"),
+            ("check", "unknown", "Ops Repo"),
+            ("restore_check", "needs_backup", "Empty Repo"),
+        ]
+        failed_prune = data["activity_feed"][5]
+        assert failed_prune["message"] == "Prune failed"
+        assert failed_prune["error"] == "prune failed"
+        needs_backup = data["activity_feed"][-1]
+        assert needs_backup["message"] == "Restore check needs backup"
+        assert (
+            needs_backup["error"] == "Run a backup, then run this restore check again"
+        )
+        health = {item["name"]: item for item in data["repository_health"]}["Ops Repo"]
+        # the queued run is the live status, the failed one the verdict
+        assert health["latest_restore_check_status"] == "pending"
+        assert health["latest_restore_check_error"] == "Canary manifest not found"
+        assert health["dimension_health"]["restore"] == "critical"
+        assert "Restore check failed: Canary manifest not found" in health["warnings"]
+        empty_health = {item["name"]: item for item in data["repository_health"]}[
+            "Empty Repo"
+        ]
+        assert empty_health["latest_restore_check_status"] == "needs_backup"
+        assert empty_health["dimension_health"]["restore"] == "warning"
+        assert (
+            "Run a backup, then run this restore check again"
+            in empty_health["warnings"]
+        )
 
     def test_dashboard_overview_uses_configured_backup_health_thresholds(
         self,

--- a/tests/unit/test_operations_job_facade.py
+++ b/tests/unit/test_operations_job_facade.py
@@ -6,12 +6,20 @@ import pytest
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
-from app.database.models import Base, CheckJob, Operation, Repository
+from app.database.models import (
+    Base,
+    CheckJob,
+    Operation,
+    Repository,
+    RestoreCheckJob,
+)
 from app.services.operations.job_facade import (
     MAINTENANCE_KINDS,
     MaintenanceJobFacade,
     claim_running,
+    latest_maintenance_jobs_by_repository,
     legacy_status,
+    maintenance_jobs_started_since,
     operation_status,
     resolve_agent_maintenance_job,
     resolve_maintenance_job,
@@ -446,3 +454,238 @@ def test_resolve_agent_job_rejects_bad_shapes(db, repository):
     payload["operation"]["maintenance_job"]["kind"] = "wipe"
     assert resolve_agent_maintenance_job(db, payload) is None
     assert resolve_agent_maintenance_job(db, _payload(1), kinds=("prune",)) is None
+
+
+def test_started_since_unions_both_tables_newest_first(db, repository):
+    since = datetime(2026, 9, 1)
+    old = CheckJob(
+        repository_id=repository.id,
+        repository_path=repository.path,
+        status="completed",
+        started_at=datetime(2026, 8, 30),
+    )
+    legacy = CheckJob(
+        repository_id=repository.id,
+        repository_path=repository.path,
+        status="completed",
+        started_at=datetime(2026, 9, 2),
+    )
+    db.add_all([old, legacy])
+    db.commit()
+    op = _operation(db, repository, status="completed")
+    op.started_at = datetime(2026, 9, 3)
+    unrelated = _operation(db, repository, kind="prune", status="completed")
+    unrelated.started_at = datetime(2026, 9, 4)
+    db.commit()
+
+    jobs = maintenance_jobs_started_since(db, "check", since)
+
+    assert [(type(job).__name__, job.id) for job in jobs] == [
+        ("MaintenanceJobFacade", op.id),
+        ("CheckJob", legacy.id),
+    ]
+    assert jobs[0].repository_path == repository.path
+
+
+def test_latest_by_repository_takes_the_newer_row_from_either_table(db):
+    ops_repo = Repository(name="ops", path="/repo/ops", borg_version=1)
+    legacy_repo = Repository(name="legacy", path="/repo/legacy", borg_version=1)
+    idle_repo = Repository(name="idle", path="/repo/idle", borg_version=1)
+    db.add_all([ops_repo, legacy_repo, idle_repo])
+    db.commit()
+    db.add_all(
+        [
+            RestoreCheckJob(
+                repository_id=ops_repo.id,
+                repository_path=ops_repo.path,
+                status="completed",
+                created_at=datetime(2026, 9, 1),
+            ),
+            RestoreCheckJob(
+                repository_id=legacy_repo.id,
+                repository_path=legacy_repo.path,
+                status="failed",
+                created_at=datetime(2026, 9, 5),
+            ),
+            RestoreCheckJob(
+                repository_id=legacy_repo.id,
+                repository_path=legacy_repo.path,
+                status="completed",
+                created_at=datetime(2026, 9, 4),
+            ),
+        ]
+    )
+    db.commit()
+    newer = _operation(db, ops_repo, kind="restore_check", status="failed")
+    newer.created_at = datetime(2026, 9, 2)
+    older = _operation(db, legacy_repo, kind="restore_check", status="completed")
+    older.created_at = datetime(2026, 9, 3)
+    db.commit()
+
+    latest = latest_maintenance_jobs_by_repository(
+        db, "restore_check", [ops_repo.id, legacy_repo.id, idle_repo.id]
+    )
+
+    assert set(latest) == {ops_repo.id, legacy_repo.id}
+    assert isinstance(latest[ops_repo.id], MaintenanceJobFacade)
+    assert latest[ops_repo.id].id == newer.id
+    assert isinstance(latest[legacy_repo.id], RestoreCheckJob)
+    assert latest[legacy_repo.id].status == "failed"
+    assert latest_maintenance_jobs_by_repository(db, "restore_check", []) == {}
+
+
+def test_latest_by_repository_gives_a_tie_to_the_operation(db, repository):
+    when = datetime(2026, 9, 6)
+    db.add(
+        RestoreCheckJob(
+            repository_id=repository.id,
+            repository_path=repository.path,
+            status="failed",
+            created_at=when,
+        )
+    )
+    db.commit()
+    op = _operation(db, repository, kind="restore_check", status="completed")
+    op.created_at = when
+    db.commit()
+
+    latest = latest_maintenance_jobs_by_repository(db, "restore_check", [repository.id])
+
+    assert isinstance(latest[repository.id], MaintenanceJobFacade)
+    assert latest[repository.id].id == op.id
+
+
+def test_latest_by_repository_reports_the_live_row_or_the_last_verdict(db, repository):
+    failed = RestoreCheckJob(
+        repository_id=repository.id,
+        repository_path=repository.path,
+        status="failed",
+        created_at=datetime(2026, 9, 6),
+    )
+    db.add(failed)
+    db.commit()
+    queued = _operation(db, repository, kind="restore_check", status="queued")
+    queued.created_at = datetime(2026, 9, 7)
+    running = _operation(db, repository, kind="restore_check", status="running")
+    running.created_at = datetime(2026, 9, 8)
+    db.commit()
+
+    live = latest_maintenance_jobs_by_repository(db, "restore_check", [repository.id])
+    verdicts = latest_maintenance_jobs_by_repository(
+        db, "restore_check", [repository.id], settled=True
+    )
+
+    assert live[repository.id].id == running.id
+    assert live[repository.id].status == "running"
+    assert isinstance(verdicts[repository.id], RestoreCheckJob)
+    assert verdicts[repository.id].id == failed.id
+
+
+def test_latest_by_repository_has_no_verdict_for_a_first_run_still_queued(
+    db, repository
+):
+    pending = RestoreCheckJob(
+        repository_id=repository.id,
+        repository_path=repository.path,
+        status="pending",
+        created_at=datetime(2026, 9, 6),
+    )
+    db.add(pending)
+    db.commit()
+    queued = _operation(db, repository, kind="restore_check", status="queued")
+    queued.created_at = datetime(2026, 9, 7)
+    db.commit()
+
+    live = latest_maintenance_jobs_by_repository(db, "restore_check", [repository.id])
+
+    assert live[repository.id].id == queued.id
+    assert live[repository.id].status == "pending"
+    assert (
+        latest_maintenance_jobs_by_repository(
+            db, "restore_check", [repository.id], settled=True
+        )
+        == {}
+    )
+
+
+def test_latest_by_repository_survives_a_legacy_row_without_created_at(db, repository):
+    db.add(
+        RestoreCheckJob(
+            repository_id=repository.id,
+            repository_path=repository.path,
+            status="failed",
+        )
+    )
+    db.commit()
+    # rows written before the column existed carry NULL; force it past the default
+    db.query(RestoreCheckJob).update({"created_at": None})
+    db.commit()
+    assert db.query(RestoreCheckJob.created_at).scalar() is None
+    op = _operation(db, repository, kind="restore_check", status="completed")
+    op.created_at = datetime(2026, 9, 7)
+    db.commit()
+
+    latest = latest_maintenance_jobs_by_repository(db, "restore_check", [repository.id])
+
+    assert latest[repository.id].id == op.id
+
+
+def test_readers_name_an_unknown_kind(db, repository):
+    with pytest.raises(ValueError, match="restorecheck"):
+        maintenance_jobs_started_since(db, "restorecheck", datetime(2026, 9, 1))
+    with pytest.raises(ValueError, match="restorecheck"):
+        latest_maintenance_jobs_by_repository(db, "restorecheck", [repository.id])
+
+
+def test_latest_by_repository_counts_a_skipped_run_as_the_verdict(db, repository):
+    failed = _operation(db, repository, kind="restore_check", status="failed")
+    failed.created_at = datetime(2026, 9, 6)
+    skipped = _operation(db, repository, kind="restore_check", status="skipped")
+    skipped.created_at = datetime(2026, 9, 7)
+    skipped.skip_reason = "needs_backup"
+    db.commit()
+
+    verdicts = latest_maintenance_jobs_by_repository(
+        db, "restore_check", [repository.id], settled=True
+    )
+
+    assert verdicts[repository.id].id == skipped.id
+    assert verdicts[repository.id].skip_reason == "needs_backup"
+
+
+def test_needs_backup_is_written_as_a_skip_and_read_back(db, repository):
+    op = _operation(db, repository, kind="restore_check")
+    job = MaintenanceJobFacade(db, op)
+
+    job.status = "needs_backup"
+    db.commit()
+    db.refresh(op)
+
+    assert (op.status, op.skip_reason) == ("skipped", "needs_backup")
+    assert job.status == "needs_backup"
+    assert operation_status("needs_backup") == "skipped"
+    other = _operation(db, repository, kind="restore_check", status="skipped")
+    other.skip_reason = "dependency_failed"
+    assert MaintenanceJobFacade(db, other).status == "skipped"
+
+
+def test_latest_by_repository_counts_a_legacy_row_without_status_as_settled(
+    db, repository
+):
+    db.add(
+        RestoreCheckJob(
+            repository_id=repository.id,
+            repository_path=repository.path,
+            created_at=datetime(2026, 9, 6),
+        )
+    )
+    db.commit()
+    db.query(RestoreCheckJob).update({"status": None})
+    db.commit()
+
+    live = latest_maintenance_jobs_by_repository(db, "restore_check", [repository.id])
+    verdicts = latest_maintenance_jobs_by_repository(
+        db, "restore_check", [repository.id], settled=True
+    )
+
+    assert live[repository.id].id == verdicts[repository.id].id

--- a/tests/unit/test_operations_maintenance_executors.py
+++ b/tests/unit/test_operations_maintenance_executors.py
@@ -555,3 +555,31 @@ async def test_restore_check_cancellation_terminates_the_tracked_borg_process(
         fake_process.terminate.assert_called_once()
     finally:
         restore_check_service.running_processes.pop(op.id, None)
+
+
+@pytest.mark.asyncio
+async def test_restore_check_needs_backup_is_a_skip_with_that_reason(
+    db, repository, monkeypatch
+):
+    from app.services.operations.executors import maintenance
+    from app.services.restore_check_service import restore_check_service
+
+    op = _operation(db, repository, kind="restore_check", category="restore")
+    ctx = FakeContext(db, op)
+
+    async def needs_backup(job_id, repository_id):
+        job = MaintenanceJobFacade(db, db.get(Operation, job_id))
+        job.status = "needs_backup"
+        job.error_message = "Run a backup, then run this restore check again"
+        db.commit()
+
+    monkeypatch.setattr(restore_check_service, "execute_restore_check", needs_backup)
+
+    outcome = await maintenance.run_restore_check(ctx)
+
+    assert outcome.status == "skipped"
+    assert outcome.skip_reason == "needs_backup"
+    assert outcome.error_message == "Run a backup, then run this restore check again"
+    db.refresh(op)
+    assert (op.status, op.skip_reason) == ("skipped", "needs_backup")
+    assert MaintenanceJobFacade(db, op).status == "needs_backup"


### PR DESCRIPTION
## Description

Phase 5 moved check, prune, compact and restore check onto the `operations` table, but the dashboard overview kept reading only the legacy job tables. On an install running current main the timeline's check, compact, prune and restore lanes are empty for every run since the migration (the last dots are the legacy rows written before it), and the restore health signal no longer sees the latest restore check. Backup already reads the union (phase 8); the maintenance kinds now do the same, following spec section 14 (legacy rows are read through the union until phase 9).

What changes:

- `maintenance_jobs_started_since(db, kind, since)` on the maintenance facade module unions both tables for one kind; the four identical feed loops in `get_dashboard_overview` collapse into one over it, resolving the repository name the way they always did (captured path, then id, then the path's last segment); an operations row captures no path, its facade resolves it from the repository.
- `latest_maintenance_jobs_by_repository(db, kind, ids, settled=...)` ranks each table in SQL (`newest_per_group`, now public) and takes the newer row per repository, an operation winning a tie. The dashboard asks for it twice: the newest row drives the live status (`latest_restore_check_status` keeps saying `running`/`pending`), the newest row with a verdict drives the severity, so a run queued for hours behind a running backup no longer hides the failure before it. `build_restore_check_health` takes the verdict as `last_verdict`; without it the newest row is the verdict when it has one, so existing callers behave as before.
- A `skipped` verdict is named in the health warning with its reason. The restore check's `needs_backup` outcome is `skipped` with `skip_reason = "needs_backup"` on an operation (spec 6.3), which the facade did not map yet: it wrote the legacy word into `operations.status`, a value outside the vocabulary, and the maintenance executor, not knowing it, recorded the run as `failed`. The facade now writes the mapping and reads it back as `needs_backup` (so the service's own status checks and the dashboard payload keep the legacy word), and the executor accepts `skipped` as the row's terminal word, passing the reason and the service's message through.
- The tooltip error falls back to the verdict's message while the live row has none, the `completed` verdict is folded into `last_success` before the pending/running branch, and the cancelled wording no longer claims the newest run was the cancelled one.

The Activity page is unaffected; it has had its own union over `operations` since phase 1.

**Where this sits against the phase plan.** Section 13 leaves the dashboard readers to phase 9 ("Activity reads only `operations`; delete legacy job tables"), so phase 9 would have closed this gap by deleting the legacy half. This PR pulls the operations half forward: with phases 5 to 8 shipped, every install on main runs its maintenance through the runner, and a dashboard that shows nothing for those runs is not usable in the meantime. The readers are written so that phase 9 only has to drop their legacy branch (`maintenance_jobs_started_since` and `latest_maintenance_jobs_by_repository` lose the `LEGACY_MODELS` query, `build_restore_check_health` keeps its `last_verdict` shape); nothing here adds to what phase 9 has to remove. If you would rather fold this into the phase 9 branch, the dashboard part of the diff is self-contained; the `needs_backup` mapping is a phase 5 correction either way.

## Related Issue

No issue filed; found on an install running main after #988 (phase 8) with plans that prune and compact after the backup. Related to the phase 5 work in the operations spec.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

- Unit: `pytest tests/unit -p no:randomly` on the branch: 3891 passed, 14 skipped (rebased onto main 39ee2e3c).
- New tests: union reader ordering and kind validation; newest-per-repository across both tables (tie, NULL `created_at`, live row vs verdict, first run still queued, skipped as verdict); dashboard overview reading operations rows for all four lanes, an orphaned operation naming "Unknown", the queued run as live status next to the failed verdict; the health builders with a live run over a failed, completed or skipped verdict (full and observe mode); an operation-backed `needs_backup` restore check through the endpoint; the facade writing `needs_backup` as `skipped` and reading it back; the executor passing a `skipped` row through as that outcome.
- `ruff check` and `ruff format --check` clean. No frontend change.
- Verified against the data shape that showed the gap: legacy prune/compact/check rows stop at the day the install moved onto phase 5, operations rows carry every run since; the timeline reads both after this change.

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none needed; the phase 9 collapse is already in the spec)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

None; the visible effect is that the check, compact, prune and restore lanes of the dashboard timeline fill again for runs recorded as operations.

## Additional Context

Side findings from the same day on an install running main. The first is fixed here; 2 and 4 are filed as karanhudia/borg-ui#1002 and karanhudia/borg-ui#1003; 3 is #982/#983 with sharper evidence:

1. **#947 (phase 5) recorded the restore check's `needs_backup` as `failed`.** The facade's status setter only mapped `pending`, so the service's `needs_backup` landed verbatim in `operations.status`; the executor's terminal set did not include it, the run counted as "no verdict" and became a failure with the service's message. Fixed in this PR as described above; until now the dashboard did not read operations rows, so it never showed.
2. **`stats` on the index lane fails on the admission 409 instead of deferring** (filed as #1002). The agent branch of `run_stats` goes through `_update_agent_repository_stats`, which catches the `repositoryOperationActive` HTTPException and only logs it; the falsy return becomes `Outcome(status="failed", "agent repository stats refresh failed")`. `archive_sync` lets the same 409 out of `queue_agent_repository_operation_job` and the runner defers it ("Operation deferred, repository busy"). Observed since the follow-up chains of #949: the backup chain's and the compact chain's `stats` start in the same second as the prune chain's `archive_sync` and both fail, two to three red `stats` per backup wave; during a backlog drain with `index_workers=2` the runner also starts two `stats` for one repository at once and admission rejects the second. Fix sketch: let the 409 reach the runner from the agent branch of `run_stats` (or give `_update_agent_repository_stats` a raise-busy option).
3. **#982 recurs with an empty queue.** Backup completes, the runner wakes on the completion and enqueues the follow-up `archive_sync` list job, and the plan's inline prune starts about 30 ms later and gets the 409. With #983 the prune operation then stays `running` with no agent job and no task, and every backup of that repository is refused until the row is set to failed by hand. The race is rolled on every plan run.
4. **`archive_sync` failing with `list_archives exited with code 2`** (filed as #1003, with the per-repository serialisation proposal) while a `stats` rinfo job runs on the same Borg 1 repository: admission allows list next to rinfo (both `repository_read`, no duplicate), but borg holds the cache lock during `info`, so the parallel list dies. Together with 2 and 3 this argues for serialising the index kinds per repository in the runner tick (no second index operation on a repository that already runs one), beyond the 409 deferral for `stats`.

The `(type, id)` pair in `activity_feed` is not unique across the two tables; that is the unqualified id space Appendix B of the operations spec accepts until phase 9 and the same ambiguity the backup entries carry since phase 8. Phase 9 removes both the legacy readers here and the second id space.
