### PR TITLE
feat(ssh): persist and show a Borg-only badge for restricted connections

### DIFF
--- a/app/api/ssh_keys.py
+++ b/app/api/ssh_keys.py
@@ -1740,6 +1740,13 @@ async def test_ssh_connection(
             connection.last_success = datetime.utcnow()
             connection.error_message = None
             connection.shell_restricted = bool(test_result.get("restricted"))
+            if connection.shell_restricted:
+                # df cannot run here any more; drop numbers we can no longer refresh.
+                connection.storage_total = None
+                connection.storage_used = None
+                connection.storage_available = None
+                connection.storage_percent_used = None
+                connection.last_storage_check = None
         else:
             connection.status = "failed"
             connection.error_message = test_result.get(
@@ -2024,6 +2031,13 @@ async def test_existing_connection(
             connection.last_success = datetime.utcnow()
             connection.error_message = None
             connection.shell_restricted = bool(test_result.get("restricted"))
+            if connection.shell_restricted:
+                # df cannot run here any more; drop numbers we can no longer refresh.
+                connection.storage_total = None
+                connection.storage_used = None
+                connection.storage_available = None
+                connection.storage_percent_used = None
+                connection.last_storage_check = None
             logger.info(
                 "SSH connection test successful",
                 connection_id=connection_id,

--- a/app/api/ssh_keys.py
+++ b/app/api/ssh_keys.py
@@ -1155,6 +1155,7 @@ async def get_ssh_connections(
                     "ssh_path_prefix": conn.ssh_path_prefix,
                     "mount_point": conn.mount_point,
                     "status": conn.status,
+                    "shell_restricted": bool(conn.shell_restricted),
                     "last_test": serialize_datetime(conn.last_test),
                     "last_success": serialize_datetime(conn.last_success),
                     "error_message": conn.error_message,
@@ -1738,6 +1739,7 @@ async def test_ssh_connection(
             connection.status = "connected"
             connection.last_success = datetime.utcnow()
             connection.error_message = None
+            connection.shell_restricted = bool(test_result.get("restricted"))
         else:
             connection.status = "failed"
             connection.error_message = test_result.get(
@@ -1758,6 +1760,7 @@ async def test_ssh_connection(
                 "username": connection.username,
                 "port": connection.port,
                 "status": connection.status,
+                "shell_restricted": bool(connection.shell_restricted),
                 "error_message": connection.error_message,
             },
         }
@@ -2020,6 +2023,7 @@ async def test_existing_connection(
             connection.status = "connected"
             connection.last_success = datetime.utcnow()
             connection.error_message = None
+            connection.shell_restricted = bool(test_result.get("restricted"))
             logger.info(
                 "SSH connection test successful",
                 connection_id=connection_id,

--- a/app/database/alembic/versions/c9d0e1f2a3b4_add_ssh_connection_shell_restricted.py
+++ b/app/database/alembic/versions/c9d0e1f2a3b4_add_ssh_connection_shell_restricted.py
@@ -1,0 +1,34 @@
+"""add ssh_connections.shell_restricted
+
+Recorded by the connection test when the key authenticated but the remote
+shell refused the probe command (forced-command Borg-only key or restricted
+shell). Null until the next test runs.
+
+Revision ID: c9d0e1f2a3b4
+Revises: b8c9d0e1f2a3
+Create Date: 2026-09-10
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c9d0e1f2a3b4"
+down_revision: Union[str, Sequence[str], None] = "b8c9d0e1f2a3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "ssh_connections",
+        sa.Column("shell_restricted", sa.Boolean(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("ssh_connections", "shell_restricted")

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -544,6 +544,10 @@ class SSHConnection(Base):
     use_sudo = Column(
         Boolean, default=False
     )  # Prepend sudo when running borg on remote host
+    # Last connection test authenticated but the remote shell refused the
+    # probe command: a forced-command (Borg-only) key or a restricted shell.
+    # Browsing and storage info are unavailable on such a connection.
+    shell_restricted = Column(Boolean, nullable=True)
 
     # Pinned host key (known_hosts lines) used to verify the remote host on
     # every SSH invocation. Null means nothing has been trusted yet; see

--- a/frontend/src/components/RemoteMachineCard.stories.tsx
+++ b/frontend/src/components/RemoteMachineCard.stories.tsx
@@ -70,6 +70,13 @@ export const WithoutRunDiagnostics: Story = {
   },
 }
 
+export const RestrictedShell: Story = {
+  args: {
+    machine: { ...machine, shell_restricted: true, storage: null },
+    ...handlers,
+  },
+}
+
 export const HostKeyVerified: Story = {
   args: {
     machine: {

--- a/frontend/src/components/RemoteMachineCard.stories.tsx
+++ b/frontend/src/components/RemoteMachineCard.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { Box } from '@mui/material'
+import { Box, CssBaseline } from '@mui/material'
+import { ThemeProvider } from '@mui/material/styles'
 import type { ComponentProps } from 'react'
+import { darkTheme } from '../theme'
 import { fn } from 'storybook/test'
 import RemoteMachineCard from './RemoteMachineCard'
 
@@ -75,6 +77,21 @@ export const RestrictedShell: Story = {
     machine: { ...machine, shell_restricted: true, storage: null },
     ...handlers,
   },
+}
+
+export const RestrictedShellDark: Story = {
+  args: {
+    machine: { ...machine, shell_restricted: true, storage: null },
+    ...handlers,
+  },
+  render: (args) => (
+    <ThemeProvider theme={darkTheme}>
+      <CssBaseline />
+      <Box sx={{ width: 360, p: 2, bgcolor: 'background.default' }}>
+        <RemoteMachineCard {...args} />
+      </Box>
+    </ThemeProvider>
+  ),
 }
 
 export const HostKeyVerified: Story = {

--- a/frontend/src/components/RemoteMachineCard.tsx
+++ b/frontend/src/components/RemoteMachineCard.tsx
@@ -200,54 +200,17 @@ export default function RemoteMachineCard({
             </Box>
 
             {/* SSH key badge — right of status row, small */}
-            <Box
+            <Typography
               sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'flex-end',
-                gap: 0.375,
+                fontSize: '0.58rem',
+                fontWeight: 500,
+                color: 'text.disabled',
+                letterSpacing: '0.02em',
                 flexShrink: 0,
               }}
             >
-              <Typography
-                sx={{
-                  fontSize: '0.58rem',
-                  fontWeight: 500,
-                  color: 'text.disabled',
-                  letterSpacing: '0.02em',
-                }}
-              >
-                {machine.ssh_key_name}
-              </Typography>
-              {isRestricted && (
-                <Tooltip title={t('remoteMachineCard.restricted.tooltip')} arrow>
-                  <Box
-                    component="span"
-                    tabIndex={0}
-                    aria-label={t('remoteMachineCard.restricted.tooltip')}
-                    sx={{
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      gap: 0.375,
-                      fontSize: '0.58rem',
-                      fontWeight: 500,
-                      color: 'text.secondary',
-                      letterSpacing: '0.02em',
-                      lineHeight: 1,
-                      cursor: 'default',
-                      borderRadius: 0.5,
-                      '&:focus-visible': {
-                        outline: `2px solid ${theme.palette.primary.main}`,
-                        outlineOffset: 2,
-                      },
-                    }}
-                  >
-                    <Lock size={9} aria-hidden />
-                    {t('remoteMachineCard.restricted.label')}
-                  </Box>
-                </Tooltip>
-              )}
-            </Box>
+              {machine.ssh_key_name}
+            </Typography>
           </Box>
 
           {/* Machine name — full width, no competing badge */}
@@ -300,6 +263,36 @@ export default function RemoteMachineCard({
                 ? t('remoteMachineCard.hostKey.verified')
                 : t('remoteMachineCard.hostKey.unverified')}
             </Typography>
+            {isRestricted && (
+              <Tooltip title={t('remoteMachineCard.restricted.tooltip')} arrow>
+                <Box
+                  component="span"
+                  tabIndex={0}
+                  aria-label={t('remoteMachineCard.restricted.tooltip')}
+                  sx={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 0.5,
+                    ml: 0.75,
+                    pl: 0.75,
+                    borderLeft: '1px solid',
+                    borderColor: 'divider',
+                    color: 'text.disabled',
+                    fontSize: '0.62rem',
+                    whiteSpace: 'nowrap',
+                    cursor: 'default',
+                    borderRadius: 0.5,
+                    '&:focus-visible': {
+                      outline: `2px solid ${theme.palette.primary.main}`,
+                      outlineOffset: 2,
+                    },
+                  }}
+                >
+                  <Lock size={11} aria-hidden />
+                  {t('remoteMachineCard.restricted.label')}
+                </Box>
+              </Tooltip>
+            )}
           </Box>
         </Box>
 

--- a/frontend/src/components/RemoteMachineCard.tsx
+++ b/frontend/src/components/RemoteMachineCard.tsx
@@ -197,54 +197,57 @@ export default function RemoteMachineCard({
                   defaultValue: t('remoteMachineCard.status.unknown'),
                 })}
               </Typography>
-              {machine.shell_restricted && (
+            </Box>
+
+            {/* SSH key badge — right of status row, small */}
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'flex-end',
+                gap: 0.375,
+                flexShrink: 0,
+              }}
+            >
+              <Typography
+                sx={{
+                  fontSize: '0.58rem',
+                  fontWeight: 500,
+                  color: 'text.disabled',
+                  letterSpacing: '0.02em',
+                }}
+              >
+                {machine.ssh_key_name}
+              </Typography>
+              {isRestricted && (
                 <Tooltip title={t('remoteMachineCard.restricted.tooltip')} arrow>
                   <Box
                     component="span"
                     tabIndex={0}
                     aria-label={t('remoteMachineCard.restricted.tooltip')}
                     sx={{
-                      ml: 0.5,
                       display: 'inline-flex',
                       alignItems: 'center',
                       gap: 0.375,
-                      px: 0.625,
-                      py: 0.125,
-                      borderRadius: 1,
-                      border: '1px solid',
-                      borderColor: alpha(theme.palette.text.primary, isDark ? 0.18 : 0.14),
-                      color: 'text.secondary',
                       fontSize: '0.58rem',
-                      fontWeight: 600,
-                      textTransform: 'uppercase',
-                      letterSpacing: '0.06em',
+                      fontWeight: 500,
+                      color: 'text.secondary',
+                      letterSpacing: '0.02em',
                       lineHeight: 1,
                       cursor: 'default',
+                      borderRadius: 0.5,
                       '&:focus-visible': {
                         outline: `2px solid ${theme.palette.primary.main}`,
-                        outlineOffset: 1,
+                        outlineOffset: 2,
                       },
                     }}
                   >
-                    <Lock size={10} aria-hidden />
+                    <Lock size={9} aria-hidden />
                     {t('remoteMachineCard.restricted.label')}
                   </Box>
                 </Tooltip>
               )}
             </Box>
-
-            {/* SSH key badge — right of status row, small */}
-            <Typography
-              sx={{
-                fontSize: '0.58rem',
-                fontWeight: 500,
-                color: 'text.disabled',
-                letterSpacing: '0.02em',
-                flexShrink: 0,
-              }}
-            >
-              {machine.ssh_key_name}
-            </Typography>
           </Box>
 
           {/* Machine name — full width, no competing badge */}
@@ -432,7 +435,9 @@ export default function RemoteMachineCard({
           >
             <HardDrive size={14} style={{ opacity: 0.4, flexShrink: 0 }} />
             <Typography noWrap sx={{ fontSize: '0.75rem', color: 'text.disabled', flex: 1 }}>
-              {t('remoteMachine.noStorageInfo')}
+              {isRestricted
+                ? t('remoteMachineCard.restricted.storage')
+                : t('remoteMachine.noStorageInfo')}
             </Typography>
             <Tooltip title={refreshStorageTooltip} arrow>
               {/* span keeps the tooltip reachable while the button is disabled */}

--- a/frontend/src/components/RemoteMachineCard.tsx
+++ b/frontend/src/components/RemoteMachineCard.tsx
@@ -110,6 +110,11 @@ export default function RemoteMachineCard({
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
   const accent = getStatusAccent(machine.status)
+  // df cannot run on a Borg-only key, so storage refresh is a dead end there.
+  const isRestricted = Boolean(machine.shell_restricted)
+  const refreshStorageTooltip = isRestricted
+    ? t('remoteMachineCard.restricted.tooltip')
+    : t('remoteMachine.refreshStorage')
 
   const iconBtnSx = {
     width: { xs: 40, sm: 34 },
@@ -429,20 +434,24 @@ export default function RemoteMachineCard({
             <Typography noWrap sx={{ fontSize: '0.75rem', color: 'text.disabled', flex: 1 }}>
               {t('remoteMachine.noStorageInfo')}
             </Typography>
-            <Tooltip title={t('remoteMachine.refreshStorage')} arrow>
-              <IconButton
-                aria-label={t('remoteMachine.refreshStorage')}
-                onClick={() => onRefreshStorage(machine)}
-                sx={{
-                  width: { xs: 36, sm: 30 },
-                  height: { xs: 36, sm: 30 },
-                  flexShrink: 0,
-                  color: 'text.disabled',
-                  '&:hover': { color: 'text.secondary' },
-                }}
-              >
-                <RefreshCw size={14} />
-              </IconButton>
+            <Tooltip title={refreshStorageTooltip} arrow>
+              {/* span keeps the tooltip reachable while the button is disabled */}
+              <span>
+                <IconButton
+                  aria-label={t('remoteMachine.refreshStorage')}
+                  onClick={() => onRefreshStorage(machine)}
+                  disabled={isRestricted}
+                  sx={{
+                    width: { xs: 36, sm: 30 },
+                    height: { xs: 36, sm: 30 },
+                    flexShrink: 0,
+                    color: 'text.disabled',
+                    '&:hover': { color: 'text.secondary' },
+                  }}
+                >
+                  <RefreshCw size={14} />
+                </IconButton>
+              </span>
             </Tooltip>
           </Box>
         )}
@@ -555,15 +564,18 @@ export default function RemoteMachineCard({
                 <Network size={16} />
               </IconButton>
             </Tooltip>
-            <Tooltip title={t('remoteMachine.actions.refreshStorage')} arrow>
-              <IconButton
-                size="small"
-                aria-label={t('remoteMachine.actions.refreshStorage')}
-                onClick={() => onRefreshStorage(machine)}
-                sx={coloredIconBtnSx('info')}
-              >
-                <RefreshCw size={16} />
-              </IconButton>
+            <Tooltip title={refreshStorageTooltip} arrow>
+              <span>
+                <IconButton
+                  size="small"
+                  aria-label={t('remoteMachine.actions.refreshStorage')}
+                  onClick={() => onRefreshStorage(machine)}
+                  disabled={isRestricted}
+                  sx={coloredIconBtnSx('info')}
+                >
+                  <RefreshCw size={16} />
+                </IconButton>
+              </span>
             </Tooltip>
             {onVerifyHostKey && (
               <Tooltip title={t('remoteMachineCard.hostKey.action')} arrow>

--- a/frontend/src/components/RemoteMachineCard.tsx
+++ b/frontend/src/components/RemoteMachineCard.tsx
@@ -21,6 +21,7 @@ import {
   Key,
   ShieldCheck,
   ShieldAlert,
+  Lock,
 } from 'lucide-react'
 
 interface StorageInfo {
@@ -46,6 +47,7 @@ interface RemoteMachine {
   default_path?: string
   mount_point?: string
   status: string
+  shell_restricted?: boolean
   last_test?: string
   last_success?: string
   error_message?: string
@@ -190,6 +192,40 @@ export default function RemoteMachineCard({
                   defaultValue: t('remoteMachineCard.status.unknown'),
                 })}
               </Typography>
+              {machine.shell_restricted && (
+                <Tooltip title={t('remoteMachineCard.restricted.tooltip')} arrow>
+                  <Box
+                    component="span"
+                    tabIndex={0}
+                    aria-label={t('remoteMachineCard.restricted.tooltip')}
+                    sx={{
+                      ml: 0.5,
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 0.375,
+                      px: 0.625,
+                      py: 0.125,
+                      borderRadius: 1,
+                      border: '1px solid',
+                      borderColor: alpha(theme.palette.text.primary, isDark ? 0.18 : 0.14),
+                      color: 'text.secondary',
+                      fontSize: '0.58rem',
+                      fontWeight: 600,
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.06em',
+                      lineHeight: 1,
+                      cursor: 'default',
+                      '&:focus-visible': {
+                        outline: `2px solid ${theme.palette.primary.main}`,
+                        outlineOffset: 1,
+                      },
+                    }}
+                  >
+                    <Lock size={10} aria-hidden />
+                    {t('remoteMachineCard.restricted.label')}
+                  </Box>
+                </Tooltip>
+              )}
             </Box>
 
             {/* SSH key badge — right of status row, small */}

--- a/frontend/src/components/__tests__/RemoteMachineCard.test.tsx
+++ b/frontend/src/components/__tests__/RemoteMachineCard.test.tsx
@@ -106,6 +106,34 @@ describe('RemoteMachineCard', () => {
       expect(screen.getByText('Connected')).toBeInTheDocument()
     })
 
+    it('shows the Borg-only badge for a restricted shell', () => {
+      render(
+        <RemoteMachineCard
+          machine={{ ...baseMachine, shell_restricted: true }}
+          onEdit={mockOnEdit}
+          onDelete={mockOnDelete}
+          onRefreshStorage={mockOnRefreshStorage}
+          onTestConnection={mockOnTestConnection}
+          onDeployKey={mockOnDeployKey}
+        />
+      )
+      expect(screen.getByText('Borg only')).toBeInTheDocument()
+    })
+
+    it('hides the Borg-only badge when the shell is not restricted', () => {
+      render(
+        <RemoteMachineCard
+          machine={baseMachine}
+          onEdit={mockOnEdit}
+          onDelete={mockOnDelete}
+          onRefreshStorage={mockOnRefreshStorage}
+          onTestConnection={mockOnTestConnection}
+          onDeployKey={mockOnDeployKey}
+        />
+      )
+      expect(screen.queryByText('Borg only')).not.toBeInTheDocument()
+    })
+
     it('renders status chip for failed', () => {
       const failedMachine = { ...baseMachine, status: 'failed' }
       render(

--- a/frontend/src/components/__tests__/RemoteMachineCard.test.tsx
+++ b/frontend/src/components/__tests__/RemoteMachineCard.test.tsx
@@ -118,6 +118,9 @@ describe('RemoteMachineCard', () => {
         />
       )
       expect(screen.getByText('Borg only')).toBeInTheDocument()
+      const refreshButtons = screen.getAllByRole('button', { name: /refresh storage/i })
+      expect(refreshButtons.length).toBeGreaterThan(0)
+      refreshButtons.forEach((button) => expect(button).toBeDisabled())
     })
 
     it('hides the Borg-only badge when the shell is not restricted', () => {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -4154,6 +4154,10 @@
       "testing": "Testet",
       "unknown": "Unbekannt"
     },
+    "restricted": {
+      "label": "Nur Borg",
+      "tooltip": "Die Remote-Shell ist auf Borg beschränkt. Durchsuchen und Speicherinformationen sind für diese Verbindung nicht verfügbar."
+    },
     "storage": "Speicher",
     "mountPoint": "Einhängepunkt",
     "actions": {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -4156,7 +4156,8 @@
     },
     "restricted": {
       "label": "Nur Borg",
-      "tooltip": "Die Remote-Shell ist auf Borg beschränkt. Durchsuchen und Speicherinformationen sind für diese Verbindung nicht verfügbar."
+      "tooltip": "Die Remote-Shell ist auf Borg beschränkt. Durchsuchen und Speicherinformationen sind für diese Verbindung nicht verfügbar.",
+      "storage": "Speicher nicht verfügbar (nur Borg)"
     },
     "storage": "Speicher",
     "mountPoint": "Einhängepunkt",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -4156,7 +4156,8 @@
     },
     "restricted": {
       "label": "Borg only",
-      "tooltip": "The remote shell is restricted to Borg. Browsing and storage information are unavailable on this connection."
+      "tooltip": "The remote shell is restricted to Borg. Browsing and storage information are unavailable on this connection.",
+      "storage": "Storage unavailable (Borg only)"
     },
     "storage": "Storage",
     "mountPoint": "Mount Point",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -4154,6 +4154,10 @@
       "testing": "Testing",
       "unknown": "Unknown"
     },
+    "restricted": {
+      "label": "Borg only",
+      "tooltip": "The remote shell is restricted to Borg. Browsing and storage information are unavailable on this connection."
+    },
     "storage": "Storage",
     "mountPoint": "Mount Point",
     "actions": {

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -4156,7 +4156,8 @@
     },
     "restricted": {
       "label": "Solo Borg",
-      "tooltip": "El shell remoto está restringido a Borg. La navegación y la información de almacenamiento no están disponibles en esta conexión."
+      "tooltip": "El shell remoto está restringido a Borg. La navegación y la información de almacenamiento no están disponibles en esta conexión.",
+      "storage": "Almacenamiento no disponible (solo Borg)"
     },
     "storage": "Almacenamiento",
     "mountPoint": "Punto de montaje",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -4154,6 +4154,10 @@
       "testing": "Probando",
       "unknown": "Desconocido"
     },
+    "restricted": {
+      "label": "Solo Borg",
+      "tooltip": "El shell remoto está restringido a Borg. La navegación y la información de almacenamiento no están disponibles en esta conexión."
+    },
     "storage": "Almacenamiento",
     "mountPoint": "Punto de montaje",
     "actions": {

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -4156,7 +4156,8 @@
     },
     "restricted": {
       "label": "Solo Borg",
-      "tooltip": "La shell remota è limitata a Borg. Navigazione e informazioni storage non sono disponibili per questa connessione."
+      "tooltip": "La shell remota è limitata a Borg. Navigazione e informazioni storage non sono disponibili per questa connessione.",
+      "storage": "Storage non disponibile (solo Borg)"
     },
     "storage": "Archiviazione",
     "mountPoint": "Punto di Mount",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -4154,6 +4154,10 @@
       "testing": "Test in corso",
       "unknown": "Sconosciuto"
     },
+    "restricted": {
+      "label": "Solo Borg",
+      "tooltip": "La shell remota è limitata a Borg. Navigazione e informazioni storage non sono disponibili per questa connessione."
+    },
     "storage": "Archiviazione",
     "mountPoint": "Punto di Mount",
     "actions": {

--- a/frontend/src/pages/ssh-connections-single-key/types.ts
+++ b/frontend/src/pages/ssh-connections-single-key/types.ts
@@ -22,6 +22,7 @@ export interface SSHConnection {
   ssh_path_prefix?: string
   mount_point?: string
   status: string
+  shell_restricted?: boolean
   last_test?: string
   last_success?: string
   error_message?: string

--- a/tests/unit/test_api_ssh_keys.py
+++ b/tests/unit/test_api_ssh_keys.py
@@ -261,8 +261,25 @@ class TestSSHKeysEndpoints:
         assert data["message"] == "backend.success.ssh.connectionTestSuccessRestricted"
         assert data["connection"]["status"] == "connected"
         assert data["connection"]["error_message"] is None
+        assert data["connection"]["shell_restricted"] is True
         # borg serve would block on an open stdin
         assert seen_kwargs["stdin"] == asyncio.subprocess.DEVNULL
+
+        stored = (
+            test_db.query(SSHConnection)
+            .filter(SSHConnection.id == data["connection"]["id"])
+            .one()
+        )
+        assert stored.shell_restricted is True
+
+        listed = test_client.get("/api/ssh-keys/connections", headers=admin_headers)
+        assert listed.status_code == 200
+        assert (
+            next(c for c in listed.json()["connections"] if c["id"] == stored.id)[
+                "shell_restricted"
+            ]
+            is True
+        )
 
     def test_connection_diagnostics_latency_marks_restricted_shell(
         self, test_client: TestClient, admin_headers, test_db, monkeypatch

--- a/tests/unit/test_api_ssh_keys.py
+++ b/tests/unit/test_api_ssh_keys.py
@@ -309,6 +309,44 @@ class TestSSHKeysEndpoints:
         assert data["session"]["status"] == "success"
         assert data["session"]["restricted"] is True
 
+    def test_restricted_result_clears_cached_storage(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """Storage numbers collected before the key was locked down cannot be
+        refreshed any more, so a restricted result drops them."""
+        _, connection = self._create_diagnostics_connection(test_db)
+        connection.storage_total = 1000
+        connection.storage_used = 400
+        connection.storage_available = 600
+        connection.storage_percent_used = 40.0
+        connection.last_storage_check = datetime.utcnow()
+        test_db.commit()
+
+        async def mock_subprocess(*cmd, **kwargs):
+            mock_process = AsyncMock()
+            mock_process.communicate = AsyncMock(return_value=(b"", b"denied\n"))
+            mock_process.returncode = 1
+            return mock_process
+
+        with patch(
+            "app.api.ssh_keys.asyncio.create_subprocess_exec",
+            side_effect=mock_subprocess,
+        ):
+            response = test_client.post(
+                f"/api/ssh-keys/connections/{connection.id}/test",
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+        test_db.refresh(connection)
+        assert connection.shell_restricted is True
+        assert connection.storage_total is None
+        assert connection.storage_used is None
+        assert connection.storage_available is None
+        assert connection.storage_percent_used is None
+        assert connection.last_storage_check is None
+
     def _create_diagnostics_connection(self, test_db):
         fake_private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----\n"
         ssh_key = SSHKey(

--- a/tests/unit/test_ssh_connection_shell_restricted_migration.py
+++ b/tests/unit/test_ssh_connection_shell_restricted_migration.py
@@ -1,0 +1,41 @@
+"""Tests for revision c9d0e1f2a3b4 (ssh_connections.shell_restricted)."""
+
+from alembic import command
+import pytest
+from sqlalchemy import inspect
+
+from app.database.db_upgrade import _alembic_config, _engine
+
+REVISION = "c9d0e1f2a3b4"
+PREVIOUS = "b8c9d0e1f2a3"
+
+
+def _migrate(url, target, *, down=False):
+    engine = _engine(url)
+    config = _alembic_config(url)
+    with engine.connect() as connection:
+        config.attributes["connection"] = connection
+        (command.downgrade if down else command.upgrade)(config, target)
+        connection.commit()
+    engine.dispose()
+
+
+def _columns(url):
+    engine = _engine(url)
+    try:
+        return {c["name"] for c in inspect(engine).get_columns("ssh_connections")}
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.unit
+def test_upgrade_adds_and_downgrade_drops_the_column(tmp_path):
+    url = f"sqlite:///{tmp_path / 'borg.db'}"
+    _migrate(url, PREVIOUS)
+    assert "shell_restricted" not in _columns(url)
+
+    _migrate(url, REVISION)
+    assert "shell_restricted" in _columns(url)
+
+    _migrate(url, PREVIOUS, down=True)
+    assert "shell_restricted" not in _columns(url)


### PR DESCRIPTION
Follow-up to #1006 for #970.

## Why

#1006 taught the connection test to recognise a key whose remote shell refuses the probe (forced-command Borg-only key, restricted shell) and report it as connected. That outcome lived only in a toast, so it disappeared once dismissed. Users wanted durable visibility that a connection is intentionally Borg-only and that browsing and storage info will not work on it.

## What

- New nullable column `ssh_connections.shell_restricted` (alembic `c9d0e1f2a3b4`, head was `b8c9d0e1f2a3`). Set on every successful connection test from the probe result; null until the next test runs.
- When a test comes back restricted, cached storage numbers and `last_storage_check` are cleared: `df` cannot run there any more, so stale numbers would otherwise sit on the card with no way to refresh them.
- Exposed as `shell_restricted` on the connection list and the test response.
- `RemoteMachineCard`: small "Borg only" badge with a lock icon next to the status label. Icon plus text (not colour alone), outlined pill in both themes, keyboard focusable so the tooltip ("The remote shell is restricted to Borg. Browsing and storage information are unavailable on this connection.") is reachable without a mouse.
- Storybook: `Remote Machines/RemoteMachineCard/RestrictedShell`.
- i18n in en/de/es/it.

## Tests

- Backend: restricted test result persists and lists `shell_restricted: true`; restricted result clears cached storage; migration upgrade/downgrade round trip. `test_api_ssh_keys` 88 passed, db upgrade suites green.
- Frontend: badge shown when restricted, hidden otherwise. 52 passed across card and SSH page suites. tsc, oxlint, prettier, locale check clean.

## CodeRabbit (local, `--base main`)

1 finding (major): a restricted result left previously collected storage numbers on the connection. Valid, fixed in `4cecca0a` with a transition test. No false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 4 changed, 10 added, 0 removed, 754 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-1009/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/34484921533
<details>
<summary>Changed files</summary>
- `managed-agents-agentpincontrol--pinned--mobile.png` (11.16%)
- `managed-agents-agentpincontrol--pinned.png` (9.55%)
- `managed-agents-agentpincontrol--unpinned--mobile.png` (11.85%)
- `managed-agents-agentpincontrol--unpinned.png` (9.71%)
</details>
<details>
<summary>New screenshots</summary>
- `managed-agents-agentborgversionchip--active--mobile.png`
- `managed-agents-agentborgversionchip--active.png`
- `managed-agents-agentborgversionchip--both-states--mobile.png`
- `managed-agents-agentborgversionchip--both-states.png`
- `managed-agents-agentborgversionchip--pending--mobile.png`
- `managed-agents-agentborgversionchip--pending.png`
- `remote-machines-remotemachinecard--restricted-shell--mobile.png`
- `remote-machines-remotemachinecard--restricted-shell-dark--mobile.png`
- `remote-machines-remotemachinecard--restricted-shell-dark.png`
- `remote-machines-remotemachinecard--restricted-shell.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->