### PR TITLE
fix(agents): align the upgrade and Borg pin chips with their neighbours

### DIFF
--- a/frontend/src/pages/managed-agents/AgentBorgVersionChip.tsx
+++ b/frontend/src/pages/managed-agents/AgentBorgVersionChip.tsx
@@ -45,15 +45,13 @@ export default function AgentBorgVersionChip({
 
   return (
     <Tooltip title={tooltip} arrow>
-      <span>
-        <Chip
-          size="small"
-          variant="outlined"
-          color={satisfied ? 'info' : 'warning'}
-          label={label}
-          sx={agentChipSx}
-        />
-      </span>
+      <Chip
+        size="small"
+        variant="outlined"
+        color={satisfied ? 'info' : 'warning'}
+        label={label}
+        sx={agentChipSx}
+      />
     </Tooltip>
   )
 }

--- a/frontend/src/pages/managed-agents/AgentCardChips.stories.tsx
+++ b/frontend/src/pages/managed-agents/AgentCardChips.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { ReactNode } from 'react'
+import { Box, ThemeProvider, Typography } from '@mui/material'
+import { darkTheme } from '../../theme'
+import AgentBorgVersionChip from './AgentBorgVersionChip'
+import AgentManualUpgradeChip from './AgentManualUpgradeChip'
+import AgentUpgradeChip from './AgentUpgradeChip'
+import AgentUpgradeStateChip from './AgentUpgradeStateChip'
+
+/**
+ * The chip cluster in the top-right corner of an agent card, rendered with the
+ * same flex row the card uses, so any chip that sits a few pixels off its
+ * neighbours shows up here.
+ */
+function ChipRow({ children }: { children: ReactNode }) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'flex-end',
+        flexWrap: 'wrap',
+        minWidth: 0,
+        gap: 0.5,
+        width: 420,
+        p: 2,
+        bgcolor: 'background.paper',
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: '0.58rem',
+          fontWeight: 500,
+          color: 'text.disabled',
+          letterSpacing: '0.02em',
+        }}
+      >
+        v0.1.0
+      </Typography>
+      {children}
+    </Box>
+  )
+}
+
+const meta: Meta<typeof ChipRow> = {
+  title: 'Managed Agents/AgentCardChips',
+  component: ChipRow,
+}
+export default meta
+
+type Story = StoryObj<typeof ChipRow>
+
+const unknownAndManual = (
+  <>
+    <AgentUpgradeChip status="unknown" />
+    <AgentManualUpgradeChip />
+  </>
+)
+
+const everything = (
+  <>
+    <AgentUpgradeChip status="outdated" targetVersion="0.1.3" />
+    <AgentBorgVersionChip desiredBorgVersion="2" borgVersions={[{ major: 1 }]} />
+    <AgentManualUpgradeChip />
+    <AgentUpgradeStateChip state="requested" targetVersion="0.1.3" />
+  </>
+)
+
+export const UnknownAndManual: Story = {
+  render: () => <ChipRow>{unknownAndManual}</ChipRow>,
+}
+
+export const Everything: Story = {
+  render: () => <ChipRow>{everything}</ChipRow>,
+}
+
+export const EverythingDark: Story = {
+  render: () => (
+    <ThemeProvider theme={darkTheme}>
+      <ChipRow>{everything}</ChipRow>
+    </ThemeProvider>
+  ),
+}

--- a/frontend/src/pages/managed-agents/AgentUpgradeChip.tsx
+++ b/frontend/src/pages/managed-agents/AgentUpgradeChip.tsx
@@ -65,7 +65,7 @@ export default function AgentUpgradeChip({
   const title = tooltipText()
   return title ? (
     <Tooltip title={title} arrow>
-      <span>{chip}</span>
+      {chip}
     </Tooltip>
   ) : (
     chip


### PR DESCRIPTION
## Summary
- The tooltip on the upgrade chip and the Borg pin chip wrapped each chip in a plain inline span. The span takes the parent line height (24px around an 18px chip), so those chips sat about 2px lower than the manual upgrade chip next to them in the agent card header.
- Attach the tooltip to the chip directly, matching what the manual upgrade chip already does. Nothing else changes.
- New story: Managed Agents / AgentCardChips renders the card's top-right chip cluster in the same flex row (unknown + manual, everything, everything dark) so an offset is visible in Storybook and Argos.

## Verification
- tsc, oxlint, and the managed-agents vitest suite (80 tests) pass.
- Measured in Storybook: all chips on the row now share the same top edge; re-wrapping one in a span reproduces the 2px drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 8 changed, 6 added, 0 removed, 760 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-1015/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/34501434027
<details>
<summary>Changed files</summary>
- `managed-agents-agentborgversionchip--both-states--mobile.png` (0.46%)
- `managed-agents-agentborgversionchip--both-states.png` (0.15%)
- `managed-agents-agentupgradechip--all-states--mobile.png` (1.27%)
- `managed-agents-agentupgradechip--all-states.png` (0.42%)
- `pages-managedagents--agent-fleet-upgrade-selection--mobile.png` (0.49%)
- `pages-managedagents--agent-fleet-upgrade-selection.png` (6.13%)
- `pages-managedagents--agent-fleet-version-states--mobile.png` (20.94%)
- `pages-managedagents--agent-fleet-version-states.png` (7.57%)
</details>
<details>
<summary>New screenshots</summary>
- `managed-agents-agentcardchips--everything--mobile.png`
- `managed-agents-agentcardchips--everything-dark--mobile.png`
- `managed-agents-agentcardchips--everything-dark.png`
- `managed-agents-agentcardchips--everything.png`
- `managed-agents-agentcardchips--unknown-and-manual--mobile.png`
- `managed-agents-agentcardchips--unknown-and-manual.png`
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->