### PR TITLE
fix(plans): wait out transient read work before refusing a plan's prune or compact

### DIFF
--- a/app/core/borg_router.py
+++ b/app/core/borg_router.py
@@ -10,9 +10,12 @@ Never add borg_version checks directly inside v1 service code.
 Use BorgRouter instead so the routing stays in one place.
 """
 
+import asyncio
+import time
+from typing import Callable, List, Optional
+
 import structlog
 from sqlalchemy.orm import Session
-from typing import List, Optional
 
 from app.utils.borg_env import effective_repository_remote_path
 
@@ -66,6 +69,49 @@ async def _fail_orphaned_maintenance_job(
                 await broadcast_operation_updated(job.operation, db)
     except Exception:
         db.rollback()
+
+
+class _MaintenanceWaitCancelled(Exception):
+    """The caller's run was cancelled while its maintenance job waited for
+    read work; the job was never queued."""
+
+
+def _cancel_unqueued_maintenance_job(
+    db: Session, maintenance_kind: str, maintenance_job_id: int
+) -> None:
+    """Close a maintenance job as cancelled when its run was cancelled
+    before the agent job was queued, so the row ends the way the run did
+    rather than as a failure or a `running` orphan.
+
+    A failure to close it is logged and re-raised: returning normally would
+    tell the caller the step ended while the row is still active and blocks
+    the repository. The caller's failure path then gets its turn at the row
+    and the run ends with the cause.
+    """
+    from datetime import datetime
+
+    from app.services.operations.job_facade import resolve_maintenance_job
+
+    try:
+        db.rollback()
+        job = resolve_maintenance_job(db, maintenance_job_id, maintenance_kind)
+        if job is not None and job.status in ("pending", "running"):
+            job.status = "cancelled"
+            if hasattr(job, "error_message"):
+                job.error_message = (
+                    job.error_message or "cancelled before the agent job was queued"
+                )
+            if hasattr(job, "completed_at"):
+                job.completed_at = job.completed_at or datetime.utcnow()
+            db.commit()
+    except Exception:
+        db.rollback()
+        logger.exception(
+            "Could not close the cancelled maintenance job",
+            maintenance_kind=maintenance_kind,
+            maintenance_job_id=maintenance_job_id,
+        )
+        raise
 
 
 class BorgRouter:
@@ -525,6 +571,9 @@ class BorgRouter:
         maintenance_kind: str,
         maintenance_job_id: int,
         operation: Optional[dict] = None,
+        is_cancelled: Optional[Callable[[], bool]] = None,
+        wait_for_read_work: bool = False,
+        retry_pause_seconds: float = 1.0,
     ) -> None:
         """Delegate a maintenance op to the managed agent and wait for it.
 
@@ -542,7 +591,6 @@ class BorgRouter:
         from app.database.models import Repository, SystemSettings
         from app.services.agent_job_dispatcher import dispatch_agent_job_best_effort
         from app.services.repository_executor import (
-            queue_agent_repository_operation_job,
             wait_for_agent_repository_operation_job,
         )
 
@@ -561,21 +609,38 @@ class BorgRouter:
                 else settings.backup_timeout
             )
             try:
-                agent_job = queue_agent_repository_operation_job(
+                agent_job = await self._queue_agent_maintenance_job(
                     db,
                     repository,
                     job_kind=job_kind,
                     operation=operation,
-                    maintenance_job_kind=maintenance_kind,
+                    maintenance_kind=maintenance_kind,
                     maintenance_job_id=maintenance_job_id,
+                    is_cancelled=is_cancelled,
+                    wait_for_read_work=wait_for_read_work,
+                    retry_pause_seconds=retry_pause_seconds,
                 )
-            except Exception as exc:
+            except _MaintenanceWaitCancelled:
+                # The run was cancelled while the job waited for read work:
+                # close the row as cancelled and return, the caller reads
+                # the row and reports the cancellation itself. If the row
+                # cannot be closed, that error propagates instead, so the
+                # caller's failure path gets the row and the run ends with
+                # the cause rather than reporting a clean cancellation over
+                # a row that is still active.
+                _cancel_unqueued_maintenance_job(
+                    db, maintenance_kind, maintenance_job_id
+                )
+                return
+            except BaseException as exc:
                 # The maintenance job row was created by the caller before this
                 # runs. If we cannot even queue the agent job (a refused
                 # admission, a locked database), no agent job will ever update
                 # it -> it would stay active forever and block the repo via
                 # admission. Fail it closed so it never orphans, then propagate
-                # the error.
+                # the error. Base: a cancellation arriving during the wait for
+                # read work must close the row too, and CancelledError is not
+                # an Exception.
                 await _fail_orphaned_maintenance_job(
                     db, maintenance_kind, maintenance_job_id, exc
                 )
@@ -598,6 +663,166 @@ class BorgRouter:
             ) from exc
         finally:
             db.close()
