### PR TITLE
fix(ssh): restricted (forced-command) keys report as connected, not failed

### DIFF
--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -52,7 +52,7 @@ from app.services.operations.enqueue import enqueue, wake_runner
 from app.services.operations.rclone_facade import RcloneSyncFacade
 from app.services.operations.repository_status import LastRuns, last_runs
 from app.core.authorization import authorize_request
-from app.core.security import get_current_user, check_repo_access, decrypt_secret
+from app.core.security import get_current_user, check_repo_access
 from app.core.borg import BorgInterface
 from app.core.borg_router import BorgRouter
 from app.core.borg_errors import is_lock_error
@@ -117,7 +117,6 @@ from app.services.rclone_repository_service import (
     normalize_rclone_relative_path,
     rclone_repository_service,
 )
-from app.utils.ssh_host_keys import host_key_ssh_opts
 from app.utils.datetime_utils import (
     parse_borg_archive_time,
     serialize_borg_archive_time,
@@ -146,7 +145,6 @@ from app.utils.borg_env import (
 )
 from app.utils.ssh_utils import (
     resolve_repo_ssh_key_file,  # noqa: F401
-    ssh_key_auth_args,
 )  # Backward-compatible patch target for tests
 
 logger = structlog.get_logger()
@@ -5881,89 +5879,6 @@ async def get_repository_statistics(
         raise HTTPException(
             status_code=500, detail={"key": "backend.errors.repo.failedToGetStatistics"}
         )
-
-
-async def check_remote_borg_installation(
-    host: str, username: str, port: int, ssh_key_id: int
-) -> Dict[str, Any]:
-    """Check if borg is installed on remote machine"""
-    temp_key_file = None
-    try:
-        logger.info(
-            "Checking remote borg installation", host=host, username=username, port=port
-        )
-
-        # Get SSH key from database
-        from app.database.models import SSHKey
-        from app.database.database import get_db
-        import tempfile
-
-        db = next(get_db())
-        ssh_key = db.query(SSHKey).filter(SSHKey.id == ssh_key_id).first()
-        if not ssh_key:
-            return {"success": False, "error": "SSH key not found", "has_borg": False}
-
-        # Decrypt private key
-        private_key = decrypt_secret(ssh_key.private_key)
-
-        # Ensure private key ends with newline
-        if not private_key.endswith("\n"):
-            private_key += "\n"
-
-        # Create temporary key file
-        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
-            f.write(private_key)
-            temp_key_file = f.name
-
-        os.chmod(temp_key_file, 0o600)
-
-        # Check for borg
-        borg_cmd = [
-            "ssh",
-            *ssh_key_auth_args(temp_key_file),
-            *host_key_ssh_opts(None),
-            "-o",
-            "ConnectTimeout=10",
-            "-p",
-            str(port),
-            f"{username}@{host}",
-            "which borg",
-        ]
-
-        borg_process = await asyncio.create_subprocess_exec(
-            *borg_cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
-        )
-        borg_stdout, borg_stderr = await asyncio.wait_for(
-            borg_process.communicate(), timeout=15
-        )
-        has_borg = borg_process.returncode == 0
-
-        logger.info("Remote borg check completed", host=host, has_borg=has_borg)
-
-        return {
-            "success": True,
-            "has_borg": has_borg,
-            "borg_path": borg_stdout.decode().strip() if has_borg else None,
-        }
-
-    except asyncio.TimeoutError:
-        logger.error("Remote borg check timed out", host=host)
-        return {
-            "success": False,
-            "error": "Connection timeout while checking remote borg installation",
-            "has_borg": False,
-        }
-    except Exception as e:
-        logger.error(
-            "Failed to check remote borg installation", host=host, error=str(e)
-        )
-        return {"success": False, "error": str(e), "has_borg": False}
-    finally:
-        if temp_key_file and os.path.exists(temp_key_file):
-            try:
-                os.unlink(temp_key_file)
-            except Exception as e:
-                logger.warning("Failed to clean up temp SSH key", error=str(e))
 
 
 async def verify_existing_repository(

--- a/app/api/ssh_keys.py
+++ b/app/api/ssh_keys.py
@@ -110,8 +110,12 @@ async def _run_df_command(
         df_command,
     ]
 
+    # Closed stdin: a forced `borg serve` key would otherwise hold this open.
     process = await asyncio.create_subprocess_exec(
-        *df_cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        *df_cmd,
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
     )
     stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=15)
 
@@ -1194,6 +1198,11 @@ def _ssh_connect_timeout(timeout_seconds: float) -> str:
     return str(max(1, math.ceil(timeout_seconds)))
 
 
+# ssh(1) exits 255 for its own errors; otherwise it returns the remote
+# command's exit status, which means the key authenticated.
+SSH_CLIENT_FAILURE_EXIT_CODE = 255
+
+
 def _ssh_command_base(
     connection: SSHConnection, key_file_path: str, timeout_seconds: float
 ) -> list[str]:
@@ -1329,8 +1338,12 @@ async def _run_ssh_latency_probe(
         )
 
     elapsed = _elapsed_ms(started_at)
-    if return_code == 0:
+    if return_code != SSH_CLIENT_FAILURE_EXIT_CODE:
+        # The session was established; a refused `pwd` (restricted shell or
+        # forced-command key) still measures the round trip.
         result: dict[str, Any] = {"status": "success", "elapsed_ms": elapsed}
+        if return_code != 0:
+            result["restricted"] = True
         output = stdout.decode(errors="replace").strip()
         if output:
             result["output"] = output
@@ -1736,7 +1749,7 @@ async def test_ssh_connection(
 
         return {
             "success": test_result["success"],
-            "message": "backend.success.ssh.connectionTestSuccess"
+            "message": test_result["message"]
             if test_result["success"]
             else "backend.success.ssh.connectionTestFailed",
             "connection": {
@@ -2029,7 +2042,7 @@ async def test_existing_connection(
 
         return {
             "success": test_result["success"],
-            "message": "backend.success.ssh.connectionTestSuccess"
+            "message": test_result["message"]
             if test_result["success"]
             else "backend.success.ssh.connectionTestFailed",
             "status": connection.status,
@@ -2987,8 +3000,14 @@ async def test_ssh_key_connection(
         )
 
         try:
+            # stdin must be closed: a key forced to `command="borg serve ..."`
+            # runs borg serve for this probe too, and borg serve waits on
+            # stdin until EOF.
             process = await asyncio.create_subprocess_exec(
-                *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+                *cmd,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
             )
 
             stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=15)
@@ -3007,21 +3026,34 @@ async def test_ssh_key_connection(
                     "output": stdout.decode().strip(),
                     "key_file": key_file_path,
                 }
+            elif process.returncode != SSH_CLIENT_FAILURE_EXIT_CODE:
+                # ssh itself failed (auth, DNS, refused, host key) only on 255.
+                # Any other status is the remote side refusing `pwd`: a
+                # restricted shell (Hetzner, rsync.net) or a forced-command key
+                # that only allows `borg serve`. The key authenticated, so the
+                # connection is fine for Borg; browsing and storage info are not.
+                logger.info(
+                    "ssh_connection_test_successful_restricted",
+                    host=host,
+                    username=username,
+                    port=port,
+                    return_code=process.returncode,
+                    stderr=stderr.decode(errors="replace")[:500] if stderr else None,
+                )
+                return {
+                    "success": True,
+                    "restricted": True,
+                    "message": "backend.success.ssh.connectionTestSuccessRestricted",
+                    "output": stdout.decode(errors="replace").strip(),
+                    "key_file": key_file_path,
+                }
             else:
                 stdout_str = stdout.decode() if stdout else ""
                 stderr_str = stderr.decode() if stderr else ""
                 error_msg = stderr_str or stdout_str or "SSH connection failed"
 
                 # Parse common errors with helpful hints
-                if (
-                    "Command not found" in error_msg
-                    or "Command not found" in stdout_str
-                ):
-                    error_summary = (
-                        f"SSH connection works but remote shell is restricted"
-                    )
-                    helpful_hint = "Server uses restricted shell (e.g., Hetzner Storage Box). Connection is valid for borg/rsync/sftp operations."
-                elif _is_ssh_dns_resolution_error(error_msg):
+                if _is_ssh_dns_resolution_error(error_msg):
                     error_summary = f"Host did not resolve: {host}"
                     helpful_hint = "Check the saved host value, DNS records/resolvers, provider sub-account existence, and container/runtime DNS."
                 elif "Connection refused" in error_msg:

--- a/docs/ssh-keys.md
+++ b/docs/ssh-keys.md
@@ -289,13 +289,39 @@ Passphrase-protected keys are not suitable for unattended scheduled backups unle
 
 ## Restrict Remote Access
 
-For backup-only remote users, consider restricting the public key in `authorized_keys`:
+For backup-only remote users, restrict the public key in `authorized_keys` so
+it can only run Borg:
 
 ```text
 command="borg serve --restrict-to-path /backups",restrict ssh-ed25519 AAAA... borg-ui
 ```
 
-Adjust the path for your server.
+Adjust the path for your server. Borg UI detects such keys: the connection
+test reports "SSH connection works, remote shell restricted" and stays green,
+because the key authenticated even though the probe command was refused.
+Everything that needs a shell on the repository host is unavailable with a
+restricted key and degrades without failing the connection:
+
+| Feature | Remote command | With a restricted key |
+|---|---|---|
+| Connection test, diagnostics latency | `pwd` | connected (restricted) |
+| Storage information | `df -k <path>` | hidden |
+| Path browsing, repository detection | `ls`, `stat`, SFTP | enter paths manually |
+| Mount connection | SFTP subsystem | unavailable |
+| Borg operations | `<remote_path> serve …` | work |
+
+Do not widen the key's allowlist to make those features work; a backup key
+should stay Borg-only.
+
+If you use a wrapper script instead of a fixed `borg serve` command, match
+`$SSH_ORIGINAL_COMMAND` against what Borg UI actually sends: the repository's
+**Remote Borg path** (default `borg`) followed by `serve` and flags, for example
+`borg serve --umask=077 --info`. With **Use sudo** enabled it is
+`sudo -n -H <remote_path> serve …`. The repository wizard's command preview
+shows the exact remote command for your settings. Match on the prefix rather
+than the full string, since Borg adds flags such as `--info` or `--debug`.
+Note that for a subsystem request `SSH_ORIGINAL_COMMAND` arrives with a
+trailing space (`/usr/lib/openssh/sftp-server `).
 
 ## Troubleshooting
 

--- a/docs/ssh-keys.md
+++ b/docs/ssh-keys.md
@@ -320,8 +320,8 @@ If you use a wrapper script instead of a fixed `borg serve` command, match
 `sudo -n -H <remote_path> serve …`. The repository wizard's command preview
 shows the exact remote command for your settings. Match on the prefix rather
 than the full string, since Borg adds flags such as `--info` or `--debug`.
-Note that for a subsystem request `SSH_ORIGINAL_COMMAND` arrives with a
-trailing space (`/usr/lib/openssh/sftp-server `).
+Note that for a subsystem request `SSH_ORIGINAL_COMMAND` arrives with one
+trailing ASCII space; shell-quoted it is `'/usr/lib/openssh/sftp-server '`.
 
 ## Troubleshooting
 

--- a/frontend/src/components/CommandPreview.tsx
+++ b/frontend/src/components/CommandPreview.tsx
@@ -29,6 +29,7 @@ interface CommandPreviewProps {
   sourceDirs?: string[]
   customFlags?: string
   remotePath?: string
+  useSudo?: boolean
   repositoryMode?: 'full' | 'observe'
   // Remote source props
   dataSource?: 'local' | 'remote'
@@ -125,6 +126,7 @@ export default function CommandPreview({
   sourceDirs = [],
   customFlags = '',
   remotePath = '',
+  useSudo = false,
   repositoryMode = 'full',
   dataSource = 'local',
   sourceSshConnection = null,
@@ -143,7 +145,9 @@ export default function CommandPreview({
   const remotePathFlag = remotePath ? `--remote-path ${remotePath} ` : ''
   // What the repository host's forced-command wrapper has to accept.
   const remoteServeCommand =
-    repositoryLocation === 'ssh' ? `${remotePath || 'borg'} serve --umask=077` : ''
+    repositoryLocation === 'ssh'
+      ? `${useSudo ? 'sudo -n -H ' : ''}${remotePath || 'borg'} serve --umask=077`
+      : ''
 
   // Generate init command
   const initCommand = generateBorgInitCommand({

--- a/frontend/src/components/CommandPreview.tsx
+++ b/frontend/src/components/CommandPreview.tsx
@@ -149,6 +149,33 @@ export default function CommandPreview({
       ? `${useSudo ? 'sudo -n -H ' : ''}${remotePath || 'borg'} serve --umask=077`
       : ''
 
+  const remoteServeBlock = remoteServeCommand ? (
+    <Box sx={{ mb: 2 }}>
+      <Typography
+        variant="caption"
+        sx={{
+          color: 'primary.main',
+          fontWeight: 600,
+          mb: 0.5,
+          display: 'block',
+        }}
+      >
+        {t('commandPreview.remoteServeCommand')}
+      </Typography>
+      <CopyableCommandBox command={remoteServeCommand} />
+      <Typography
+        variant="caption"
+        sx={{
+          color: 'text.secondary',
+          mt: 0.5,
+          display: 'block',
+        }}
+      >
+        {t('commandPreview.remoteServeCommandDesc')}
+      </Typography>
+    </Box>
+  ) : null
+
   // Generate init command
   const initCommand = generateBorgInitCommand({
     repositoryPath: fullRepoPath,
@@ -272,6 +299,8 @@ export default function CommandPreview({
             <CopyableCommandBox command={initCommand} />
           </Box>
         )}
+
+        {remoteServeBlock}
 
         <Box sx={{ mb: 2 }}>
           <Typography
@@ -403,32 +432,7 @@ export default function CommandPreview({
         </Box>
       )}
 
-      {remoteServeCommand && (
-        <Box sx={{ mb: 2 }}>
-          <Typography
-            variant="caption"
-            sx={{
-              color: 'primary.main',
-              fontWeight: 600,
-              mb: 0.5,
-              display: 'block',
-            }}
-          >
-            {t('commandPreview.remoteServeCommand')}
-          </Typography>
-          <CopyableCommandBox command={remoteServeCommand} />
-          <Typography
-            variant="caption"
-            sx={{
-              color: 'text.secondary',
-              mt: 0.5,
-              display: 'block',
-            }}
-          >
-            {t('commandPreview.remoteServeCommandDesc')}
-          </Typography>
-        </Box>
-      )}
+      {remoteServeBlock}
 
       {repositoryMode === 'full' && (
         <Box>

--- a/frontend/src/components/CommandPreview.tsx
+++ b/frontend/src/components/CommandPreview.tsx
@@ -141,6 +141,9 @@ export default function CommandPreview({
   }
 
   const remotePathFlag = remotePath ? `--remote-path ${remotePath} ` : ''
+  // What the repository host's forced-command wrapper has to accept.
+  const remoteServeCommand =
+    repositoryLocation === 'ssh' ? `${remotePath || 'borg'} serve --umask=077` : ''
 
   // Generate init command
   const initCommand = generateBorgInitCommand({
@@ -392,6 +395,33 @@ export default function CommandPreview({
             }}
           >
             {t('commandPreview.initRepositoryDesc')}
+          </Typography>
+        </Box>
+      )}
+
+      {remoteServeCommand && (
+        <Box sx={{ mb: 2 }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: 'primary.main',
+              fontWeight: 600,
+              mb: 0.5,
+              display: 'block',
+            }}
+          >
+            {t('commandPreview.remoteServeCommand')}
+          </Typography>
+          <CopyableCommandBox command={remoteServeCommand} />
+          <Typography
+            variant="caption"
+            sx={{
+              color: 'text.secondary',
+              mt: 0.5,
+              display: 'block',
+            }}
+          >
+            {t('commandPreview.remoteServeCommandDesc')}
           </Typography>
         </Box>
       )}

--- a/frontend/src/components/__tests__/CommandPreview.test.tsx
+++ b/frontend/src/components/__tests__/CommandPreview.test.tsx
@@ -85,6 +85,23 @@ describe('CommandPreview', () => {
         />
       )
       expect(screen.getByText('/usr/local/bin/borg serve --umask=077')).toBeInTheDocument()
+
+      rerender(
+        <CommandPreview
+          mode="create"
+          repositoryLocation="ssh"
+          repositoryPath="/backups/repo"
+          host="repo.example"
+          username="borg"
+          remotePath="/usr/local/sbin/borg-serve"
+          useSudo
+          repositoryMode="full"
+          dataSource="local"
+        />
+      )
+      expect(
+        screen.getByText('sudo -n -H /usr/local/sbin/borg-serve serve --umask=077')
+      ).toBeInTheDocument()
     })
 
     it('renders borg2 init and backup commands for Borg 2 repositories', () => {

--- a/frontend/src/components/__tests__/CommandPreview.test.tsx
+++ b/frontend/src/components/__tests__/CommandPreview.test.tsx
@@ -57,6 +57,36 @@ describe('CommandPreview', () => {
       expect(screen.getByText(/borg create/)).toBeInTheDocument()
     })
 
+    it('shows the remote serve command for SSH repositories', () => {
+      const { rerender } = render(
+        <CommandPreview
+          mode="create"
+          repositoryLocation="ssh"
+          repositoryPath="/backups/repo"
+          host="repo.example"
+          username="borg"
+          repositoryMode="full"
+          dataSource="local"
+        />
+      )
+      expect(screen.getByText('Remote command (for restricted keys)')).toBeInTheDocument()
+      expect(screen.getByText('borg serve --umask=077')).toBeInTheDocument()
+
+      rerender(
+        <CommandPreview
+          mode="create"
+          repositoryLocation="ssh"
+          repositoryPath="/backups/repo"
+          host="repo.example"
+          username="borg"
+          remotePath="/usr/local/bin/borg"
+          repositoryMode="full"
+          dataSource="local"
+        />
+      )
+      expect(screen.getByText('/usr/local/bin/borg serve --umask=077')).toBeInTheDocument()
+    })
+
     it('renders borg2 init and backup commands for Borg 2 repositories', () => {
       render(
         <CommandPreview

--- a/frontend/src/components/__tests__/CommandPreview.test.tsx
+++ b/frontend/src/components/__tests__/CommandPreview.test.tsx
@@ -231,6 +231,25 @@ describe('CommandPreview', () => {
       expect(screen.getByText(/fusermount -u/)).toBeInTheDocument()
     })
 
+    it('shows the remote serve command for an SSH repository with a remote source', () => {
+      render(
+        <CommandPreview
+          mode="create"
+          repositoryLocation="ssh"
+          repositoryPath="/backups/repo"
+          host="repo.example"
+          username="borg"
+          sourceDirs={['/var/data']}
+          repositoryMode="full"
+          dataSource="remote"
+          sourceSshConnection={sshConnection}
+        />
+      )
+
+      expect(screen.getByText('borg serve --umask=077')).toBeInTheDocument()
+      expect(screen.getByText(/sshfs admin@192.168.1.100/)).toBeInTheDocument()
+    })
+
     it('renders mount, backup, cleanup steps for import mode with remote source', () => {
       render(
         <CommandPreview

--- a/frontend/src/components/wizard/WizardStepReview.tsx
+++ b/frontend/src/components/wizard/WizardStepReview.tsx
@@ -34,6 +34,7 @@ interface SSHConnection {
   ssh_key_id: number
   default_path?: string
   ssh_path_prefix?: string
+  use_sudo?: boolean
 }
 
 interface AgentMachine {
@@ -191,6 +192,7 @@ export default function WizardStepReview({
             sourceDirs={data.sourceDirs}
             customFlags={data.customFlags}
             remotePath={data.remotePath}
+            useSudo={getRepoSshConnection()?.use_sudo}
             repositoryMode={data.repositoryMode}
             dataSource={data.dataSource}
             sourceSshConnection={getSourceSshConnection()}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -5790,7 +5790,7 @@
         "adminAccessRequired": "Administratorzugriff erforderlich",
         "cannotEnableAsBackupSource": "Kann nicht als Sicherungsquelle aktiviert werden: {{error}}",
         "connectionTestFailed": "SSH-Verbindungstest fehlgeschlagen: {{error}}",
-        "failedCollectStorage": "Speicherinformationen nicht verfügbar: Die Remote-Shell erlaubt kein df. Borg-Backups sind nicht betroffen.",
+        "failedCollectStorage": "Speicherinformationen sind für diese Verbindung nicht verfügbar.",
         "failedGenerateKey": "SSH-Schlüssel konnte nicht generiert werden: {{error}}",
         "invalidKeyType": "Ungültiger Schlüsseltyp. Muss einer der folgenden sein: {{types}}",
         "invalidPrivateKeyFormat": "Ungültiges Format des privaten Schlüssels",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -5041,7 +5041,9 @@
     "copyToClipboard": "In Zwischenablage kopieren",
     "copied": "Kopiert!",
     "commandCopied": "Befehl in die Zwischenablage kopiert",
-    "copyFailed": "Kopieren in die Zwischenablage fehlgeschlagen"
+    "copyFailed": "Kopieren in die Zwischenablage fehlgeschlagen",
+    "remoteServeCommand": "Remote-Befehl (für eingeschränkte Schlüssel)",
+    "remoteServeCommandDesc": "Borg führt dies auf dem Repository-Host aus. Ein forced-command-Wrapper in authorized_keys muss ihn akzeptieren."
   },
   "cronBuilderComponent": {
     "runEvery": "Alle",
@@ -5788,7 +5790,7 @@
         "adminAccessRequired": "Administratorzugriff erforderlich",
         "cannotEnableAsBackupSource": "Kann nicht als Sicherungsquelle aktiviert werden: {{error}}",
         "connectionTestFailed": "SSH-Verbindungstest fehlgeschlagen: {{error}}",
-        "failedCollectStorage": "Speicherinformationen konnten nicht gesammelt werden",
+        "failedCollectStorage": "Speicherinformationen nicht verfügbar: Die Remote-Shell erlaubt kein df. Borg-Backups sind nicht betroffen.",
         "failedGenerateKey": "SSH-Schlüssel konnte nicht generiert werden: {{error}}",
         "invalidKeyType": "Ungültiger Schlüsseltyp. Muss einer der folgenden sein: {{types}}",
         "invalidPrivateKeyFormat": "Ungültiges Format des privaten Schlüssels",
@@ -6052,6 +6054,7 @@
         "connectionDeleted": "SSH-Verbindung erfolgreich gelöscht",
         "connectionTestFailed": "SSH-Verbindungstest fehlgeschlagen",
         "connectionTestSuccess": "SSH-Verbindungstest erfolgreich",
+        "connectionTestSuccessRestricted": "SSH-Verbindung funktioniert. Die Remote-Shell ist auf Borg beschränkt, daher sind Durchsuchen und Speicherinformationen nicht verfügbar.",
         "connectionUpdated": "SSH-Verbindung erfolgreich aktualisiert",
         "sshKeyCreated": "SSH-Schlüssel erfolgreich erstellt",
         "sshKeyDeleted": "SSH-Schlüssel erfolgreich gelöscht",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -5041,7 +5041,9 @@
     "copyToClipboard": "Copy to clipboard",
     "copied": "Copied!",
     "commandCopied": "Command copied to clipboard",
-    "copyFailed": "Failed to copy to clipboard"
+    "copyFailed": "Failed to copy to clipboard",
+    "remoteServeCommand": "Remote command (for restricted keys)",
+    "remoteServeCommandDesc": "Borg runs this on the repository host. A forced-command wrapper in authorized_keys must accept it."
   },
   "cronBuilderComponent": {
     "runEvery": "Run every",
@@ -5788,7 +5790,7 @@
         "adminAccessRequired": "Admin access required",
         "cannotEnableAsBackupSource": "Cannot enable as backup source: {{error}}",
         "connectionTestFailed": "SSH connection test failed: {{error}}",
-        "failedCollectStorage": "Failed to collect storage information",
+        "failedCollectStorage": "Storage information is unavailable: the remote shell does not allow df. Borg backups are not affected.",
         "failedGenerateKey": "Failed to generate SSH key: {{error}}",
         "invalidKeyType": "Invalid key type. Must be one of: {{types}}",
         "invalidPrivateKeyFormat": "Invalid private key format",
@@ -6052,6 +6054,7 @@
         "connectionDeleted": "SSH connection deleted successfully",
         "connectionTestFailed": "SSH connection test failed",
         "connectionTestSuccess": "SSH connection test successful",
+        "connectionTestSuccessRestricted": "SSH connection works. The remote shell is restricted to Borg, so browsing and storage information are unavailable.",
         "connectionUpdated": "SSH connection updated successfully",
         "sshKeyCreated": "SSH key created successfully",
         "sshKeyDeleted": "SSH key deleted successfully",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -5790,7 +5790,7 @@
         "adminAccessRequired": "Admin access required",
         "cannotEnableAsBackupSource": "Cannot enable as backup source: {{error}}",
         "connectionTestFailed": "SSH connection test failed: {{error}}",
-        "failedCollectStorage": "Storage information is unavailable: the remote shell does not allow df. Borg backups are not affected.",
+        "failedCollectStorage": "Storage information is unavailable for this connection.",
         "failedGenerateKey": "Failed to generate SSH key: {{error}}",
         "invalidKeyType": "Invalid key type. Must be one of: {{types}}",
         "invalidPrivateKeyFormat": "Invalid private key format",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -5041,7 +5041,9 @@
     "copyToClipboard": "Copiar al portapapeles",
     "copied": "¡Copiado!",
     "commandCopied": "Comando copiado al portapapeles",
-    "copyFailed": "No se pudo copiar al portapapeles"
+    "copyFailed": "No se pudo copiar al portapapeles",
+    "remoteServeCommand": "Comando remoto (para claves restringidas)",
+    "remoteServeCommandDesc": "Borg ejecuta esto en el host del repositorio. Un wrapper forced-command en authorized_keys debe aceptarlo."
   },
   "cronBuilderComponent": {
     "runEvery": "Ejecutar cada",
@@ -5788,7 +5790,7 @@
         "adminAccessRequired": "Se requiere acceso de administrador",
         "cannotEnableAsBackupSource": "No se puede habilitar como fuente de copia de seguridad: {{error}}",
         "connectionTestFailed": "Prueba de conexión SSH fallida: {{error}}",
-        "failedCollectStorage": "Error al recopilar información de almacenamiento",
+        "failedCollectStorage": "Información de almacenamiento no disponible: el shell remoto no permite df. Las copias de Borg no se ven afectadas.",
         "failedGenerateKey": "Error al generar clave SSH: {{error}}",
         "invalidKeyType": "Tipo de clave no válido. Debe ser uno de: {{types}}",
         "invalidPrivateKeyFormat": "Formato de clave privada no válido",
@@ -6052,6 +6054,7 @@
         "connectionDeleted": "Conexión SSH eliminada correctamente",
         "connectionTestFailed": "Prueba de conexión SSH fallida",
         "connectionTestSuccess": "Prueba de conexión SSH exitosa",
+        "connectionTestSuccessRestricted": "La conexión SSH funciona. El shell remoto está restringido a Borg, por lo que la navegación y la información de almacenamiento no están disponibles.",
         "connectionUpdated": "Conexión SSH actualizada correctamente",
         "sshKeyCreated": "Clave SSH creada correctamente",
         "sshKeyDeleted": "Clave SSH eliminada correctamente",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -5790,7 +5790,7 @@
         "adminAccessRequired": "Se requiere acceso de administrador",
         "cannotEnableAsBackupSource": "No se puede habilitar como fuente de copia de seguridad: {{error}}",
         "connectionTestFailed": "Prueba de conexión SSH fallida: {{error}}",
-        "failedCollectStorage": "Información de almacenamiento no disponible: el shell remoto no permite df. Las copias de Borg no se ven afectadas.",
+        "failedCollectStorage": "La información de almacenamiento no está disponible para esta conexión.",
         "failedGenerateKey": "Error al generar clave SSH: {{error}}",
         "invalidKeyType": "Tipo de clave no válido. Debe ser uno de: {{types}}",
         "invalidPrivateKeyFormat": "Formato de clave privada no válido",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -5041,7 +5041,9 @@
     "copyToClipboard": "Copia negli appunti",
     "copied": "Copiato!",
     "commandCopied": "Comando copiato negli appunti",
-    "copyFailed": "Impossibile copiare negli appunti"
+    "copyFailed": "Impossibile copiare negli appunti",
+    "remoteServeCommand": "Comando remoto (per chiavi limitate)",
+    "remoteServeCommandDesc": "Borg lo esegue sull'host del repository. Un wrapper forced-command in authorized_keys deve accettarlo."
   },
   "cronBuilderComponent": {
     "runEvery": "Esegui ogni",
@@ -5788,7 +5790,7 @@
         "adminAccessRequired": "Accesso amministratore richiesto",
         "cannotEnableAsBackupSource": "Impossibile abilitare come sorgente di backup: {{error}}",
         "connectionTestFailed": "Test connessione SSH fallito: {{error}}",
-        "failedCollectStorage": "Impossibile raccogliere informazioni di archiviazione",
+        "failedCollectStorage": "Informazioni storage non disponibili: la shell remota non consente df. I backup Borg non sono interessati.",
         "failedGenerateKey": "Impossibile generare la chiave SSH: {{error}}",
         "invalidKeyType": "Tipo chiave non valido. Deve essere uno di: {{types}}",
         "invalidPrivateKeyFormat": "Formato chiave privata non valido",
@@ -6052,6 +6054,7 @@
         "connectionDeleted": "Connessione SSH eliminata con successo",
         "connectionTestFailed": "Test connessione SSH fallito",
         "connectionTestSuccess": "Test connessione SSH riuscito",
+        "connectionTestSuccessRestricted": "La connessione SSH funziona. La shell remota è limitata a Borg, quindi navigazione e informazioni storage non sono disponibili.",
         "connectionUpdated": "Connessione SSH aggiornata con successo",
         "sshKeyCreated": "Chiave SSH creata con successo",
         "sshKeyDeleted": "Chiave SSH eliminata con successo",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -5790,7 +5790,7 @@
         "adminAccessRequired": "Accesso amministratore richiesto",
         "cannotEnableAsBackupSource": "Impossibile abilitare come sorgente di backup: {{error}}",
         "connectionTestFailed": "Test connessione SSH fallito: {{error}}",
-        "failedCollectStorage": "Informazioni storage non disponibili: la shell remota non consente df. I backup Borg non sono interessati.",
+        "failedCollectStorage": "Le informazioni storage non sono disponibili per questa connessione.",
         "failedGenerateKey": "Impossibile generare la chiave SSH: {{error}}",
         "invalidKeyType": "Tipo chiave non valido. Deve essere uno di: {{types}}",
         "invalidPrivateKeyFormat": "Formato chiave privata non valido",

--- a/frontend/src/pages/SSHConnectionsSingleKey.tsx
+++ b/frontend/src/pages/SSHConnectionsSingleKey.tsx
@@ -150,7 +150,9 @@ export default function SSHConnectionsSingleKey() {
       sshKeysAPI.testSSHConnection(data.keyId, data.connectionData),
     onSuccess: (response) => {
       if (response.data.success) {
-        toast.success(t('sshConnections.toasts.connectionTestSuccess'))
+        toast.success(
+          translateBackendKey(response.data.message, 'sshConnections.toasts.connectionTestSuccess')
+        )
         track(EventCategory.SSH, EventAction.TEST, { resource: 'connection' })
       } else {
         toast.error(t('sshConnections.toasts.connectionTestFailed'))
@@ -214,8 +216,16 @@ export default function SSHConnectionsSingleKey() {
 
   const refreshStorageMutation = useMutation({
     mutationFn: (connectionId: number) => sshKeysAPI.refreshConnectionStorage(connectionId),
-    onSuccess: () => {
-      toast.success(t('sshConnections.toasts.storageRefreshed'))
+    onSuccess: (response) => {
+      // The backend answers 200 with success=false when the remote shell
+      // refuses `df` (restricted key); that is not an error, just no data.
+      if (response.data.success) {
+        toast.success(t('sshConnections.toasts.storageRefreshed'))
+      } else {
+        toast(
+          translateBackendKey(response.data.message, 'sshConnections.toasts.storageRefreshFailed')
+        )
+      }
       queryClient.invalidateQueries({ queryKey: ['ssh-connections'] })
       track(EventCategory.SSH, EventAction.VIEW, { resource: 'storage' })
     },
@@ -232,7 +242,9 @@ export default function SSHConnectionsSingleKey() {
     mutationFn: (connectionId: number) => sshKeysAPI.testExistingConnection(connectionId),
     onSuccess: (response) => {
       if (response.data.success) {
-        toast.success(t('sshConnections.toasts.connectionTestSuccess'))
+        toast.success(
+          translateBackendKey(response.data.message, 'sshConnections.toasts.connectionTestSuccess')
+        )
       } else {
         toast.error(
           translateBackendKey(response.data.error) ||

--- a/tests/unit/test_api_ssh_keys.py
+++ b/tests/unit/test_api_ssh_keys.py
@@ -217,6 +217,81 @@ class TestSSHKeysEndpoints:
         )
         assert listed_connection["error_message"] == error_message
 
+    def test_connection_test_restricted_shell_counts_as_connected(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """A forced-command key refuses `pwd` but authenticated: that is connected."""
+        from app.core.security import encrypt_secret
+
+        fake_private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----\n"
+        ssh_key = SSHKey(
+            name="Restricted key",
+            public_key="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAItest test@test",
+            private_key=encrypt_secret(fake_private_key),
+            is_active=True,
+        )
+        test_db.add(ssh_key)
+        test_db.commit()
+        test_db.refresh(ssh_key)
+
+        seen_kwargs: dict = {}
+
+        async def mock_subprocess(*cmd, **kwargs):
+            seen_kwargs.update(kwargs)
+            mock_process = AsyncMock()
+            mock_process.communicate = AsyncMock(
+                return_value=(b"", b"Only borg serve is permitted\n")
+            )
+            mock_process.returncode = 64
+            return mock_process
+
+        with patch(
+            "app.api.ssh_keys.asyncio.create_subprocess_exec",
+            side_effect=mock_subprocess,
+        ):
+            response = test_client.post(
+                f"/api/ssh-keys/{ssh_key.id}/test-connection",
+                json={"host": "repo.example", "username": "borg", "port": 22},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["message"] == "backend.success.ssh.connectionTestSuccessRestricted"
+        assert data["connection"]["status"] == "connected"
+        assert data["connection"]["error_message"] is None
+        # borg serve would block on an open stdin
+        assert seen_kwargs["stdin"] == asyncio.subprocess.DEVNULL
+
+    def test_connection_diagnostics_latency_marks_restricted_shell(
+        self, test_client: TestClient, admin_headers, test_db, monkeypatch
+    ):
+        _, connection = self._create_diagnostics_connection(test_db)
+
+        async def fake_run_ssh_process(cmd, timeout_seconds):
+            if "-W" in cmd:
+                return 0, b"", b""
+            if cmd[-1].startswith("dd if=/dev/zero"):
+                return 0, b"x" * 131072, b""
+            return 1, b"", b"Only borg serve is permitted\n"
+
+        monkeypatch.setattr(
+            ssh_keys_api, "_run_ssh_process", fake_run_ssh_process, raising=False
+        )
+        self._patch_monotonic(monkeypatch, [10.0, 10.0, 10.0, 10.025])
+
+        response = test_client.post(
+            f"/api/ssh-keys/connections/{connection.id}/diagnostics",
+            json={"timeout_seconds": 4},
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["session"]["status"] == "success"
+        assert data["session"]["restricted"] is True
+
     def _create_diagnostics_connection(self, test_db):
         fake_private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----\n"
         ssh_key = SSHKey(


### PR DESCRIPTION
Closes #970

## Problem

A key locked down in `authorized_keys` with `restrict,command="borg serve …"` (the pattern our own docs recommend) refuses the `pwd` probe, so the connection test flipped the connection to **failed** even though the key authenticated and Borg worked. Users were widening the key allowlist (`pwd`, `df`, sftp) just to get a green status.

Two things the report did not mention, found while tracing:

- With a *fixed* forced command, `ssh host pwd` actually starts `borg serve`, which waits on stdin until EOF. The probe ran with an inherited stdin, so the test could hang to the 15 s timeout.
- Storage refresh did not mark the connection failed; it showed a **success** toast on `success: false` and left the widget empty.

## Fix

- `ssh(1)` exits 255 for its own failures and otherwise returns the remote command's status. Any other non-zero exit now means "authenticated, remote shell restricted": the connection is **connected**, the toast says browsing and storage are unavailable. This replaces the old `Command not found` special case (Hetzner, rsync.net) and applies to the diagnostics latency probe too.
- `pwd` and `df` probes run with `stdin=DEVNULL`.
- Storage refresh: informational toast on `success: false`, widget stays hidden.
- Repository wizard command preview shows the exact remote command (`[sudo -n -H ]<remote_path|borg> serve --umask=077`) so wrapper authors can match it.
- Docs: which features need a shell on the repository host and how each degrades, "do not widen the allowlist", wrapper matching guidance, sftp trailing-space note.
- Removed the unused `check_remote_borg_installation` (`which borg`).

Not done: a persisted `restricted` flag / badge on the connection card, and auto-hiding browse/mount for restricted connections. The toast and docs cover it; easy to add if asked.

## Tests

- Backend: connection test with exit 64 → connected + `connectionTestSuccessRestricted` + DEVNULL stdin; latency probe marks `restricted`. `tests/unit/test_api_ssh_keys.py` 87 passed, repositories suites 308 passed.
- Frontend: CommandPreview renders the serve command with default, custom path, and sudo. 290 passed. tsc, oxlint, prettier, locale check clean.

## CodeRabbit (local, `--base main`)

1 finding (major): the command preview ignored the connection's `use_sudo`, so it showed `borg serve` where the real command is `sudo -n -H … serve`. Valid, fixed in daefb721. No false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- visual-regression:start -->
## Visual regression report
No visual changes detected: 0 changed, 0 added, 0 removed, 758 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-1006/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/34473965349
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- None
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->