### PR TITLE
fix(operations): close the inline maintenance operation when its agent job cannot be queued

### DIFF
--- a/app/api/agents.py
+++ b/app/api/agents.py
@@ -45,7 +45,7 @@ from app.services.operations.backup_facade import (
 )
 from app.services.operations.job_facade import (
     LEGACY_MODELS,
-    resolve_maintenance_job,
+    resolve_agent_maintenance_job,
 )
 from app.services.agent_artifact_relay import agent_artifact_relay
 from app.services.agent_connection_manager import (
@@ -664,19 +664,12 @@ def _finish_linked_backup_job(
 
 
 def _get_repository_operation_job(agent_job: AgentJob, db: Session) -> Any | None:
-    payload = agent_job.payload or {}
-    operation = payload.get("operation") if isinstance(payload, dict) else None
-    maintenance_job = (
-        operation.get("maintenance_job") if isinstance(operation, dict) else None
+    """The maintenance job this agent job reports on. The payload names its
+    table since the marker exists; a payload without one is resolved by the
+    repository it carries (see `resolve_agent_maintenance_job`)."""
+    return resolve_agent_maintenance_job(
+        db, agent_job.payload, kinds=REPOSITORY_OPERATION_JOB_KINDS
     )
-    if not isinstance(maintenance_job, dict):
-        return None
-
-    kind = str(maintenance_job.get("kind") or "")
-    job_id = maintenance_job.get("id")
-    if kind not in REPOSITORY_OPERATION_JOB_KINDS or not job_id:
-        return None
-    return resolve_maintenance_job(db, int(job_id), kind)
 
 
 def _maintenance_kind(operation_job: Any) -> Optional[str]:

--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -43,6 +43,7 @@ from app.api.maintenance_jobs import (
 )
 from app.services.operations.maintenance_start import (
     active_maintenance_operation,
+    fail_inline_maintenance,
     finish_inline_maintenance,
     start_inline_maintenance,
     start_maintenance,
@@ -5667,17 +5668,22 @@ async def prune_repository(
 
         # Wait for prune to complete and get logs
         prune_kwargs = {"keep_within": keep_within} if keep_within is not None else {}
-        await BorgRouter(repository).prune(
-            prune_job.id,
-            keep_hourly,
-            keep_daily,
-            keep_weekly,
-            keep_monthly,
-            keep_quarterly,
-            keep_yearly,
-            dry_run,
-            **prune_kwargs,
-        )
+        try:
+            await BorgRouter(repository).prune(
+                prune_job.id,
+                keep_hourly,
+                keep_daily,
+                keep_weekly,
+                keep_monthly,
+                keep_quarterly,
+                keep_yearly,
+                dry_run,
+                **prune_kwargs,
+            )
+        except Exception as exc:
+            # The row was created `running`; a step that raised never closed it.
+            await fail_inline_maintenance(db, prune_job, exc)
+            raise
 
         # Refresh job to get updated status and logs
         db.refresh(prune_job)

--- a/app/api/schedule.py
+++ b/app/api/schedule.py
@@ -24,6 +24,7 @@ from app.core.borg_router import BorgRouter
 from app.core.security import get_current_user, check_repo_access
 from app.config import settings
 from app.services.operations.maintenance_start import (
+    fail_inline_maintenance,
     finish_inline_maintenance,
     start_inline_maintenance,
 )
@@ -2348,6 +2349,10 @@ async def execute_multi_repo_schedule(scheduled_job: ScheduledJob, db: Session):
             # Run prune/compact if enabled and backup succeeded
             refresh_backup_job(db, backup_job)
             if backup_job.status in ["completed", "completed_with_warnings"]:
+                # A prune step that raised leaves the repository in a state the
+                # next step cannot rely on: its agent may still be pruning (the
+                # wait gave up), so compact is skipped for this run.
+                maintenance_aborted = False
                 # Run prune if enabled
                 if scheduled_job.run_prune_after:
                     prune_job = None
@@ -2410,12 +2415,11 @@ async def execute_multi_repo_schedule(scheduled_job: ScheduledJob, db: Session):
                     except Exception as e:
                         # Ensure maintenance_status is always cleared even if commit fails
                         try:
+                            # Close the prune operation if it was created; it
+                            # rolls the session back, so it goes first.
+                            if prune_job is not None:
+                                await fail_inline_maintenance(db, prune_job, e)
                             backup_job.maintenance_status = "prune_failed"
-                            # Update the prune operation if it was created
-                            if prune_job:
-                                prune_job.status = "failed"
-                                prune_job.completed_at = datetime.now(timezone.utc)
-                                prune_job.error_message = str(e)
                             db.commit()
                         except Exception as commit_error:
                             logger.error(
@@ -2423,12 +2427,14 @@ async def execute_multi_repo_schedule(scheduled_job: ScheduledJob, db: Session):
                             )
                             # If commit fails, at least clear the running status in memory
                             backup_job.maintenance_status = None
+                        maintenance_aborted = True
                         logger.error(
                             "Scheduled prune failed", repository=repo.path, error=str(e)
                         )
 
                 # Run compact if enabled
-                if scheduled_job.run_compact_after:
+                if scheduled_job.run_compact_after and not maintenance_aborted:
+                    compact_job = None
                     try:
                         logger.info("Running scheduled compact", repository=repo.path)
                         compact_job = start_inline_maintenance(
@@ -2467,24 +2473,20 @@ async def execute_multi_repo_schedule(scheduled_job: ScheduledJob, db: Session):
                                 error=compact_job.error_message,
                             )
                     except Exception as e:
-                        backup_job.maintenance_status = "compact_failed"
-                        # Update CompactJob record if it was created
+                        # Ensure maintenance_status is always cleared even if commit fails
                         try:
-                            if "compact_job" in locals():
-                                db.refresh(compact_job)
-                                if compact_job.status not in [
-                                    "failed",
-                                    "cancelled",
-                                    "completed",
-                                ]:
-                                    compact_job.status = "failed"
-                                    compact_job.completed_at = datetime.now(
-                                        timezone.utc
-                                    )
-                                    compact_job.error_message = str(e)
-                        except:
-                            pass
-                        db.commit()
+                            # Close the compact operation if it was created; it
+                            # rolls the session back, so it goes first.
+                            if compact_job is not None:
+                                await fail_inline_maintenance(db, compact_job, e)
+                            backup_job.maintenance_status = "compact_failed"
+                            db.commit()
+                        except Exception as commit_error:
+                            logger.error(
+                                "Failed to update compact status",
+                                error=str(commit_error),
+                            )
+                            backup_job.maintenance_status = None
                         logger.error(
                             "Scheduled compact failed",
                             repository=repo.path,
@@ -2611,6 +2613,10 @@ async def execute_scheduled_backup_with_maintenance(
             )
             return
 
+        # A prune step that raised leaves the repository in a state the next
+        # step cannot rely on: its agent may still be pruning (the wait gave
+        # up), so compact is skipped for this run.
+        maintenance_aborted = False
         # Run prune if enabled
         if scheduled_job.run_prune_after:
             prune_job = None
@@ -2683,12 +2689,11 @@ async def execute_scheduled_backup_with_maintenance(
             except Exception as e:
                 # Ensure maintenance_status is always cleared even if commit fails
                 try:
+                    # Close the prune operation if it was created; it rolls
+                    # the session back, so it goes first.
+                    if prune_job is not None:
+                        await fail_inline_maintenance(db, prune_job, e)
                     backup_job.maintenance_status = "prune_failed"
-                    # Update the prune operation if it was created
-                    if prune_job:
-                        prune_job.status = "failed"
-                        prune_job.completed_at = datetime.now(timezone.utc)
-                        prune_job.error_message = str(e)
                     db.commit()
                 except Exception as commit_error:
                     logger.error(
@@ -2696,16 +2701,16 @@ async def execute_scheduled_backup_with_maintenance(
                     )
                     # If commit fails, at least clear the running status in memory
                     backup_job.maintenance_status = None
+                maintenance_aborted = True
                 logger.error(
                     "Failed to run scheduled prune",
                     scheduled_job_id=scheduled_job_id,
                     error=str(e),
                 )
 
-        # Run compact if enabled (only after successful prune or if prune not enabled)
-        if scheduled_job.run_compact_after and (
-            scheduled_job.run_prune_after or not scheduled_job.run_prune_after
-        ):
+        # Run compact if enabled, unless the prune step raised
+        if scheduled_job.run_compact_after and not maintenance_aborted:
+            compact_job = None
             try:
                 logger.info(
                     "Running scheduled compact",
@@ -2754,24 +2759,20 @@ async def execute_scheduled_backup_with_maintenance(
                     )
 
             except Exception as e:
-                backup_job.maintenance_status = "compact_failed"
-
-                # Update CompactJob record if it was created
+                # Ensure maintenance_status is always cleared even if commit fails
                 try:
-                    if "compact_job" in locals():
-                        db.refresh(compact_job)
-                        if compact_job.status not in [
-                            "failed",
-                            "cancelled",
-                            "completed",
-                        ]:
-                            compact_job.status = "failed"
-                            compact_job.completed_at = datetime.now(timezone.utc)
-                            compact_job.error_message = str(e)
-                except:
-                    pass
-
-                db.commit()
+                    # Close the compact operation if it was created; it rolls
+                    # the session back, so it goes first.
+                    if compact_job is not None:
+                        await fail_inline_maintenance(db, compact_job, e)
+                    backup_job.maintenance_status = "compact_failed"
+                    db.commit()
+                except Exception as commit_error:
+                    logger.error(
+                        "Failed to update compact status", error=str(commit_error)
+                    )
+                    # If commit fails, at least clear the running status in memory
+                    backup_job.maintenance_status = None
                 logger.error(
                     "Failed to run scheduled compact",
                     scheduled_job_id=scheduled_job_id,

--- a/app/core/borg_router.py
+++ b/app/core/borg_router.py
@@ -19,44 +19,51 @@ from app.utils.borg_env import effective_repository_remote_path
 logger = structlog.get_logger()
 
 
-def _fail_orphaned_maintenance_job(
-    db: Session, maintenance_kind: str, maintenance_job_id: int
+def _queue_failure_message(error: BaseException) -> str:
+    """The cause of a refused dispatch, for the row it leaves behind."""
+    from app.services.operations.maintenance_start import failure_text
+
+    return f"agent job could not be queued: {failure_text(error)}"
+
+
+async def _fail_orphaned_maintenance_job(
+    db: Session,
+    maintenance_kind: str,
+    maintenance_job_id: int,
+    error: BaseException,
 ) -> None:
-    """Mark a maintenance ``*_job`` failed when its agent job could not be queued.
+    """Fail the maintenance job whose agent job could not be queued.
 
-    Without this the row stays 'pending' with no backing work and blocks the
-    repository via admission control until a reaper eventually clears it.
+    The caller created the row before dispatch; left alone it stays active
+    with no work behind it and blocks the repository via admission control.
+    Since phase 5 that row is an `operations` row (a legacy ``*_jobs`` row
+    only on a pre-upgrade install), so the lookup goes through the facade
+    rather than the legacy tables: by legacy id the operation is never found,
+    or an unrelated old row is, and the operation stays `running` for good.
     """
-    from datetime import datetime
+    from app.database.models import utc_now
+    from app.services.operations.events import broadcast_operation_updated
+    from app.services.operations.job_facade import (
+        MaintenanceJobFacade,
+        resolve_maintenance_job,
+    )
 
-    from app.database.models import CheckJob, CompactJob, DeleteArchiveJob, PruneJob
-
-    models = {
-        "check": CheckJob,
-        "compact": CompactJob,
-        "prune": PruneJob,
-        "delete_archive": DeleteArchiveJob,
-    }
-    model = models.get(maintenance_kind)
-    if model is None:
-        return
     try:
         # The failed queue attempt (e.g. "database is locked") may have left this
         # session's transaction unusable, which would make the query below raise
         # and skip the update. Reset it first; the row was committed by the caller
         # before dispatch, so the rollback cannot lose it.
         db.rollback()
-        job = db.query(model).filter(model.id == maintenance_job_id).first()
+        job = resolve_maintenance_job(db, maintenance_job_id, maintenance_kind)
+        # The facade speaks the legacy vocabulary (`queued` reads as `pending`),
+        # so one check covers both shapes.
         if job is not None and job.status in ("pending", "running"):
             job.status = "failed"
-            if hasattr(job, "error_message"):
-                job.error_message = (
-                    job.error_message
-                    or "agent job could not be queued (dispatch failed)"
-                )
-            if hasattr(job, "completed_at"):
-                job.completed_at = job.completed_at or datetime.utcnow()
+            job.error_message = job.error_message or _queue_failure_message(error)
+            job.completed_at = job.completed_at or utc_now()
             db.commit()
+            if isinstance(job, MaintenanceJobFacade):
+                await broadcast_operation_updated(job.operation, db)
     except Exception:
         db.rollback()
 
@@ -562,13 +569,16 @@ class BorgRouter:
                     maintenance_job_kind=maintenance_kind,
                     maintenance_job_id=maintenance_job_id,
                 )
-            except Exception:
-                # The maintenance *_job row was created by the caller before this
-                # runs. If we cannot even queue the agent job (e.g. database is
-                # locked), no agent job will ever update it -> it would stay
-                # 'pending' forever and block the repo via admission. Fail it
-                # closed so it never orphans, then propagate the error.
-                _fail_orphaned_maintenance_job(db, maintenance_kind, maintenance_job_id)
+            except Exception as exc:
+                # The maintenance job row was created by the caller before this
+                # runs. If we cannot even queue the agent job (a refused
+                # admission, a locked database), no agent job will ever update
+                # it -> it would stay active forever and block the repo via
+                # admission. Fail it closed so it never orphans, then propagate
+                # the error.
+                await _fail_orphaned_maintenance_job(
+                    db, maintenance_kind, maintenance_job_id, exc
+                )
                 raise
             await dispatch_agent_job_best_effort(
                 db, agent_job, repository_id=repository.id
@@ -581,8 +591,11 @@ class BorgRouter:
             # post-backup flows that have no HTTP context. Translate to a plain
             # error so background maintenance doesn't surface an HTTP-specific
             # exception; the linked maintenance job already records the detail.
-            detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
-            raise RuntimeError(f"agent {maintenance_kind} failed: {detail}") from exc
+            from app.services.operations.maintenance_start import detail_text
+
+            raise RuntimeError(
+                f"agent {maintenance_kind} failed: {detail_text(exc.detail)}"
+            ) from exc
         finally:
             db.close()
 

--- a/app/services/agent_job_reaper.py
+++ b/app/services/agent_job_reaper.py
@@ -235,16 +235,26 @@ def reap_stale_agent_upgrades(
 
 def _reap_once(
     failed_backup_job_ids: Optional[list[tuple[str, int]]] = None,
+    reaped_operation_ids: Optional[list[int]] = None,
 ) -> int:
     """One reap pass with its own session (runs in a worker thread)."""
     from app.utils.process_utils import (
         reconcile_orphaned_maintenance_jobs,
+        reconcile_orphaned_maintenance_operations,
         reconcile_stale_backup_maintenance,
     )
 
     db = SessionLocal()
     try:
         reaped = reap_stale_agent_jobs(db, failed_backup_job_ids=failed_backup_job_ids)
+        # A `running` maintenance operation an inline caller handed to an
+        # agent and never closed: with no agent job behind it, it would block
+        # the repository via admission control until the next restart. Runs
+        # before the backup-row pass below so the backup's maintenance state
+        # is reconciled in the same tick.
+        reaped += reconcile_orphaned_maintenance_operations(
+            db, reaped_operation_ids=reaped_operation_ids
+        )
         # Reconcile backup rows stuck in a running maintenance state whose
         # maintenance op died without writing a terminal status (startup-only
         # cleanup previously left these "running" until the next restart).
@@ -300,6 +310,22 @@ async def _release_upgrade_waves() -> None:
         db.close()
 
 
+async def _broadcast_reaped_operations(operation_ids: list[int]) -> None:
+    """Tell the operations feed about rows the reaper failed, the way every
+    other writer of a terminal status does; the reap pass itself runs in a
+    worker thread and cannot await."""
+    from app.services.operations.events import broadcast_operation_updated
+
+    db = SessionLocal()
+    try:
+        for operation_id in operation_ids:
+            operation = db.get(Operation, operation_id)
+            if operation is not None:
+                await broadcast_operation_updated(operation, db)
+    finally:
+        db.close()
+
+
 async def start_agent_job_reaper(
     interval_seconds: float = REAPER_INTERVAL_SECONDS,
 ) -> None:
@@ -316,9 +342,14 @@ async def start_agent_job_reaper(
             # blocks the event loop. The session is created and used inside the
             # thread (SQLite connections are thread-affine).
             failed_backup_job_ids: list[tuple[str, int]] = []
-            await asyncio.to_thread(_reap_once, failed_backup_job_ids)
+            reaped_operation_ids: list[int] = []
+            await asyncio.to_thread(
+                _reap_once, failed_backup_job_ids, reaped_operation_ids
+            )
             if failed_backup_job_ids:
                 await _notify_reaped_backup_jobs(failed_backup_job_ids)
+            if reaped_operation_ids:
+                await _broadcast_reaped_operations(reaped_operation_ids)
             # A slot frees when an endpoint leaves "requested", by success or
             # by the timeout reaped just above, so the next wave starts here
             # (spec section 8). This runs on the loop rather than in the

--- a/app/services/backup_plan_execution_service.py
+++ b/app/services/backup_plan_execution_service.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional
 
 import structlog
 from fastapi import HTTPException
@@ -35,6 +35,8 @@ from app.database.models import (
     SSHKey,
 )
 from app.services.operations.maintenance_start import (
+    fail_inline_maintenance,
+    failure_text,
     finish_inline_maintenance,
     start_inline_maintenance,
 )
@@ -2094,11 +2096,59 @@ class BackupPlanExecutionService:
                 error=str(exc),
             )
             self._mark_repository_failed(
-                run_id, repository_context.repository_id, str(exc)
+                run_id, repository_context.repository_id, failure_text(exc)
             )
             return "failed"
         finally:
             db.close()
+
+    async def _run_inline_maintenance(
+        self,
+        db: Session,
+        backup_job: Any,
+        operation: Operation,
+        run_id: int,
+        step: Callable[[], Awaitable[Any]],
+    ) -> None:
+        """Drive one inline maintenance operation to a terminal status.
+
+        The router writes the status itself when the step runs. When it
+        raises instead (an agent job refused by admission, a lost database),
+        the operation the plan created `running` would otherwise stay that
+        way and block the repository until the next restart: it is closed
+        with the cause unless an agent is still working on it, the backup's
+        maintenance state records the failed step, and the error propagates
+        so the repository's run ends failed with that cause, as it did
+        before, instead of starting the next step on a repository whose
+        state is unknown."""
+        operation_id, kind = operation.id, operation.kind
+        try:
+            await step()
+        except Exception as exc:
+            closed = await fail_inline_maintenance(db, operation, exc)
+            try:
+                backup_job.maintenance_status = f"{kind}_failed"
+                db.commit()
+            except Exception as commit_error:
+                # the cause below must reach the run, not this commit's error
+                db.rollback()
+                logger.warning(
+                    "Could not record the failed maintenance step",
+                    run_id=run_id,
+                    operation_id=operation_id,
+                    error=str(commit_error),
+                )
+            logger.error(
+                "Backup plan maintenance step failed",
+                run_id=run_id,
+                operation_id=operation_id,
+                kind=kind,
+                operation_closed=closed,
+                error=str(exc),
+            )
+            raise
+        db.refresh(operation)
+        finish_inline_maintenance(db, operation)
 
     async def _run_maintenance(
         self,
@@ -2133,19 +2183,23 @@ class BackupPlanExecutionService:
             )
             backup_job.maintenance_status = "running_prune"
             db.commit()
-            await BorgRouter(repo).prune(
-                job_id=prune_job.id,
-                keep_hourly=context.prune_keep_hourly,
-                keep_daily=context.prune_keep_daily,
-                keep_weekly=context.prune_keep_weekly,
-                keep_monthly=context.prune_keep_monthly,
-                keep_quarterly=context.prune_keep_quarterly,
-                keep_yearly=context.prune_keep_yearly,
-                dry_run=False,
-                keep_within=context.prune_keep_within,
+            await self._run_inline_maintenance(
+                db,
+                backup_job,
+                prune_job,
+                run_id,
+                lambda: BorgRouter(repo).prune(
+                    job_id=prune_job.id,
+                    keep_hourly=context.prune_keep_hourly,
+                    keep_daily=context.prune_keep_daily,
+                    keep_weekly=context.prune_keep_weekly,
+                    keep_monthly=context.prune_keep_monthly,
+                    keep_quarterly=context.prune_keep_quarterly,
+                    keep_yearly=context.prune_keep_yearly,
+                    dry_run=False,
+                    keep_within=context.prune_keep_within,
+                ),
             )
-            db.refresh(prune_job)
-            finish_inline_maintenance(db, prune_job)
             if self._is_run_cancelled(run_id):
                 return "cancelled"
             if prune_job.status == "completed":
@@ -2169,9 +2223,13 @@ class BackupPlanExecutionService:
             )
             backup_job.maintenance_status = "running_compact"
             db.commit()
-            await BorgRouter(repo).compact(compact_job.id)
-            db.refresh(compact_job)
-            finish_inline_maintenance(db, compact_job)
+            await self._run_inline_maintenance(
+                db,
+                backup_job,
+                compact_job,
+                run_id,
+                lambda: BorgRouter(repo).compact(compact_job.id),
+            )
             if self._is_run_cancelled(run_id):
                 return "cancelled"
             if compact_job.status == "completed":
@@ -2199,9 +2257,13 @@ class BackupPlanExecutionService:
             )
             backup_job.maintenance_status = "running_check"
             db.commit()
-            await BorgRouter(repo).check(check_job.id)
-            db.refresh(check_job)
-            finish_inline_maintenance(db, check_job)
+            await self._run_inline_maintenance(
+                db,
+                backup_job,
+                check_job,
+                run_id,
+                lambda: BorgRouter(repo).check(check_job.id),
+            )
             if self._is_run_cancelled(run_id):
                 return "cancelled"
             if check_job.status == "completed":

--- a/app/services/job_history_retention.py
+++ b/app/services/job_history_retention.py
@@ -47,7 +47,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from app.config import settings as app_config
-from typing import Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, Optional
 
 import structlog
 from sqlalchemy import func, or_
@@ -113,6 +113,48 @@ _JOB_TABLES = (
     (AvailabilityScheduleSkip, ()),
     (Operation, ()),
 )
+
+
+def _prune_job_for(db: Session, payload: Any) -> Any:
+    """The prune job an agent job's payload names: an `operations` row (a
+    facade) or a legacy `prune_jobs` row, as the payload's table marker and
+    repository say. Only prunes are of interest here."""
+    from app.services.operations.job_facade import resolve_agent_maintenance_job
+
+    return resolve_agent_maintenance_job(db, payload, kinds=("prune",))
+
+
+def _store_prune_log(prune_job: Any, full_log: str) -> None:
+    """Write the complete agent log onto the prune job. A legacy row keeps
+    it in its `logs` column; an operation keeps only its log file, and the
+    facade's setter never overwrites an existing file (that protects a
+    service's captured output from a later marker), so the repair writes
+    the file itself."""
+    from app.services.operations.job_facade import MaintenanceJobFacade
+
+    if not isinstance(prune_job, MaintenanceJobFacade):
+        prune_job.logs = full_log
+        prune_job.has_logs = True
+        return
+    from pathlib import Path
+
+    from app.services.operations.runner import operation_log_path
+
+    path = prune_job.log_file_path or str(operation_log_path(prune_job.id))
+    try:
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(full_log)
+    except OSError as exc:
+        # a full or read-only data directory loses this repair, not the
+        # marking below it or the rest of the retention pass
+        logger.warning(
+            "Could not repair the prune operation's log file",
+            operation_id=prune_job.id,
+            error=str(exc),
+        )
+        return
+    prune_job.log_file_path = path
 
 
 def _older_than(model, cutoff):
@@ -525,13 +567,7 @@ def sweep_pruned_archive_records(
         payload = agent_job.payload if isinstance(agent_job.payload, dict) else {}
         if str(payload.get("job_kind") or "") != "repository.prune":
             continue
-        operation = payload.get("operation") or {}
-        maintenance = (
-            operation.get("maintenance_job") if isinstance(operation, dict) else None
-        )
-        prune_job = None
-        if isinstance(maintenance, dict) and maintenance.get("id"):
-            prune_job = db.get(PruneJob, int(maintenance["id"]))
+        prune_job = _prune_job_for(db, payload)
         if prune_job is None:
             continue
 
@@ -546,8 +582,7 @@ def sweep_pruned_archive_records(
             continue
 
         if len(full_log) > len(prune_job.logs or ""):
-            prune_job.logs = full_log
-            prune_job.has_logs = True
+            _store_prune_log(prune_job, full_log)
             db.commit()
 
         marked += mark_jobs_of_pruned_archives(

--- a/app/services/operations/job_facade.py
+++ b/app/services/operations/job_facade.py
@@ -13,7 +13,7 @@ read `Operation` directly.
 """
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
@@ -338,6 +338,71 @@ def resolve_maintenance_job(db: Session, job_id: int, kind: str) -> Any:
     if model is None:
         return None
     return db.query(model).filter(model.id == job_id).first()
+
+
+def resolve_agent_maintenance_job(
+    db: Session, payload: Any, *, kinds: Iterable[str] = MAINTENANCE_KINDS
+) -> Any:
+    """The maintenance job an agent job's payload names, or None; only for
+    the `kinds` the caller handles.
+
+    The payload's `operation.maintenance_job` carries `kind`, `id` and, for
+    every job queued since the marker exists, `table`. The `operations` ids
+    and the legacy ``*_jobs`` ids are separate sequences, so the table is
+    what tells them apart. A payload without it predates the marker and may
+    name either; the payload's repository decides (the row of the same
+    repository, an operation first, and nothing when neither row is that
+    repository's), and a payload without a repository takes the operation,
+    as before.
+    """
+    if not isinstance(payload, dict):
+        return None
+    operation_payload = payload.get("operation")
+    maintenance = (
+        operation_payload.get("maintenance_job")
+        if isinstance(operation_payload, dict)
+        else None
+    )
+    if not isinstance(maintenance, dict):
+        return None
+    kind = str(maintenance.get("kind") or "")
+    if kind not in MAINTENANCE_KINDS or kind not in set(kinds):
+        return None
+    try:
+        job_id = int(maintenance.get("id"))
+    except (TypeError, ValueError):
+        return None
+    if job_id <= 0:
+        return None
+    table = maintenance.get("table")
+    operation = (
+        db.query(Operation)
+        .filter(Operation.id == job_id, Operation.kind == kind)
+        .first()
+    )
+    if table == Operation.__tablename__:
+        return MaintenanceJobFacade(db, operation) if operation is not None else None
+    model = LEGACY_MODELS[kind]
+    if table and table != model.__tablename__:
+        return None
+    legacy = db.query(model).filter(model.id == job_id).first()
+    if table:
+        return legacy
+    repository = payload.get("repository")
+    repository_id = repository.get("id") if isinstance(repository, dict) else None
+    candidates = [
+        candidate
+        for candidate in (
+            MaintenanceJobFacade(db, operation) if operation is not None else None,
+            legacy,
+        )
+        if candidate is not None
+    ]
+    if repository_id is not None:
+        # a row of another repository is never the one this job reports on
+        matching = [c for c in candidates if c.repository_id == repository_id]
+        return matching[0] if matching else None
+    return candidates[0] if candidates else None
 
 
 def refresh_job(db: Session, job: Any) -> None:

--- a/app/services/operations/maintenance_start.py
+++ b/app/services/operations/maintenance_start.py
@@ -11,12 +11,15 @@ the button keeps behaving as users expect.
 
 from typing import Any, Optional
 
+import structlog
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from app.database.models import Operation, Repository
 from app.services.operations.enqueue import enqueue
 from app.services.operations.job_facade import LEGACY_MODELS, MAINTENANCE_KINDS
+
+logger = structlog.get_logger()
 
 ACTIVE_STATUSES = ("queued", "running")
 
@@ -132,13 +135,16 @@ def start_inline_maintenance(
 ) -> Operation:
     """An operation the caller runs itself, right now, instead of leaving to
     the runner. Created `running` so the runner's queued-only sweep (spec 7.1)
-    never picks it up a second time. The caller is responsible for the
-    terminal status.
+    never picks it up a second time, with no `started_at`: that is the shape
+    `claim_running` recognises as a manual start, and the Borg 2 services
+    claim the row through it before they run (a row that already carries a
+    start is not theirs to claim, and they return without running). The
+    caller is responsible for the terminal status.
 
     Post-backup maintenance passes the backup's `run_id` and id so the child
     is the backup's child in the run (spec 6.3: `running_prune` is `running`
     on the child prune operation while the backup itself is completed)."""
-    from app.database.models import utc_now
+    from app.services.repository_executor import is_agent_executor
 
     operation = enqueue(
         db,
@@ -149,13 +155,144 @@ def start_inline_maintenance(
         triggered_by_user_id=user_id,
         run_id=run_id,
         depends_on_id=depends_on_id,
+        # Recorded on the row so a later reader (the runtime reaper) judges
+        # the operation by the executor it ran under, not by what the
+        # repository is set to by then.
+        execution_mode="agent" if is_agent_executor(repository) else "server",
         commit=False,
     )
     operation.status = "running"
-    operation.started_at = utc_now()
     db.commit()
     db.refresh(operation)
     return operation
+
+
+def detail_text(detail: Any) -> str:
+    """An HTTPException detail as one line: its message or key, as the other
+    detail flatteners do, except that the admission's generic "repository
+    busy" key says which operation holds the repository instead."""
+    from app.services.job_admission import REPOSITORY_OPERATION_ACTIVE_KEY
+
+    if isinstance(detail, dict):
+        message = detail.get("message")
+        if message:
+            return str(message)
+        key = detail.get("key")
+        params = detail.get("params")
+        active = params.get("active_operation") if isinstance(params, dict) else None
+        if key == REPOSITORY_OPERATION_ACTIVE_KEY and active:
+            return f"{active} is active on the repository"
+        if key:
+            return str(key)
+    return str(detail)
+
+
+def failure_text(error: BaseException) -> str:
+    """An exception as one line safe to store on a row users read. A
+    SQLAlchemy statement error renders the statement and its parameters in
+    `str()`, and the agent job insert carries the repository secrets, so
+    only the driver's own error is kept; an HTTPException reads as its
+    detail."""
+    from sqlalchemy.exc import StatementError
+
+    if isinstance(error, HTTPException):
+        return detail_text(error.detail)
+    if isinstance(error, StatementError):
+        orig = error.orig
+        if orig is not None:
+            return f"{type(orig).__name__}: {orig}"
+        return type(error).__name__
+    return str(error) or type(error).__name__
+
+
+async def fail_inline_maintenance(
+    db: Session, operation: Operation, error: BaseException
+) -> bool:
+    """Close an inline operation whose caller raised instead of writing the
+    terminal status, and say whether it did.
+
+    A row that already reached a terminal status (the agent path fails it
+    itself when its job is refused) is kept as written. So is a row a live
+    agent job is still carrying: the caller's wait may have given up on a
+    long prune the agent is still running, and the agent's report will
+    close the row; failing it here would free the repository for the next
+    step while that prune still holds it. A queued agent job counts too:
+    admission holds the repository for it on its own, the agent runs it on
+    its next hello, and the row must say so rather than contradict the job.
+    Any other row would stay `running` with nothing behind it and block the
+    repository via admission control until the next restart.
+
+    Rolls the session back first, since the failure that got the caller
+    here may have left its transaction unusable, and commits through the
+    lock-retrying helper, since a locked database is one of those failures;
+    call it before writing anything else on that session.
+    """
+    from sqlalchemy import func
+
+    from app.database.models import utc_now
+    from app.services.operations.events import broadcast_operation_updated
+    from app.utils.db_retries import commit_with_retry
+    from app.utils.process_utils import has_active_agent_job_for
+
+    operation_id = kind = None
+    closed = 0
+
+    def close():
+        # A guarded UPDATE rather than attribute writes: it is re-issued on
+        # every retry (a rollback discards attribute writes), and a report
+        # that reached the row first keeps its own verdict.
+        nonlocal closed
+        closed = (
+            db.query(Operation)
+            .filter(Operation.id == operation_id, Operation.status == "running")
+            .update(
+                {
+                    Operation.status: "failed",
+                    # a diagnostic the service recorded before raising is
+                    # more specific than the exception that wrapped it
+                    Operation.error_message: func.coalesce(
+                        Operation.error_message, failure_text(error)
+                    ),
+                    Operation.completed_at: utc_now(),
+                },
+                synchronize_session=False,
+            )
+        )
+
+    try:
+        # First thing: the failure that got the caller here may have left the
+        # transaction unusable, and even reading the row's id would raise.
+        db.rollback()
+        operation_id, kind = operation.id, operation.kind
+        db.refresh(operation)
+        # Same condition as the UPDATE's guard below: only the `running` row
+        # an inline caller created is ours to close.
+        if operation.status != "running":
+            return False
+        if has_active_agent_job_for(
+            db, kind, operation_id, table=Operation.__tablename__
+        ):
+            return False
+        await commit_with_retry(
+            db,
+            prepare=close,
+            logger=logger,
+            action="fail_inline_maintenance",
+            operation_id=operation_id,
+        )
+        if closed:
+            db.refresh(operation)
+            await broadcast_operation_updated(operation, db)
+        return bool(closed)
+    except Exception as exc:
+        db.rollback()
+        logger.warning(
+            "Could not close the inline operation after a failure",
+            operation_id=operation_id,
+            kind=kind,
+            error=failure_text(exc),
+        )
+        return False
 
 
 def finish_inline_maintenance(
@@ -164,11 +301,51 @@ def finish_inline_maintenance(
     """Give an inline operation the follow-up chain the runner would have
     enqueued for it (spec 7.4). Call after the caller has written the terminal
     status."""
+    from app.database.models import utc_now
     from app.services.operations.enqueue import enqueue_chain
     from app.services.operations.executors import registered_kinds
     from app.services.operations.followups import chain_for, history_enabled
-    from app.services.operations.vocab import SUCCESS_STATUSES
+    from app.services.operations.vocab import SUCCESS_STATUSES, TERMINAL_STATUSES
 
+    if operation.status not in TERMINAL_STATUSES:
+        # The service returned without recording a verdict, which is a bug
+        # in the service (the runner's maintenance executor makes the same
+        # call). Left `running`, the row would block the repository via
+        # admission control until the next restart. Guarded, so a report
+        # that reaches the row in the meantime keeps its verdict; and
+        # nothing here may raise past the caller, or the row stays as it is.
+        try:
+            db.query(Operation).filter(
+                Operation.id == operation.id,
+                Operation.status.notin_(TERMINAL_STATUSES),
+            ).update(
+                {
+                    Operation.status: "failed",
+                    Operation.error_message: (
+                        "the service returned without recording a verdict"
+                    ),
+                    Operation.completed_at: utc_now(),
+                },
+                synchronize_session=False,
+            )
+            db.commit()
+        except Exception as exc:
+            db.rollback()
+            logger.warning(
+                "Could not close the inline operation that returned no verdict",
+                operation_id=operation.id,
+                kind=operation.kind,
+                error=failure_text(exc),
+            )
+            return
+        db.refresh(operation)
+        logger.warning(
+            "Inline operation returned without a verdict",
+            operation_id=operation.id,
+            kind=operation.kind,
+            status=operation.status,
+        )
+        return
     if not enqueue_followups or operation.status not in SUCCESS_STATUSES:
         return
     kinds = chain_for(

--- a/app/services/repository_executor.py
+++ b/app/services/repository_executor.py
@@ -222,9 +222,14 @@ def build_agent_repository_operation_payload(
 
     operation_payload = dict(operation or {})
     if maintenance_job_kind and maintenance_job_id:
+        # Since phase 5 every maintenance job is an `operations` row. The
+        # legacy `*_jobs` ids are an independent sequence, so the table is
+        # named: a payload without it was written before the upgrade and
+        # names a legacy row.
         operation_payload["maintenance_job"] = {
             "kind": maintenance_job_kind,
             "id": maintenance_job_id,
+            "table": "operations",
         }
 
     secrets = {}

--- a/app/utils/process_utils.py
+++ b/app/utils/process_utils.py
@@ -344,27 +344,56 @@ _ORPHAN_MAINTENANCE_MODELS = (
 )
 
 
-def _has_active_agent_job_for(
-    db: Session, maintenance_kind: str, maintenance_job_id: int
-) -> bool:
-    """True if a live agent job exists for this maintenance ``*_job``."""
+def active_agent_maintenance_jobs(db: Session) -> set[tuple[str, str, int]]:
+    """The `(table, kind, id)` of every maintenance job a live agent job is
+    carrying, read once so a reap pass can check many rows against it.
+    `operations` ids and the legacy `*_jobs` ids are separate sequences. A
+    payload that names no table predates the marker and may refer to
+    either (a pre-phase-5 legacy row, or an operation queued by the build
+    before this one), so it counts for both: an ambiguous reference keeps
+    a row alive rather than reaping a live one."""
+    from app.services.operations.job_facade import LEGACY_MODELS
+
     active = (
-        db.query(AgentJob)
+        db.query(AgentJob.payload)
         .filter(
             AgentJob.job_type == "repository",
             AgentJob.status.in_(_ACTIVE_AGENT_STATUSES),
         )
         .all()
     )
-    for agent_job in active:
-        payload = agent_job.payload if isinstance(agent_job.payload, dict) else {}
-        maintenance_job = (payload.get("operation") or {}).get("maintenance_job") or {}
-        if (
-            maintenance_job.get("kind") == maintenance_kind
-            and maintenance_job.get("id") == maintenance_job_id
-        ):
-            return True
-    return False
+    refs: set[tuple[str, str, int]] = set()
+    for (payload,) in active:
+        operation = payload.get("operation") if isinstance(payload, dict) else None
+        maintenance_job = (
+            operation.get("maintenance_job") if isinstance(operation, dict) else None
+        )
+        if not isinstance(maintenance_job, dict):
+            continue
+        kind, job_id = maintenance_job.get("kind"), maintenance_job.get("id")
+        if not kind or job_id is None:
+            continue
+        table = maintenance_job.get("table")
+        if table:
+            refs.add((table, kind, job_id))
+            continue
+        refs.add((Operation.__tablename__, kind, job_id))
+        model = LEGACY_MODELS.get(kind)
+        if model is not None:
+            refs.add((model.__tablename__, kind, job_id))
+    return refs
+
+
+def has_active_agent_job_for(
+    db: Session, maintenance_kind: str, maintenance_job_id: int, *, table: str
+) -> bool:
+    """True if a live agent job exists for this maintenance job: an
+    `operations` row or a legacy ``*_job``, as `table` says."""
+    return (
+        table,
+        maintenance_kind,
+        maintenance_job_id,
+    ) in active_agent_maintenance_jobs(db)
 
 
 def reconcile_orphaned_maintenance_jobs(
@@ -399,7 +428,7 @@ def reconcile_orphaned_maintenance_jobs(
         for job_id, created_at, repository_id in candidates:
             if created_at is not None and _strip_tz(created_at) > cutoff:
                 continue  # too fresh; its agent job may be queued a moment later
-            if _has_active_agent_job_for(db, kind, job_id):
+            if has_active_agent_job_for(db, kind, job_id, table=model.__tablename__):
                 continue  # dispatched, waiting for the agent
             # Fail closed with a guarded UPDATE: it only touches a row that is
             # STILL 'pending', so a concurrent dispatch that has meanwhile moved
@@ -427,7 +456,7 @@ def reconcile_orphaned_maintenance_jobs(
             # been queued between the check above and this UPDATE (status was
             # still 'pending' then). If so, preserve the dispatched job by
             # reverting rather than committing a spurious 'failed'.
-            if _has_active_agent_job_for(db, kind, job_id):
+            if has_active_agent_job_for(db, kind, job_id, table=model.__tablename__):
                 db.rollback()
                 continue
             db.commit()
@@ -438,6 +467,121 @@ def reconcile_orphaned_maintenance_jobs(
                 job_id=job_id,
                 repository_id=repository_id,
             )
+
+    return reaped
+
+
+def reconcile_orphaned_maintenance_operations(
+    db: Session,
+    *,
+    now: Optional[datetime] = None,
+    reap_after: timedelta = MAINTENANCE_RECONCILE_AFTER,
+    reaped_operation_ids: Optional[list[int]] = None,
+) -> int:
+    """Fail `running` maintenance operations of agent-executed repositories
+    that no agent job is working on.
+
+    A caller that runs maintenance inline (post-backup prune, compact, check)
+    creates the operation `running` and hands it to the agent; when the agent
+    job is refused or lost, only that caller could close the row. If it does
+    not, the operation counts as active write work and every backup of the
+    repository is refused until a restart. Startup recovery applies this
+    rule to every row; at runtime it is safe only where liveness is provable,
+    which is the agent case: the agent job carries the operation's id, so a
+    `running` operation with no live agent job has nothing behind it. The
+    executor is read from the row (`execution_mode`, recorded when the
+    inline operation was created), not from the repository's current
+    setting. A server-side operation is left alone: the Borg process runs
+    in this process, a prune records no pid, and the runner's own tasks
+    carry no marker on the row. The age guard covers the moment between
+    creating the row and queueing its agent job. The ids of the rows it
+    failed are appended to `reaped_operation_ids` (when given) so the caller,
+    which runs this in a worker thread, can broadcast the change from the
+    event loop.
+    """
+    from app.services.operations.job_facade import MAINTENANCE_KINDS
+    from app.services.operations.runner import operation_runner
+
+    now = _strip_tz(now or datetime.utcnow())
+    cutoff = now - reap_after
+
+    candidates = (
+        db.query(
+            Operation.id,
+            Operation.kind,
+            Operation.repository_id,
+            Operation.started_at,
+            Operation.created_at,
+        )
+        .filter(
+            Operation.kind.in_(MAINTENANCE_KINDS),
+            Operation.status == "running",
+            Operation.execution_mode == "agent",
+            Operation.process_pid.is_(None),
+        )
+        .all()
+    )
+    if not candidates:
+        return 0
+    live = active_agent_maintenance_jobs(db)
+    reaped = 0
+    for operation_id, kind, repository_id, started_at, created_at in candidates:
+        started = started_at or created_at
+        if started is not None and _strip_tz(started) > cutoff:
+            continue  # its agent job may be queued a moment later
+        if operation_id in operation_runner.running_tasks:
+            continue  # the runner is executing it in this process
+        if (Operation.__tablename__, kind, operation_id) in live:
+            continue  # dispatched, the agent is on it
+        # Guarded UPDATE, same shape as the legacy pass above: only a row that
+        # is still `running` is touched, so a caller that closed it meanwhile
+        # keeps its own terminal status. A locked database on one row must
+        # not end the pass for the others.
+        try:
+            updated = (
+                db.query(Operation)
+                .filter(Operation.id == operation_id, Operation.status == "running")
+                .update(
+                    {
+                        Operation.status: "failed",
+                        Operation.error_message: func.coalesce(
+                            Operation.error_message,
+                            "orphaned: no agent job is working on this operation",
+                        ),
+                        Operation.completed_at: func.coalesce(
+                            Operation.completed_at, now
+                        ),
+                    },
+                    synchronize_session=False,
+                )
+            )
+            if not updated:
+                db.rollback()  # closed by its caller between the read and the update
+                continue
+            if has_active_agent_job_for(
+                db, kind, operation_id, table=Operation.__tablename__
+            ):
+                db.rollback()  # queued between the read and the update
+                continue
+            db.commit()
+        except Exception as exc:
+            db.rollback()
+            logger.warning(
+                "Could not reap an orphaned maintenance operation",
+                operation_id=operation_id,
+                kind=kind,
+                error=str(exc),
+            )
+            continue
+        reaped += 1
+        if reaped_operation_ids is not None:
+            reaped_operation_ids.append(operation_id)
+        logger.info(
+            "Reaped orphaned running maintenance operation",
+            operation_id=operation_id,
+            kind=kind,
+            repository_id=repository_id,
+        )
 
     return reaped
 

--- a/docs/architecture/job-system.md
+++ b/docs/architecture/job-system.md
@@ -141,6 +141,28 @@ against the backup row holding the lane in `running_prune`. An inline
 operation still gets a real row and the same follow-up chain a
 runner-dispatched one would get, just without the runner's queueing.
 
+The caller of an inline operation owns its terminal status. When the step
+raises instead of writing one (an agent job refused by admission because
+the backup's follow-up listing still holds the repository, a locked
+database), the caller closes the row as `failed` with the cause
+(`fail_inline_maintenance`) and the plan's or schedule's run records the
+failed step; the agent path does the same for the operation itself when
+its job cannot be queued. A row a live agent job is still carrying is not
+closed: the caller's wait may have given up on a prune the agent is still
+running (or one still queued for an offline agent, which holds the
+repository through admission on its own), and the agent's report closes
+it. A step that returns with the
+row still `running` (a service bug) is closed by `finish_inline_maintenance`
+with that reason. A `running` operation nobody
+closes counts as active write work and would refuse every backup of the
+repository until the next restart, so the agent job reaper also fails,
+once a minute, a `running` inline maintenance operation recorded as
+agent-executed (`execution_mode`, which only `start_inline_maintenance`
+sets for these kinds; a runner-dispatched operation is the runner's task
+and ends with it) that is older than a few minutes and has no live agent
+job behind it. Server-side operations are not reaped at runtime: a prune
+records no pid, so nothing there proves the row dead.
+
 A Borg 2 compact runs with `--stats` under `BORG_UNITS=raw` (the server
 adds `--info`, the level Borg prints the lines on there). The repository
 statistics Borg 2 reports only there ("Repository size is N B in M

--- a/tests/unit/test_agent_upgrade_waves.py
+++ b/tests/unit/test_agent_upgrade_waves.py
@@ -160,7 +160,7 @@ async def test_reaper_tick_releases_the_next_wave(monkeypatch):
     monkeypatch.setattr(
         "app.services.agent_upgrades.release_agent_upgrade_waves", fake_release
     )
-    monkeypatch.setattr(agent_job_reaper, "_reap_once", lambda ids=None: 0)
+    monkeypatch.setattr(agent_job_reaper, "_reap_once", lambda *args: 0)
 
     task = asyncio.create_task(
         agent_job_reaper.start_agent_job_reaper(interval_seconds=0.01)

--- a/tests/unit/test_api_backup_plans.py
+++ b/tests/unit/test_api_backup_plans.py
@@ -29,6 +29,7 @@ from app.database.models import (
     SystemSettings,
     UserRepositoryPermission,
 )
+from app.core.borg_router import BorgRouter
 from app.core.security import get_password_hash
 from app.services.backup_plan_execution_service import backup_plan_execution_service
 from app.services.operations.backup_facade import (
@@ -4812,6 +4813,154 @@ class TestBackupPlanRoutes:
         assert sorted(execution_order) == sorted(repo.path for repo in repos)
         assert {child.status for child in run.repositories} == {"completed"}
         assert run.status == "completed"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "raising_step, steps_before",
+        [("prune", []), ("compact", ["prune"]), ("check", ["prune", "compact"])],
+    )
+    async def test_maintenance_step_that_raises_fails_its_operation(
+        self, test_db, raising_step, steps_before
+    ):
+        """A step whose agent job is refused raises out of the router. The
+        operation the plan created `running` must end `failed` with the
+        cause and the repository's run must end failed with that cause -
+        not leave the operation `running` (which blocks every later backup
+        of the repository) while the run reports a generic execution
+        failure. The steps after it do not run on a repository in unknown
+        state; the steps before it completed normally."""
+        repo = _create_repo(test_db, "Primary", "/repos/primary")
+        _plan, run = _create_execution_plan(
+            test_db,
+            [repo],
+            run_prune_after=True,
+            run_compact_after=True,
+            run_check_after=True,
+        )
+
+        async def fake_execute_backup(job_id, repository, db, **kwargs):
+            job = resolve_backup_job(db, job_id)
+            job.status = "completed"
+            job.completed_at = datetime.utcnow()
+            db.commit()
+
+        calls = []
+
+        def step(kind):
+            async def run(self, job_id, *args, **kwargs):
+                calls.append(kind)
+                if kind == raising_step:
+                    raise RuntimeError(
+                        f"agent {kind} failed: list_archives is active on the "
+                        "repository"
+                    )
+                operation = test_db.get(Operation, job_id)
+                operation.status = "completed"
+                operation.completed_at = datetime.utcnow()
+                test_db.commit()
+
+            return run
+
+        with (
+            patch(
+                "app.services.backup_plan_execution_service.wait_for_backup_operation",
+                new=_plan_backup_seam(fake_execute_backup),
+            ),
+            patch.object(BorgRouter, "prune", new=step("prune")),
+            patch.object(BorgRouter, "compact", new=step("compact")),
+            patch.object(BorgRouter, "check", new=step("check")),
+        ):
+            await backup_plan_execution_service.execute_run(run.id)
+
+        cause = (
+            f"agent {raising_step} failed: list_archives is active on the repository"
+        )
+        test_db.expire_all()
+        run = test_db.query(BackupPlanRun).filter_by(id=run.id).one()
+        child = run.repositories[0]
+        assert child.status == "failed"
+        assert child.error_message == cause
+        assert run.status == "failed"
+        assert calls == steps_before + [raising_step]
+        by_kind = {
+            operation.kind: operation
+            for operation in test_db.query(Operation)
+            .filter(Operation.repository_id == repo.id)
+            .all()
+        }
+        assert by_kind[raising_step].status == "failed"
+        assert by_kind[raising_step].error_message == cause
+        assert by_kind[raising_step].completed_at is not None
+        for kind in steps_before:
+            assert by_kind[kind].status == "completed"
+        # A completed step enqueues its follow-up chain; the maintenance
+        # kinds themselves stop at the one that raised.
+        assert set(by_kind) & {"prune", "compact", "check"} == {
+            *steps_before,
+            raising_step,
+        }
+        backup_job = BackupJobFacade(test_db, by_kind["backup"])
+        assert backup_job.maintenance_status == f"{raising_step}_failed"
+        assert (
+            test_db.query(Operation).filter(Operation.status == "running").count() == 0
+        )
+
+    @pytest.mark.asyncio
+    async def test_maintenance_step_left_to_its_agent_still_fails_the_run(
+        self, test_db
+    ):
+        """When the close is declined (a live agent job still carries the
+        operation), the step is still recorded as failed on the backup and
+        the run ends failed with the cause; the row stays for the agent."""
+        repo = _create_repo(test_db, "Primary", "/repos/primary")
+        _plan, run = _create_execution_plan(
+            test_db, [repo], run_prune_after=True, run_compact_after=True
+        )
+
+        async def fake_execute_backup(job_id, repository, db, **kwargs):
+            job = resolve_backup_job(db, job_id)
+            job.status = "completed"
+            job.completed_at = datetime.utcnow()
+            db.commit()
+
+        with (
+            patch(
+                "app.services.backup_plan_execution_service.wait_for_backup_operation",
+                new=_plan_backup_seam(fake_execute_backup),
+            ),
+            patch.object(
+                BorgRouter,
+                "prune",
+                new=AsyncMock(
+                    side_effect=RuntimeError(
+                        "agent prune failed: repositoryOperationTimeout"
+                    )
+                ),
+            ),
+            patch(
+                "app.services.backup_plan_execution_service.fail_inline_maintenance",
+                new=AsyncMock(return_value=False),
+            ),
+        ):
+            await backup_plan_execution_service.execute_run(run.id)
+
+        test_db.expire_all()
+        run = test_db.query(BackupPlanRun).filter_by(id=run.id).one()
+        assert run.repositories[0].status == "failed"
+        assert (
+            run.repositories[0].error_message
+            == "agent prune failed: repositoryOperationTimeout"
+        )
+        by_kind = {
+            operation.kind: operation
+            for operation in test_db.query(Operation)
+            .filter(Operation.repository_id == repo.id)
+            .all()
+        }
+        assert by_kind["prune"].status == "running"
+        assert "compact" not in by_kind
+        backup_job = BackupJobFacade(test_db, by_kind["backup"])
+        assert backup_job.maintenance_status == "prune_failed"
 
     @pytest.mark.asyncio
     async def test_maintenance_failure_marks_repository_warning(self, test_db):

--- a/tests/unit/test_api_repositories.py
+++ b/tests/unit/test_api_repositories.py
@@ -26,6 +26,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import text
 from app.core.agent_auth import AGENT_AUTH_HEADER
 from app.core.security import get_password_hash
+from app.services.operations.maintenance_start import active_maintenance_operation
 from app.database.models import (
     AgentJob,
     AgentMachine,
@@ -1848,6 +1849,77 @@ class TestRepositoriesCreate:
         if routed_keep_within is None and len(args) >= 9:
             routed_keep_within = args[8]
         assert routed_keep_within == "1d"
+
+    def test_prune_dry_run_closes_its_operation_when_the_router_raises(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """The dry-run preview runs inline on an operation created `running`.
+        A router error must close that row, or it blocks the repository via
+        admission control until the next restart."""
+        repo = Repository(**_base_repository_payload(name="Dry Run Prune"))
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+
+        with patch(
+            "app.api.repositories.BorgRouter.prune",
+            new=AsyncMock(side_effect=RuntimeError("agent prune failed: refused")),
+        ):
+            response = test_client.post(
+                f"/api/repositories/{repo.id}/prune",
+                json={"keep_daily": 7, "dry_run": True},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 500
+        test_db.expire_all()
+        prune = test_db.query(Operation).filter(Operation.kind == "prune").one()
+        assert prune.status == "failed"
+        assert prune.error_message == "agent prune failed: refused"
+        assert prune.completed_at is not None
+
+    def test_prune_dry_run_on_an_agent_repository_records_the_refusal(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """End to end through the router: admission refuses the agent job,
+        the router fails the operation with the cause, and the route's own
+        handler leaves that verdict alone."""
+        from fastapi import HTTPException
+
+        repo = Repository(
+            **_base_repository_payload(name="Dry Run Agent Prune"),
+            executor_type="agent",
+            execution_target="agent",
+        )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+        refused = HTTPException(
+            status_code=409,
+            detail={
+                "key": "backend.errors.jobs.repositoryOperationActive",
+                "params": {"active_operation": "list_archives"},
+            },
+        )
+
+        with patch(
+            "app.services.repository_executor.queue_agent_repository_operation_job",
+            side_effect=refused,
+        ):
+            response = test_client.post(
+                f"/api/repositories/{repo.id}/prune",
+                json={"keep_daily": 7, "dry_run": True},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 500
+        test_db.expire_all()
+        prune = test_db.query(Operation).filter(Operation.kind == "prune").one()
+        assert prune.status == "failed"
+        assert prune.error_message == (
+            "agent job could not be queued: list_archives is active on the repository"
+        )
+        assert active_maintenance_operation(test_db, repo.id, "prune") is None
 
     def test_legacy_prune_route_rejects_non_string_keep_within(
         self, test_client: TestClient, admin_headers, test_db

--- a/tests/unit/test_api_schedule_routes.py
+++ b/tests/unit/test_api_schedule_routes.py
@@ -20,6 +20,7 @@ from app.database.models import (
     ScheduledJobRepository,
     SSHConnection,
 )
+from app.services.operations.backup_facade import BackupJobFacade
 from app.services.rclone_service import RcloneCommandResult
 
 
@@ -512,6 +513,212 @@ class TestScheduleRouteContracts:
         assert operation.execution_mode == "remote_ssh"
         assert details.source_ssh_connection_id == connection.id
         assert test_db.query(BackupJob).count() == 0
+
+    @pytest.mark.asyncio
+    async def test_multi_repo_schedule_closes_the_prune_operation_when_the_step_raises(
+        self, test_db, monkeypatch
+    ):
+        """The post-backup prune is an inline operation created `running`.
+        When the router raises (an agent job refused by admission), the
+        handler must close that row with the cause and record the failed
+        step on the backup, or the row blocks the repository until a
+        restart."""
+        repo = _create_repo(test_db, "Prune Repo", "/repos/prune")
+        schedule = _create_schedule(
+            test_db,
+            "Prune After",
+            run_prune_after=True,
+            prune_keep_daily=7,
+            run_compact_after=True,
+        )
+        test_db.add(
+            ScheduledJobRepository(
+                scheduled_job_id=schedule.id,
+                repository_id=repo.id,
+                execution_order=0,
+            )
+        )
+        test_db.commit()
+
+        async def _complete(db, operation_id, **kwargs):
+            operation = db.get(Operation, operation_id)
+            operation.status = "completed"
+            db.commit()
+            return "completed"
+
+        monkeypatch.setattr("app.api.schedule.wait_for_backup_operation", _complete)
+        monkeypatch.setattr(
+            "app.api.schedule.BorgRouter.prune",
+            AsyncMock(side_effect=RuntimeError("agent prune failed: refused")),
+        )
+
+        await schedule_api.execute_multi_repo_schedule(schedule, test_db)
+
+        test_db.expire_all()
+        prune = test_db.query(Operation).filter(Operation.kind == "prune").one()
+        assert prune.status == "failed"
+        assert prune.error_message == "agent prune failed: refused"
+        assert prune.completed_at is not None
+        backup = test_db.query(Operation).filter(Operation.kind == "backup").one()
+        assert BackupJobFacade(test_db, backup).maintenance_status == "prune_failed"
+        # the compact does not run on a repository whose prune step raised
+        assert test_db.query(Operation).filter(Operation.kind == "compact").count() == 0
+
+    @pytest.mark.asyncio
+    async def test_multi_repo_schedule_keeps_a_prune_its_agent_is_still_running(
+        self, test_db, monkeypatch
+    ):
+        """The wait on an agent prune can give up (504) while the agent is
+        still running it. The handler records the failed step but must not
+        close the operation: the agent's report will, and until then the
+        repository really is busy."""
+        from app.core.security import get_password_hash
+        from app.database.models import AgentJob, AgentMachine
+
+        repo = _create_repo(test_db, "Slow Prune Repo", "/repos/slow-prune")
+        agent = AgentMachine(
+            name="Agent",
+            agent_id="agt_slow_prune",
+            token_hash=get_password_hash("secret"),
+            token_prefix="secret",
+            status="online",
+        )
+        test_db.add(agent)
+        schedule = _create_schedule(
+            test_db, "Slow Prune After", run_prune_after=True, prune_keep_daily=7
+        )
+        test_db.add(
+            ScheduledJobRepository(
+                scheduled_job_id=schedule.id,
+                repository_id=repo.id,
+                execution_order=0,
+            )
+        )
+        test_db.commit()
+
+        async def _complete(db, operation_id, **kwargs):
+            operation = db.get(Operation, operation_id)
+            operation.status = "completed"
+            db.commit()
+            return "completed"
+
+        async def _timeout(self, job_id, *args, **kwargs):
+            # The agent job for this operation exists and is running when
+            # the server-side wait gives up.
+            test_db.add(
+                AgentJob(
+                    agent_machine_id=agent.id,
+                    job_type="repository",
+                    status="running",
+                    payload={
+                        "job_kind": "repository.prune",
+                        "operation": {
+                            "maintenance_job": {
+                                "kind": "prune",
+                                "id": job_id,
+                                "table": "operations",
+                            }
+                        },
+                    },
+                )
+            )
+            test_db.commit()
+            raise RuntimeError(
+                "agent prune failed: backend.errors.agents.repositoryOperationTimeout"
+            )
+
+        monkeypatch.setattr("app.api.schedule.wait_for_backup_operation", _complete)
+        monkeypatch.setattr("app.api.schedule.BorgRouter.prune", _timeout)
+
+        await schedule_api.execute_multi_repo_schedule(schedule, test_db)
+
+        test_db.expire_all()
+        prune = test_db.query(Operation).filter(Operation.kind == "prune").one()
+        assert prune.status == "running"
+        assert prune.error_message is None
+        backup = test_db.query(Operation).filter(Operation.kind == "backup").one()
+        assert BackupJobFacade(test_db, backup).maintenance_status == "prune_failed"
+
+    @pytest.mark.asyncio
+    async def test_multi_repo_schedule_closes_the_compact_operation_when_the_step_raises(
+        self, test_db, monkeypatch
+    ):
+        repo = _create_repo(test_db, "Compact Repo", "/repos/compact")
+        schedule = _create_schedule(test_db, "Compact After", run_compact_after=True)
+        test_db.add(
+            ScheduledJobRepository(
+                scheduled_job_id=schedule.id,
+                repository_id=repo.id,
+                execution_order=0,
+            )
+        )
+        test_db.commit()
+
+        async def _complete(db, operation_id, **kwargs):
+            operation = db.get(Operation, operation_id)
+            operation.status = "completed"
+            db.commit()
+            return "completed"
+
+        monkeypatch.setattr("app.api.schedule.wait_for_backup_operation", _complete)
+        monkeypatch.setattr(
+            "app.api.schedule.BorgRouter.compact",
+            AsyncMock(side_effect=RuntimeError("agent compact failed: refused")),
+        )
+
+        await schedule_api.execute_multi_repo_schedule(schedule, test_db)
+
+        test_db.expire_all()
+        compact = test_db.query(Operation).filter(Operation.kind == "compact").one()
+        assert compact.status == "failed"
+        assert compact.error_message == "agent compact failed: refused"
+        backup = test_db.query(Operation).filter(Operation.kind == "backup").one()
+        assert BackupJobFacade(test_db, backup).maintenance_status == "compact_failed"
+
+    @pytest.mark.asyncio
+    async def test_single_repo_schedule_closes_the_prune_operation_when_the_step_raises(
+        self, test_db, monkeypatch
+    ):
+        """The single-repository schedule path has its own post-backup
+        handlers; they must close the inline operation the same way."""
+        from app.services.operations.backup_facade import create_backup_operation
+
+        repo = _create_repo(test_db, "Single Prune Repo", "/repos/single-prune")
+        schedule = _create_schedule(
+            test_db, "Single Prune After", run_prune_after=True, prune_keep_daily=7
+        )
+        backup_job = create_backup_operation(
+            test_db,
+            repo,
+            trigger="schedule",
+            executor="server",
+            params={},
+            scheduled_job_id=schedule.id,
+        )
+        backup_job.status = "completed"
+        backup_job.completed_at = datetime.utcnow()
+        test_db.commit()
+
+        async def _completed(db, operation_id, **kwargs):
+            return "completed"
+
+        monkeypatch.setattr("app.api.schedule.wait_for_backup_operation", _completed)
+        monkeypatch.setattr(
+            "app.api.schedule.BorgRouter.prune",
+            AsyncMock(side_effect=RuntimeError("agent prune failed: refused")),
+        )
+
+        await schedule_api.execute_scheduled_backup_with_maintenance(
+            backup_job.id, repo.path, schedule.id
+        )
+
+        test_db.expire_all()
+        prune = test_db.query(Operation).filter(Operation.kind == "prune").one()
+        assert prune.status == "failed"
+        assert prune.error_message == "agent prune failed: refused"
+        assert prune.completed_at is not None
+        backup = test_db.get(Operation, backup_job.id)
+        assert BackupJobFacade(test_db, backup).maintenance_status == "prune_failed"
 
     def test_dispatch_due_multi_repo_schedule_defers_for_active_repository_work(
         self, test_db, monkeypatch

--- a/tests/unit/test_borg_router.py
+++ b/tests/unit/test_borg_router.py
@@ -1,8 +1,12 @@
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 import json
 
 import pytest
+
+from fastapi import HTTPException
+from sqlalchemy.exc import OperationalError
 
 from app.core.borg_router import BorgRouter
 
@@ -1110,3 +1114,172 @@ async def test_prune_delegates_to_v2_service():
         keep_yearly=6,
         dry_run=True,
     )
+
+
+@pytest.mark.parametrize(
+    "maintenance_kind, job_kind, extra",
+    [
+        ("prune", "repository.prune", {}),
+        ("compact", "repository.compact", {}),
+        ("check", "repository.check", {}),
+        ("delete_archive", "repository.delete_archive", {"archive_name": "arch-1"}),
+    ],
+)
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_agent_maintenance_fails_the_operation_when_queue_is_refused(
+    db_session, maintenance_kind, job_kind, extra
+):
+    # Since phase 5 the maintenance job is an `operations` row the caller
+    # created `running` (post-backup prune/compact/check). When admission
+    # refuses the agent job, that row - not a legacy *_jobs row - must be
+    # failed, or it counts as active work and blocks every backup of the
+    # repository until a restart. A legacy row that happens to share the id
+    # (the two id spaces are independent) must stay untouched.
+    from app.database.models import Operation, Repository
+    from app.services.operations.job_facade import LEGACY_MODELS
+    from app.services.operations.maintenance_start import (
+        active_maintenance_operation,
+        start_inline_maintenance,
+    )
+
+    repo_row = Repository(
+        name=f"Refused {maintenance_kind}",
+        path=f"/repos/refused-{maintenance_kind}",
+        encryption="none",
+        repository_type="local",
+        executor_type="agent",
+        execution_target="agent",
+    )
+    db_session.add(repo_row)
+    db_session.commit()
+    operation = start_inline_maintenance(
+        db_session, repo_row, maintenance_kind, params=extra, user_id=None
+    )
+    operation_id = operation.id
+    repository_id = repo_row.id
+    legacy_model = LEGACY_MODELS[maintenance_kind]
+    legacy = legacy_model(
+        id=operation_id,
+        repository_id=repository_id,
+        repository_path=repo_row.path,
+        status="completed",
+        created_at=datetime.utcnow(),
+        **extra,
+    )
+    db_session.add(legacy)
+    db_session.commit()
+
+    repo = SimpleNamespace(borg_version=1, id=repository_id, executor_type="agent")
+    refused = HTTPException(
+        status_code=409,
+        detail={
+            "key": "backend.errors.jobs.repositoryOperationActive",
+            "params": {
+                "requested_operation": maintenance_kind,
+                "active_operation": "list_archives",
+                "active_job_table": "agent_jobs",
+                "active_status": "running",
+            },
+        },
+    )
+
+    with (
+        patch("app.database.database.SessionLocal", return_value=db_session),
+        patch(
+            "app.services.repository_executor.queue_agent_repository_operation_job",
+            side_effect=refused,
+        ),
+        pytest.raises(
+            RuntimeError,
+            match=(
+                f"agent {maintenance_kind} failed: "
+                "list_archives is active on the repository"
+            ),
+        ),
+    ):
+        await BorgRouter(repo)._run_agent_maintenance(
+            job_kind=job_kind,
+            maintenance_kind=maintenance_kind,
+            maintenance_job_id=operation_id,
+        )
+
+    # The router closed the session it was handed; read the rows back fresh.
+    stored = db_session.get(Operation, operation_id)
+    assert stored.status == "failed"
+    assert stored.completed_at is not None
+    assert (
+        stored.error_message
+        == "agent job could not be queued: list_archives is active on the repository"
+    )
+    assert db_session.get(legacy_model, operation_id).status == "completed"
+    # Nothing is left that admission would count as active maintenance.
+    assert (
+        active_maintenance_operation(db_session, repository_id, maintenance_kind)
+        is None
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "error, expected",
+    [
+        (
+            HTTPException(
+                status_code=409,
+                detail={
+                    "key": "backend.errors.jobs.repositoryOperationActive",
+                    "params": {"active_operation": "list_archives"},
+                },
+            ),
+            "agent job could not be queued: list_archives is active on the repository",
+        ),
+        (
+            HTTPException(
+                status_code=409,
+                detail={"key": "backend.errors.agents.noQueueableAgent"},
+            ),
+            "agent job could not be queued: backend.errors.agents.noQueueableAgent",
+        ),
+        (
+            RuntimeError("database is locked"),
+            "agent job could not be queued: database is locked",
+        ),
+        (
+            HTTPException(
+                status_code=409,
+                detail={
+                    "key": "backend.errors.repo.pruneAlreadyRunning",
+                    "params": {"active_operation": "prune"},
+                },
+            ),
+            "agent job could not be queued: backend.errors.repo.pruneAlreadyRunning",
+        ),
+        (
+            HTTPException(
+                status_code=502, detail={"key": "x", "message": "agent gone"}
+            ),
+            "agent job could not be queued: agent gone",
+        ),
+        (RuntimeError(), "agent job could not be queued: RuntimeError"),
+    ],
+)
+def test_queue_failure_message_names_the_cause(error, expected):
+    from app.core.borg_router import _queue_failure_message
+
+    assert _queue_failure_message(error) == expected
+
+
+@pytest.mark.unit
+def test_queue_failure_message_keeps_a_database_error_as_the_cause():
+    # SQLAlchemy errors carry a `detail` attribute too (an empty list); only
+    # an HTTPException's detail is the cause, anything else is rendered as is.
+    from app.core.borg_router import _queue_failure_message
+
+    message = _queue_failure_message(
+        OperationalError("INSERT INTO agent_jobs", {}, Exception("database is locked"))
+    )
+
+    # The statement and its parameters (the agent job payload, secrets
+    # included) stay out of the row; the driver's error is the cause.
+    assert message == "agent job could not be queued: Exception: database is locked"

--- a/tests/unit/test_job_history_retention.py
+++ b/tests/unit/test_job_history_retention.py
@@ -8,6 +8,8 @@ freshest timestamp, so genuinely live work never looks old.
 
 from datetime import timedelta
 
+from unittest.mock import patch
+
 import pytest
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
@@ -1077,3 +1079,208 @@ def test_recent_extension_log_columns_are_kept(db):
 
     db.expunge_all()
     assert db.get(OperationRcloneDetails, rclone_id).log_text == "copied 2 files"
+
+
+@pytest.mark.unit
+def test_sweep_resolves_an_operations_backed_prune_by_its_table(
+    db, monkeypatch, tmp_path
+):
+    """Since phase 5 an agent prune's `maintenance_job` names an `operations`
+    row, and its payload says so. The sweep must read that row, not the
+    legacy `prune_jobs` row that happens to share the id (the id spaces are
+    separate): here that decoy belongs to another repository, whose backup
+    must not be marked."""
+    import uuid
+
+    from app.database.models import Operation
+
+    # the repaired log is a file under data_dir
+    monkeypatch.setattr("app.config.settings.data_dir", str(tmp_path))
+    _settings(db)
+    machine = _machine(db)
+    repo_b = _repo(db)
+    repo_a = Repository(
+        name="other", path="/repo/other", encryption="none", borg_version=1
+    )
+    db.add(repo_a)
+    db.flush()
+    when = utc_now() - timedelta(hours=6)
+    finished = when + timedelta(minutes=5)
+    backups = {}
+    for repo, name in ((repo_b, "host-old"), (repo_a, "host-old")):
+        job = BackupJob(
+            repository_id=repo.id,
+            status="completed",
+            archive_name=name,
+            completed_at=when - timedelta(hours=1),
+            created_at=when - timedelta(hours=1),
+        )
+        db.add(job)
+        db.flush()
+        backups[repo.id] = job.id
+    operation = Operation(
+        kind="prune",
+        category="maintenance",
+        status="completed",
+        repository_id=repo_b.id,
+        run_id=str(uuid.uuid4()),
+        started_at=when,
+        completed_at=finished,
+        created_at=when,
+    )
+    db.add(operation)
+    db.flush()
+    decoy = PruneJob(
+        id=operation.id,
+        repository_id=repo_a.id,
+        status="completed",
+        started_at=when,
+        completed_at=finished,
+        created_at=when,
+        logs="decoy",
+        has_logs=True,
+    )
+    db.add(decoy)
+    agent_job = AgentJob(
+        agent_machine_id=machine.id,
+        job_type="repository",
+        status="completed",
+        payload={
+            "job_kind": "repository.prune",
+            "operation": {
+                "maintenance_job": {
+                    "kind": "prune",
+                    "id": operation.id,
+                    "table": "operations",
+                }
+            },
+        },
+        claimed_at=when,
+        completed_at=finished,
+        created_at=when,
+        updated_at=when,
+    )
+    db.add(agent_job)
+    db.flush()
+    db.add(
+        AgentJobLog(
+            agent_job_id=agent_job.id,
+            sequence=0,
+            stream="stderr",
+            message="Pruning archive: host-old"
+            "                     Mon, 2026-07-20 03:00:00 [aa00] (1/1)",
+            created_at=when,
+        )
+    )
+    db.commit()
+
+    repo_a_id, repo_b_id, operation_id = repo_a.id, repo_b.id, operation.id
+
+    # A data directory that cannot be written loses the log repair, not the
+    # marking (the retention pass must not abort on it).
+    with patch("builtins.open", side_effect=OSError("read-only file system")):
+        assert sweep_pruned_archive_records(db) == 1
+    db.expunge_all()
+    assert db.get(BackupJob, backups[repo_b_id]).archive_pruned_at == finished
+    db.query(BackupJob).filter(BackupJob.id == backups[repo_b_id]).update(
+        {BackupJob.archive_pruned_at: None}, synchronize_session=False
+    )
+    db.commit()
+
+    assert sweep_pruned_archive_records(db) == 1
+
+    db.expunge_all()
+    assert db.get(BackupJob, backups[repo_b_id]).archive_pruned_at == finished
+    assert db.get(BackupJob, backups[repo_a_id]).archive_pruned_at is None
+    assert db.get(PruneJob, operation_id).logs == "decoy"
+    # The operation keeps its log in a file; the repair writes the full log
+    # there (the facade's own setter would leave an existing file alone).
+    from app.services.operations.job_facade import MaintenanceJobFacade
+
+    repaired = MaintenanceJobFacade(db, db.get(Operation, operation_id))
+    assert "Pruning archive: host-old" in repaired.logs
+
+
+@pytest.mark.unit
+def test_sweep_resolves_a_table_less_prune_by_its_repository(db):
+    """An agent prune queued by the build before the table marker names an
+    `operations` id without saying so. The payload's repository tells it
+    apart from a legacy row sharing the id."""
+    import uuid
+
+    from app.database.models import Operation
+
+    _settings(db)
+    machine = _machine(db)
+    repo_b = _repo(db)
+    repo_a = Repository(
+        name="other", path="/repo/other", encryption="none", borg_version=1
+    )
+    db.add(repo_a)
+    db.flush()
+    when = utc_now() - timedelta(hours=6)
+    finished = when + timedelta(minutes=5)
+    pruned = BackupJob(
+        repository_id=repo_b.id,
+        status="completed",
+        archive_name="host-old",
+        completed_at=when - timedelta(hours=1),
+        created_at=when - timedelta(hours=1),
+    )
+    db.add(pruned)
+    db.flush()
+    operation = Operation(
+        kind="prune",
+        category="maintenance",
+        status="completed",
+        repository_id=repo_b.id,
+        run_id=str(uuid.uuid4()),
+        started_at=when,
+        completed_at=finished,
+        created_at=when,
+    )
+    db.add(operation)
+    db.flush()
+    db.add(
+        PruneJob(
+            id=operation.id,
+            repository_id=repo_a.id,
+            status="completed",
+            started_at=when,
+            completed_at=finished,
+            created_at=when,
+        )
+    )
+    agent_job = AgentJob(
+        agent_machine_id=machine.id,
+        job_type="repository",
+        status="completed",
+        payload={
+            "job_kind": "repository.prune",
+            "repository": {"id": repo_b.id, "path": repo_b.path},
+            "operation": {"maintenance_job": {"kind": "prune", "id": operation.id}},
+        },
+        claimed_at=when,
+        completed_at=finished,
+        created_at=when,
+        updated_at=when,
+    )
+    db.add(agent_job)
+    db.flush()
+    db.add(
+        AgentJobLog(
+            agent_job_id=agent_job.id,
+            sequence=0,
+            stream="stderr",
+            message="Pruning archive: host-old"
+            "                     Mon, 2026-07-20 03:00:00 [aa00] (1/1)",
+            created_at=when,
+        )
+    )
+    db.commit()
+    pruned_id = pruned.id
+
+    assert sweep_pruned_archive_records(db) == 1
+
+    db.expunge_all()
+    assert db.get(BackupJob, pruned_id).archive_pruned_at == finished

--- a/tests/unit/test_maintenance_start.py
+++ b/tests/unit/test_maintenance_start.py
@@ -1,11 +1,13 @@
 """Phase 5: maintenance work is enqueued, not dispatched."""
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from fastapi import HTTPException
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
-from app.database.models import Base, Operation, Repository
+from app.database.models import Base, Operation, Repository, utc_now
 from app.services.operations.maintenance_start import (
     active_maintenance_operation,
     start_maintenance,
@@ -235,7 +237,9 @@ def test_inline_maintenance_starts_running_so_the_runner_leaves_it_alone(
 
     # Spec 7.1 dispatches queued rows only, so an inline row is never picked up.
     assert op.status == "running"
-    assert op.started_at is not None
+    # no start yet: the service's `claim_running` records it (see the
+    # claimability test below)
+    assert op.started_at is None
 
 
 def test_start_inline_maintenance_can_join_a_run(db, repository):
@@ -362,3 +366,348 @@ def test_active_delete_sees_a_legacy_row_for_the_same_archive(db, repository):
 
     assert active_delete_for_archive(db, repository.id, "nightly-1") is not None
     assert active_delete_for_archive(db, repository.id, "nightly-2") is None
+
+
+async def test_fail_inline_closes_a_running_operation_with_the_cause(db, repository):
+    from app.services.operations.maintenance_start import (
+        fail_inline_maintenance,
+        start_inline_maintenance,
+    )
+
+    op = start_inline_maintenance(db, repository, "prune", params={}, user_id=None)
+    assert op.status == "running"
+
+    assert await fail_inline_maintenance(
+        db, op, RuntimeError("agent prune failed: refused")
+    )
+
+    db.expire_all()
+    stored = db.get(Operation, op.id)
+    assert stored.status == "failed"
+    assert stored.error_message == "agent prune failed: refused"
+    assert stored.completed_at is not None
+
+
+async def test_fail_inline_keeps_a_terminal_status_the_step_already_wrote(
+    db, repository
+):
+    """The agent path fails the operation itself when its job is refused; the
+    caller's handler must not overwrite that (or a completion that raced the
+    exception) with its own message."""
+    from app.services.operations.maintenance_start import (
+        fail_inline_maintenance,
+        start_inline_maintenance,
+    )
+
+    op = start_inline_maintenance(db, repository, "compact", params={}, user_id=None)
+    op.status = "completed"
+    op.completed_at = utc_now()
+    db.commit()
+
+    assert not await fail_inline_maintenance(db, op, RuntimeError("late failure"))
+
+    db.expire_all()
+    stored = db.get(Operation, op.id)
+    assert stored.status == "completed"
+    assert stored.error_message is None
+
+
+async def test_fail_inline_keeps_an_operation_a_live_agent_job_is_carrying(
+    db, repository
+):
+    """The caller's wait can give up (504) on a prune the agent is still
+    running. Failing the row then would free the repository for the next
+    step while the agent still holds it; the agent's report closes it."""
+    from app.core.security import get_password_hash
+    from app.database.models import AgentJob, AgentMachine
+    from app.services.operations.maintenance_start import (
+        fail_inline_maintenance,
+        start_inline_maintenance,
+    )
+
+    agent = AgentMachine(
+        name="Agent",
+        agent_id="agt_inline_live",
+        token_hash=get_password_hash("secret"),
+        token_prefix="secret",
+        status="online",
+    )
+    db.add(agent)
+    db.commit()
+    op = start_inline_maintenance(db, repository, "prune", params={}, user_id=None)
+    db.add(
+        AgentJob(
+            agent_machine_id=agent.id,
+            job_type="repository",
+            status="running",
+            payload={
+                "job_kind": "repository.prune",
+                "operation": {
+                    "maintenance_job": {
+                        "kind": "prune",
+                        "id": op.id,
+                        "table": "operations",
+                    }
+                },
+            },
+        )
+    )
+    db.commit()
+
+    assert not await fail_inline_maintenance(
+        db, op, RuntimeError("agent prune failed: repositoryOperationTimeout")
+    )
+
+    db.expire_all()
+    assert db.get(Operation, op.id).status == "running"
+
+
+async def test_fail_inline_recovers_a_session_the_failure_left_unusable(db, repository):
+    """The failure that brings the caller here may have doomed its
+    transaction (a failed flush stands in for a locked database); the row
+    must still be closed, or it blocks the repository until a restart."""
+    from sqlalchemy.exc import IntegrityError
+
+    from app.database.models import PruneJob
+    from app.services.operations.maintenance_start import (
+        fail_inline_maintenance,
+        start_inline_maintenance,
+    )
+
+    op = start_inline_maintenance(db, repository, "check", params={}, user_id=None)
+    with pytest.raises(IntegrityError):
+        db.add(PruneJob(repository_path="/x", status="pending"))
+        db.flush()  # repository_id is NOT NULL
+
+    assert await fail_inline_maintenance(db, op, RuntimeError("database is locked"))
+
+    db.expire_all()
+    stored = db.get(Operation, op.id)
+    assert stored.status == "failed"
+    assert stored.error_message == "database is locked"
+
+
+async def test_fail_inline_retries_a_locked_commit_with_the_write(db, repository):
+    """A locked database is one of the failures that bring a caller here;
+    the retry helper rolls back between attempts, so the close must be
+    re-issued on each one rather than written once as attributes."""
+    from sqlalchemy.exc import OperationalError
+
+    from app.services.operations.maintenance_start import (
+        fail_inline_maintenance,
+        start_inline_maintenance,
+    )
+
+    op = start_inline_maintenance(db, repository, "prune", params={}, user_id=None)
+    real_commit = db.commit
+    attempts = []
+
+    def flaky_commit():
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise OperationalError(
+                "UPDATE operations", {}, Exception("database is locked")
+            )
+        real_commit()
+
+    with (
+        patch.object(db, "commit", side_effect=flaky_commit),
+        patch("app.utils.db_retries.asyncio.sleep", new=AsyncMock()),
+    ):
+        assert await fail_inline_maintenance(db, op, RuntimeError("refused"))
+
+    assert len(attempts) == 2
+    db.expire_all()
+    stored = db.get(Operation, op.id)
+    assert stored.status == "failed"
+    assert stored.error_message == "refused"
+
+
+async def test_fail_inline_gives_up_after_the_retries_and_says_so(db, repository):
+    """When every commit attempt hits the lock, the row cannot be closed from
+    this session; the caller learns that from the return value (and the
+    warning), rather than from a `running` row it believes it closed."""
+    from sqlalchemy.exc import OperationalError
+
+    from app.services.operations.maintenance_start import (
+        fail_inline_maintenance,
+        start_inline_maintenance,
+    )
+
+    op = start_inline_maintenance(db, repository, "prune", params={}, user_id=None)
+
+    def locked_commit():
+        raise OperationalError("UPDATE operations", {}, Exception("database is locked"))
+
+    with (
+        patch.object(db, "commit", side_effect=locked_commit),
+        patch("app.utils.db_retries.asyncio.sleep", new=AsyncMock()),
+    ):
+        assert not await fail_inline_maintenance(db, op, RuntimeError("refused"))
+
+    db.expire_all()
+    assert db.get(Operation, op.id).status == "running"
+
+
+def test_finish_inline_closes_a_row_the_step_returned_without_a_verdict(db, repository):
+    """A service that returns with the operation still `running` is a bug in
+    the service; the row must not stay `running` for it."""
+    from app.services.operations.maintenance_start import (
+        finish_inline_maintenance,
+        start_inline_maintenance,
+    )
+
+    op = start_inline_maintenance(db, repository, "compact", params={}, user_id=None)
+
+    finish_inline_maintenance(db, op)
+
+    db.expire_all()
+    stored = db.get(Operation, op.id)
+    assert stored.status == "failed"
+    assert stored.error_message == "the service returned without recording a verdict"
+    assert stored.completed_at is not None
+    assert db.query(Operation).filter(Operation.kind != "compact").count() == 0
+
+
+async def test_fail_inline_keeps_an_operation_a_queued_agent_job_is_waiting_on(
+    db, repository
+):
+    """A queued agent job holds the repository through admission on its own
+    and runs on the agent's next hello; the row must agree with the job
+    rather than read `failed` while the prune is still going to happen."""
+    from app.core.security import get_password_hash
+    from app.database.models import AgentJob, AgentMachine
+    from app.services.operations.maintenance_start import (
+        fail_inline_maintenance,
+        start_inline_maintenance,
+    )
+
+    agent = AgentMachine(
+        name="Agent",
+        agent_id="agt_inline_queued",
+        token_hash=get_password_hash("secret"),
+        token_prefix="secret",
+        status="offline",
+    )
+    db.add(agent)
+    db.commit()
+    op = start_inline_maintenance(db, repository, "prune", params={}, user_id=None)
+    db.add(
+        AgentJob(
+            agent_machine_id=agent.id,
+            job_type="repository",
+            status="queued",
+            payload={
+                "job_kind": "repository.prune",
+                "operation": {
+                    "maintenance_job": {
+                        "kind": "prune",
+                        "id": op.id,
+                        "table": "operations",
+                    }
+                },
+            },
+        )
+    )
+    db.commit()
+
+    assert not await fail_inline_maintenance(
+        db, op, RuntimeError("agent prune failed: repositoryOperationTimeout")
+    )
+
+    db.expire_all()
+    assert db.get(Operation, op.id).status == "running"
+
+
+def test_start_inline_records_the_executor(db):
+    from app.services.operations.maintenance_start import start_inline_maintenance
+
+    server = Repository(name="server", path="/repo/server", borg_version=1)
+    agent = Repository(
+        name="agent",
+        path="/repo/agent",
+        borg_version=1,
+        executor_type="agent",
+        execution_target="agent",
+    )
+    db.add_all([server, agent])
+    db.commit()
+
+    on_server = start_inline_maintenance(db, server, "prune", params={}, user_id=None)
+    on_agent = start_inline_maintenance(db, agent, "prune", params={}, user_id=None)
+
+    assert on_server.execution_mode == "server"
+    assert on_agent.execution_mode == "agent"
+
+
+def test_failure_text_keeps_statement_parameters_out():
+    """A statement error renders the SQL and its parameters, and the agent
+    job insert carries the repository secrets; only the driver's error is
+    a message users may read."""
+    from sqlalchemy.exc import OperationalError
+
+    from app.services.operations.maintenance_start import failure_text
+
+    error = OperationalError(
+        "INSERT INTO agent_jobs (payload)",
+        {"payload": '{"secrets": {"BORG_PASSPHRASE": {"value": "hunter2"}}}'},
+        Exception("database is locked"),
+    )
+
+    assert failure_text(error) == "Exception: database is locked"
+    assert failure_text(RuntimeError("agent prune failed")) == "agent prune failed"
+    assert failure_text(RuntimeError()) == "RuntimeError"
+    # an HTTPException reads as its detail, not as `409: {...}`
+    assert (
+        failure_text(
+            HTTPException(
+                status_code=409,
+                detail={
+                    "key": "backend.errors.jobs.repositoryOperationActive",
+                    "params": {"active_operation": "list_archives"},
+                },
+            )
+        )
+        == "list_archives is active on the repository"
+    )
+
+
+def test_start_inline_leaves_the_claim_to_the_service(db, repository):
+    """The Borg 2 services claim the row through `claim_running` before they
+    run and return without running when the claim fails; a `running` row
+    with a start already recorded is exactly what they cannot claim."""
+    from datetime import datetime, timezone
+
+    from app.services.operations.job_facade import claim_running
+    from app.services.operations.maintenance_start import start_inline_maintenance
+
+    op = start_inline_maintenance(db, repository, "prune", params={}, user_id=None)
+    assert op.status == "running"
+    assert op.started_at is None
+
+    assert claim_running(db, op.id, "prune", datetime.now(timezone.utc)) == 1
+    db.commit()
+    db.expire_all()
+    assert db.get(Operation, op.id).started_at is not None
+
+
+def test_finish_inline_swallows_a_failed_close_and_leaves_the_row(db, repository):
+    """The close must never raise past the caller (the plan calls it outside
+    its handler); a locked database leaves the row for the next writer."""
+    from sqlalchemy.exc import OperationalError
+
+    from app.services.operations.maintenance_start import (
+        finish_inline_maintenance,
+        start_inline_maintenance,
+    )
+
+    op = start_inline_maintenance(db, repository, "check", params={}, user_id=None)
+
+    def locked():
+        raise OperationalError("UPDATE operations", {}, Exception("database is locked"))
+
+    with patch.object(db, "commit", side_effect=locked):
+        finish_inline_maintenance(db, op)
+
+    db.expire_all()
+    assert db.get(Operation, op.id).status == "running"

--- a/tests/unit/test_operations_job_facade.py
+++ b/tests/unit/test_operations_job_facade.py
@@ -13,6 +13,7 @@ from app.services.operations.job_facade import (
     claim_running,
     legacy_status,
     operation_status,
+    resolve_agent_maintenance_job,
     resolve_maintenance_job,
 )
 
@@ -355,3 +356,93 @@ def test_stats_live_in_the_operation_result(db, repository):
     job.stats = None
     assert op.result == {"logs": True}
     assert job.stats is None
+
+
+def _twin_rows(db, repository):
+    """An operation and a legacy check row sharing one id, on two different
+    repositories: the two id spaces are independent sequences."""
+    from datetime import datetime
+
+    other = Repository(name="other", path="/repo/other", borg_version=1)
+    db.add(other)
+    db.commit()
+    operation = Operation(
+        kind="check",
+        category="maintenance",
+        status="running",
+        repository_id=repository.id,
+        run_id="run-twin",
+        created_at=datetime(2026, 9, 1),
+    )
+    db.add(operation)
+    db.flush()
+    legacy = CheckJob(
+        id=operation.id,
+        repository_id=other.id,
+        repository_path=other.path,
+        status="completed",
+        created_at=datetime(2026, 8, 1),
+    )
+    db.add(legacy)
+    db.commit()
+    return operation, legacy, other
+
+
+def _payload(job_id, **maintenance_extra):
+    return {
+        "job_kind": "repository.check",
+        "operation": {
+            "maintenance_job": {"kind": "check", "id": job_id, **maintenance_extra}
+        },
+    }
+
+
+def test_resolve_agent_job_follows_the_table_marker(db, repository):
+    operation, legacy, _ = _twin_rows(db, repository)
+
+    as_operation = resolve_agent_maintenance_job(
+        db, _payload(operation.id, table="operations")
+    )
+    as_legacy = resolve_agent_maintenance_job(
+        db, _payload(operation.id, table="check_jobs")
+    )
+
+    assert isinstance(as_operation, MaintenanceJobFacade)
+    assert as_operation.id == operation.id
+    assert as_legacy is legacy
+    assert resolve_agent_maintenance_job(db, _payload(operation.id, table="x")) is None
+
+
+def test_resolve_agent_job_breaks_a_table_less_tie_by_repository(db, repository):
+    operation, legacy, other = _twin_rows(db, repository)
+
+    payload = _payload(operation.id)
+    payload["repository"] = {"id": other.id, "path": other.path}
+    assert resolve_agent_maintenance_job(db, payload) is legacy
+
+    payload["repository"] = {"id": repository.id, "path": repository.path}
+    assert resolve_agent_maintenance_job(db, payload).id == operation.id
+
+    # a repository neither row belongs to: nothing, never another
+    # repository's row
+    payload["repository"] = {"id": other.id + repository.id + 1, "path": "/x"}
+    assert resolve_agent_maintenance_job(db, payload) is None
+
+    # no repository in the payload: the operation, as before the marker
+    assert isinstance(
+        resolve_agent_maintenance_job(db, _payload(operation.id)), MaintenanceJobFacade
+    )
+
+
+def test_resolve_agent_job_rejects_bad_shapes(db, repository):
+    assert resolve_agent_maintenance_job(db, None) is None
+    assert (
+        resolve_agent_maintenance_job(db, {"operation": {"maintenance_job": []}})
+        is None
+    )
+    assert resolve_agent_maintenance_job(db, _payload("not-a-number")) is None
+    assert resolve_agent_maintenance_job(db, _payload(0)) is None
+    payload = _payload(1)
+    payload["operation"]["maintenance_job"]["kind"] = "wipe"
+    assert resolve_agent_maintenance_job(db, payload) is None
+    assert resolve_agent_maintenance_job(db, _payload(1), kinds=("prune",)) is None

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from unittest.mock import patch, mock_open, MagicMock
@@ -11,6 +11,7 @@ from app.utils.process_utils import (
     cleanup_orphaned_mounts,
     reconcile_stale_backup_maintenance,
     reconcile_orphaned_maintenance_jobs,
+    reconcile_orphaned_maintenance_operations,
 )
 from app.database.models import (
     AgentJob,
@@ -41,6 +42,7 @@ _MAINTENANCE_CASES = [
     ),
 ]
 from app.core.security import get_password_hash
+from app.services.operations.job_facade import MAINTENANCE_KINDS
 
 # ==========================================
 # Datetime Utils Tests
@@ -564,9 +566,10 @@ class TestProcessUtils:
         db_session.refresh(backup_job)
         assert backup_job.maintenance_status == "running_prune"
 
-    def test_reap_once_runs_all_three_reaper_passes(self):
+    def test_reap_once_runs_every_reaper_pass(self):
         # The background loop must run the agent-job reaper, the maintenance
-        # status reconciler AND the orphaned-*_job reaper each tick.
+        # status reconciler, the orphaned-*_job reaper AND the orphaned
+        # operation reaper each tick.
         with (
             patch("app.services.agent_job_reaper.SessionLocal"),
             patch(
@@ -581,15 +584,30 @@ class TestProcessUtils:
                 "app.utils.process_utils.reconcile_orphaned_maintenance_jobs",
                 return_value=1,
             ) as m_orphan,
+            patch(
+                "app.utils.process_utils.reconcile_orphaned_maintenance_operations",
+                return_value=4,
+            ) as m_operations,
         ):
             from app.services.agent_job_reaper import _reap_once
 
-            total = _reap_once()
+            order = MagicMock()
+            order.attach_mock(m_operations, "operations")
+            order.attach_mock(m_maint, "maintenance")
+            reaped_operation_ids: list[int] = []
+            total = _reap_once(None, reaped_operation_ids)
 
-        assert total == 6
+        assert total == 10
         m_agent.assert_called_once()
-        m_maint.assert_called_once()
         m_orphan.assert_called_once()
+        # the ids the pass failed travel back to the loop for the broadcast
+        assert (
+            m_operations.call_args.kwargs["reaped_operation_ids"]
+            is reaped_operation_ids
+        )
+        # The orphaned operation is failed before the backup-row pass, so the
+        # backup's maintenance state is reconciled in the same tick.
+        assert [call[0] for call in order.mock_calls] == ["operations", "maintenance"]
 
     @pytest.mark.parametrize("kind, model, extra, job_kind", _MAINTENANCE_CASES)
     def test_reconcile_orphaned_reaps_old_pending_without_agent_job(
@@ -701,7 +719,7 @@ class TestProcessUtils:
         # is selected as a candidate but before the guarded UPDATE. The
         # correlation check still reports no active agent job, so only the
         # WHERE status == 'pending' guard can prevent a spurious 'failed'.
-        def _flip_to_running(db, kind, job_id):
+        def _flip_to_running(db, kind, job_id, **_):
             db.query(PruneJob).filter(PruneJob.id == job_id).update(
                 {PruneJob.status: "running"}, synchronize_session=False
             )
@@ -709,7 +727,7 @@ class TestProcessUtils:
             return False
 
         with patch(
-            "app.utils.process_utils._has_active_agent_job_for",
+            "app.utils.process_utils.has_active_agent_job_for",
             side_effect=_flip_to_running,
         ):
             reaped = reconcile_orphaned_maintenance_jobs(db_session)
@@ -745,7 +763,7 @@ class TestProcessUtils:
         # appears before the re-check after the guarded UPDATE (second call ->
         # True). The row must be rolled back to 'pending', not reaped.
         with patch(
-            "app.utils.process_utils._has_active_agent_job_for",
+            "app.utils.process_utils.has_active_agent_job_for",
             side_effect=[False, True],
         ):
             reaped = reconcile_orphaned_maintenance_jobs(db_session)
@@ -1125,3 +1143,255 @@ class TestProcessUtils:
             "-uz",
             str(orphaned_dir),
         ]
+
+
+def _agent_repository(db_session, name: str) -> Repository:
+    repo = Repository(
+        name=name,
+        path=f"/repos/{name}",
+        encryption="none",
+        repository_type="local",
+        executor_type="agent",
+        execution_target="agent",
+    )
+    db_session.add(repo)
+    db_session.commit()
+    return repo
+
+
+def _running_operation(
+    db_session,
+    repo: Repository,
+    kind: str,
+    *,
+    age_minutes: int,
+    execution_mode: str | None = "agent",
+):
+    """An inline maintenance operation as `start_inline_maintenance` leaves
+    it: `running`, no pid, the executor recorded, started `age_minutes`
+    ago."""
+    from app.services.operations.enqueue import enqueue
+
+    operation = enqueue(
+        db_session,
+        kind,
+        repository_id=repo.id,
+        execution_mode=execution_mode,
+        commit=False,
+    )
+    operation.status = "running"
+    operation.started_at = datetime.utcnow() - timedelta(minutes=age_minutes)
+    db_session.commit()
+    return operation
+
+
+class TestReconcileOrphanedMaintenanceOperations:
+    """A `running` maintenance operation of an agent-executed repository with
+    no agent job behind it blocks the repository until a restart (#983)."""
+
+    @pytest.mark.parametrize("kind", MAINTENANCE_KINDS)
+    def test_reaps_an_old_running_operation_without_agent_job(self, db_session, kind):
+        repo = _agent_repository(db_session, f"orphan-{kind}")
+        operation = _running_operation(db_session, repo, kind, age_minutes=10)
+
+        reaped_ids: list[int] = []
+        reaped = reconcile_orphaned_maintenance_operations(
+            db_session, reaped_operation_ids=reaped_ids
+        )
+
+        assert reaped == 1
+        assert reaped_ids == [operation.id]
+        db_session.refresh(operation)
+        assert operation.status == "failed"
+        assert operation.completed_at is not None
+        assert operation.error_message == (
+            "orphaned: no agent job is working on this operation"
+        )
+
+    def test_keeps_a_fresh_operation(self, db_session):
+        repo = _agent_repository(db_session, "fresh")
+        operation = _running_operation(db_session, repo, "prune", age_minutes=1)
+
+        assert reconcile_orphaned_maintenance_operations(db_session) == 0
+        db_session.refresh(operation)
+        assert operation.status == "running"
+
+    def test_ages_a_row_without_started_at_by_its_creation(self, db_session):
+        repo = _agent_repository(db_session, "unstarted")
+        operation = _running_operation(db_session, repo, "prune", age_minutes=10)
+        operation.started_at = None
+        operation.created_at = datetime.utcnow() - timedelta(minutes=10)
+        db_session.commit()
+
+        assert reconcile_orphaned_maintenance_operations(db_session) == 1
+        db_session.refresh(operation)
+        assert operation.status == "failed"
+
+    def test_keeps_an_operation_with_a_live_agent_job(self, db_session):
+        repo = _agent_repository(db_session, "dispatched")
+        agent = AgentMachine(
+            name="Agent",
+            agent_id="agt_orphan_operation",
+            token_hash=get_password_hash("secret"),
+            token_prefix="secret",
+            status="online",
+        )
+        db_session.add(agent)
+        db_session.flush()
+        operation = _running_operation(db_session, repo, "prune", age_minutes=10)
+        db_session.add(
+            AgentJob(
+                agent_machine_id=agent.id,
+                job_type="repository",
+                status="running",
+                payload={
+                    "job_kind": "repository.prune",
+                    "operation": {
+                        "maintenance_job": {
+                            "kind": "prune",
+                            "id": operation.id,
+                            "table": "operations",
+                        },
+                    },
+                },
+            )
+        )
+        db_session.commit()
+
+        assert reconcile_orphaned_maintenance_operations(db_session) == 0
+        db_session.refresh(operation)
+        assert operation.status == "running"
+
+    def test_keeps_an_operation_a_table_less_agent_job_may_refer_to(self, db_session):
+        # A payload without a table marker predates it and may name either a
+        # legacy row or this operation (an agent job queued by the previous
+        # build); the ambiguity keeps the row rather than reaping a live one.
+        repo = _agent_repository(db_session, "table-less")
+        agent = AgentMachine(
+            name="Agent",
+            agent_id="agt_table_less",
+            token_hash=get_password_hash("secret"),
+            token_prefix="secret",
+            status="online",
+        )
+        db_session.add(agent)
+        db_session.flush()
+        operation = _running_operation(db_session, repo, "prune", age_minutes=10)
+        db_session.add(
+            AgentJob(
+                agent_machine_id=agent.id,
+                job_type="repository",
+                status="queued",
+                payload={
+                    "job_kind": "repository.prune",
+                    "operation": {
+                        "maintenance_job": {"kind": "prune", "id": operation.id},
+                    },
+                },
+            )
+        )
+        db_session.commit()
+
+        assert reconcile_orphaned_maintenance_operations(db_session) == 0
+        db_session.refresh(operation)
+        assert operation.status == "running"
+
+    def test_keeps_a_server_side_operation(self, db_session):
+        # The Borg process of a server-side prune runs in this process and
+        # records no pid, so its absence proves nothing; that row belongs to
+        # startup recovery, not to the runtime reaper. The executor is read
+        # from the row: a repository switched to an agent while its
+        # server-side prune still runs does not make that prune reapable.
+        repo = _agent_repository(db_session, "was-server-side")
+        operation = _running_operation(
+            db_session, repo, "prune", age_minutes=10, execution_mode="server"
+        )
+
+        assert reconcile_orphaned_maintenance_operations(db_session) == 0
+        db_session.refresh(operation)
+        assert operation.status == "running"
+
+    def test_keeps_an_operation_with_a_recorded_process(self, db_session):
+        # A row with a pid belongs to the process-liveness rules (startup
+        # recovery), whatever its executor says.
+        repo = _agent_repository(db_session, "with-pid")
+        operation = _running_operation(db_session, repo, "compact", age_minutes=10)
+        operation.process_pid = 4242
+        operation.process_start_time = 1.0
+        db_session.commit()
+
+        assert reconcile_orphaned_maintenance_operations(db_session) == 0
+        db_session.refresh(operation)
+        assert operation.status == "running"
+
+    def test_keeps_an_operation_the_runner_is_executing(self, db_session):
+        from app.services.operations.runner import operation_runner
+
+        repo = _agent_repository(db_session, "runner-owned")
+        operation = _running_operation(db_session, repo, "check", age_minutes=10)
+
+        with patch.dict(operation_runner.running_tasks, {operation.id: object()}):
+            assert reconcile_orphaned_maintenance_operations(db_session) == 0
+        db_session.refresh(operation)
+        assert operation.status == "running"
+
+    def test_keeps_an_operation_whose_agent_job_arrives_mid_reap(self, db_session):
+        # The pass reads the live agent jobs once; the re-check after the
+        # guarded update is what catches a job queued in between.
+        repo = _agent_repository(db_session, "racing")
+        operation = _running_operation(db_session, repo, "compact", age_minutes=10)
+
+        with patch(
+            "app.utils.process_utils.has_active_agent_job_for", return_value=True
+        ):
+            assert reconcile_orphaned_maintenance_operations(db_session) == 0
+        db_session.refresh(operation)
+        assert operation.status == "running"
+
+    def test_keeps_the_status_a_caller_wrote_mid_reap(self, db_session):
+        # The caller closed the row between the read and the guarded update:
+        # the update matches nothing and the caller's status stands.
+        repo = _agent_repository(db_session, "closed-meanwhile")
+        operation = _running_operation(db_session, repo, "prune", age_minutes=10)
+
+        def close_it(db):
+            db.query(Operation).filter(Operation.id == operation.id).update(
+                {Operation.status: "completed"}, synchronize_session=False
+            )
+            db.commit()
+            return set()
+
+        with patch(
+            "app.utils.process_utils.active_agent_maintenance_jobs",
+            side_effect=close_it,
+        ):
+            assert reconcile_orphaned_maintenance_operations(db_session) == 0
+        db_session.refresh(operation)
+        assert operation.status == "completed"
+        assert operation.error_message is None
+
+
+class TestBroadcastReapedOperations:
+    async def test_broadcasts_each_reaped_operation(self, db_session):
+        from app.services.agent_job_reaper import _broadcast_reaped_operations
+
+        repo = _agent_repository(db_session, "broadcast")
+        operation = _running_operation(db_session, repo, "prune", age_minutes=10)
+        operation_id = operation.id
+        seen = []
+
+        async def record(op, db=None):
+            seen.append(op.id)
+
+        with (
+            patch(
+                "app.services.agent_job_reaper.SessionLocal", return_value=db_session
+            ),
+            patch(
+                "app.services.operations.events.broadcast_operation_updated",
+                new=record,
+            ),
+        ):
+            await _broadcast_reaped_operations([operation_id, 999_999])
+
+        assert seen == [operation_id]


### PR DESCRIPTION
## Description

**Severity: on main since phase 5 (#947, merged 2026-09-07), a backup plan with a post-backup prune or compact on an agent-executed repository ends up with every backup of that repository refused, permanently, until the server process is restarted.** The trigger is the ordinary race between the backup's own follow-up listing (#949) and the plan's prune (#982): it fires on plan runs with an empty queue about 30 ms apart, and on every first cycle after a restart with a backlog. Once hit, the repository's backups, index refreshes and archive listings all answer `repositoryOperationActive`; nothing at runtime clears it, and the next plan run repeats it on the next repository. Two installations lost all scheduled backups of several repositories this way within a day of deploying main. For anyone running agents with plans, this makes the application unusable until restarted, and restarting only buys the time until the next occurrence.

Since phase 5 (#947) a backup plan's post-backup prune, compact or check is an `operations` row the caller creates `running`. When the agent job for it cannot be queued, three gaps left that row `running` for good, and admission then refused every backup of the repository (`repositoryOperationActive`) until the server restarted. The trigger seen in the wild is the race in #982 (the backup's follow-up listing still holds the repository when the plan asks for the prune), but any queue failure takes the same path.

What changes:

- **`_fail_orphaned_maintenance_job` resolves the job through the facade.** It used to look the job up in the legacy `*_jobs` table by that id, where it found nothing (or an unrelated old row, since the two id spaces are independent). It now uses `resolve_maintenance_job` and fails whichever shape it gets, with the admission's cause as the error message (`agent job could not be queued: list_archives is active on the repository`).
- **The backup plan closes the operation when a step raises.** `_run_maintenance` had no handler around the router call, so the exception ended the repository's run without a terminal status on the row. Each step now runs through `_run_inline_maintenance`: a raised error closes the operation with the cause (`fail_inline_maintenance`, new in `maintenance_start.py`), records the failed step on the backup's maintenance state, and re-raises, so the run ends failed with that cause as before and the remaining steps do not run on a repository in unknown state. The helper keeps a row that already reached a terminal status, and a row a live agent job is still carrying (the wait can give up on a prune the agent is still running; the agent's report closes it, and until then the repository really is busy). A queued agent job counts as live on purpose: admission holds the repository for a queued agent job on its own, and the agent runs it on its next hello, so failing the row would only make it contradict the job; the queued job of an agent that never comes back is the existing reaper gap, not this PR's. It rolls the session back first and commits through `commit_with_retry`, since a locked database is one of the failures that bring a caller there. The scheduled-backup path in `schedule.py` and the dry-run prune preview use the same helper instead of their ad-hoc blocks, and `finish_inline_maintenance` closes a row a step returned on without a verdict (a service bug the runner's maintenance executor already handles for its own rows).
- **Inline rows are claimable again on Borg 2.** `start_inline_maintenance` stamped `started_at`; the Borg 2 services claim the row through `claim_running`, which treats a `running` row *with* a start as already claimed, so they logged "reached a terminal state before start, skipping" and returned without running, leaving the row `running`. The inline row now carries no start until the service claims it (measured: `claim_running` returned 0 for an inline row, 1 after this change). The runner's own claim stamps `started_at` the same way, so runner-driven Borg 2 check/prune/compact/delete hit the same skip and end as `service returned no result`; that is #1005.
- **The agent payload names the table of its maintenance job.** `operations` ids and legacy `*_jobs` ids are separate sequences; the liveness check (`has_active_agent_job_for`, `active_agent_maintenance_jobs`) keys on `(table, kind, id)`, and a payload without a table predates the marker and counts for both spaces (an ambiguous reference keeps a row rather than reaping a live one). One resolver (`resolve_agent_maintenance_job`) reads it for the agent callback and for the retention pass (`repair_prune_logs`): with the marker the named table only; without it (a job queued by the build before this one) the payload's repository breaks the tie, and without a repository the operation is preferred, as before. The retention pass also repairs an operation's log file itself, since the facade's setter never overwrites an existing file. The runtime reaper hands the ids it failed back to the reaper loop, which broadcasts `operation.updated` for them the way every other writer of a terminal status does.
- **Stored error messages keep secrets out.** A SQLAlchemy statement error renders the statement and its parameters, and the agent job insert carries the repository passphrase; rows and the plan's child error now store only the driver's error (`failure_text`).
- **A runtime safety net.** The agent job reaper now runs `reconcile_orphaned_maintenance_operations` each tick, before the backup-row pass: a `running` maintenance operation recorded as agent-executed (`start_inline_maintenance` now sets `execution_mode`), older than the reconcile bound (5 minutes), with no pid, not owned by the runner and with no live agent job carrying its id, is failed with an explicit reason. A payload without the table marker (queued by the build before this one) counts for both id spaces, so an ambiguous reference keeps a row rather than reaping a live one. The admission's 409 detail is also rendered readably on both the row and the raised error (`agent prune failed: list_archives is active on the repository` instead of the detail dict). Server-side operations are left to startup recovery: a prune records no pid, so nothing at runtime proves them dead. This also closes the case where the agent job behind an inline operation is reaped by the agent-job reaper (its operation is failed on the next tick).

## Related Issue
Fixes #983

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

New tests:

- `test_borg_router.py`: a refused queue (409 from admission) fails the `operations` row with the readable cause, keeps the kind's legacy row that shares the id untouched, and leaves nothing `active_maintenance_operation` would count (prune, compact, check, delete_archive); every branch of the message rendering.
- `test_api_backup_plans.py`: a prune, compact or check step whose router call raises ends with its operation `failed` with the cause, the steps before it completed, the ones after it never started, the backup's maintenance state names the failed step, the repository's run ends failed with the cause, and no operation is left `running`.
- `test_api_schedule_routes.py`: the scheduled-backup handler closes the prune operation when the router raises; it keeps a prune whose agent job is still running (the 504 case) while recording the failed step.
- `test_maintenance_start.py`: `fail_inline_maintenance` closes a running operation, keeps a terminal status, keeps an operation a live agent job carries, and recovers a session the failure left unusable.
- `test_utils.py`: the reaper fails an old running operation of an agent repository without agent job (every maintenance kind) and one a pre-upgrade legacy agent job merely shares an id with; keeps a fresh one, one with a live agent job, a server-side one, one the runner is executing, one whose agent job arrives between the check and the update, and one its caller closed meanwhile; `_reap_once` runs the new pass.

```
pytest tests/unit -q
3871 passed, 14 skipped in 730.84s
ruff check app tests && ruff format --check app tests
All checks passed! / 617 files already formatted
```

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

n/a

## Additional Context

Two things this PR does not touch, seen while building it:

- Runner-driven Borg 2 maintenance: the runner's claim stamps `started_at`, so `claim_running` in the Borg 2 check/prune/compact/delete services returns 0 and they skip; the executor then reports `service returned no result`. Filed as #1005 with the measurement.
- `run_stats` fails a `stats` operation whose agent job admission refuses, while `archive_sync` defers on the same 409: #1002 (and the side-by-side index operations behind most of those refusals: #1003).

No migration. #982 (the race itself) stays a separate change: with a bounded wait in the plan's dispatch the refusal becomes rare, this PR is about the failure path never leaving a ghost, whatever the reason.
