### PR TITLE
fix(auth): treat a blank INITIAL_ADMIN_PASSWORD as unset

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -701,10 +701,23 @@ async def create_first_user():
         user_count = db.query(User).count()
         if user_count == 0:
             # Create default admin user
-            # Use environment variable if set, otherwise use default
+            # Use environment variable if set, otherwise use default. A
+            # template with a blank password field (the Unraid template, a
+            # Compose file with `${INITIAL_ADMIN_PASSWORD:-}`) sets the
+            # variable to an empty string; that must not create an admin with
+            # an empty password, so empty or whitespace-only reads as unset.
+            # Surrounding whitespace is dropped from a real value too (an env
+            # file's trailing space would otherwise lock the operator out of
+            # an admin nobody can reset without a user), and said so.
             import os
 
-            default_password = os.getenv("INITIAL_ADMIN_PASSWORD", "admin123")
+            configured = os.getenv("INITIAL_ADMIN_PASSWORD", "")
+            default_password = configured.strip() or "admin123"
+            if configured.strip() and configured != configured.strip():
+                logger.warning(
+                    "Surrounding whitespace dropped from INITIAL_ADMIN_PASSWORD",
+                    username="admin",
+                )
             hashed_password = get_password_hash(default_password)
 
             admin_user = User(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ Most configuration is available in the UI under Settings. Use environment variab
 | `DATA_DIR` | `/data` | App database, logs, SSH material, generated secret |
 | `BORG_CACHE_DIR` | `/home/borg/.cache/borg` | Borg files/chunks cache directory. Keep the matching volume persistent for backup performance |
 | `SECRET_KEY` | generated | JWT/session signing key. Auto-generated into `/data/.secret_key` if omitted |
-| `INITIAL_ADMIN_PASSWORD` | `admin123` | Password for the first `admin` user |
+| `INITIAL_ADMIN_PASSWORD` | `admin123` | Password for the first `admin` user, used on first start only. Empty or whitespace-only counts as unset; surrounding whitespace is dropped |
 | `LOG_LEVEL` | `INFO` | Backend log level |
 | `LOCAL_MOUNT_POINTS` | `/local` | Comma-separated container paths shown as local mounts in the file browser |
 | `BASE_PATH` | empty | Sub-path deployment, for example `/borg-ui` |

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -93,3 +93,55 @@ def test_create_access_token():
     assert isinstance(token, str)
     # JWT tokens have 3 parts separated by dots
     assert token.count(".") == 2
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "configured, expected, warns",
+    [
+        (None, "admin123", "admin123"),  # not set: the documented default
+        ("", "admin123", "admin123"),  # a blank template field: empty string
+        ("   ", "admin123", "admin123"),  # whitespace only is no password
+        ("admin123", "admin123", "admin123"),  # the default, set explicitly
+        ("change-me", "change-me", None),
+        (" padded ", "padded", "whitespace"),  # an env file's stray space
+        (" admin123 ", "admin123", "whitespace"),  # trimmed to the default, said
+    ],
+)
+@pytest.mark.asyncio
+async def test_first_admin_password_falls_back_when_the_variable_is_blank(
+    db_session, monkeypatch, configured, expected, warns
+):
+    """A template with a blank password field sets INITIAL_ADMIN_PASSWORD to
+    an empty string; the first admin must then get the documented default,
+    never an empty password, and the operator must see the warning that
+    says so. A trimmed value is announced too. The forced password change
+    stays."""
+    from unittest.mock import patch
+
+    from app.core.security import create_first_user
+    from app.database.models import User
+
+    if configured is None:
+        monkeypatch.delenv("INITIAL_ADMIN_PASSWORD", raising=False)
+    else:
+        monkeypatch.setenv("INITIAL_ADMIN_PASSWORD", configured)
+    assert db_session.query(User).count() == 0
+
+    # `create_first_user` closes the session it gets; the fixture's StaticPool
+    # keeps the in-memory database alive for the assertions below.
+    with (
+        patch("app.core.security.get_db", side_effect=lambda: iter([db_session])),
+        patch("app.core.security.logger") as log,
+    ):
+        await create_first_user()
+
+    admin = db_session.query(User).filter(User.username == "admin").one()
+    assert verify_password(expected, admin.password_hash)
+    assert admin.must_change_password is True
+    assert admin.role == "admin"
+    warnings = " ".join(str(call) for call in log.warning.call_args_list)
+    if warns is None:
+        assert not log.warning.called
+    else:
+        assert warns in warnings


### PR DESCRIPTION
## Description

`create_first_user` read the initial admin password with `os.getenv("INITIAL_ADMIN_PASSWORD", "admin123")`, which falls back only when the variable is absent. A template with a blank password field (the Unraid template today; any Compose file with `${INITIAL_ADMIN_PASSWORD:-}`) sets the variable to an empty string, so the first admin was created with an empty password instead of the documented `admin123`. The Portainer stack file guards with `:?` and refuses to deploy on a blank value, so it was not affected.

What changes:

- An empty or whitespace-only `INITIAL_ADMIN_PASSWORD` reads as unset and the admin gets `admin123`, with the existing warning. A real value is stripped of surrounding whitespace, as the issue proposes: an env file's trailing space would otherwise create an admin nobody can log in as, and `create_first_user` never runs again once the row exists. When that happens a warning says so, and `docs/configuration.md` documents both rules.
- `must_change_password` stays set, so the first login still forces a change either way.

The Unraid and Portainer templates can go back to an optional password field with the documented default once this ships; that is left to the templates' own PR.

## Related Issue
Fixes #977

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

New test in `tests/unit/test_security.py`, parametrised over the variable being absent, empty, whitespace-only, the default set explicitly, a value, and a value with surrounding whitespace: the admin is created with the expected password, the default-password warning is logged when the default is in use, the trimming warning when whitespace was dropped, no warning otherwise, and `must_change_password` is set.

```
pytest tests/unit -q   (rebased onto main 3bbc7dda)
4019 passed, 14 skipped
ruff check app tests && ruff format --check app tests
All checks passed!
```

Reviewed by CodeRabbit on the fork before opening here; its one finding (warn about dropped whitespace even when what remains is `admin123`) is in, with the `" admin123 "` test case.

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

n/a

## Additional Context

No migration. Existing installs are unaffected: the admin is created only when no user exists.

Two things seen next to this, left as they are because they are product decisions rather than this fix:

- The templates declare the field required; with this change a blank value yields the documented `admin123` (with the warning) rather than a refused start or a generated one-time password. That is what the issue asks for; if a blank required field should be a configuration error instead, that is a different change.
- A value longer than bcrypt's 72 bytes makes `get_password_hash` raise inside `create_first_user`; the broad handler there logs and the instance starts with no user at all. The request path guards this with `enforce_bcrypt_password_length`; the bootstrap does not. Worth its own small issue.
- An install whose admin was created by the old code with a blank value still has an empty-password admin; `create_first_user` returns early once the row exists, and the login path does not reject an empty password. A startup check that flags such a hash would close that for existing installs.