+
+    async def _queue_agent_maintenance_job(
+        self,
+        db: Session,
+        repository,
+        *,
+        job_kind: str,
+        operation: Optional[dict],
+        maintenance_kind: str,
+        maintenance_job_id: int,
+        is_cancelled: Optional[Callable[[], bool]] = None,
+        wait_for_read_work: bool = False,
+        retry_pause_seconds: float = 1.0,
+        cancel_check_interval_seconds: float = 5.0,
+    ):
+        """Queue the agent job for a maintenance operation; with
+        `wait_for_read_work`, wait out transient read work instead of
+        failing on it.
+
+        A completed backup enqueues its index follow-up at once, and the
+        runner has a listing on the agent within a second; a plan's prune
+        or compact asks for the repository in the same second. Admission is
+        right to refuse a write beside a listing, but the listing is over in
+        seconds, and the runner already defers its own operations behind
+        such work. This is the plan side's equivalent: while admission
+        refuses the job for transient read work (a listing, a repository
+        info), wait for that work to finish and ask again, for at most
+        `TRANSIENT_READ_WAIT_SECONDS` after the first refusal. A refusal for
+        anything else and every other error propagate unchanged; so does the
+        latest refusal once the budget is spent or the wait reports work
+        that will not clear. A cancelled run raises
+        `_MaintenanceWaitCancelled` instead of a refusal, and is never
+        queued. Without `wait_for_read_work` (the runner, the routes, the
+        schedulers) the first refusal is the answer, as before.
+        """
+        from fastapi import HTTPException
+
+        from app.services.job_admission import (
+            READ_WORK_CANCELLED,
+            READ_WORK_CLEARED,
+            TRANSIENT_READ_WAIT_SECONDS,
+            refused_by_transient_read_work,
+            wait_for_transient_read_work,
+        )
+        from app.services.agent_job_dispatcher import (
+            dispatch_agent_cancel_if_connected,
+        )
+        from app.services.repository_executor import (
+            abandon_agent_repository_operation_job,
+            queue_agent_repository_operation_job,
+        )
+
+        def _queue():
+            return queue_agent_repository_operation_job(
+                db,
+                repository,
+                job_kind=job_kind,
+                operation=operation,
+                maintenance_job_kind=maintenance_kind,
+                maintenance_job_id=maintenance_job_id,
+            )
+
+        if not wait_for_read_work:
+            return _queue()
+
+        # The caller's check may cost a query of its own (the plan opens a
+        # session for it). The polls share one answer for a few seconds;
+        # the decision to queue always asks afresh.
+        cached = {"at": float("-inf"), "value": False}
+
+        def _cancelled(*, fresh: bool = False) -> bool:
+            if is_cancelled is None:
+                return False
+            now = time.monotonic()
+            if fresh or now - cached["at"] >= cancel_check_interval_seconds:
+                cached["value"] = bool(is_cancelled())
+                cached["at"] = now
+            return cached["value"]
+
+        log = logger.bind(
+            repository_id=repository.id,
+            maintenance_kind=maintenance_kind,
+            maintenance_job_id=maintenance_job_id,
+        )
+        deadline: Optional[float] = None
+        attempts = 0
+        while True:
+            # never queue a write for a run that has been cancelled, whether
+            # the cancel arrived before the first attempt or during a pause
+            if _cancelled(fresh=True):
+                raise _MaintenanceWaitCancelled()
+            attempts += 1
+            try:
+                job = _queue()
+            except HTTPException as exc:
+                if not refused_by_transient_read_work(exc):
+                    raise
+                refusal = exc
+            else:
+                # The cancel may have landed between the check above and the
+                # commit inside `_queue()`. Nothing has been dispatched yet:
+                # take the job back before it can be, and report the cancel.
+                # An agent that polls for queued work can still claim it in
+                # these milliseconds; it then receives the cancel request.
+                if _cancelled(fresh=True):
+                    abandoned = abandon_agent_repository_operation_job(db, job.id)
+                    if abandoned is not None and abandoned.status == "cancel_requested":
+                        await dispatch_agent_cancel_if_connected(abandoned)
+                    raise _MaintenanceWaitCancelled()
+                return job
+            params = (
+                refusal.detail.get("params")
+                if isinstance(refusal.detail, dict)
+                else None
+            )
+            active_operation = (params or {}).get("active_operation")
+            if deadline is None:
+                deadline = time.monotonic() + TRANSIENT_READ_WAIT_SECONDS
+                log.info(
+                    "Maintenance waits for read work on the repository",
+                    active_operation=active_operation,
+                    timeout_seconds=TRANSIENT_READ_WAIT_SECONDS,
+                )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                log.warning(
+                    "Maintenance gave up waiting for read work on the repository",
+                    reason="budget spent",
+                    attempts=attempts,
+                    active_operation=active_operation,
+                    timeout_seconds=TRANSIENT_READ_WAIT_SECONDS,
+                )
+                raise refusal
+            # The wait ends this session's transaction around each poll,
+            # which also releases the row lock the refused admission took.
+            outcome = await wait_for_transient_read_work(
+                db,
+                repository,
+                timeout_seconds=remaining,
+                is_cancelled=lambda: _cancelled(),
+            )
+            if outcome == READ_WORK_CANCELLED or _cancelled(fresh=True):
+                raise _MaintenanceWaitCancelled()
+            if outcome != READ_WORK_CLEARED:
+                log.warning(
+                    "Maintenance gave up waiting for read work on the repository",
+                    reason=outcome,
+                    attempts=attempts,
+                    active_operation=active_operation,
+                    waited_seconds=round(
+                        TRANSIENT_READ_WAIT_SECONDS - (deadline - time.monotonic())
+                    ),
+                )
+                raise refusal
+            # A short pause before asking again: the follow-up chain queues
+            # one archive info after another, and a retry that lands in the
+            # gap between two of them must not spin against admission.
+            await asyncio.sleep(
+                min(retry_pause_seconds, max(0.0, deadline - time.monotonic()))
+            )
 
     async def _run_agent_break_lock(self) -> dict:
         """Break the repository lock on the managed agent and wait for it.
@@ -663,13 +888,28 @@ class BorgRouter:
 
             await check_service.execute_check(job_id, self.repo.id)
 
-    async def compact(self, job_id: int) -> None:
-        """Run repository compaction through the version-aware service layer."""
+    async def compact(
+        self,
+        job_id: int,
+        *,
+        is_cancelled: Optional[Callable[[], bool]] = None,
+        wait_for_read_work: bool = False,
+    ) -> None:
+        """Run repository compaction through the version-aware service layer.
+
+        `wait_for_read_work` lets an agent compact wait out a listing that
+        is refusing it (a plan's post-backup step, see
+        `_queue_agent_maintenance_job`); `is_cancelled` ends that wait when
+        the caller's run has been cancelled meanwhile. Every other caller
+        keeps the immediate refusal.
+        """
         if self._is_agent():
             await self._run_agent_maintenance(
                 job_kind="repository.compact",
                 maintenance_kind="compact",
                 maintenance_job_id=job_id,
+                is_cancelled=is_cancelled,
+                wait_for_read_work=wait_for_read_work,
             )
             return
         if self.is_v2:
@@ -692,13 +932,25 @@ class BorgRouter:
         keep_yearly: int,
         dry_run: bool = False,
         keep_within: str | None = None,
+        *,
+        is_cancelled: Optional[Callable[[], bool]] = None,
+        wait_for_read_work: bool = False,
     ) -> None:
-        """Run repository pruning through the version-aware service layer."""
+        """Run repository pruning through the version-aware service layer.
+
+        `wait_for_read_work` lets an agent prune wait out a listing that is
+        refusing it (a plan's post-backup step, see
+        `_queue_agent_maintenance_job`); `is_cancelled` ends that wait when
+        the caller's run has been cancelled meanwhile. Every other caller
+        keeps the immediate refusal.
+        """
         if self._is_agent():
             await self._run_agent_maintenance(
                 job_kind="repository.prune",
                 maintenance_kind="prune",
                 maintenance_job_id=job_id,
+                is_cancelled=is_cancelled,
+                wait_for_read_work=wait_for_read_work,
                 operation={
                     "keep_hourly": keep_hourly,
                     "keep_daily": keep_daily,

--- a/app/services/backup_plan_execution_service.py
+++ b/app/services/backup_plan_execution_service.py
@@ -2198,6 +2198,8 @@ class BackupPlanExecutionService:
                     keep_yearly=context.prune_keep_yearly,
                     dry_run=False,
                     keep_within=context.prune_keep_within,
+                    is_cancelled=lambda: self._is_run_cancelled(run_id),
+                    wait_for_read_work=True,
                 ),
             )
             if self._is_run_cancelled(run_id):
@@ -2228,7 +2230,11 @@ class BackupPlanExecutionService:
                 backup_job,
                 compact_job,
                 run_id,
-                lambda: BorgRouter(repo).compact(compact_job.id),
+                lambda: BorgRouter(repo).compact(
+                    compact_job.id,
+                    is_cancelled=lambda: self._is_run_cancelled(run_id),
+                    wait_for_read_work=True,
+                ),
             )
             if self._is_run_cancelled(run_id):
                 return "cancelled"

--- a/app/services/job_admission.py
+++ b/app/services/job_admission.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from fastapi import HTTPException, status
 from sqlalchemy import or_, text
@@ -442,6 +444,136 @@ def ensure_repository_admission(
                     active,
                 ),
             )
+
+
+# Read work that is over in seconds: the listing and the repository info
+# the agent runs for the index follow-up chain and the stats refresh. A
+# write refused because of one can be asked for again shortly. Every other
+# read-class operation (a check, a restore, an archive listing someone
+# browses, a mirror) runs for minutes to hours, and a queued one cannot
+# even start while the caller's own exclusive row is running, so waiting
+# for it is pointless.
+TRANSIENT_READ_OPERATIONS = frozenset(
+    {
+        OPERATION_REPOSITORY_INFO,
+        OPERATION_REPOSITORY_LIST_ARCHIVES,
+    }
+)
+# How long a write may wait for transient read work. The work a plan's
+# prune collides with is one listing plus a bounded batch of archive infos
+# (`index_archive_info_per_run`), each a few seconds; transient work still
+# active after this is an agent that stopped answering, which the agent job
+# reaper handles. Deliberately not the borg list/info timeouts: operators
+# raise those for very large repositories, and a plan run must not stall
+# behind one repository for that long.
+TRANSIENT_READ_WAIT_SECONDS = 180.0
+
+
+def refused_by_transient_read_work(exc: BaseException) -> bool:
+    """True for the admission's 409 whose blocker is transient read work.
+
+    Anything else (a conflicting write, a duplicate of the same operation,
+    a long-running read, another error) is not worth a wait and must reach
+    the caller unchanged.
+    """
+    if getattr(exc, "status_code", None) != status.HTTP_409_CONFLICT:
+        return False
+    detail = getattr(exc, "detail", None)
+    if (
+        not isinstance(detail, dict)
+        or detail.get("key") != REPOSITORY_OPERATION_ACTIVE_KEY
+    ):
+        return False
+    params = detail.get("params")
+    if not isinstance(params, dict):
+        return False
+    active = params.get("active_operation")
+    if active == params.get("requested_operation"):
+        # the same operation is already active: a duplicate, not a lock wait
+        return False
+    return (
+        params.get("active_operation_class") == OPERATION_CLASS_REPOSITORY_READ
+        and active in TRANSIENT_READ_OPERATIONS
+    )
+
+
+# What `wait_for_transient_read_work` came back with.
+READ_WORK_CLEARED = "cleared"  # no read work left
+READ_WORK_BLOCKED = "blocked"  # read work that will not clear on its own
+READ_WORK_UNCLAIMED = "unclaimed"  # only never-claimed jobs left, past the grace
+READ_WORK_CANCELLED = "cancelled"  # the caller's run was cancelled
+READ_WORK_TIMEOUT = "timeout"  # transient work still active at the deadline
+# A queued agent job is usually claimed within a second of its dispatch.
+# One the agent never picks up (it dropped between queue and dispatch) is
+# not reaped: the agent job reaper watches claimed and running jobs only.
+# Past this grace a wait that sees nothing but queued read work gives up.
+UNCLAIMED_READ_WORK_GRACE_SECONDS = 30.0
+
+
+async def wait_for_transient_read_work(
+    db: Session,
+    repository: Repository,
+    *,
+    timeout_seconds: float,
+    poll_interval_seconds: float = 1.0,
+    is_cancelled: Optional[Callable[[], bool]] = None,
+    unclaimed_grace_seconds: float = UNCLAIMED_READ_WORK_GRACE_SECONDS,
+) -> str:
+    """Wait until no transient read work is active on the repository.
+
+    Returns `READ_WORK_CLEARED` once the repository is free of read work.
+    Returns at once with `READ_WORK_BLOCKED` when read work that will not
+    clear on its own is active (any read-class operation outside
+    `TRANSIENT_READ_OPERATIONS`: a check, a restore, a mirror) and with
+    `READ_WORK_CANCELLED` when `is_cancelled` says so; with
+    `READ_WORK_UNCLAIMED` when the only read work left is queued jobs no
+    agent has claimed for `unclaimed_grace_seconds`, counted from the
+    moment that became the case for those jobs; and with
+    `READ_WORK_TIMEOUT` when the deadline passes with transient work still
+    active. Write work is not looked at: a write refused by a write is not
+    this function's case.
+
+    The session's transaction is ended before every poll and before
+    returning: the refused admission that brings a caller here left the
+    repository row locked, and neither the polls nor the caller's pause
+    afterwards may hold that lock or pin a pooled connection idle in a
+    transaction. `is_cancelled` is asked once per poll; a caller whose
+    check is expensive hands in a throttled one.
+    """
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    # The grace runs from the moment nothing but queued jobs is left, for
+    # that set of jobs: a listing that ran for a while and then queued a
+    # new job must not use up the new job's grace, and a claim in between
+    # starts it over.
+    unclaimed_since: Optional[float] = None
+    unclaimed_jobs: frozenset[tuple[str, int]] = frozenset()
+    while True:
+        db.rollback()
+        read_work = [
+            work
+            for work in list_active_repository_work(db, repository)
+            if work.operation_class == OPERATION_CLASS_REPOSITORY_READ
+        ]
+        db.rollback()
+        if not read_work:
+            return READ_WORK_CLEARED
+        if any(work.operation not in TRANSIENT_READ_OPERATIONS for work in read_work):
+            return READ_WORK_BLOCKED
+        now = time.monotonic()
+        if all(work.status == "queued" for work in read_work):
+            jobs = frozenset((work.job_table, work.job_id) for work in read_work)
+            if unclaimed_since is None or jobs != unclaimed_jobs:
+                unclaimed_since, unclaimed_jobs = now, jobs
+            elif now - unclaimed_since >= unclaimed_grace_seconds:
+                return READ_WORK_UNCLAIMED
+        else:
+            unclaimed_since, unclaimed_jobs = None, frozenset()
+        if is_cancelled is not None and is_cancelled():
+            return READ_WORK_CANCELLED
+        remaining = deadline - now
+        if remaining <= 0:
+            return READ_WORK_TIMEOUT
+        await asyncio.sleep(min(poll_interval_seconds, remaining))
 
 
 def count_active_manual_backup_jobs(db: Session) -> int:

--- a/tests/unit/test_api_backup_plans.py
+++ b/tests/unit/test_api_backup_plans.py
@@ -5048,14 +5048,20 @@ class TestBackupPlanRoutes:
             async def prune(self, job_id, **kwargs):
                 maintenance_calls.append("prune")
                 assert kwargs["keep_within"] == "1d"
+                # the plan's step waits out a listing and hands in its
+                # run's cancel check
+                assert kwargs["wait_for_read_work"] is True
+                assert kwargs["is_cancelled"]() is False
                 op = test_db.query(Operation).filter_by(id=job_id, kind="prune").one()
                 assert op.repository_id == repo.id
                 op.status = "completed"
                 op.completed_at = datetime.utcnow()
                 test_db.commit()
 
-            async def compact(self, job_id):
+            async def compact(self, job_id, **kwargs):
                 maintenance_calls.append("compact")
+                assert kwargs["wait_for_read_work"] is True
+                assert kwargs["is_cancelled"]() is False
                 op = test_db.query(Operation).filter_by(id=job_id, kind="compact").one()
                 assert op.repository_id == repo.id
                 op.status = "completed"

--- a/tests/unit/test_borg_router.py
+++ b/tests/unit/test_borg_router.py
@@ -213,6 +213,8 @@ async def test_compact_delegates_to_agent_when_managed():
         job_kind="repository.compact",
         maintenance_kind="compact",
         maintenance_job_id=7,
+        is_cancelled=None,
+        wait_for_read_work=False,
     )
     mock_v2.assert_not_awaited()
 
@@ -239,6 +241,8 @@ async def test_prune_delegates_to_agent_when_managed():
         job_kind="repository.prune",
         maintenance_kind="prune",
         maintenance_job_id=7,
+        is_cancelled=None,
+        wait_for_read_work=False,
         operation={
             "keep_hourly": 1,
             "keep_daily": 2,

--- a/tests/unit/test_plan_maintenance_read_wait.py
+++ b/tests/unit/test_plan_maintenance_read_wait.py
@@ -1,0 +1,672 @@
+"""The plan's maintenance step waits out transient read work instead of
+failing on it.
+
+A backup's index follow-up lists the repository within a second of the
+backup finishing, which is when a plan asks for its prune or compact.
+Admission refuses the write; the plan side now waits for the listing to
+finish and asks again, bounded, symmetric to the runner's deferral.
+"""
+
+import asyncio
+import inspect
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+import app.core.borg_router as borg_router_module
+from app.core.borg_router import BorgRouter
+from app.core.security import get_password_hash
+from app.database.models import AgentJob, AgentMachine, Operation, Repository
+from app.services.job_admission import (
+    OPERATION_CLASS_REPOSITORY_READ,
+    READ_WORK_BLOCKED,
+    READ_WORK_CANCELLED,
+    READ_WORK_CLEARED,
+    READ_WORK_TIMEOUT,
+    READ_WORK_UNCLAIMED,
+    OPERATION_CLASS_REPOSITORY_WRITE,
+    OPERATION_PRUNE,
+    REPOSITORY_OPERATION_ACTIVE_KEY,
+    ensure_repository_admission,
+    refused_by_transient_read_work,
+    wait_for_transient_read_work,
+)
+
+
+def _refusal(
+    active_class: str = OPERATION_CLASS_REPOSITORY_READ,
+    *,
+    requested: str = "prune",
+    active: str = "repository.list_archives",
+    key: str = REPOSITORY_OPERATION_ACTIVE_KEY,
+) -> HTTPException:
+    """A refusal shaped like `_conflict_detail` builds it (the real shape is
+    exercised against admission below)."""
+    return HTTPException(
+        status_code=409,
+        detail={
+            "key": key,
+            "params": {
+                "repository_id": 8,
+                "repository": "/repos/eight",
+                "requested_operation": requested,
+                "active_operation": active,
+                "active_operation_class": active_class,
+                "active_job_table": "agent_jobs",
+                "active_job_id": 83482,
+                "active_status": "claimed",
+            },
+        },
+    )
+
+
+def _agent_repository(db_session, name: str):
+    agent = AgentMachine(
+        name=f"agent-{name}",
+        agent_id=f"agt_{name}",
+        token_hash=get_password_hash("agent-secret"),
+        token_prefix="agent-secret",
+        status="online",
+    )
+    repo = Repository(
+        name=name,
+        path=f"/repos/{name}",
+        encryption="none",
+        repository_type="local",
+        executor_type="agent",
+        agent_machine_id=1,
+    )
+    db_session.add_all([agent, repo])
+    db_session.flush()
+    repo.agent_machine_id = agent.id
+    db_session.commit()
+    return agent, repo
+
+
+def _agent_job(db_session, agent, repo, *, kind="repository.list_archives"):
+    job = AgentJob(
+        agent_machine_id=agent.id,
+        job_type="repository",
+        status="claimed",
+        payload={
+            "schema_version": 1,
+            "job_kind": kind,
+            "repository": {"id": repo.id, "path": repo.path},
+        },
+    )
+    db_session.add(job)
+    db_session.commit()
+    return job
+
+
+def _operation(db_session, repo, kind, status, *, category="maintenance"):
+    op = Operation(
+        repository_id=repo.id,
+        kind=kind,
+        category=category,
+        status=status,
+        trigger="manual",
+        run_id=f"run-{kind}-{status}",
+    )
+    db_session.add(op)
+    db_session.commit()
+    return op
+
+
+# -- the predicate ------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("active", ["repository.list_archives", "repository.info"])
+def test_transient_read_work_in_the_way_is_worth_a_wait(active):
+    assert refused_by_transient_read_work(_refusal(active=active))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "exc",
+    [
+        # read class, but long-running, and a queued one cannot start while
+        # the caller's own exclusive row is running
+        _refusal(active="check"),
+        _refusal(active="restore"),
+        _refusal(active="repository.list_archive_contents"),
+        _refusal(active="repository.rclone_sync"),
+        _refusal(OPERATION_CLASS_REPOSITORY_WRITE, active="backup"),
+        _refusal(requested="prune", active="prune"),
+        _refusal(key="backend.errors.other"),
+        HTTPException(status_code=502, detail={"key": REPOSITORY_OPERATION_ACTIVE_KEY}),
+        HTTPException(status_code=409, detail="not a dict"),
+        HTTPException(status_code=409, detail={"key": REPOSITORY_OPERATION_ACTIVE_KEY}),
+        RuntimeError("database is locked"),
+    ],
+)
+def test_every_other_refusal_reaches_the_caller(exc):
+    assert not refused_by_transient_read_work(exc)
+
+
+@pytest.mark.unit
+def test_the_predicate_reads_what_admission_actually_raises(db_session):
+    # The hand-built refusals above mirror `_conflict_detail`; this pins the
+    # predicate to the real shape, against real rows.
+    agent, repo = _agent_repository(db_session, "listing-refusal")
+    _agent_job(db_session, agent, repo)
+
+    with pytest.raises(HTTPException) as refused_by_listing:
+        ensure_repository_admission(db_session, repo, OPERATION_PRUNE)
+    assert refused_by_transient_read_work(refused_by_listing.value)
+
+    db_session.rollback()
+    db_session.query(AgentJob).delete()
+    _operation(db_session, repo, "check", "queued")
+
+    with pytest.raises(HTTPException) as refused_by_check:
+        ensure_repository_admission(db_session, repo, OPERATION_PRUNE)
+    assert not refused_by_transient_read_work(refused_by_check.value)
+
+
+# -- the wait, against real rows ------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_wait_returns_once_the_listing_is_gone(db_session):
+    agent, repo = _agent_repository(db_session, "listing")
+    job = _agent_job(db_session, agent, repo)
+
+    async def _finish_listing():
+        await asyncio.sleep(0.05)
+        job.status = "completed"
+        db_session.commit()
+
+    finisher = asyncio.ensure_future(_finish_listing())
+    cleared = await wait_for_transient_read_work(
+        db_session, repo, timeout_seconds=5, poll_interval_seconds=0.01
+    )
+    await finisher
+
+    assert cleared == READ_WORK_CLEARED
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_wait_gives_up_at_once_on_read_work_that_cannot_clear(db_session):
+    # A queued check is read class, but it is exclusive and waits for the
+    # caller's own running row: waiting for it would burn the whole budget.
+    agent, repo = _agent_repository(db_session, "checked")
+    _operation(db_session, repo, "check", "queued")
+
+    started = time.monotonic()
+    cleared = await wait_for_transient_read_work(
+        db_session, repo, timeout_seconds=5, poll_interval_seconds=0.01
+    )
+
+    assert cleared == READ_WORK_BLOCKED
+    assert time.monotonic() - started < 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_wait_does_not_look_at_write_work(db_session):
+    # A write refused by a write never reaches the wait; running write work
+    # on its own is not something to wait for.
+    agent, repo = _agent_repository(db_session, "writing")
+    _operation(db_session, repo, "backup", "running", category="backup")
+
+    assert (
+        await wait_for_transient_read_work(
+            db_session, repo, timeout_seconds=5, poll_interval_seconds=0.01
+        )
+        == READ_WORK_CLEARED
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_wait_stops_at_the_timeout_and_on_cancellation(db_session):
+    agent, repo = _agent_repository(db_session, "stuck")
+    _agent_job(db_session, agent, repo, kind="repository.info")
+
+    started = time.monotonic()
+    outcome = await wait_for_transient_read_work(
+        db_session, repo, timeout_seconds=0.2, poll_interval_seconds=0.01
+    )
+    assert outcome == READ_WORK_TIMEOUT
+    # it polled until the deadline rather than giving up on the first look
+    assert time.monotonic() - started >= 0.2
+
+    assert (
+        await wait_for_transient_read_work(
+            db_session,
+            repo,
+            timeout_seconds=5,
+            poll_interval_seconds=0.01,
+            is_cancelled=lambda: True,
+        )
+        == READ_WORK_CANCELLED
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_wait_gives_up_on_a_listing_no_agent_ever_claims(db_session):
+    # queued is active work for admission, but the reaper never reaps it:
+    # past the grace, nothing but queued jobs means the agent is gone
+    agent, repo = _agent_repository(db_session, "unclaimed")
+    job = _agent_job(db_session, agent, repo)
+    job.status = "queued"
+    db_session.commit()
+
+    started = time.monotonic()
+    outcome = await wait_for_transient_read_work(
+        db_session,
+        repo,
+        timeout_seconds=5,
+        poll_interval_seconds=0.01,
+        unclaimed_grace_seconds=0.1,
+    )
+    assert outcome == READ_WORK_UNCLAIMED
+    assert 0.1 <= time.monotonic() - started < 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_unclaimed_grace_starts_when_only_queued_jobs_are_left(db_session):
+    # a listing that runs for a while and then queues a new job must not
+    # use up the new job's grace; the grace counts from the moment nothing
+    # but that queued job is left
+    agent, repo = _agent_repository(db_session, "grace-restart")
+    listing = _agent_job(db_session, agent, repo)
+
+    async def _finish_listing_then_queue_an_info():
+        await asyncio.sleep(0.15)
+        listing.status = "completed"
+        info = _agent_job(db_session, agent, repo, kind="repository.info")
+        info.status = "queued"
+        db_session.commit()
+
+    switch = asyncio.ensure_future(_finish_listing_then_queue_an_info())
+    started = time.monotonic()
+    outcome = await wait_for_transient_read_work(
+        db_session,
+        repo,
+        timeout_seconds=5,
+        poll_interval_seconds=0.01,
+        unclaimed_grace_seconds=0.1,
+    )
+    await switch
+
+    assert outcome == READ_WORK_UNCLAIMED
+    # the claimed phase (0.15 s) plus the queued job's own grace (0.1 s)
+    assert time.monotonic() - started >= 0.25
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_wait_ends_the_transaction_before_every_poll():
+    # The refused admission left the repository row locked in this session,
+    # and a poll must not pin a pooled connection idle in a transaction.
+    db = MagicMock()
+    repository = SimpleNamespace(id=8, path="/repos/eight")
+    listing = SimpleNamespace(
+        operation="repository.list_archives",
+        operation_class=OPERATION_CLASS_REPOSITORY_READ,
+        status="claimed",
+    )
+    listings = [[listing], [listing], []]
+    seen_rollbacks: list[int] = []
+
+    def _list(*args, **kwargs):
+        seen_rollbacks.append(db.rollback.call_count)
+        return listings.pop(0)
+
+    with patch("app.services.job_admission.list_active_repository_work", _list):
+        outcome = await wait_for_transient_read_work(
+            db, repository, timeout_seconds=5, poll_interval_seconds=0.01
+        )
+    assert outcome == READ_WORK_CLEARED
+    # a rollback before every poll, and one more after the last so the
+    # caller's pause afterwards does not sit in a transaction
+    assert all(count >= index + 1 for index, count in enumerate(seen_rollbacks))
+    assert db.rollback.call_count > seen_rollbacks[-1]
+
+
+# -- the router: retry loop around the queue call ----------------------------------
+
+
+class _Router:
+    """`_run_agent_maintenance` with the queue call, the wait and the orphan
+    helper replaced; the row-closing paths are checked against real rows
+    further down."""
+
+    def __init__(
+        self, queue_side_effects, *, wait_results=(READ_WORK_CLEARED,), budget=180.0
+    ):
+        self.db = MagicMock()
+        self.db.query.return_value.get.return_value = SimpleNamespace(
+            id=8, path="/repos/eight"
+        )
+        self.db.query.return_value.first.return_value = None
+        self.queue = MagicMock(side_effect=list(queue_side_effects))
+        self.wait = AsyncMock(side_effect=list(wait_results))
+        # the orphan helper is synchronous on main and awaited once #1008
+        # lands; the same test must hold on both sides of that merge
+        self.abandon = MagicMock(return_value=SimpleNamespace(id=99, status="canceled"))
+        self.dispatch = AsyncMock()
+        self.fail_orphan = (
+            AsyncMock()
+            if inspect.iscoroutinefunction(
+                borg_router_module._fail_orphaned_maintenance_job
+            )
+            else MagicMock()
+        )
+        self.cancel_row = MagicMock()
+        self.budget = budget
+
+    async def prune(self, *, wait_for_read_work=True, **kwargs):
+        repo = SimpleNamespace(borg_version=1, id=8, executor_type="agent")
+        with (
+            patch("app.database.database.SessionLocal", return_value=self.db),
+            patch(
+                "app.services.repository_executor.queue_agent_repository_operation_job",
+                self.queue,
+            ),
+            patch(
+                "app.services.agent_job_dispatcher.dispatch_agent_job_best_effort",
+                self.dispatch,
+            ),
+            patch(
+                "app.services.agent_job_dispatcher.dispatch_agent_cancel_if_connected",
+                new=AsyncMock(),
+            ),
+            patch(
+                "app.services.repository_executor.abandon_agent_repository_operation_job",
+                self.abandon,
+            ),
+            patch(
+                "app.services.repository_executor.wait_for_agent_repository_operation_job",
+                new=AsyncMock(return_value={}),
+            ),
+            patch("app.services.job_admission.wait_for_transient_read_work", self.wait),
+            patch(
+                "app.services.job_admission.TRANSIENT_READ_WAIT_SECONDS", self.budget
+            ),
+            patch(
+                "app.core.borg_router._fail_orphaned_maintenance_job", self.fail_orphan
+            ),
+            patch(
+                "app.core.borg_router._cancel_unqueued_maintenance_job", self.cancel_row
+            ),
+        ):
+            await BorgRouter(repo)._run_agent_maintenance(
+                job_kind="repository.prune",
+                maintenance_kind="prune",
+                maintenance_job_id=9908,
+                operation={"keep_daily": 7},
+                wait_for_read_work=wait_for_read_work,
+                retry_pause_seconds=0.0,
+                **kwargs,
+            )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_without_opting_in_the_first_refusal_is_the_answer():
+    # the runner (which defers on its own), the routes and the schedulers
+    # keep the immediate refusal
+    router = _Router([_refusal(), SimpleNamespace(id=99)])
+
+    with pytest.raises(RuntimeError, match="agent prune failed"):
+        await router.prune(wait_for_read_work=False)
+
+    assert router.queue.call_count == 1
+    router.wait.assert_not_awaited()
+    router.fail_orphan.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_prune_waits_out_the_listing_and_asks_again():
+    router = _Router([_refusal(), SimpleNamespace(id=99)])
+
+    await router.prune()
+
+    assert router.queue.call_count == 2
+    router.wait.assert_awaited_once()
+    kwargs = router.wait.await_args.kwargs
+    assert 0 < kwargs["timeout_seconds"] <= 180
+    router.fail_orphan.assert_not_called()
+    router.cancel_row.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_prune_keeps_asking_while_listings_keep_landing_in_the_gap():
+    # history_index queues one archive_info after another; the retry may
+    # land in the sub-second gap between two of them and be refused again
+    router = _Router(
+        [_refusal(), _refusal(active="repository.info"), SimpleNamespace(id=99)],
+        wait_results=(READ_WORK_CLEARED, READ_WORK_CLEARED),
+    )
+
+    await router.prune()
+
+    assert router.queue.call_count == 3
+    assert router.wait.await_count == 2
+    router.fail_orphan.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_prune_refused_by_a_write_fails_at_once():
+    router = _Router([_refusal(OPERATION_CLASS_REPOSITORY_WRITE, active="backup")])
+
+    with pytest.raises(RuntimeError, match="agent prune failed"):
+        await router.prune()
+
+    assert router.queue.call_count == 1
+    router.wait.assert_not_awaited()
+    router.fail_orphan.assert_called_once()
+    assert router.fail_orphan.call_args.args[1:3] == ("prune", 9908)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_prune_gives_up_when_the_read_work_will_not_clear():
+    router = _Router([_refusal(), _refusal()], wait_results=(READ_WORK_BLOCKED,))
+
+    with pytest.raises(RuntimeError, match="agent prune failed"):
+        await router.prune()
+
+    assert router.queue.call_count == 1
+    router.wait.assert_awaited_once()
+    router.fail_orphan.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_prune_stops_waiting_once_the_budget_is_spent():
+    router = _Router([_refusal(), _refusal()], budget=0.0)
+
+    with pytest.raises(RuntimeError, match="agent prune failed"):
+        await router.prune()
+
+    assert router.queue.call_count == 1
+    router.wait.assert_not_awaited()
+    router.fail_orphan.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_cancelled_run_ends_the_wait_as_cancelled_not_failed():
+    router = _Router(
+        [_refusal(), SimpleNamespace(id=99)], wait_results=(READ_WORK_CANCELLED,)
+    )
+    cancelled = iter([False, True])
+
+    # not cancelled when refused, cancelled by the time the wait gives up
+    await router.prune(is_cancelled=lambda: next(cancelled, True))
+
+    assert router.queue.call_count == 1
+    router.wait.assert_awaited_once()
+    router.cancel_row.assert_called_once()
+    assert router.cancel_row.call_args.args[1:] == ("prune", 9908)
+    router.fail_orphan.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_run_already_cancelled_is_never_queued():
+    router = _Router([SimpleNamespace(id=99)])
+
+    await router.prune(is_cancelled=lambda: True)
+
+    router.queue.assert_not_called()
+    router.wait.assert_not_awaited()
+    router.cancel_row.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_run_cancelled_during_the_pause_is_not_queued_on_the_retry():
+    # not cancelled before the first attempt nor right after the wait; the
+    # cancel lands during the pause, and the retry's own check catches it
+    router = _Router(
+        [_refusal(), SimpleNamespace(id=99)], wait_results=(READ_WORK_CLEARED,)
+    )
+    cancelled = iter([False, False, True])
+
+    await router.prune(is_cancelled=lambda: next(cancelled, True))
+
+    assert router.queue.call_count == 1
+    router.wait.assert_awaited_once()
+    router.cancel_row.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_cancel_landing_between_check_and_commit_takes_the_job_back():
+    # the check before the attempt saw no cancel; by the time the agent job
+    # is committed the run is cancelled: the job is abandoned before any
+    # dispatch, and the outcome is a cancellation
+    router = _Router([SimpleNamespace(id=99)])
+    cancelled = iter([False, True])
+
+    await router.prune(is_cancelled=lambda: next(cancelled, True))
+
+    assert router.queue.call_count == 1
+    router.abandon.assert_called_once()
+    assert router.abandon.call_args.args[1] == 99
+    router.dispatch.assert_not_awaited()
+    router.cancel_row.assert_called_once()
+    router.fail_orphan.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cancellation_during_the_wait_still_reaches_the_orphan_helper():
+    router = _Router([_refusal()], wait_results=(asyncio.CancelledError(),))
+
+    with pytest.raises(asyncio.CancelledError):
+        await router.prune()
+
+    router.fail_orphan.assert_called_once()
+
+
+# -- the rows the router closes itself ------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_cancelled_run_closes_the_operation_row_as_cancelled(db_session):
+    # Cancellation is the one outcome this change owns end to end: the row
+    # the plan created `running` must read cancelled afterwards, so the
+    # plan reports the run as cancelled and nothing blocks the repository.
+    agent, repo = _agent_repository(db_session, "cancel-row")
+    _agent_job(db_session, agent, repo)
+    prune = _operation(db_session, repo, "prune", "running")
+    prune_id = prune.id
+    router_repo = SimpleNamespace(borg_version=1, id=repo.id, executor_type="agent")
+
+    with (
+        patch("app.database.database.SessionLocal", return_value=db_session),
+        # capabilities are the agent's business; admission is what matters here
+        patch(
+            "app.services.repository_executor.validate_agent_repository_operation",
+            return_value=agent,
+        ),
+    ):
+        await BorgRouter(router_repo)._run_agent_maintenance(
+            job_kind="repository.prune",
+            maintenance_kind="prune",
+            maintenance_job_id=prune_id,
+            operation={"keep_daily": 7},
+            is_cancelled=lambda: True,
+            wait_for_read_work=True,
+        )
+
+    # the router closed the session it was handed; read the row afresh
+    row = db_session.get(Operation, prune_id)
+    assert row.status == "cancelled"
+    assert row.completed_at is not None
+    assert "cancelled" in row.error_message
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_cancelled_row_that_cannot_be_closed_is_not_reported_as_clean():
+    # returning normally would leave an active row behind a "cancelled" run
+    router = _Router([SimpleNamespace(id=99)])
+    router.cancel_row.side_effect = RuntimeError("database is locked")
+
+    with pytest.raises(RuntimeError, match="database is locked"):
+        await router.prune(is_cancelled=lambda: True)
+
+    router.queue.assert_not_called()
+    router.cancel_row.assert_called_once()
+
+
+@pytest.mark.unit
+def test_the_cancel_helper_logs_and_re_raises_when_the_row_cannot_be_closed():
+    from app.core.borg_router import _cancel_unqueued_maintenance_job
+
+    db = MagicMock()
+    with (
+        patch(
+            "app.services.operations.job_facade.resolve_maintenance_job",
+            side_effect=RuntimeError("database is locked"),
+        ),
+        pytest.raises(RuntimeError, match="database is locked"),
+    ):
+        _cancel_unqueued_maintenance_job(db, "prune", 9908)
+    # rolled back before the attempt and again after the failure
+    assert db.rollback.call_count == 2
+    db.commit.assert_not_called()
+
+
+# -- the callers hand in their cancel check ----------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["prune", "compact"])
+async def test_router_entry_points_forward_the_wait_and_the_cancel_check(method):
+    repo = SimpleNamespace(borg_version=1, id=8, executor_type="agent")
+    is_cancelled = lambda: False  # noqa: E731
+    with patch.object(
+        BorgRouter, "_run_agent_maintenance", new=AsyncMock()
+    ) as run_agent:
+        if method == "prune":
+            await BorgRouter(repo).prune(
+                1, 0, 7, 4, 6, 0, 1, is_cancelled=is_cancelled, wait_for_read_work=True
+            )
+        else:
+            await BorgRouter(repo).compact(
+                1, is_cancelled=is_cancelled, wait_for_read_work=True
+            )
+    kwargs = run_agent.await_args.kwargs
+    assert kwargs["is_cancelled"] is is_cancelled
+    assert kwargs["wait_for_read_work"] is True


### PR DESCRIPTION
## Description

A completed backup enqueues its index follow-up at once (#949), and the runner has a `repository.list_archives` job on the agent within a second; a plan's post-backup prune (and compact one step later) asks the same agent for a write in the same second. Admission is right to refuse a write beside a listing, but the plan step treated the refusal like "could not queue at all": the prune of that cycle was skipped (#982), and since phase 5 the refused `operations` row stayed `running` and blocked every later backup, listing and index operation of the repository until the process restarted (#983). With phase 8 the backup itself is an operation on the runner, but the plan's prune and compact still run inline, so the race is rolled on every plan cycle; on an install with hourly plans it hit two or three of fourteen repositories per wave, with an idle queue.

The runner already defers its own operations behind such work (#948). This PR gives the plan side the same behaviour, bounded and only for work that clears on its own:

- **`job_admission.TRANSIENT_READ_OPERATIONS`** names the read work worth waiting for: the listing and the repository info the index chain and the stats refresh run, over in seconds. A check, a restore, an archive listing someone browses or a mirror are read class too, but run for minutes to hours, and a queued one cannot even start while the caller's own exclusive row is `running`; a refusal for those is not waited out.
- **`refused_by_transient_read_work`** recognises the admission's 409 for such work (the duplicate case, same operation already active, is excluded). **`wait_for_transient_read_work`** polls `list_active_repository_work` until the transient work is gone and reports why it stopped (`cleared`, `blocked`, `unclaimed`, `cancelled`, `timeout`), so the caller logs the actual reason. It ends the session's transaction around every poll (the refused admission left the repository row locked, and neither the polls nor the pause between attempts may hold it or pin a pooled connection idle in a transaction), gives up at once on read work that cannot clear, and gives up after a 30 s grace when nothing but never-claimed `queued` jobs is left: the agent job reaper watches claimed and running jobs only, so a listing the agent never picked up would otherwise cost the full budget on every run.
- **`BorgRouter._queue_agent_maintenance_job`** wraps the queue call in `_run_agent_maintenance`: while admission refuses the job for transient read work, wait and ask again, for at most **`TRANSIENT_READ_WAIT_SECONDS` (180 s)** after the first refusal, with a short pause between attempts so a retry that lands in the gap between two archive-info jobs neither gives up nor spins. The budget is deliberately not the borg list/info timeout: operators raise those for very large repositories, and a plan run must not stall behind one repository for that long. Any other refusal and every other error propagate unchanged; so does the latest refusal once the budget is spent.
- **The wait is opt-in.** `prune` and `compact` take a keyword-only `wait_for_read_work`, and only the plan's post-backup steps set it. The runner defers its own operations on the 409 already (#948), and the routes (the dry-run prune) and the schedulers keep the immediate refusal they have today, so no request handler or scheduler coroutine is parked behind a listing.
- **Cancellation ends the wait as a cancellation, not a failure, and a cancelled run is never queued.** `prune` and `compact` take an `is_cancelled` check; the plan passes its run's (`_is_run_cancelled`). It is asked afresh before every attempt; the polls during the wait share one answer for five seconds, since the plan's check opens a session of its own. A cancelled run stops the wait, the maintenance row is closed `cancelled` (through `resolve_maintenance_job`, so it works for an `operations` row and a legacy row alike) and the call returns; the plan then reports the run as cancelled through its existing checks instead of marking the repository failed with a stringified 409. A task cancellation arriving during the wait still reaches the orphan helper (`except BaseException` around the queue step).

What this does not change: admission itself, the runner's deferral, and the orphan helper `_fail_orphaned_maintenance_job`. When the wait is exhausted the refusal takes the same path as before this PR, and on current main that path still cannot close an `operations` row (the helper looks the id up in the legacy tables only), so a repository whose listing outlasts the budget is left with a `running` prune exactly as it is today after the immediate refusal. That is #983, fixed by #1008, deliberately not duplicated here: the two are independent, #1008 makes a refusal harmless, this PR makes it rare. Whichever lands second rebases once (the hunks are adjacent in `_run_agent_maintenance`; after #1008 the orphan helper is awaited, one `await` at the call site, and the cancelled-row helper here can share its `resolve_maintenance_job` lookup). Against #1010 (phase 9) the same applies: `_cancel_unqueued_maintenance_job` goes through the facade only so it works on a pre-phase-9 install; once the legacy tables are gone it reads the `Operation` directly, three lines.

## Related Issue

Fixes #982. Related: #983 / #1008 (the orphan a refusal leaves behind), #1002 (`stats` fails on the same 409 instead of deferring), #1003 (index operations of one repository running side by side), #948 (runner deferral), #949 (backup follow-up chain).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

- Unit: `pytest tests/unit` on the branch (rebased onto upstream main 30ca96a0): 3952 passed, 14 skipped.
- New `tests/unit/test_plan_maintenance_read_wait.py` (33 tests): the predicate against hand-built and real refusals raised by `ensure_repository_admission` (a claimed listing job: worth a wait; a queued check: not); the wait against real rows (a listing that finishes while waiting, a queued check that gives an immediate no, write work left alone, a listing no agent ever claims, timeout, cancellation, the transaction ended around every poll); the router's outcomes (opted out: the first refusal is the answer; wait then succeed; repeated refusals across the archive-info gap; a write refusal failing at once; read work that will not clear; a spent budget; a run cancelled before the first attempt and during the pause; a task cancellation still reaching the orphan helper); the cancelled row closed on a real session; the plan's prune and compact steps handing in the opt-in and their run's cancel check (asserted inside the plan-level test's fake router).
- Existing tests: the two "delegates to agent" router tests for prune and compact now expect `is_cancelled=None, wait_for_read_work=False`; the plan-level fake router accepts the keywords.
- `ruff check` and `ruff format --check` clean. No frontend change.
- Four rounds of an isolated blind review plus the CodeRabbit CLI on the branch before opening. Round one's blocker (waiting for a queued check that can never start behind the caller's own row) led to the transient set and the fixed budget; round two's (a cancel during the wait reported as a failure) to the cancelled outcome; round three's (the wait reaching the runner, the routes and the schedulers) to the opt-in; round four's findings to the reported reason, the unclaimed-job grace and the cancel-check cache. Every round also flagged the orphan helper's legacy-only lookup; that is #983 and stays with #1008 (see below).

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none needed; spec 7.4's follow-up chain and the runner's deferral are unchanged, this adds the plan side's counterpart)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

None. The visible effect is on the Activity page: a plan run's prune step no longer shows a red `prune` with "repository.list_archives is active on the repository" in the second after the backup, and no `running` prune stays behind when the run is cancelled during that wait.

## Additional Context

Timeline of one occurrence on an install running current main (UTC), queue empty:

| Time | Actor | Event |
|---|---|---|
| 08:45:49.212 | agent | `backup.create` completed |
| 08:45:49.645 | operations runner | woken by the completion, starts the backup's `archive_sync` follow-up, queues `repository.list_archives` (claimed) |
| 08:45:49.675 | plan run | prune step asks to queue `repository.prune` |
| 08:45:49.675 | admission | 409 `repositoryOperationActive`: requested `prune`, active `repository.list_archives` (`repository_read`, claimed) |

With this PR the plan step waits for that listing (a few seconds) and queues the prune afterwards. The `stats` step of the backup chain that runs after the listing still meets the now-running prune and fails as described in #1002; that is the runner's side and out of scope here.
