### PR TITLE
fix(archives): give agent repositories a history capability instead of a stage that always skips

### DIFF
--- a/app/api/archive_index.py
+++ b/app/api/archive_index.py
@@ -6,7 +6,7 @@ from typing import Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
-from sqlalchemy import func
+from sqlalchemy import and_, case, func
 from sqlalchemy.orm import Session
 
 from app.api.maintenance_jobs import get_repository_with_access
@@ -25,11 +25,18 @@ from app.database.models import (
 from app.services.operations import anomalies
 from app.services.operations.enqueue import enqueue_chain
 from app.services.operations.executors.history import (
+    MAX_HISTORY_ATTEMPTS,
     SIZE_LOOKUP_CHUNK,
     predecessor_of,
     successor_of,
 )
-from app.services.operations.followups import PLAN_GATED_KINDS, history_enabled
+from app.services.operations.followups import (
+    HISTORY_AGENT_UNSUPPORTED,
+    HISTORY_AVAILABLE,
+    PLAN_GATED_KINDS,
+    history_capability,
+    history_enabled,
+)
 from app.services.operations.history_fold import Change, fold_sequence, rows_to_changes
 from app.services.operations.index_mode import allows as mode_allows
 from app.services.operations.index_mode import filter_kinds
@@ -155,6 +162,10 @@ async def list_archives(
     db: Session = Depends(get_db),
 ):
     repository = _repo(db, current_user, repo_id)
+    # The plan lookup commits the session; read it before the rows so the
+    # commit cannot expire them (one refresh per archive otherwise; the
+    # repository row alone is refreshed once).
+    history = history_enabled(db)
     rows = (
         _archives_query(db, repository, series, _naive_utc(since), _naive_utc(until))
         .order_by(Archive.start.desc(), Archive.id.desc())
@@ -173,7 +184,11 @@ async def list_archives(
         "series": all_series,
         "sync_state": state,
         "last_synced_at": last_at,
-        "history_available": history_enabled(db),
+        # `history_available` keeps its meaning (the plan has the feature);
+        # the capability says whether this repository has the stage, and
+        # why not.
+        "history_available": history,
+        "history_capability": history_capability(db, repository, history=history),
     }
 
 
@@ -266,6 +281,7 @@ async def get_archive(
     db: Session = Depends(get_db),
 ):
     repository = _repo(db, current_user, repo_id)
+    history = history_enabled(db)  # commits; before the archive rows load
     archive = _archive_or_404(db, repository, archive_id)
     predecessor = predecessor_of(db, archive)
     successor = successor_of(db, archive)
@@ -273,7 +289,8 @@ async def get_archive(
         **serialize_archive(archive),
         "predecessor_id": predecessor.id if predecessor else None,
         "successor_id": successor.id if successor else None,
-        "history_available": history_enabled(db),
+        "history_available": history,
+        "history_capability": history_capability(db, repository, history=history),
     }
 
 
@@ -313,6 +330,15 @@ async def rebuild(
     a manual run at priority 20 (spec 9.2)."""
     repository = _repo(db, current_user, repo_id, role="operator")
     history = history_enabled(db)
+    capability = history_capability(db, repository, history=history)
+    if body.from_stage == "history" and capability == HISTORY_AGENT_UNSUPPORTED:
+        # A rebuild that can only skip again would reset every archive to
+        # `pending` for nothing and read as "not yet" in the UI. Before the
+        # plan gate: an upgrade would not make this rebuild work.
+        raise HTTPException(
+            status_code=409,
+            detail={"key": "backend.errors.archives.historyUnavailableForAgent"},
+        )
     if body.from_stage == "history":
         require_feature_access(db, "archive_history")
     archives = db.query(Archive).filter(Archive.repository_id == repository.id).all()
@@ -328,13 +354,14 @@ async def rebuild(
             )
         for a in archives:
             a.history_state = "pending"
+            a.history_attempts = 0
             a.history_indexed_at = None
             a.history_rows = None
             a.history_truncated = False
         kinds = ["history_index", "stats"]
     else:
         kinds = ["stats"]
-    if not history:
+    if capability != HISTORY_AVAILABLE:
         kinds = [k for k in kinds if k not in PLAN_GATED_KINDS]
     mode = index_mode_of(repository)
     # Spec 6.8: manual work is not blocked by the mode, but a mode that
@@ -435,12 +462,14 @@ async def archive_changes(
     archive of the same series with the intermediate deltas folded (spec
     9.2). `cursor` is an offset into the filtered, path-ordered result."""
     repository = _repo(db, current_user, repo_id)
+    history = history_enabled(db)  # commits; before the archive rows load
     target = _archive_or_404(db, repository, archive_id)
     predecessor = predecessor_of(db, target)
     base = {
         "archive_id": target.id,
         "history_state": target.history_state,
         "history_truncated": target.history_truncated,
+        "history_capability": history_capability(db, repository, history=history),
     }
     if compare_to is None:
         compare = predecessor
@@ -552,6 +581,7 @@ async def path_history(
     db: Session = Depends(get_db),
 ):
     repository = _repo(db, current_user, repo_id)
+    history = history_enabled(db)  # commits; before the archive rows load
     rows = (
         db.query(ArchiveChange, Archive)
         .join(Archive, Archive.id == ArchiveChange.archive_id)
@@ -586,11 +616,44 @@ async def path_history(
             r["series"] == newest.series and r["to_archive_id"] is None for r in ranges
         )
     )
+    # What the answer is based on: with nothing indexed the entries say
+    # nothing about the path, and with a partial index they cover only the
+    # indexed archives. `total` counts every archive, `skipped` ones
+    # included: they are not covered either, whether an agent's repository
+    # will never index them (the capability says so) or a server's still
+    # carries them from an agent-executed past. `exhausted` are the failures
+    # the executor gave up on.
+    total, indexed, exhausted = (
+        db.query(
+            func.count(Archive.id),
+            func.sum(case((Archive.history_state == "indexed", 1), else_=0)),
+            func.sum(
+                case(
+                    (
+                        and_(
+                            Archive.history_state == "failed",
+                            Archive.history_attempts >= MAX_HISTORY_ATTEMPTS,
+                        ),
+                        1,
+                    ),
+                    else_=0,
+                )
+            ),
+        )
+        .filter(Archive.repository_id == repository.id)
+        .one()
+    )
     return {
         "path": path,
         "entries": list(reversed(ascending)),
         "present": ranges,
         "present_in_latest": present_in_latest,
+        "coverage": {
+            "indexed": int(indexed or 0),
+            "exhausted": int(exhausted or 0),
+            "total": int(total or 0),
+            "capability": history_capability(db, repository, history=history),
+        },
     }
 
 

--- a/app/api/operations.py
+++ b/app/api/operations.py
@@ -31,7 +31,11 @@ from app.database.models import (
     utc_now,
 )
 from app.services.log_policy import get_log_save_policy, job_has_logs_by_policy
-from app.services.operations.followups import history_enabled
+from app.services.operations.followups import (
+    HistoryCapability,
+    history_capability,
+    history_enabled,
+)
 from app.services.operations.lanes import lane_free, running_count
 from app.services.operations.models import is_terminal, serialize_operation
 from app.services.operations.index_mode import mode_of as index_mode_of
@@ -156,6 +160,10 @@ class HubRepository(BaseModel):
     last_history_at: Optional[datetime] = None
     archives: int = 0
     history: HistorySummary
+    # Whether the history stage exists for this repository: `available`,
+    # `plan_locked`, or `agent_unsupported` (a managed agent's repository
+    # cannot be diffed). The board offers no history stage otherwise.
+    history_capability: HistoryCapability = "available"
 
 
 class HubTotals(BaseModel):
@@ -503,6 +511,9 @@ async def get_repositories_hub(
     q = db.query(Repository)
     if accessible is not None:
         q = q.filter(Repository.id.in_(accessible))
+    # The plan lookup commits the session; read it before the rows so the
+    # commit cannot expire them (one refresh per repository otherwise).
+    history_plan = history_enabled(db)
     repositories = q.order_by(func.lower(Repository.name), Repository.id).all()
 
     settings = _settings_row(db)
@@ -534,6 +545,7 @@ async def get_repositories_hub(
                 last_history_at=facts["last_history_at"] if facts else None,
                 archives=facts["archives"] if facts else 0,
                 history=facts["summary"] if facts else HistorySummary(),
+                history_capability=history_capability(db, repo, history=history_plan),
             )
         )
 
@@ -557,7 +569,7 @@ async def get_repositories_hub(
         ),
         last_reconcile_at=last_reconcile,
         reconcile_interval_minutes=interval,
-        history_available=history_enabled(db),
+        history_available=history_plan,
     )
 
 

--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -17,6 +17,7 @@ import uuid
 from app.database.database import get_db, SessionLocal
 from app.database.models import (
     AgentMachine,
+    Archive,
     DEFAULT_HISTORY_INDEX_EXCLUDES,
     Operation,
     RcloneRemote,
@@ -46,7 +47,7 @@ from app.services.operations.maintenance_start import (
 from app.services.operations.job_facade import MaintenanceJobFacade
 from app.services.operations.enqueue import enqueue, wake_runner
 from app.services.operations.rclone_facade import RcloneSyncFacade
-from app.services.operations.index_mode import MODE_KINDS
+from app.services.operations.index_mode import MODE_KINDS, indexes_history
 from app.services.operations.index_mode import mode_of as index_mode_of
 from app.services.operations.reconcile import enqueue_reconcile_run
 from app.services.operations.runner import operation_runner
@@ -5000,6 +5001,8 @@ async def update_repository(
         executor_changed = (
             "executor_type" in update_data or repo_data.execution_target is not None
         )
+        previous_executor_type = repository_executor_type(repository)
+        reopen_history = False
         if executor_changed:
             if target_executor_type == "agent":
                 requested_agent_id = (
@@ -5023,6 +5026,7 @@ async def update_repository(
                     repository_location="ssh" if repository.connection_id else "local",
                 )
                 repository.agent_machine_id = None
+                reopen_history = previous_executor_type == "agent"
 
         elif (
             "connection_id" in update_data
@@ -5054,12 +5058,52 @@ async def update_repository(
         ):
             _apply_mirror_source_strategy(existing_rclone_storage, repository)
 
+        if reopen_history:
+            # On the server the history stage exists again: the archives an
+            # agent left `skipped` go back to `pending` with a fresh retry
+            # budget, and so does a `failed` one the agent's listing had not
+            # marked yet (the same rule either way, not one that depends on
+            # whether a listing ran in between), in the same transaction as
+            # the executor change, so neither is stored without the other. A
+            # mode that excludes the
+            # history stage keeps them `pending`, which is what every archive
+            # of such a repository reads as; a later return to `full` catches
+            # them up (spec 6.8).
+            db.query(Archive).filter(
+                Archive.repository_id == repository.id,
+                Archive.history_state.in_(("skipped", "failed")),
+            ).update(
+                {Archive.history_state: "pending", Archive.history_attempts: 0},
+                synchronize_session=False,
+            )
+
         repository.updated_at = datetime.utcnow()
         db.commit()
 
         if repo_data.index_mode is not None:
             await _apply_index_mode_change(db, repository, changed=index_mode_changed)
 
+        if (
+            reopen_history
+            and indexes_history(index_mode_of(repository))
+            # a mode change to `full` in the same update queued its own
+            # forced catch-up run just above; a second one would only
+            # re-diff every archive
+            and not (repo_data.index_mode is not None and index_mode_changed)
+        ):
+            # An index run for the reopened archives now rather than at the
+            # hourly tick. Forced past the in-flight check: a listing the
+            # agent's chain still has queued carries no history stage and
+            # would not reach them. Best effort, like the mode catch-up.
+            try:
+                enqueue_reconcile_run(db, repository.id, force=True)
+            except Exception as e:
+                db.rollback()
+                logger.error(
+                    "Failed to queue the history index after the executor change",
+                    repo_id=repository.id,
+                    error=str(e),
+                )
         if sync_cloud_mirror_after_update:
             try:
                 _queue_initial_cloud_mirror_sync(db, repository)

--- a/app/services/operations/executors/history.py
+++ b/app/services/operations/executors/history.py
@@ -336,8 +336,6 @@ async def run_history_index(ctx) -> Outcome:
     if repository is None:
         return Outcome(status="skipped", skip_reason="repository_missing")
     db = ctx.db
-    if not history_enabled(db):
-        return Outcome(status="skipped", skip_reason="plan_locked")
     # "failed" is retried: nothing else moves an archive out of that state, so
     # skipping it would stall the series for good, since every later archive
     # needs an indexed predecessor. The retry is bounded, because each attempt
@@ -359,14 +357,21 @@ async def run_history_index(ctx) -> Outcome:
     ]
     pending = [a for a in candidates if a not in exhausted]
     if is_agent_executor(repository):
-        for archive in pending:
+        # The chains no longer create this stage for an agent's repository;
+        # a row that reaches it anyway marks what the listing marks: every
+        # archive not indexed, the exhausted failures included (nothing can
+        # retry them here either).
+        for archive in candidates:
             archive.history_state = "skipped"
         db.commit()
         return Outcome(
             status="skipped",
             skip_reason="agent_diff_unsupported",
-            result={"archives": len(pending)},
+            result={"archives": len(candidates)},
         )
+    if not history_enabled(db):
+        # after the executor: its reason is the durable one
+        return Outcome(status="skipped", skip_reason="plan_locked")
     if not pending:
         return Outcome(
             status="completed_with_warnings" if exhausted else "completed",
@@ -472,14 +477,17 @@ def _delete_rows(db: Session, archive_id: int) -> None:
     )
 
 
-def merge_removed_archive(db: Session, removed: Archive) -> str:
+def merge_removed_archive(
+    db: Session, removed: Archive, *, reset_state: str = "pending"
+) -> str:
     """Fold `removed` into its successor and delete it, in one transaction.
 
     Returns "folded" when both archives were indexed, "reset" when the
     successor was indexed against an archive that never was (its delta is
-    now against the wrong base, so it goes back to pending), and "dropped"
-    when there is no successor or the successor is not indexed yet (it will
-    be diffed against the new predecessor when it is).
+    now against the wrong base, so it goes back to `reset_state`: pending,
+    or skipped where no history run will come, an agent's repository), and
+    "dropped" when there is no successor or the successor is not indexed
+    yet (it will be diffed against the new predecessor when it is).
     """
     successor = successor_of(db, removed)
     try:
@@ -515,7 +523,7 @@ def merge_removed_archive(db: Session, removed: Archive) -> str:
             outcome = "folded"
         elif successor.history_state == "indexed":
             _delete_rows(db, successor.id)
-            successor.history_state = "pending"
+            successor.history_state = reset_state
             successor.history_indexed_at = None
             successor.history_rows = None
             successor.history_truncated = False
@@ -540,6 +548,10 @@ async def run_history_merge(ctx) -> Outcome:
     db = ctx.db
     counts = {"merged": 0, "folded": 0, "reset": 0, "dropped": 0}
     ids = removed_archive_ids_from_dependency(db, ctx.operation)
+    # A reset successor reads as "not yet"; on an agent's repository no run
+    # comes on any plan (the capability is the executor's), so it takes the
+    # state the listing writes there.
+    reset_state = "skipped" if is_agent_executor(repository) else "pending"
     for position, archive_id in enumerate(ids):
         if ctx.cancelled():
             break
@@ -548,7 +560,7 @@ async def run_history_merge(ctx) -> Outcome:
             continue
         # The row is gone (and expired) after the merge commits.
         name = removed.name
-        outcome = merge_removed_archive(db, removed)
+        outcome = merge_removed_archive(db, removed, reset_state=reset_state)
         counts[outcome] += 1
         counts["merged"] += 1
         ctx.log(f"{name}: {outcome}")

--- a/app/services/operations/executors/index.py
+++ b/app/services/operations/executors/index.py
@@ -23,6 +23,10 @@ from app.config import settings
 from app.core.borg_router import BorgRouter
 from app.database.models import Archive, Repository, SystemSettings, utc_now
 from app.services.operations import executors
+from app.services.operations.followups import (
+    HISTORY_AVAILABLE,
+    history_capability,
+)
 from app.services.operations.runner import Outcome, repository_busy
 from app.services.operations.series import infer_series, series_prefixes_for_repository
 from app.services.repository_command_lock import run_serialized_repository_command
@@ -588,6 +592,45 @@ async def run_archive_sync(ctx) -> Outcome:
         new_rows, removed_ids = apply_listing(
             db, repository, entries, timezone_name=timezone_name
         )
+        if is_agent_executor(repository):
+            # No history run ever reaches an agent's repository (the server
+            # cannot diff it), so the listing records the state the history
+            # run used to write: `skipped`, not a `pending` that would read
+            # as "not yet". On every plan: the capability is the executor's
+            # and outlasts a plan change. `failed` is marked too: nothing can retry it
+            # here, and a row left `failed` would flag the repository and
+            # offer a rebuild that is refused. Moving the repository back to
+            # the server reopens every `skipped` archive with a fresh retry
+            # budget.
+            db.query(Archive).filter(
+                Archive.repository_id == repository.id,
+                Archive.history_state.in_(("pending", "failed")),
+            ).update({Archive.history_state: "skipped"}, synchronize_session=False)
+            db.commit()
+        elif (
+            db.query(Archive.id)
+            .filter(
+                Archive.repository_id == repository.id,
+                Archive.history_state == "skipped",
+            )
+            .first()
+            is not None
+            and history_capability(db, repository) == HISTORY_AVAILABLE
+        ):
+            # The mirror image: `skipped` on a server's repository is left
+            # over from an agent-executed past (the executor change reopens
+            # them, but rows written before it did so stay). With the history
+            # stage available they go back to `pending` with a fresh budget,
+            # and the chain's history stage picks them up. The plan lookup
+            # behind the capability commits, so it runs only with such rows.
+            db.query(Archive).filter(
+                Archive.repository_id == repository.id,
+                Archive.history_state == "skipped",
+            ).update(
+                {Archive.history_state: "pending", Archive.history_attempts: 0},
+                synchronize_session=False,
+            )
+            db.commit()
         filled = await fill_archive_info(
             db,
             repository,

--- a/app/services/operations/followups.py
+++ b/app/services/operations/followups.py
@@ -2,7 +2,7 @@
 operation reaches a success state. Phase 2 adds plan awareness here
 (spec 11.2): history kinds are dropped for Community installs."""
 
-from typing import Optional
+from typing import Literal, Optional
 
 from app.services.operations.index_mode import (
     DEFAULT_INDEX_MODE,
@@ -71,13 +71,18 @@ def chain_for_repository(
     history: Optional[bool] = None,
     available: Optional[set[str]] = None,
 ) -> list[str]:
-    """`chain_for` with this install's executors, this install's plan, and
-    this repository's index mode. Every follow-up site calls this, so the
-    two gates are read in one place rather than six.
+    """`chain_for` with this install's executors, this install's plan, this
+    repository's index mode, and this repository's executor. Every
+    follow-up site calls this, so the three gates are read in one place
+    rather than six.
 
     `history` is the plan gate; left None it is read here, which goes
     through the licensing service and commits the session. A caller that
     wraps this call in a savepoint reads it beforehand and passes it in.
+    With the plan gate open, the executor decides next: a repository
+    executed by a managed agent cannot be diffed by the server, so it gets
+    no history stage either (`history_capability`), by the same rule as
+    the plan and the mode: a stage that will never run does not exist.
 
     `available` is for the runner, which carries its own registry and must
     not be told about executors it was not given.
@@ -86,6 +91,8 @@ def chain_for_repository(
 
     if history is None:
         history = history_enabled(db)
+    if history:
+        history = history_possible_for(db, repository_id, history=True)
     if available is None:
         available = registered_kinds()
     return chain_for(
@@ -103,6 +110,58 @@ def history_enabled(db) -> bool:
     from app.core.features import Plan, get_current_plan, plan_includes
 
     return plan_includes(get_current_plan(db), Plan.PRO)
+
+
+HistoryCapability = Literal["available", "plan_locked", "agent_unsupported"]
+HISTORY_AVAILABLE: HistoryCapability = "available"
+HISTORY_PLAN_LOCKED: HistoryCapability = "plan_locked"
+HISTORY_AGENT_UNSUPPORTED: HistoryCapability = "agent_unsupported"
+
+
+def history_capability(
+    db, repository, *, history: Optional[bool] = None
+) -> HistoryCapability:
+    """Whether change history can be built for `repository`, and if not, why.
+
+    `agent_unsupported`: the repository is executed by a managed agent, and
+    the agent protocol has no diff job, so `history_index` would only ever
+    skip it (the server runs `borg diff`, and it cannot reach an agent's
+    repository). `plan_locked`: the plan lacks the feature (spec 11.2). The
+    executor is read first: its reason outlasts any plan change, and a plan
+    chip on such a repository would promise what an upgrade cannot deliver.
+    Derived at read time from the executor and the plan rather than stored:
+    both are facts about the repository, not about one run. `history` is
+    the plan gate when the caller already read it.
+    """
+    from app.services.repository_executor import is_agent_executor
+
+    if repository is not None and is_agent_executor(repository):
+        return HISTORY_AGENT_UNSUPPORTED
+    if history is None:
+        history = history_enabled(db)
+    if not history:
+        return HISTORY_PLAN_LOCKED
+    return HISTORY_AVAILABLE
+
+
+def history_possible(db, repository, *, history: Optional[bool] = None) -> bool:
+    """The `history` argument for `chain_for`: the history stage exists for
+    this repository (it is not merely created and skipped, Appendix B)."""
+    return history_capability(db, repository, history=history) == HISTORY_AVAILABLE
+
+
+def history_possible_for(
+    db, repository_id: Optional[int], *, history: Optional[bool] = None
+) -> bool:
+    """`history_possible` for a caller holding only the repository id (the
+    runner, the follow-up enqueuers). A missing repository keeps the plan
+    answer; the executor skips its chain as `repository_missing` anyway."""
+    from app.database.models import Repository
+
+    repository = (
+        db.get(Repository, repository_id) if repository_id is not None else None
+    )
+    return history_possible(db, repository, history=history)
 
 
 def enqueue_backup_followups(

--- a/app/services/operations/reconcile.py
+++ b/app/services/operations/reconcile.py
@@ -12,7 +12,11 @@ from app.database.database import SessionLocal
 from app.database.models import Operation, Repository, SystemSettings, utc_now
 from app.services.operations.enqueue import enqueue_chain
 from app.services.operations.executors import registered_kinds
-from app.services.operations.followups import PLAN_GATED_KINDS, history_enabled
+from app.services.operations.followups import (
+    PLAN_GATED_KINDS,
+    history_enabled,
+    history_possible_for,
+)
 from app.services.operations.index_mode import (
     DEFAULT_INDEX_MODE,
     filter_kinds,
@@ -92,13 +96,19 @@ def enqueue_reconcile_run(
     `force=True` skips the in-flight check. The catch-up run on returning to
     `full` (spec 6.8) needs it: the work already queued was built for the
     narrower mode and will never produce the history stages, so deferring to
-    it would mean no catch-up at all until the next tick.
+    it would mean no catch-up at all until the next tick. The reopen of a
+    repository moved from an agent back to the server is the same case: the
+    agent's listing that may still be queued carries no history stage.
     """
     mode = mode_for_repository(db, repository_id)
     if manual and mode == "off":
         # The one-off look: archive_sync and stats, this once.
         mode = "archives"
-    kinds = reconcile_kinds(db, history=history, mode=mode)
+    # The plan gate is read once by the caller; the executor gate is per
+    # repository (an agent's repository gets no history stage).
+    kinds = reconcile_kinds(
+        db, history=history_possible_for(db, repository_id, history=history), mode=mode
+    )
     if not kinds or (not force and has_active_index_work(db, repository_id)):
         return []
     return enqueue_chain(

--- a/docs/architecture/job-system.md
+++ b/docs/architecture/job-system.md
@@ -427,8 +427,10 @@ Two more index kinds fill and maintain `archive_changes`:
   yet stays pending for the next run, and the run reports
   `completed_with_warnings` so a stalled series is visible. An archive that
   failed is retried on the next run: nothing else moves it out of that
-  state, and every later archive in the series waits on it. Managed-agent
-  repositories skip the stage with `agent_diff_unsupported`.
+  state, and every later archive in the series waits on it. A managed
+  agent's repository never gets the stage (see the history capability
+  below); should a row reach the executor anyway, it skips with
+  `agent_diff_unsupported`.
 - `history_merge` consumes `removed_archive_ids` from the `archive_sync`
   it depends on. A removed archive's rows are folded into its successor
   (the table in the spec, section 8.4), or the successor is reset to
@@ -439,6 +441,29 @@ Two more index kinds fill and maintain `archive_changes`:
 Only `history_index` is gated on the plan including `archive_history`; on
 Community installs the follow-up chains and the reconcile run omit it, and
 activating a Pro licence enqueues a reconcile run for every repository.
+The same gate applies per repository through its history capability
+(`history_capability` in `app/services/operations/followups.py`): a
+repository executed by a managed agent cannot be diffed by the server, so
+it is `agent_unsupported` and gets no `history_index` from any chain.
+`chain_for_repository` and the reconcile run read the three gates in one
+place, the plan, the repository's index mode (below) and its executor, so
+no follow-up site decides on its own. The rebuild route refuses
+`from = history` for such a repository (409) and drops the kind for
+`from = archives`. The capability is derived from the plan and the
+executor when read, not stored. `archive_sync` marks such a repository's
+`pending` and `failed` archives `skipped`, the state the history run used
+to write for them (nothing there could retry a failure), and
+`history_merge` resets a successor to `skipped` rather than `pending`
+there; moving the repository back to the server puts them back to
+`pending` with a fresh retry budget and queues an index run (a server's
+listing reopens rows an older release left `skipped` the same way). The
+archive list, detail and changes responses, the hub rows and the
+path-history `coverage` carry it, so the
+UI says "not available" where the stage does not exist rather than "not
+yet"; the file history panel reads `coverage` (indexed archives out of
+all) before it calls a repository unindexed or a path absent, and the
+series' own archive states before it counts older archives without the
+path.
 `history_merge` runs on every plan, because it is what deletes the rows of
 archives that have left the repository: `archive_sync` reports them and
 deliberately leaves the deletion to it.

--- a/frontend/src/components/archives/ArchiveChangesTab.stories.tsx
+++ b/frontend/src/components/archives/ArchiveChangesTab.stories.tsx
@@ -146,3 +146,30 @@ export const Locked: Story = {
     systemInfo: communitySystemInfo,
   },
 }
+
+// An archive of a repository executed by a managed agent: the server cannot
+// diff it, so the state is `skipped` for good and no rebuild is offered.
+export const AgentUnsupported: Story = {
+  args: {
+    archive: {
+      ...archive,
+      history_state: 'skipped',
+      history_capability: 'agent_unsupported',
+    },
+  },
+  parameters: {
+    systemInfo: proSystemInfo,
+  },
+  render: (args) => (
+    <SeededChanges
+      response={changesResponse({
+        changes: [],
+        totals: { added: 0, removed: 0, modified: 0, summary: 0 },
+        history_state: 'skipped',
+        history_capability: 'agent_unsupported',
+      })}
+    >
+      <ArchiveChangesTab {...args} />
+    </SeededChanges>
+  ),
+}

--- a/frontend/src/components/archives/ArchiveChangesTab.tsx
+++ b/frontend/src/components/archives/ArchiveChangesTab.tsx
@@ -114,6 +114,13 @@ function ArchiveChangesTabContent({ repositoryId, archive }: ArchiveChangesTabPr
   // nothing to show, the empty state would claim the archive has no changes.
   const loadFailed = isError && !changes
   const historyState = changes?.history_state ?? archive.history_state
+  // The repository decides whether history can exist at all; an archive of
+  // a repository executed by an agent is `skipped` for good, and a rebuild
+  // would only skip it again. The rebuild control is offered only where it
+  // can change the outcome.
+  const capability = changes?.history_capability ?? archive.history_capability ?? 'available'
+  const historyUnavailable = capability !== 'available'
+  const canRebuild = !historyUnavailable
   const rows = [...(changes?.changes ?? []), ...extraPages]
   const totals = changes?.totals
 
@@ -205,22 +212,29 @@ function ArchiveChangesTabContent({ repositoryId, archive }: ArchiveChangesTabPr
 
       {!isLoading && historyState !== 'indexed' && (
         <Alert
-          severity={historyState === 'failed' ? 'warning' : 'info'}
+          severity={historyState === 'failed' && !historyUnavailable ? 'warning' : 'info'}
           action={
-            <Button
-              size="small"
-              disabled={rebuildMutation.isPending}
-              onClick={() => rebuildMutation.mutate()}
-            >
-              {t('archives.changes.rebuildLink')}
-            </Button>
+            canRebuild ? (
+              <Button
+                size="small"
+                disabled={rebuildMutation.isPending}
+                onClick={() => rebuildMutation.mutate()}
+              >
+                {t('archives.changes.rebuildLink')}
+              </Button>
+            ) : undefined
           }
         >
-          {historyState === 'skipped'
-            ? t('archives.changes.skipped')
-            : historyState === 'failed'
-              ? t('archives.changes.failed')
-              : t('archives.changes.pending')}
+          {capability === 'agent_unsupported'
+            ? // whatever the archive's own state says (a failure recorded
+              // before the move included): the failed wording promises a
+              // rebuild this repository cannot have
+              t('archives.changes.agentUnsupported')
+            : historyState === 'skipped'
+              ? t('archives.changes.skipped')
+              : historyState === 'failed'
+                ? t('archives.changes.failed')
+                : t('archives.changes.pending')}
         </Alert>
       )}
 

--- a/frontend/src/components/archives/FileHistoryPanel.stories.tsx
+++ b/frontend/src/components/archives/FileHistoryPanel.stories.tsx
@@ -52,7 +52,12 @@ const history: PathHistoryResponse = {
   present_in_latest: false,
 }
 
-const archive = (id: number, name: string, start: string): ArchiveRow => ({
+const archive = (
+  id: number,
+  name: string,
+  start: string,
+  overrides: Partial<ArchiveRow> = {}
+): ArchiveRow => ({
   id,
   repository_id: repositoryId,
   borg_id: `borg-${id}`,
@@ -75,6 +80,7 @@ const archive = (id: number, name: string, start: string): ArchiveRow => ({
   history_truncated: false,
   first_seen_at: null,
   last_seen_at: null,
+  ...overrides,
 })
 
 const seriesArchives: ArchiveListResponse = {
@@ -134,4 +140,135 @@ export const Locked: Story = {
   parameters: {
     systemInfo: communitySystemInfo,
   },
+}
+
+// The panel says what its answer is based on. A repository executed by an
+// agent has no index at all (the server cannot diff it), and a repository
+// indexed only in part covers the indexed archives only; both seed a
+// history of their own under a different path so the decorator's full
+// index is left alone.
+function SeededCoverage({
+  children,
+  storyPath,
+  response,
+  listing,
+}: {
+  children: ReactNode
+  storyPath: string
+  response: PathHistoryResponse
+  listing?: { series: string; response: ArchiveListResponse }
+}) {
+  const queryClient = useQueryClient()
+  useState(() => {
+    queryClient.setQueryData(['path-history', repositoryId, storyPath], response)
+    if (listing) {
+      queryClient.setQueryData(
+        ['archive-series-for-history', repositoryId, listing.series],
+        listing.response
+      )
+    }
+    return null
+  })
+  return <>{children}</>
+}
+
+const agentPath = 'etc/hosts'
+const partialPath = 'home/karan/notes.md'
+
+export const AgentUnsupported: Story = {
+  args: { path: agentPath },
+  parameters: { systemInfo: proSystemInfo },
+  render: (args) => (
+    <SeededCoverage
+      storyPath={agentPath}
+      response={{
+        path: agentPath,
+        entries: [],
+        present: [],
+        present_in_latest: false,
+        coverage: { indexed: 0, exhausted: 0, total: 12, capability: 'agent_unsupported' },
+      }}
+    >
+      <FileHistoryPanel {...args} />
+    </SeededCoverage>
+  ),
+}
+
+// The path's series decides the coverage once its listing is known: a
+// series of its own here, with archives the index has not reached yet.
+const partialSeries = 'weekly'
+const partialListing = (state: ArchiveRow['history_state']): ArchiveListResponse => ({
+  archives: [
+    archive(11, 'weekly-2026-08-23', '2026-08-23T03:00:00Z', { series: partialSeries }),
+    archive(12, 'weekly-2026-08-30', '2026-08-30T03:00:00Z', { series: partialSeries }),
+    archive(13, 'weekly-2026-09-06', '2026-09-06T03:00:00Z', {
+      series: partialSeries,
+      history_state: state,
+    }),
+    archive(14, 'weekly-2026-09-13', '2026-09-13T03:00:00Z', {
+      series: partialSeries,
+      history_state: state,
+    }),
+  ],
+  series: [partialSeries],
+  sync_state: 'fresh',
+  last_synced_at: '2026-09-13T03:10:00Z',
+  history_available: true,
+})
+
+export const PartiallyIndexed: Story = {
+  args: { path: partialPath },
+  parameters: { systemInfo: proSystemInfo },
+  render: (args) => (
+    <SeededCoverage
+      storyPath={partialPath}
+      response={{
+        path: partialPath,
+        entries: [
+          entry({
+            archive_id: 12,
+            archive_name: 'weekly-2026-08-30',
+            series: partialSeries,
+            start: '2026-08-30T03:00:00Z',
+          }),
+        ],
+        present: [{ series: partialSeries, from_archive_id: 12, to_archive_id: null }],
+        present_in_latest: true,
+        coverage: { indexed: 5, exhausted: 0, total: 12, capability: 'available' },
+      }}
+      listing={{ series: partialSeries, response: partialListing('pending') }}
+    >
+      <FileHistoryPanel {...args} />
+    </SeededCoverage>
+  ),
+}
+
+// An index built on the server before the repository moved to an agent:
+// the entries stay, the archives listed since are skipped, and the
+// coverage says how far the index got.
+export const AgentWithOlderIndex: Story = {
+  args: { path: partialPath },
+  parameters: { systemInfo: proSystemInfo },
+  render: (args) => (
+    <SeededCoverage
+      storyPath={partialPath}
+      response={{
+        path: partialPath,
+        entries: [
+          entry({
+            archive_id: 12,
+            archive_name: 'weekly-2026-08-30',
+            series: partialSeries,
+            start: '2026-08-30T03:00:00Z',
+          }),
+        ],
+        present: [{ series: partialSeries, from_archive_id: 12, to_archive_id: null }],
+        present_in_latest: true,
+        coverage: { indexed: 5, exhausted: 0, total: 12, capability: 'agent_unsupported' },
+      }}
+      listing={{ series: partialSeries, response: partialListing('skipped') }}
+    >
+      <FileHistoryPanel {...args} />
+    </SeededCoverage>
+  ),
 }

--- a/frontend/src/components/archives/FileHistoryPanel.tsx
+++ b/frontend/src/components/archives/FileHistoryPanel.tsx
@@ -25,7 +25,18 @@ function FileHistoryPanelContent({ repositoryId, path, onRestoreEntry }: FileHis
     enabled: !!path,
   })
 
-  const series = data?.entries[0]?.series ?? null
+  // The path's own series, when its entries all belong to one (a Borg 2
+  // repository can hold several): the older-archive count and the coverage
+  // caption are statements about that series. Spread over several, or with
+  // no entries at all, the repository-wide coverage stands.
+  const series = useMemo(() => {
+    if (!data) return null
+    const names = new Set([
+      ...data.entries.map((entry) => entry.series),
+      ...data.present.map((range) => range.series),
+    ])
+    return names.size === 1 ? [...names][0] : null
+  }, [data])
 
   const { data: seriesArchives } = useQuery({
     queryKey: ['archive-series-for-history', repositoryId, series],
@@ -34,17 +45,58 @@ function FileHistoryPanelContent({ repositoryId, path, onRestoreEntry }: FileHis
     enabled: !!series,
   })
 
-  const notPresentOlderCount = useMemo(() => {
-    if (!data || !seriesArchives) return 0
-    const earliestPresentId = data.present.reduce<number | null>(
-      (min, range) => (min === null || range.from_archive_id < min ? range.from_archive_id : min),
-      null
+  // "Not present in N older archives" is a statement about the archives of
+  // the path's series older than its first sighting, so it needs exactly
+  // those indexed, not the whole repository (a backup that just landed is
+  // still pending and says nothing about the past).
+  // Older by archive time, the id only as the tie-breaker: a listing can
+  // add an archive with an earlier start under a larger id.
+  const { notPresentOlderCount, olderArchivesIndexed } = useMemo(() => {
+    if (!data || !seriesArchives) return { notPresentOlderCount: 0, olderArchivesIndexed: true }
+    const firstSeen = new Set(data.present.map((range) => range.from_archive_id))
+    const byAge = [...seriesArchives.archives].sort((a, b) =>
+      a.start < b.start ? -1 : a.start > b.start ? 1 : a.id - b.id
     )
-    if (earliestPresentId === null) return 0
-    return seriesArchives.archives.filter((row) => row.id < earliestPresentId).length
+    const earliestPresent = byAge.findIndex((row) => firstSeen.has(row.id))
+    if (earliestPresent < 0) return { notPresentOlderCount: 0, olderArchivesIndexed: true }
+    const older = byAge.slice(0, earliestPresent)
+    return {
+      notPresentOlderCount: older.length,
+      olderArchivesIndexed: older.every((row) => row.history_state === 'indexed'),
+    }
   }, [data, seriesArchives])
 
   const entries = data?.entries ?? []
+  // What the answer is based on. With nothing indexed the entries say
+  // nothing about the path; with a partial index they cover the indexed
+  // archives only, so "no earlier archive contains this path" is only true
+  // once every archive is indexed. The route's coverage counts the whole
+  // repository; once the path's series is known, its own archives decide
+  // (the listing carries their states), since every statement below is
+  // about that series. A `skipped` archive is uncovered like a `pending`
+  // one: on an agent's repository it never gets indexed (the capability
+  // says so), on a server's it is a leftover the next listing reopens.
+  // Only `indexed` and `total` are re-scoped; `exhausted` is read below
+  // from the repository-wide object alone.
+  const coverage = useMemo(() => {
+    const repositoryWide = data?.coverage
+    if (!repositoryWide || !seriesArchives) return repositoryWide
+    const rows = seriesArchives.archives
+    return {
+      ...repositoryWide,
+      indexed: rows.filter((row) => row.history_state === 'indexed').length,
+      total: rows.length,
+    }
+  }, [data, seriesArchives])
+  // Entries can outlive a reset of the archive states (a series rename puts
+  // every archive back to pending without deleting its rows), so the
+  // "nothing indexed" answer is given only when there is nothing to show.
+  const nothingIndexed =
+    coverage != null && coverage.total > 0 && coverage.indexed === 0 && entries.length === 0
+  // Entries with nothing indexed (a series reset left them) still get the
+  // caption: "0 of N" is what they are based on.
+  const partiallyIndexed = coverage != null && coverage.indexed < coverage.total
+  const fullyIndexed = coverage == null || coverage.indexed >= coverage.total
   const sortedEntries = [...entries].sort((a, b) => (a.start < b.start ? 1 : -1))
   const firstAddedId = [...entries]
     .filter((e) => e.change === 'added')
@@ -52,11 +104,45 @@ function FileHistoryPanelContent({ repositoryId, path, onRestoreEntry }: FileHis
 
   const theme = useTheme()
 
+  // With nothing to show for the path on an agent's repository, the reason
+  // comes first: no index at all, or one that stays partial (whatever was
+  // indexed on the server before the move stays, nothing is added). Only a
+  // complete index says the path is absent.
+  const unavailableForAgent =
+    coverage != null &&
+    coverage.capability === 'agent_unsupported' &&
+    entries.length === 0 &&
+    coverage.indexed < coverage.total
+  if (data && (nothingIndexed || unavailableForAgent)) {
+    return (
+      <Box>
+        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+          {unavailableForAgent
+            ? t('archives.files.historyUnavailableAgent')
+            : data.coverage != null && data.coverage.exhausted >= data.coverage.total
+              ? // the executor has given up on every archive: not "yet"
+                t('archives.files.historyFailed')
+              : t('archives.files.historyNotIndexed')}
+        </Typography>
+      </Box>
+    )
+  }
+
   return (
     <Box>
       {data && sortedEntries.length === 0 && (
         <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-          {t('archives.files.historyEmpty')}
+          {fullyIndexed
+            ? t('archives.files.historyEmpty')
+            : t('archives.files.historyEmptyIndexed')}
+        </Typography>
+      )}
+      {partiallyIndexed && coverage && (
+        <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block', mb: 1 }}>
+          {t('archives.files.historyCoverage', {
+            indexed: coverage.indexed,
+            count: coverage.total,
+          })}
         </Typography>
       )}
       <Box>
@@ -111,7 +197,7 @@ function FileHistoryPanelContent({ repositoryId, path, onRestoreEntry }: FileHis
           )
         })}
       </Box>
-      {notPresentOlderCount > 0 && (
+      {olderArchivesIndexed && notPresentOlderCount > 0 && (
         <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block', mt: 1 }}>
           {t('archives.files.notPresent', { count: notPresentOlderCount })}
         </Typography>

--- a/frontend/src/components/archives/__tests__/ArchiveChangesTab.test.tsx
+++ b/frontend/src/components/archives/__tests__/ArchiveChangesTab.test.tsx
@@ -223,6 +223,89 @@ describe('ArchiveChangesTab', () => {
     )
   })
 
+  it('says history is not available for an agent repository and offers no rebuild', async () => {
+    vi.mocked(archivesAPI.getChanges).mockResolvedValue({
+      data: baseChangesResponse({
+        changes: [],
+        history_state: 'skipped',
+        history_capability: 'agent_unsupported',
+      }),
+    } as never)
+    renderWithProviders(
+      <ArchiveChangesTab
+        repositoryId={7}
+        archive={{
+          ...archive,
+          history_state: 'skipped',
+          history_capability: 'agent_unsupported',
+        }}
+      />
+    )
+    expect(
+      await screen.findByText(/not available for repositories executed by an agent/i)
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /rebuild/i })).not.toBeInTheDocument()
+    expect(screen.queryByText(/was skipped for this archive/i)).not.toBeInTheDocument()
+  })
+
+  it('says the same for an agent archive the listing has not marked yet', async () => {
+    // the archive is still `pending` (its listing has not run since it was
+    // created); the repository decides, not the archive's state
+    vi.mocked(archivesAPI.getChanges).mockResolvedValue({
+      data: baseChangesResponse({
+        changes: [],
+        history_state: 'pending',
+        history_capability: 'agent_unsupported',
+      }),
+    } as never)
+    renderWithProviders(
+      <ArchiveChangesTab
+        repositoryId={7}
+        archive={{ ...archive, history_state: 'pending', history_capability: 'agent_unsupported' }}
+      />
+    )
+    expect(
+      await screen.findByText(/not available for repositories executed by an agent/i)
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /rebuild/i })).not.toBeInTheDocument()
+    expect(screen.queryByText(/has not been indexed yet/i)).not.toBeInTheDocument()
+  })
+
+  it('says the same for a failed archive of an agent repository, without a rebuild', async () => {
+    // the failed wording promises a rebuild this repository cannot have
+    vi.mocked(archivesAPI.getChanges).mockResolvedValue({
+      data: baseChangesResponse({
+        changes: [],
+        history_state: 'failed',
+        history_capability: 'agent_unsupported',
+      }),
+    } as never)
+    renderWithProviders(
+      <ArchiveChangesTab
+        repositoryId={7}
+        archive={{ ...archive, history_state: 'failed', history_capability: 'agent_unsupported' }}
+      />
+    )
+    expect(
+      await screen.findByText(/not available for repositories executed by an agent/i)
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /rebuild/i })).not.toBeInTheDocument()
+    expect(screen.queryByText(/could not be indexed/i)).not.toBeInTheDocument()
+  })
+
+  it('still offers the rebuild for a skipped archive of a repository that can be indexed', async () => {
+    vi.mocked(archivesAPI.getChanges).mockResolvedValue({
+      data: baseChangesResponse({
+        changes: [],
+        history_state: 'skipped',
+        history_capability: 'available',
+      }),
+    } as never)
+    renderTab()
+    expect(await screen.findByText(/was skipped for this archive/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /rebuild/i })).toBeInTheDocument()
+  })
+
   it('shows the inert preview to a plan without the feature', () => {
     mockPlanCan.mockReturnValue(false)
     renderTab()

--- a/frontend/src/components/archives/__tests__/FileHistoryPanel.test.tsx
+++ b/frontend/src/components/archives/__tests__/FileHistoryPanel.test.tsx
@@ -103,6 +103,9 @@ describe('FileHistoryPanel', () => {
         ],
         present: [{ series: 'nightly', from_archive_id: 12, to_archive_id: null }],
         present_in_latest: true,
+        // another series of the repository is still pending; this one is
+        // fully indexed, so the statement about its older archives stands
+        coverage: { indexed: 4, exhausted: 0, total: 6, capability: 'available' },
       },
     } as never)
     vi.mocked(archivesAPI.listStored).mockResolvedValue({
@@ -117,7 +120,7 @@ describe('FileHistoryPanel', () => {
             series: 'nightly',
             start: '2026-09-02T02:00:00Z',
           },
-        ],
+        ].map((row) => ({ ...row, history_state: 'indexed' })),
         series: ['nightly'],
         sync_state: 'fresh',
         last_synced_at: null,
@@ -155,6 +158,283 @@ describe('FileHistoryPanel', () => {
     const button = await screen.findByRole('button', { name: /restore this/i })
     fireEvent.click(button)
     expect(onRestore).toHaveBeenCalledWith(expect.objectContaining({ archive_id: 12 }))
+  })
+
+  it('says history is not available for an agent repository instead of judging the path', async () => {
+    vi.mocked(archivesAPI.getPathHistory).mockResolvedValue({
+      data: {
+        path: 'etc/hosts',
+        entries: [],
+        present: [],
+        present_in_latest: false,
+        coverage: { indexed: 0, exhausted: 0, total: 12, capability: 'agent_unsupported' },
+      },
+    } as never)
+    renderPanel('etc/hosts')
+    expect(
+      await screen.findByText(/not available for repositories executed by an agent/i)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/no earlier archive contains this path/i)).not.toBeInTheDocument()
+  })
+
+  it('says history is not available for an agent repository even with a partial older index', async () => {
+    vi.mocked(archivesAPI.getPathHistory).mockResolvedValue({
+      data: {
+        path: 'etc/hosts',
+        entries: [],
+        present: [],
+        present_in_latest: false,
+        coverage: { indexed: 3, exhausted: 0, total: 12, capability: 'agent_unsupported' },
+      },
+    } as never)
+    renderPanel('etc/hosts')
+    expect(
+      await screen.findByText(/not available for repositories executed by an agent/i)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/archives indexed/i)).not.toBeInTheDocument()
+  })
+
+  it('says no archive contains the path when an agent repository has a complete older index', async () => {
+    // built on the server before the move, nothing skipped since: the
+    // index is complete and the path is simply absent
+    vi.mocked(archivesAPI.getPathHistory).mockResolvedValue({
+      data: {
+        path: 'etc/hosts',
+        entries: [],
+        present: [],
+        present_in_latest: false,
+        coverage: { indexed: 12, exhausted: 0, total: 12, capability: 'agent_unsupported' },
+      },
+    } as never)
+    renderPanel('etc/hosts')
+    expect(await screen.findByText(/no earlier archive contains this path/i)).toBeInTheDocument()
+    expect(screen.queryByText(/executed by an agent/i)).not.toBeInTheDocument()
+  })
+
+  it('shows the entries an agent repository indexed before it moved, with their coverage', async () => {
+    vi.mocked(archivesAPI.getPathHistory).mockResolvedValue({
+      data: {
+        path: 'etc/hosts',
+        entries: [
+          {
+            archive_id: 2,
+            archive_name: 'nas-2026-09-02T02:00',
+            series: 'nightly',
+            start: '2026-09-02T02:00:00Z',
+            change: 'added',
+            size_before: null,
+            size_after: 374_000,
+            mode_changed: false,
+            owner_changed: false,
+          },
+        ],
+        present: [{ series: 'nightly', from_archive_id: 2, to_archive_id: null }],
+        present_in_latest: true,
+        coverage: { indexed: 3, exhausted: 0, total: 12, capability: 'agent_unsupported' },
+      },
+    } as never)
+    // the series: three indexed on the server, nine the agent's listing skipped
+    vi.mocked(archivesAPI.listStored).mockResolvedValue({
+      data: {
+        archives: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map((id) => ({
+          id,
+          name: `a${id}`,
+          series: 'nightly',
+          start: `2026-09-${String(id).padStart(2, '0')}T02:00:00Z`,
+          history_state: id <= 3 ? 'indexed' : 'skipped',
+        })),
+        series: ['nightly'],
+        sync_state: 'fresh',
+        last_synced_at: null,
+        history_available: true,
+      },
+    } as never)
+    renderPanel('etc/hosts')
+    expect(await screen.findByText('nas-2026-09-02T02:00')).toBeInTheDocument()
+    expect(await screen.findByText(/3 of 12 archives indexed/i)).toBeInTheDocument()
+    expect(screen.queryByText(/executed by an agent/i)).not.toBeInTheDocument()
+    // the one older archive is indexed, so the statement about it stands
+    expect(screen.getByText(/not present in 1 older archive/i)).toBeInTheDocument()
+  })
+
+  it('keeps the repository-wide coverage when the path spans several series', async () => {
+    vi.mocked(archivesAPI.getPathHistory).mockResolvedValue({
+      data: {
+        path: 'etc/hosts',
+        entries: [
+          {
+            archive_id: 2,
+            archive_name: 'nightly-2026-09-02',
+            series: 'nightly',
+            start: '2026-09-02T02:00:00Z',
+            change: 'added',
+            size_before: null,
+            size_after: 374_000,
+            mode_changed: false,
+            owner_changed: false,
+          },
+          {
+            archive_id: 5,
+            archive_name: 'weekly-2026-09-06',
+            series: 'weekly',
+            start: '2026-09-06T02:00:00Z',
+            change: 'added',
+            size_before: null,
+            size_after: 374_000,
+            mode_changed: false,
+            owner_changed: false,
+          },
+        ],
+        present: [
+          { series: 'nightly', from_archive_id: 2, to_archive_id: null },
+          { series: 'weekly', from_archive_id: 5, to_archive_id: null },
+        ],
+        present_in_latest: true,
+        coverage: { indexed: 4, exhausted: 0, total: 10, capability: 'available' },
+      },
+    } as never)
+    renderPanel('etc/hosts')
+    expect(await screen.findByText(/4 of 10 archives indexed/i)).toBeInTheDocument()
+    expect(archivesAPI.listStored).not.toHaveBeenCalled()
+  })
+
+  it('says the repository could not be indexed when the executor gave up on every archive', async () => {
+    vi.mocked(archivesAPI.getPathHistory).mockResolvedValue({
+      data: {
+        path: 'etc/hosts',
+        entries: [],
+        present: [],
+        present_in_latest: false,
+        coverage: { indexed: 0, exhausted: 5, total: 5, capability: 'available' },
+      },
+    } as never)
+    renderPanel('etc/hosts')
+    expect(await screen.findByText(/could not be indexed/i)).toBeInTheDocument()
+    expect(screen.queryByText(/has not been indexed yet/i)).not.toBeInTheDocument()
+  })
+
+  it('says the repository is not indexed yet when nothing is indexed', async () => {
+    vi.mocked(archivesAPI.getPathHistory).mockResolvedValue({
+      data: {
+        path: 'etc/hosts',
+        entries: [],
+        present: [],
+        present_in_latest: false,
+        coverage: { indexed: 0, exhausted: 0, total: 3, capability: 'available' },
+      },
+    } as never)
+    renderPanel('etc/hosts')
+    expect(await screen.findByText(/has not been indexed yet/i)).toBeInTheDocument()
+    expect(screen.queryByText(/no earlier archive contains this path/i)).not.toBeInTheDocument()
+  })
+
+  it('qualifies an empty history by its partial coverage', async () => {
+    vi.mocked(archivesAPI.getPathHistory).mockResolvedValue({
+      data: {
+        path: 'etc/hosts',
+        entries: [],
+        present: [],
+        present_in_latest: false,
+        coverage: { indexed: 2, exhausted: 0, total: 5, capability: 'available' },
+      },
+    } as never)
+    renderPanel('etc/hosts')
+    expect(
+      await screen.findByText(/none of the indexed archives contains this path/i)
+    ).toBeInTheDocument()
+    expect(screen.getByText(/2 of 5 archives indexed/i)).toBeInTheDocument()
+    expect(screen.queryByText(/no earlier archive contains this path/i)).not.toBeInTheDocument()
+  })
+
+  it('counts older archives without the path only when those archives are indexed', async () => {
+    const history = {
+      path: 'home/karan/docs/invoices.xlsx',
+      entries: [
+        {
+          archive_id: 12,
+          archive_name: 'nas-2026-09-02T02:00',
+          series: 'nightly',
+          start: '2026-09-02T02:00:00Z',
+          change: 'added',
+          size_before: null,
+          size_after: 374_000,
+          mode_changed: false,
+          owner_changed: false,
+        },
+      ],
+      present: [{ series: 'nightly', from_archive_id: 12, to_archive_id: null }],
+      present_in_latest: true,
+      coverage: { indexed: 4, exhausted: 0, total: 5, capability: 'available' },
+    }
+    const listing = (pendingId: number) => ({
+      data: {
+        archives: [9, 10, 11, 12, 13].map((id) => ({
+          id,
+          name: `a${id}`,
+          series: 'nightly',
+          start: `2026-08-${10 + id}T02:00:00Z`,
+          history_state: id === pendingId ? 'pending' : 'indexed',
+        })),
+        series: ['nightly'],
+        sync_state: 'fresh',
+        last_synced_at: null,
+        history_available: true,
+      },
+    })
+
+    // the newest archive (a backup that just landed) is pending: the older
+    // ones are all indexed, so the statement about them stands
+    vi.mocked(archivesAPI.getPathHistory).mockResolvedValue({ data: history } as never)
+    vi.mocked(archivesAPI.listStored).mockResolvedValue(listing(13) as never)
+    const first = renderWithProviders(
+      <FileHistoryPanel
+        repositoryId={7}
+        path="home/karan/docs/invoices.xlsx"
+        onRestoreEntry={vi.fn()}
+      />
+    )
+    expect(await screen.findByText(/not present in 3 older archives/i)).toBeInTheDocument()
+    first.unmount()
+
+    // an older archive is pending: nothing can be said about the older ones
+    vi.mocked(archivesAPI.listStored).mockResolvedValue(listing(10) as never)
+    renderWithProviders(
+      <FileHistoryPanel
+        repositoryId={7}
+        path="home/karan/docs/invoices.xlsx"
+        onRestoreEntry={vi.fn()}
+      />
+    )
+    expect(await screen.findByText('nas-2026-09-02T02:00')).toBeInTheDocument()
+    expect(screen.queryByText(/not present in/i)).not.toBeInTheDocument()
+  })
+
+  it('keeps entries a series reset left behind instead of calling the repository unindexed', async () => {
+    vi.mocked(archivesAPI.getPathHistory).mockResolvedValue({
+      data: {
+        path: 'etc/hosts',
+        entries: [
+          {
+            archive_id: 12,
+            archive_name: 'nas-2026-09-02T02:00',
+            series: 'nightly',
+            start: '2026-09-02T02:00:00Z',
+            change: 'added',
+            size_before: null,
+            size_after: 374_000,
+            mode_changed: false,
+            owner_changed: false,
+          },
+        ],
+        present: [{ series: 'nightly', from_archive_id: 12, to_archive_id: null }],
+        present_in_latest: true,
+        coverage: { indexed: 0, exhausted: 0, total: 4, capability: 'available' },
+      },
+    } as never)
+    renderPanel('etc/hosts')
+    expect(await screen.findByText('nas-2026-09-02T02:00')).toBeInTheDocument()
+    expect(screen.queryByText(/has not been indexed yet/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/0 of 4 archives indexed/i)).toBeInTheDocument()
   })
 
   it('renders disabled when the plan lacks the feature', () => {

--- a/frontend/src/components/background-work/PipelineBoard.tsx
+++ b/frontend/src/components/background-work/PipelineBoard.tsx
@@ -109,6 +109,7 @@ export default function PipelineBoard({ canManage }: PipelineBoardProps) {
   const { can } = usePlan()
   const [trackRepository, setTrackRepository] = useState<{ id: number; name: string } | null>(null)
   const [rebuildFailed, setRebuildFailed] = useState(false)
+  const [resyncDeferred, setResyncDeferred] = useState(false)
   const [reconcileResult, setReconcileResult] = useState<number | null>(null)
   const [toolbar, setToolbarState] = useState<HubToolbarState>(DEFAULT_TOOLBAR)
   const [windowSize, setWindowSize] = useState(WINDOW_SIZE)
@@ -216,7 +217,28 @@ export default function PipelineBoard({ canManage }: PipelineBoardProps) {
   const rebuildMutation = useMutation({
     mutationFn: ({ repositoryId, stage }: { repositoryId: number; stage: RebuildStage }) =>
       archivesAPI.rebuild(repositoryId, stage),
-    onMutate: () => setRebuildFailed(false),
+    onMutate: () => {
+      setRebuildFailed(false)
+      setResyncDeferred(false)
+    },
+    onError: () => setRebuildFailed(true),
+    onSettled: invalidateBoard,
+  })
+
+  // The listing chain (archive_sync, history_merge, stats) without
+  // invalidating anything: what a retry of the history segment needs on a
+  // repository that has no history stage, where its segment is the merge
+  // alone and a rebuild from the history stage is refused.
+  // The resync yields to index work already queued or running for the
+  // repository (it answers with no operations then); said so rather than
+  // left as a retry that visibly did nothing.
+  const resyncMutation = useMutation({
+    mutationFn: (repositoryId: number) => archivesAPI.resync(repositoryId),
+    onMutate: () => {
+      setRebuildFailed(false)
+      setResyncDeferred(false)
+    },
+    onSuccess: (res) => setResyncDeferred(res.data.operations.length === 0),
     onError: () => setRebuildFailed(true),
     onSettled: invalidateBoard,
   })
@@ -233,13 +255,32 @@ export default function PipelineBoard({ canManage }: PipelineBoardProps) {
     onSettled: invalidateBoard,
   })
 
+  const hubRepositories = hub.data?.repositories
+  const trackHubRepository =
+    trackRepository == null
+      ? undefined
+      : hubRepositories?.find((repo) => repo.repository_id === trackRepository.id)
   const handleRetry = useCallback(
     (repositoryId: number | null, stage: StageState) => {
       const rebuildStage = REBUILD_STAGE_FOR[stage.key]
       if (!rebuildStage || repositoryId == null) return
+      // A repository without the history stage (the plan lacks it, or an
+      // agent executes it) has its history segment from `history_merge`
+      // alone, and a rebuild from the history stage is refused for it. The
+      // retry re-runs the listing chain instead, which includes the merge
+      // and invalidates nothing.
+      // A row without the field (an older hub payload) takes the plan-wide
+      // answer: with the feature absent the stage is locked for everyone.
+      const capability =
+        hubRepositories?.find((repo) => repo.repository_id === repositoryId)?.history_capability ??
+        (hub.data?.history_available ? 'available' : 'plan_locked')
+      if (rebuildStage === 'history' && capability !== 'available') {
+        resyncMutation.mutate(repositoryId)
+        return
+      }
       rebuildMutation.mutate({ repositoryId, stage: rebuildStage })
     },
-    [rebuildMutation]
+    [rebuildMutation, resyncMutation, hubRepositories, hub.data?.history_available]
   )
 
   if (queue.isError) {
@@ -258,6 +299,11 @@ export default function PipelineBoard({ canManage }: PipelineBoardProps) {
       {rebuildFailed && (
         <Alert severity="error" onClose={() => setRebuildFailed(false)}>
           {t('operations.background.rebuildFailed')}
+        </Alert>
+      )}
+      {resyncDeferred && (
+        <Alert severity="info" onClose={() => setResyncDeferred(false)}>
+          {t('operations.background.retryDeferred')}
         </Alert>
       )}
       {limitsMutation.isError && (
@@ -418,6 +464,9 @@ export default function PipelineBoard({ canManage }: PipelineBoardProps) {
           onClose={() => setTrackRepository(null)}
           repositoryId={trackRepository.id}
           repositoryName={trackRepository.name}
+          historyCapability={trackHubRepository?.history_capability}
+          indexMode={trackHubRepository?.index_mode}
+          history={trackHubRepository?.history}
           operations={
             queue.data.repositories.find((repo) => repo.repository_id === trackRepository.id)
               ?.operations ?? []

--- a/frontend/src/components/background-work/RebuildStagePicker.stories.tsx
+++ b/frontend/src/components/background-work/RebuildStagePicker.stories.tsx
@@ -4,9 +4,24 @@ import { Box } from '@mui/material'
 import RebuildStagePicker from './RebuildStagePicker'
 import type { RebuildStage } from '../../types/operations'
 
-function Picker({ historyLocked, initial }: { historyLocked: boolean; initial: RebuildStage }) {
+function Picker({
+  historyLocked,
+  initial,
+  reason,
+}: {
+  historyLocked: boolean
+  initial: RebuildStage
+  reason?: 'plan' | 'agent'
+}) {
   const [value, setValue] = useState<RebuildStage>(initial)
-  return <RebuildStagePicker value={value} onChange={setValue} historyLocked={historyLocked} />
+  return (
+    <RebuildStagePicker
+      value={value}
+      onChange={setValue}
+      historyLocked={historyLocked}
+      historyLockedReason={reason}
+    />
+  )
 }
 
 const meta = {
@@ -35,4 +50,10 @@ export const FromArchives: Story = {
 
 export const Community: Story = {
   render: () => <Picker historyLocked initial="archives" />,
+}
+
+// Locked by the repository, not the plan: an agent's repository cannot be
+// diffed, so the history stage is out regardless of the plan.
+export const HistoryUnsupportedForAgent: Story = {
+  render: () => <Picker historyLocked initial="archives" reason="agent" />,
 }

--- a/frontend/src/components/background-work/RebuildStagePicker.tsx
+++ b/frontend/src/components/background-work/RebuildStagePicker.tsx
@@ -11,6 +11,9 @@ interface RebuildStagePickerProps {
   value: RebuildStage
   onChange: (stage: RebuildStage) => void
   historyLocked: boolean
+  // Why the history stage is locked: the plan (a Pro chip) or the
+  // repository's executor (an agent's repository cannot be diffed).
+  historyLockedReason?: 'plan' | 'agent'
 }
 
 // The three derived-data stages as cards. Picking one marks it and every
@@ -20,6 +23,7 @@ export default function RebuildStagePicker({
   value,
   onChange,
   historyLocked,
+  historyLockedReason = 'plan',
 }: RebuildStagePickerProps) {
   const { t } = useTranslation()
   const theme = useTheme()
@@ -108,7 +112,14 @@ export default function RebuildStagePicker({
                 <Typography variant="subtitle2" sx={{ fontWeight: 700, flex: 1 }}>
                   {index + 1}. {t(`operations.background.stages.${key}.title`)}
                 </Typography>
-                {locked ? (
+                {locked && historyLockedReason === 'agent' ? (
+                  <Typography
+                    variant="caption"
+                    sx={{ fontWeight: 600, color: 'text.disabled', textAlign: 'right' }}
+                  >
+                    {t('operations.background.stageAgentUnsupported')}
+                  </Typography>
+                ) : locked ? (
                   <Chip
                     size="small"
                     label={PLAN_LABEL.pro}

--- a/frontend/src/components/background-work/RepositoryHubRow.stories.tsx
+++ b/frontend/src/components/background-work/RepositoryHubRow.stories.tsx
@@ -87,3 +87,15 @@ export const SystemLane: Story = {
     },
   },
 }
+
+// A repository executed by a managed agent has no history stage: the cell
+// says so instead of showing a plan chip or "no file history yet".
+export const AgentRepository: Story = {
+  args: {
+    repository: hubRepository({
+      repository_name: 'k8s-node',
+      history: { indexed: 0, pending: 0, failed: 0, skipped: 18, truncated: 0, rows: 0 },
+      history_capability: 'agent_unsupported',
+    }),
+  },
+}

--- a/frontend/src/components/background-work/RepositoryHubRow.tsx
+++ b/frontend/src/components/background-work/RepositoryHubRow.tsx
@@ -20,6 +20,7 @@ import { PLAN_COLOR, PLAN_LABEL } from '../../core/features'
 import { parseBackendDate } from '../../utils/dateUtils'
 import { HUB_GRID_COLUMNS, type RepositoryTrack, type StageState } from './repositoryTrack'
 import type { HubRepository } from '../../types/operations'
+import type { HistoryCapability } from '../../types/archives'
 
 interface RepositoryHubRowProps {
   // Null for the system lane (package installs and other work with no
@@ -110,6 +111,9 @@ function HistoryCell({
   const theme = useTheme()
   const { history, archives } = repository
   const mode = repository.index_mode ?? 'full'
+  // The repository's own reason for having no history stage (an agent
+  // executes it), next to the plan-wide `historyAvailable`.
+  const historyCapability: HistoryCapability = repository.history_capability ?? 'available'
 
   // Mode before plan (spec 6.8): an upgrade would not start indexing this
   // repository, so the Pro chip below would be a false promise.
@@ -124,6 +128,16 @@ function HistoryCell({
         )}
       />
     )
+  }
+  // An index built before the repository moved to an agent is still real
+  // data (the Changes tab serves it); only a repository with none says so.
+  // Ahead of the plan chip either way: an upgrade would not unlock the
+  // stage here, so without the plan the reason is the whole answer.
+  if (
+    historyCapability === 'agent_unsupported' &&
+    (!historyAvailable || (history.indexed === 0 && history.rows === 0))
+  ) {
+    return <Cell muted primary={t('operations.background.hub.historyAgentUnsupported')} />
   }
   if (!historyAvailable) {
     return (

--- a/frontend/src/components/background-work/RepositoryTrackDialog.stories.tsx
+++ b/frontend/src/components/background-work/RepositoryTrackDialog.stories.tsx
@@ -6,9 +6,20 @@ import { Button } from '@mui/material'
 import RepositoryTrackDialog from './RepositoryTrackDialog'
 import api from '../../services/api'
 import { hubDetail, op } from './storyFixtures'
-import type { HubRepositoryDetail } from '../../types/operations'
+import type { HubHistorySummary, HubRepositoryDetail, IndexMode } from '../../types/operations'
+import type { HistoryCapability } from '../../types/archives'
 
-function Wrapper({ detail }: { detail: HubRepositoryDetail }) {
+function Wrapper({
+  detail,
+  historyCapability,
+  history,
+  indexMode,
+}: {
+  detail: HubRepositoryDetail
+  historyCapability?: HistoryCapability
+  history?: HubHistorySummary
+  indexMode?: IndexMode
+}) {
   const [open, setOpen] = useState(true)
   const [ready, setReady] = useState(false)
   useEffect(() => {
@@ -29,6 +40,9 @@ function Wrapper({ detail }: { detail: HubRepositoryDetail }) {
         onClose={() => setOpen(false)}
         repositoryId={4}
         repositoryName="laptop"
+        historyCapability={historyCapability}
+        history={history}
+        indexMode={indexMode}
         operations={[
           op({ kind: 'stats', status: 'completed' }),
           op({ id: 2, kind: 'archive_sync', status: 'running' }),
@@ -53,5 +67,40 @@ export const WithProblems: Story = {
 export const AllIndexed: Story = {
   render: () => (
     <Wrapper detail={{ repository_id: 4, failed_archives: [], truncated_archives: [] }} />
+  ),
+}
+
+// An agent's repository: the history stage is locked by the executor, with
+// its own wording rather than a plan chip.
+export const AgentRepository: Story = {
+  render: () => (
+    <Wrapper
+      detail={{ ...hubDetail, failed_archives: [], truncated_archives: [] }}
+      historyCapability="agent_unsupported"
+    />
+  ),
+}
+
+// An index still being built: the dialog says how far it got instead of
+// claiming every archive is covered.
+export const HistoryPartial: Story = {
+  render: () => (
+    <Wrapper
+      detail={{ repository_id: 4, failed_archives: [], truncated_archives: [] }}
+      history={{ indexed: 14, pending: 24, failed: 0, skipped: 0, truncated: 0, rows: 8501 }}
+    />
+  ),
+}
+
+// A repository indexed in `archives` mode: its pending archives are the
+// choice made (spec 6.8), so the summary names the mode rather than an
+// index in progress.
+export const ArchivesOnlyMode: Story = {
+  render: () => (
+    <Wrapper
+      detail={{ repository_id: 4, failed_archives: [], truncated_archives: [] }}
+      indexMode="archives"
+      history={{ indexed: 0, pending: 18, failed: 0, skipped: 0, truncated: 0, rows: 0 }}
+    />
   ),
 }

--- a/frontend/src/components/background-work/RepositoryTrackDialog.tsx
+++ b/frontend/src/components/background-work/RepositoryTrackDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   Alert,
   Box,
@@ -22,7 +22,14 @@ import { REBUILD_STAGES } from './repositoryTrack'
 import { archivesAPI, operationsAPI } from '../../services/api'
 import { usePlan } from '../../hooks/usePlan'
 import { parseBackendDate } from '../../utils/dateUtils'
-import type { HubArchive, OperationItem, RebuildStage } from '../../types/operations'
+import type {
+  HubArchive,
+  HubHistorySummary,
+  IndexMode,
+  OperationItem,
+  RebuildStage,
+} from '../../types/operations'
+import type { HistoryCapability } from '../../types/archives'
 
 interface RepositoryTrackDialogProps {
   open: boolean
@@ -30,6 +37,14 @@ interface RepositoryTrackDialogProps {
   repositoryId: number
   repositoryName: string
   operations: OperationItem[]
+  // From the hub row; the history stage is not offered when the
+  // repository cannot have one (an agent executes it), and its summary
+  // says whether an index built before that is still there.
+  historyCapability?: HistoryCapability
+  history?: HubHistorySummary
+  // The repository's index mode (spec 6.8): a mode without the history
+  // stage is a standing choice, not an index still being built.
+  indexMode?: IndexMode
 }
 
 function SectionTitle({ children }: { children: React.ReactNode }) {
@@ -100,6 +115,9 @@ export default function RepositoryTrackDialog({
   repositoryId,
   repositoryName,
   operations,
+  historyCapability = 'available',
+  history,
+  indexMode = 'full',
 }: RepositoryTrackDialogProps) {
   const { t } = useTranslation()
   const theme = useTheme()
@@ -107,7 +125,32 @@ export default function RepositoryTrackDialog({
   const [submitting, setSubmitting] = useState(false)
   const [failed, setFailed] = useState(false)
   const { can } = usePlan()
-  const historyLocked = !can('archive_history')
+  // The agent restriction names itself even when the plan lacks the feature
+  // too: a plan upgrade would not unlock the stage for such a repository.
+  const historyLocked = !can('archive_history') || historyCapability !== 'available'
+  // An index built before the repository moved to an agent (or before the
+  // plan lapsed) is still real data (the hub row and the Changes tab show
+  // it); a repository with none is told why there is none instead of
+  // "every archive has its file history".
+  const historyUnavailable =
+    historyCapability !== 'available' &&
+    (history == null || (history.indexed === 0 && history.rows === 0))
+  // Archives the index does not cover: still pending, skipped, or failed.
+  // While any remain, "every archive has its file history" would claim a
+  // completeness the hub row's own counts contradict.
+  const historyOutstanding =
+    history == null ? 0 : history.pending + history.skipped + history.failed
+  const historyIndexed = history?.indexed ?? 0
+  const historyPartial = !historyUnavailable && historyOutstanding > 0
+  // Mode before everything below (as in the hub row): under `archives` or
+  // `off` the pending archives are the choice made, not work still coming.
+  const historyByMode = indexMode !== 'full'
+  // A picked history stage that becomes locked while the dialog is open
+  // (the row's capability changed under it) would still be sent and
+  // refused; fall back to the stage before it.
+  useEffect(() => {
+    if (historyLocked && stage === 'history') setStage('archives')
+  }, [historyLocked, stage])
 
   const { data: detail } = useQuery({
     queryKey: ['operations-repository-detail', repositoryId],
@@ -233,8 +276,47 @@ export default function RepositoryTrackDialog({
                       />
                     )}
                     <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-                      {t('operations.background.hub.detailHint')}
+                      {historyCapability === 'agent_unsupported'
+                        ? // leftovers from a server-executed past: real, but
+                          // no rebuild can touch them on an agent's repository
+                          t('operations.background.hub.historyAgentUnsupported')
+                        : t('operations.background.hub.detailHint')}
                     </Typography>
+                  </Stack>
+                ) : historyByMode ? (
+                  <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                    {t(
+                      indexMode === 'archives'
+                        ? 'operations.background.hub.modeArchives'
+                        : 'operations.background.hub.modeOff'
+                    )}
+                  </Typography>
+                ) : historyUnavailable ? (
+                  // "every archive has its file history" would be a claim
+                  // about an index that was never built
+                  <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                    {historyCapability === 'agent_unsupported'
+                      ? t('operations.background.hub.historyAgentUnsupported')
+                      : t('operations.background.hub.historyNone')}
+                  </Typography>
+                ) : historyPartial ? (
+                  // an index still being built, or one that skipped or
+                  // failed archives whose list has not loaded: say how far
+                  // it got rather than that it is complete. On an agent's
+                  // repository the rest stays uncovered, and the same line
+                  // says why the stage below is locked.
+                  <Stack spacing={0.5}>
+                    <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                      {t('operations.background.hub.detailPartial', {
+                        indexed: historyIndexed,
+                        total: historyIndexed + historyOutstanding,
+                      })}
+                    </Typography>
+                    {historyCapability === 'agent_unsupported' && (
+                      <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                        {t('operations.background.hub.historyAgentUnsupported')}
+                      </Typography>
+                    )}
                   </Stack>
                 ) : (
                   <Typography
@@ -259,7 +341,12 @@ export default function RepositoryTrackDialog({
             <Typography variant="body2" sx={{ color: 'text.secondary', mb: 1.5 }}>
               {t('operations.background.rebuildMenuHint')}
             </Typography>
-            <RebuildStagePicker value={stage} onChange={setStage} historyLocked={historyLocked} />
+            <RebuildStagePicker
+              value={stage}
+              onChange={setStage}
+              historyLocked={historyLocked}
+              historyLockedReason={historyCapability === 'agent_unsupported' ? 'agent' : 'plan'}
+            />
             <Typography variant="body2" sx={{ color: 'text.secondary', mt: 1.5 }}>
               {summary}
             </Typography>

--- a/frontend/src/components/background-work/__tests__/PipelineBoard.test.tsx
+++ b/frontend/src/components/background-work/__tests__/PipelineBoard.test.tsx
@@ -16,6 +16,7 @@ vi.mock('../../../services/api', () => ({
   },
   archivesAPI: {
     rebuild: vi.fn(),
+    resync: vi.fn(),
   },
 }))
 
@@ -256,6 +257,20 @@ describe('PipelineBoard', () => {
     expect(await screen.findByText(/every archive has its file history/i)).toBeInTheDocument()
   })
 
+  it('says the history stage is not available for an agent repository', async () => {
+    mockQueue([])
+    mockHub([
+      hubRepository({
+        repository_name: 'k8s-node',
+        history: { indexed: 0, pending: 0, failed: 0, skipped: 18, truncated: 0, rows: 0 },
+        history_capability: 'agent_unsupported',
+      }),
+    ])
+    renderBoard()
+    expect(await screen.findByText(/not available for agent repositories/i)).toBeInTheDocument()
+    expect(screen.queryByText(/no file history yet/i)).not.toBeInTheDocument()
+  })
+
   it('changes the index worker count from the file history column header', async () => {
     mockQueue([])
     ;(operationsAPI.updateLimits as ReturnType<typeof vi.fn>).mockResolvedValue({ data: {} })
@@ -270,6 +285,69 @@ describe('PipelineBoard', () => {
     await screen.findAllByTestId('repository-row')
     expect(screen.queryByRole('button', { name: /more index workers/i })).not.toBeInTheDocument()
     expect(screen.getByText(/2 workers/i)).toBeInTheDocument()
+  })
+
+  it('retries a failed history segment of an agent repository through a resync', async () => {
+    // the segment is the merge (an agent repository has no index stage); a
+    // rebuild from the history stage would be refused, and one from the
+    // listing would wipe every archive's stored info; the resync runs the
+    // listing chain, merge included, and invalidates nothing
+    mockQueue([
+      {
+        repository_id: 1,
+        repository_name: 'nas',
+        lane_busy: false,
+        operations: [queueOp({ id: 9, repository_id: 1, kind: 'history_merge', status: 'failed' })],
+      },
+    ])
+    mockHub([hubRepository({ history_capability: 'agent_unsupported' })])
+    ;(archivesAPI.resync as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { run_id: 'r9', operations: [10, 11] },
+    })
+    renderBoard()
+    fireEvent.click(await screen.findByRole('button', { name: /retry/i }))
+    await waitFor(() => expect(archivesAPI.resync).toHaveBeenCalledWith(1))
+    expect(archivesAPI.rebuild).not.toHaveBeenCalled()
+    expect(screen.queryByText(/already queued or running/i)).not.toBeInTheDocument()
+  })
+
+  it('says so when the resync yields to index work already in flight', async () => {
+    mockQueue([
+      {
+        repository_id: 1,
+        repository_name: 'nas',
+        lane_busy: false,
+        operations: [queueOp({ id: 9, repository_id: 1, kind: 'history_merge', status: 'failed' })],
+      },
+    ])
+    mockHub([hubRepository({ history_capability: 'agent_unsupported' })])
+    ;(archivesAPI.resync as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { run_id: null, operations: [] },
+    })
+    renderBoard()
+    fireEvent.click(await screen.findByRole('button', { name: /retry/i }))
+    expect(await screen.findByText(/already queued or running/i)).toBeInTheDocument()
+  })
+
+  it('retries a failed history segment on a plan-locked repository through a resync too', async () => {
+    // Community: the segment is the merge as well, and a rebuild from the
+    // history stage is refused by the plan gate; the resync re-runs it
+    mockQueue([
+      {
+        repository_id: 1,
+        repository_name: 'nas',
+        lane_busy: false,
+        operations: [queueOp({ id: 9, repository_id: 1, kind: 'history_merge', status: 'failed' })],
+      },
+    ])
+    mockHub([hubRepository({ history_capability: 'plan_locked' })], { history_available: false })
+    ;(archivesAPI.resync as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { run_id: 'r9', operations: [10, 11] },
+    })
+    renderBoard()
+    fireEvent.click(await screen.findByRole('button', { name: /retry/i }))
+    await waitFor(() => expect(archivesAPI.resync).toHaveBeenCalledWith(1))
+    expect(archivesAPI.rebuild).not.toHaveBeenCalled()
   })
 
   it('has no rebuild form below the table, only the per-row menus', async () => {

--- a/frontend/src/components/background-work/__tests__/RepositoryHubRow.test.tsx
+++ b/frontend/src/components/background-work/__tests__/RepositoryHubRow.test.tsx
@@ -113,6 +113,32 @@ describe('RepositoryHubRow', () => {
     expect(screen.queryByText(/of 18 indexed/i)).not.toBeInTheDocument()
   })
 
+  it('names the agent reason ahead of the Pro chip, since an upgrade would not help', () => {
+    renderRow({
+      historyAvailable: false,
+      repository: {
+        ...repository(),
+        history_capability: 'agent_unsupported',
+        history: { indexed: 0, pending: 0, failed: 0, skipped: 18, truncated: 0, rows: 0 },
+      },
+    })
+    expect(screen.getByText(/not available for agent repositories/i)).toBeInTheDocument()
+    expect(screen.queryByText('Pro')).not.toBeInTheDocument()
+  })
+
+  it('names the agent reason over the Pro chip even when an older index survives', () => {
+    renderRow({
+      historyAvailable: false,
+      repository: {
+        ...repository(),
+        history_capability: 'agent_unsupported',
+        history: { indexed: 12, pending: 0, failed: 0, skipped: 6, truncated: 0, rows: 4000 },
+      },
+    })
+    expect(screen.getByText(/not available for agent repositories/i)).toBeInTheDocument()
+    expect(screen.queryByText('Pro')).not.toBeInTheDocument()
+  })
+
   it('shows only the stages that belong to the run', () => {
     renderRow({
       track: track({

--- a/frontend/src/components/background-work/__tests__/RepositoryTrackDialog.test.tsx
+++ b/frontend/src/components/background-work/__tests__/RepositoryTrackDialog.test.tsx
@@ -97,6 +97,94 @@ describe('RepositoryTrackDialog', () => {
     })
   })
 
+  it('says history is not available for an agent repository with no index and locks the stage with that reason', async () => {
+    renderDialog({
+      historyCapability: 'agent_unsupported',
+      history: { indexed: 0, pending: 0, failed: 0, skipped: 18, truncated: 0, rows: 0 },
+    })
+    // the detail section, once loaded, and the stage picker each say so
+    expect(await screen.findByText(/not available for agent repositories/i)).toBeInTheDocument()
+    expect(screen.getByText(/repositories executed by an agent/i)).toBeInTheDocument()
+    expect(screen.queryByText(/every archive has its file history/i)).not.toBeInTheDocument()
+    expect(screen.getByTestId('rebuild-stage-history')).toHaveAttribute('data-state', 'locked')
+  })
+
+  it('keeps showing an index an agent repository built before it moved', async () => {
+    renderDialog({
+      historyCapability: 'agent_unsupported',
+      history: { indexed: 12, pending: 0, failed: 0, skipped: 0, truncated: 0, rows: 4000 },
+    })
+    expect(await screen.findByText(/every archive has its file history/i)).toBeInTheDocument()
+    expect(screen.getByTestId('rebuild-stage-history')).toHaveAttribute('data-state', 'locked')
+  })
+
+  it('says how far an agent repository got and why the rest stays uncovered', async () => {
+    renderDialog({
+      historyCapability: 'agent_unsupported',
+      history: { indexed: 12, pending: 0, failed: 0, skipped: 6, truncated: 0, rows: 4000 },
+    })
+    expect(await screen.findByText(/covers 12 of 18 archives/i)).toBeInTheDocument()
+    expect(screen.getByText(/not available for agent repositories/i)).toBeInTheDocument()
+    expect(screen.queryByText(/every archive has its file history/i)).not.toBeInTheDocument()
+  })
+
+  it('describes a narrower index mode as the choice made, not as an index in progress', async () => {
+    renderDialog({
+      indexMode: 'archives',
+      history: { indexed: 0, pending: 18, failed: 0, skipped: 0, truncated: 0, rows: 0 },
+    })
+    expect(await screen.findByText(/archives only/i)).toBeInTheDocument()
+    expect(screen.queryByText(/covers 0 of 18 archives/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/every archive has its file history/i)).not.toBeInTheDocument()
+  })
+
+  it('makes no claim about an index a plan-locked repository never built', async () => {
+    mockCan.mockReturnValue(false)
+    renderDialog({
+      historyCapability: 'plan_locked',
+      history: { indexed: 0, pending: 18, failed: 0, skipped: 0, truncated: 0, rows: 0 },
+    })
+    expect(await screen.findByText(/no file history yet/i)).toBeInTheDocument()
+    expect(screen.queryByText(/every archive has its file history/i)).not.toBeInTheDocument()
+  })
+
+  it('says how far the index got while archives are still pending or skipped', async () => {
+    renderDialog({
+      historyCapability: 'available',
+      history: { indexed: 30, pending: 2, failed: 0, skipped: 6, truncated: 0, rows: 9000 },
+    })
+    expect(await screen.findByText(/covers 30 of 38 archives/i)).toBeInTheDocument()
+    expect(screen.queryByText(/every archive has its file history/i)).not.toBeInTheDocument()
+  })
+
+  it('drops a picked history stage when the repository loses the stage while open', async () => {
+    const { rerender } = renderDialog({ historyCapability: 'available' })
+    fireEvent.click(await screen.findByTestId('rebuild-stage-history'))
+    expect(screen.getByTestId('rebuild-stage-history')).toHaveAttribute('aria-checked', 'true')
+
+    rerender(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <MemoryRouter>
+          <RepositoryTrackDialog
+            open
+            onClose={vi.fn()}
+            repositoryId={3}
+            repositoryName="nas"
+            operations={[op({})]}
+            historyCapability="agent_unsupported"
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId('rebuild-stage-archives')).toHaveAttribute('aria-checked', 'true')
+    )
+    fireEvent.click(screen.getByRole('button', { name: /^rebuild$/i }))
+    await waitFor(() => expect(archivesAPI.rebuild).toHaveBeenCalledWith(3, 'archives'))
+  })
+
   it('renders one row per operation with its stage timing', () => {
     renderDialog({ operations: [op({ kind: 'stats' }), op({ id: 2, kind: 'archive_sync' })] })
     expect(screen.getByText('nas')).toBeInTheDocument()

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1096,7 +1096,8 @@
       "showMore": "Mehr anzeigen",
       "filterLabel": "Änderungstyp",
       "delta": "{{sign}}{{size}}",
-      "summaryFolder": "Ordner"
+      "summaryFolder": "Ordner",
+      "agentUnsupported": "Für Repositories, die ein Agent ausführt, ist keine Änderungshistorie verfügbar."
     },
     "files": {
       "size": "Größe",
@@ -1110,7 +1111,8 @@
       "unchanged": "Unverändert",
       "changed": "Geändert",
       "restoreThis": "Dies wiederherstellen",
-      "notPresent": "Nicht vorhanden in {{count}} älteren Archiven",
+      "notPresent_one": "Nicht vorhanden in {{count}} älteren Archiv",
+      "notPresent_other": "Nicht vorhanden in {{count}} älteren Archiven",
       "selected": "{{count}} ausgewählt ({{size}})",
       "restoreSelection": "Auswahl wiederherstellen",
       "selectionBar": "Auswahl",
@@ -1125,7 +1127,13 @@
       "historyEmpty": "Kein früheres Archiv enthält diesen Pfad.",
       "type": "Typ",
       "typeFile": "Datei",
-      "typeDirectory": "Ordner"
+      "typeDirectory": "Ordner",
+      "historyUnavailableAgent": "Für Repositories, die ein Agent ausführt, ist keine Änderungshistorie verfügbar.",
+      "historyNotIndexed": "Dieses Repository wurde noch nicht indiziert.",
+      "historyCoverage_one": "{{indexed}} von {{count}} Archiv indiziert",
+      "historyCoverage_other": "{{indexed}} von {{count}} Archiven indiziert",
+      "historyEmptyIndexed": "Keines der indizierten Archive enthält diesen Pfad.",
+      "historyFailed": "Dieses Repository konnte nicht indiziert werden."
     },
     "toolbarOperations": "Vorgänge",
     "hourly": {
@@ -3556,6 +3564,7 @@
       "pauseFailed": "Der Zustand der Hintergrundwarteschlange konnte nicht geändert werden.",
       "openTrack": "Ablaufverfolgung für {{repository}} öffnen",
       "rebuildFailed": "Der Neuaufbau konnte nicht gestartet werden.",
+      "retryDeferred": "Für dieses Repository ist bereits Index-Arbeit eingereiht oder aktiv, daher wurde nichts weiter eingereiht.",
       "queueFailed": "Die Hintergrundwarteschlange konnte nicht geladen werden.",
       "pauseAdminOnly": "Nur Administratoren können Hintergrundarbeiten pausieren.",
       "reason": {
@@ -3671,9 +3680,11 @@
         "detailTruncatedTitle": "Archive mit gekürztem Dateiverlauf",
         "detailAttempts_one": "{{count}} Versuch",
         "detailAttempts_other": "{{count}} Versuche",
+        "detailPartial": "Der Dateiverlauf deckt {{indexed}} von {{total}} Archiven ab.",
         "detailAllIndexed": "Jedes Archiv hat seinen Dateiverlauf.",
         "detailHint": "Baue ab Dateiverlauf neu auf, um diese Archive erneut zu indizieren.",
-        "viewIndexRuns": "Indexläufe anzeigen"
+        "viewIndexRuns": "Indexläufe anzeigen",
+        "historyAgentUnsupported": "Für Agent-Repositories nicht verfügbar"
       },
       "rebuildMenuHint": "Jede Stufe nach der gewählten wird ebenfalls neu aufgebaut. Frühere Stufen bleiben erhalten. Statistiken laufen immer zuletzt, weil sie zusammenzählen, was die anderen Stufen erzeugt haben.",
       "rebuildTitle": "Abgeleitete Daten neu aufbauen",
@@ -3681,7 +3692,8 @@
       "stageWillRebuild": "Wird neu aufgebaut",
       "stageKept": "Bleibt erhalten",
       "stageStart": "Hier beginnen",
-      "currentRun": "Aktueller Lauf"
+      "currentRun": "Aktueller Lauf",
+      "stageAgentUnsupported": "Für Repositories, die ein Agent ausführt, nicht verfügbar"
     },
     "status": {
       "queued": "In Warteschlange",
@@ -5913,7 +5925,8 @@
         "failedListArchives": "Archive konnten nicht aufgelistet werden",
         "repositoryNotFound": "Repository nicht gefunden",
         "fileNotFoundAfterExtraction": "Datei nach der Extraktion nicht gefunden",
-        "failedExtractFile": "Fehler beim Extrahieren der Datei: {{error}}"
+        "failedExtractFile": "Fehler beim Extrahieren der Datei: {{error}}",
+        "historyUnavailableForAgent": "Für Repositories, die ein Agent ausführt, ist keine Änderungshistorie verfügbar; es gibt nichts neu aufzubauen."
       },
       "borg": {
         "repositoryDoesNotExist": "Das Repository existiert nicht im angegebenen Pfad",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1096,7 +1096,8 @@
       "showMore": "Show more",
       "filterLabel": "Change type",
       "delta": "{{sign}}{{size}}",
-      "summaryFolder": "Folder"
+      "summaryFolder": "Folder",
+      "agentUnsupported": "Change history is not available for repositories executed by an agent."
     },
     "files": {
       "size": "Size",
@@ -1110,7 +1111,8 @@
       "unchanged": "Unchanged",
       "changed": "Changed",
       "restoreThis": "Restore this",
-      "notPresent": "Not present in {{count}} older archives",
+      "notPresent_one": "Not present in {{count}} older archive",
+      "notPresent_other": "Not present in {{count}} older archives",
       "selected": "{{count}} selected ({{size}})",
       "restoreSelection": "Restore selection",
       "selectionBar": "Selection",
@@ -1125,7 +1127,13 @@
       "historyEmpty": "No earlier archive contains this path.",
       "type": "Type",
       "typeFile": "File",
-      "typeDirectory": "Folder"
+      "typeDirectory": "Folder",
+      "historyUnavailableAgent": "Change history is not available for repositories executed by an agent.",
+      "historyNotIndexed": "This repository has not been indexed yet.",
+      "historyCoverage_one": "{{indexed}} of {{count}} archive indexed",
+      "historyCoverage_other": "{{indexed}} of {{count}} archives indexed",
+      "historyEmptyIndexed": "None of the indexed archives contains this path.",
+      "historyFailed": "This repository could not be indexed."
     },
     "toolbarOperations": "Operations",
     "hourly": {
@@ -3556,6 +3564,7 @@
       "pauseFailed": "Could not change the background queue state.",
       "openTrack": "Open the run track for {{repository}}",
       "rebuildFailed": "The rebuild could not be started.",
+      "retryDeferred": "Index work for this repository is already queued or running, so nothing more was queued.",
       "queueFailed": "The background queue could not be loaded.",
       "pauseAdminOnly": "Only administrators can pause background work.",
       "reason": {
@@ -3671,9 +3680,11 @@
         "detailTruncatedTitle": "Archives with truncated file history",
         "detailAttempts_one": "{{count}} attempt",
         "detailAttempts_other": "{{count}} attempts",
+        "detailPartial": "File history covers {{indexed}} of {{total}} archives.",
         "detailAllIndexed": "Every archive has its file history.",
         "detailHint": "Rebuild from File history to index these archives again.",
-        "viewIndexRuns": "View index runs"
+        "viewIndexRuns": "View index runs",
+        "historyAgentUnsupported": "Not available for agent repositories"
       },
       "rebuildMenuHint": "Every stage after the one you pick is rebuilt too. Earlier stages are kept. Stats always run last, because they total up what the other stages produced.",
       "rebuildTitle": "Rebuild derived data",
@@ -3681,7 +3692,8 @@
       "stageWillRebuild": "Will rebuild",
       "stageKept": "Kept",
       "stageStart": "Start here",
-      "currentRun": "Current run"
+      "currentRun": "Current run",
+      "stageAgentUnsupported": "Not available for repositories executed by an agent"
     },
     "status": {
       "queued": "Queued",
@@ -5913,7 +5925,8 @@
         "failedListArchives": "Failed to list archives",
         "repositoryNotFound": "Repository not found",
         "fileNotFoundAfterExtraction": "File not found after extraction",
-        "failedExtractFile": "Failed to extract file: {{error}}"
+        "failedExtractFile": "Failed to extract file: {{error}}",
+        "historyUnavailableForAgent": "Change history is not available for repositories executed by an agent, so there is nothing to rebuild."
       },
       "borg": {
         "repositoryDoesNotExist": "Repository does not exist at the specified path",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -1096,7 +1096,8 @@
       "showMore": "Mostrar más",
       "filterLabel": "Tipo de cambio",
       "delta": "{{sign}}{{size}}",
-      "summaryFolder": "Carpeta"
+      "summaryFolder": "Carpeta",
+      "agentUnsupported": "El historial de cambios no está disponible para repositorios ejecutados por un agente."
     },
     "files": {
       "size": "Tamaño",
@@ -1110,7 +1111,8 @@
       "unchanged": "Sin cambios",
       "changed": "Cambiado",
       "restoreThis": "Restaurar esto",
-      "notPresent": "No presente en {{count}} archivos anteriores",
+      "notPresent_one": "No presente en {{count}} archivo anterior",
+      "notPresent_other": "No presente en {{count}} archivos anteriores",
       "selected": "{{count}} seleccionados ({{size}})",
       "restoreSelection": "Restaurar selección",
       "selectionBar": "Selección",
@@ -1125,7 +1127,13 @@
       "historyEmpty": "Ningún archivo anterior contiene esta ruta.",
       "type": "Tipo",
       "typeFile": "Fichero",
-      "typeDirectory": "Carpeta"
+      "typeDirectory": "Carpeta",
+      "historyUnavailableAgent": "El historial de cambios no está disponible para repositorios ejecutados por un agente.",
+      "historyNotIndexed": "Este repositorio aún no se ha indexado.",
+      "historyCoverage_one": "{{indexed}} de {{count}} archivo indexado",
+      "historyCoverage_other": "{{indexed}} de {{count}} archivos indexados",
+      "historyEmptyIndexed": "Ninguno de los archivos indexados contiene esta ruta.",
+      "historyFailed": "Este repositorio no se pudo indexar."
     },
     "toolbarOperations": "Operaciones",
     "hourly": {
@@ -3556,6 +3564,7 @@
       "pauseFailed": "No se pudo cambiar el estado de la cola en segundo plano.",
       "openTrack": "Abrir el seguimiento de ejecución de {{repository}}",
       "rebuildFailed": "No se pudo iniciar la reconstrucción.",
+      "retryDeferred": "Ya hay trabajo de índice en cola o en curso para este repositorio, por lo que no se puso nada más en cola.",
       "queueFailed": "No se pudo cargar la cola en segundo plano.",
       "pauseAdminOnly": "Solo los administradores pueden pausar el trabajo en segundo plano.",
       "reason": {
@@ -3671,9 +3680,11 @@
         "detailTruncatedTitle": "Archivos con historial de ficheros truncado",
         "detailAttempts_one": "{{count}} intento",
         "detailAttempts_other": "{{count}} intentos",
+        "detailPartial": "El historial de ficheros cubre {{indexed}} de {{total}} archivos.",
         "detailAllIndexed": "Todos los archivos tienen su historial de ficheros.",
         "detailHint": "Reconstruye desde Historial de ficheros para indexar estos archivos de nuevo.",
-        "viewIndexRuns": "Ver ejecuciones de índice"
+        "viewIndexRuns": "Ver ejecuciones de índice",
+        "historyAgentUnsupported": "No disponible para repositorios de agente"
       },
       "rebuildMenuHint": "Cada etapa posterior a la elegida también se reconstruye. Las anteriores se conservan. Las estadísticas siempre van al final, porque suman lo que produjeron las demás etapas.",
       "rebuildTitle": "Reconstruir datos derivados",
@@ -3681,7 +3692,8 @@
       "stageWillRebuild": "Se reconstruirá",
       "stageKept": "Se conserva",
       "stageStart": "Empezar aquí",
-      "currentRun": "Ejecución actual"
+      "currentRun": "Ejecución actual",
+      "stageAgentUnsupported": "No disponible para repositorios ejecutados por un agente"
     },
     "status": {
       "queued": "En cola",
@@ -5913,7 +5925,8 @@
         "failedListArchives": "Error al listar los archivos",
         "repositoryNotFound": "Repositorio no encontrado",
         "fileNotFoundAfterExtraction": "Archivo no encontrado después de la extracción",
-        "failedExtractFile": "Error al extraer el archivo: {{error}}"
+        "failedExtractFile": "Error al extraer el archivo: {{error}}",
+        "historyUnavailableForAgent": "El historial de cambios no está disponible para repositorios ejecutados por un agente, así que no hay nada que reconstruir."
       },
       "borg": {
         "repositoryDoesNotExist": "El repositorio no existe en la ruta especificada",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -1096,7 +1096,8 @@
       "showMore": "Mostra altro",
       "filterLabel": "Tipo di modifica",
       "delta": "{{sign}}{{size}}",
-      "summaryFolder": "Cartella"
+      "summaryFolder": "Cartella",
+      "agentUnsupported": "La cronologia delle modifiche non è disponibile per i repository eseguiti da un agente."
     },
     "files": {
       "size": "Dimensione",
@@ -1110,7 +1111,8 @@
       "unchanged": "Invariato",
       "changed": "Modificato",
       "restoreThis": "Ripristina questo",
-      "notPresent": "Non presente in {{count}} archivi precedenti",
+      "notPresent_one": "Non presente in {{count}} archivio precedente",
+      "notPresent_other": "Non presente in {{count}} archivi precedenti",
       "selected": "{{count}} selezionati ({{size}})",
       "restoreSelection": "Ripristina selezione",
       "selectionBar": "Selezione",
@@ -1125,7 +1127,13 @@
       "historyEmpty": "Nessun archivio precedente contiene questo percorso.",
       "type": "Tipo",
       "typeFile": "File",
-      "typeDirectory": "Cartella"
+      "typeDirectory": "Cartella",
+      "historyUnavailableAgent": "La cronologia delle modifiche non è disponibile per i repository eseguiti da un agente.",
+      "historyNotIndexed": "Questo repository non è ancora stato indicizzato.",
+      "historyCoverage_one": "{{indexed}} di {{count}} archivio indicizzato",
+      "historyCoverage_other": "{{indexed}} di {{count}} archivi indicizzati",
+      "historyEmptyIndexed": "Nessuno degli archivi indicizzati contiene questo percorso.",
+      "historyFailed": "Impossibile indicizzare questo repository."
     },
     "toolbarOperations": "Operazioni",
     "hourly": {
@@ -3556,6 +3564,7 @@
       "pauseFailed": "Impossibile modificare lo stato della coda in background.",
       "openTrack": "Apri la traccia di esecuzione di {{repository}}",
       "rebuildFailed": "Non è stato possibile avviare la ricostruzione.",
+      "retryDeferred": "Per questo repository c'è già lavoro di indice in coda o in corso, quindi non è stato accodato altro.",
       "queueFailed": "Impossibile caricare la coda in background.",
       "pauseAdminOnly": "Solo gli amministratori possono mettere in pausa il lavoro in background.",
       "reason": {
@@ -3671,9 +3680,11 @@
         "detailTruncatedTitle": "Archivi con cronologia dei file troncata",
         "detailAttempts_one": "{{count}} tentativo",
         "detailAttempts_other": "{{count}} tentativi",
+        "detailPartial": "La cronologia dei file copre {{indexed}} di {{total}} archivi.",
         "detailAllIndexed": "Ogni archivio ha la sua cronologia dei file.",
         "detailHint": "Ricostruisci da Cronologia dei file per indicizzare di nuovo questi archivi.",
-        "viewIndexRuns": "Vedi esecuzioni di indicizzazione"
+        "viewIndexRuns": "Vedi esecuzioni di indicizzazione",
+        "historyAgentUnsupported": "Non disponibile per i repository agente"
       },
       "rebuildMenuHint": "Ogni fase successiva a quella scelta viene ricostruita a sua volta. Le fasi precedenti restano. Le statistiche vengono sempre per ultime, perché sommano ciò che le altre fasi hanno prodotto.",
       "rebuildTitle": "Ricostruisci i dati derivati",
@@ -3681,7 +3692,8 @@
       "stageWillRebuild": "Verrà ricostruito",
       "stageKept": "Conservato",
       "stageStart": "Inizia qui",
-      "currentRun": "Esecuzione corrente"
+      "currentRun": "Esecuzione corrente",
+      "stageAgentUnsupported": "Non disponibile per i repository eseguiti da un agente"
     },
     "status": {
       "queued": "In coda",
@@ -5913,7 +5925,8 @@
         "failedListArchives": "Impossibile elencare gli archivi",
         "repositoryNotFound": "Repository non trovato",
         "fileNotFoundAfterExtraction": "File non trovato dopo l'estrazione",
-        "failedExtractFile": "Impossibile estrarre il file: {{error}}"
+        "failedExtractFile": "Impossibile estrarre il file: {{error}}",
+        "historyUnavailableForAgent": "La cronologia delle modifiche non è disponibile per i repository eseguiti da un agente, quindi non c'è nulla da ricostruire."
       },
       "borg": {
         "repositoryDoesNotExist": "Il repository non esiste nel percorso specificato",

--- a/frontend/src/types/archives.ts
+++ b/frontend/src/types/archives.ts
@@ -1,9 +1,16 @@
 // Mirrors the response shapes in app/api/archive_index.py (spec 9.2).
 
-// Mirrors what the history executor writes: an archive starts `pending`,
-// becomes `indexed`, is `skipped` when its repository cannot be diffed,
-// and turns `failed` once its attempts run out.
+// Mirrors what the index executors write: an archive starts `pending`,
+// becomes `indexed`, is `skipped` when its repository cannot be diffed (an
+// agent executes it; the archive listing marks it, since no history run
+// ever reaches such a repository), and turns `failed` once its attempts
+// run out.
 export type HistoryState = 'pending' | 'indexed' | 'skipped' | 'failed'
+// Whether the history stage exists for a repository, and if not, why:
+// the plan lacks the feature, or a managed agent executes the repository
+// and the server cannot diff it. Derived by the backend from the plan and
+// the executor, so it is the same for every archive of the repository.
+export type HistoryCapability = 'available' | 'plan_locked' | 'agent_unsupported'
 export type SyncState = 'fresh' | 'syncing' | 'stale' | 'never'
 export type ChangeType = 'added' | 'removed' | 'modified' | 'summary'
 
@@ -38,6 +45,7 @@ export interface ArchiveListResponse {
   sync_state: SyncState
   last_synced_at: string | null
   history_available: boolean
+  history_capability?: HistoryCapability
 }
 
 export interface HeatmapDay {
@@ -72,6 +80,7 @@ export interface ArchiveDetailResponse extends ArchiveRow {
   predecessor_id: number | null
   successor_id: number | null
   history_available: boolean
+  history_capability?: HistoryCapability
 }
 
 export interface ChangeRow {
@@ -101,6 +110,7 @@ export interface ChangesResponse {
   unindexed_archive_ids: number[]
   history_state?: HistoryState
   history_truncated?: boolean
+  history_capability?: HistoryCapability
 }
 
 export interface HistoryEntry {
@@ -121,11 +131,25 @@ export interface PresentRange {
   to_archive_id: number | null
 }
 
+// What a path's history is based on: with nothing indexed the entries say
+// nothing about the path; with a partial index they cover the indexed
+// archives only.
+// `total` counts every archive, `skipped` ones included: they are uncovered
+// like `pending` ones, and `capability` says whether an index run will ever
+// reach them; `exhausted` are the failures the executor gave up on.
+export interface HistoryCoverage {
+  indexed: number
+  exhausted: number
+  total: number
+  capability: HistoryCapability
+}
+
 export interface PathHistoryResponse {
   path: string
   entries: HistoryEntry[]
   present: PresentRange[]
   present_in_latest: boolean
+  coverage?: HistoryCoverage
 }
 
 export interface SearchResult {

--- a/frontend/src/types/operations.ts
+++ b/frontend/src/types/operations.ts
@@ -1,3 +1,5 @@
+import type { HistoryCapability } from './archives'
+
 // Mirrors app/services/operations/vocab.py (spec 6.3) and the response
 // shapes in app/api/operations.py and app/api/archive_index.py.
 
@@ -119,6 +121,7 @@ export interface HubRepository {
   last_history_at: string | null
   archives: number
   history: HubHistorySummary
+  history_capability?: HistoryCapability
 }
 
 export interface HubTotals {

--- a/tests/unit/test_api_archive_index.py
+++ b/tests/unit/test_api_archive_index.py
@@ -1339,3 +1339,147 @@ def test_archive_changes_has_no_btree_index_on_the_unbounded_path():
         )
     assert not path.index
     assert any({c.name for c in idx.columns} == {"archive_id"} for idx in table.indexes)
+
+
+@pytest.mark.unit
+class TestAgentRepositoryHistoryCapability:
+    """A managed agent's repository cannot be diffed by the server, so the
+    history stage does not exist for it: the responses say so, nothing
+    enqueues it, and a rebuild of it is refused (#953)."""
+
+    @staticmethod
+    def _agent_repo(test_db):
+        return _repo(
+            test_db, name="agent", executor_type="agent", execution_target="agent"
+        )
+
+    def test_list_and_detail_name_the_capability(
+        self, test_client, test_db, admin_headers
+    ):
+        _pro(test_db)
+        agent = self._agent_repo(test_db)
+        server = _repo(test_db, name="server")
+        a = _archive(test_db, agent, "a1", 1, state="skipped")
+        b = _archive(test_db, server, "b1", 1)
+
+        r = test_client.get(
+            f"/api/repositories/{agent.id}/archives", headers=admin_headers
+        )
+        assert r.status_code == 200
+        assert r.json()["history_capability"] == "agent_unsupported"
+        # `history_available` keeps meaning "the plan has the feature"
+        assert r.json()["history_available"] is True
+        r = test_client.get(
+            f"/api/repositories/{agent.id}/archives/{a.id}", headers=admin_headers
+        )
+        assert r.json()["history_capability"] == "agent_unsupported"
+        r = test_client.get(
+            f"/api/repositories/{agent.id}/archives/{a.id}/changes",
+            headers=admin_headers,
+        )
+        assert r.json()["history_capability"] == "agent_unsupported"
+
+        r = test_client.get(
+            f"/api/repositories/{server.id}/archives", headers=admin_headers
+        )
+        assert r.json()["history_capability"] == "available"
+        assert r.json()["history_available"] is True
+        r = test_client.get(
+            f"/api/repositories/{server.id}/archives/{b.id}", headers=admin_headers
+        )
+        assert r.json()["history_capability"] == "available"
+
+    def test_community_reads_as_plan_locked(self, test_client, test_db, admin_headers):
+        server = _repo(test_db, name="server")
+        r = test_client.get(
+            f"/api/repositories/{server.id}/archives", headers=admin_headers
+        )
+        assert r.json()["history_capability"] == "plan_locked"
+        assert r.json()["history_available"] is False
+        # the executor's reason outlasts the plan: an agent's repository
+        # names it on Community too
+        agent = self._agent_repo(test_db)
+        r = test_client.get(
+            f"/api/repositories/{agent.id}/archives", headers=admin_headers
+        )
+        assert r.json()["history_capability"] == "agent_unsupported"
+        assert r.json()["history_available"] is False
+
+    def test_rebuild_from_history_is_refused_for_an_agent_repository(
+        self, test_client, test_db, admin_headers
+    ):
+        _pro(test_db)
+        agent = self._agent_repo(test_db)
+        a = _archive(test_db, agent, "a1", 1, state="skipped")
+        r = test_client.post(
+            f"/api/repositories/{agent.id}/rebuild",
+            json={"from": "history"},
+            headers=admin_headers,
+        )
+        assert r.status_code == 409
+        assert (
+            r.json()["detail"]["key"]
+            == "backend.errors.archives.historyUnavailableForAgent"
+        )
+        test_db.refresh(a)
+        assert a.history_state == "skipped"  # not reset to "pending" for nothing
+        assert test_db.query(Operation).count() == 0
+
+    def test_rebuild_from_archives_skips_the_history_stage_for_an_agent_repository(
+        self, test_client, test_db, admin_headers
+    ):
+        _pro(test_db)
+        agent = self._agent_repo(test_db)
+        _archive(test_db, agent, "a1", 1, state="skipped")
+        r = test_client.post(
+            f"/api/repositories/{agent.id}/rebuild",
+            json={"from": "archives"},
+            headers=admin_headers,
+        )
+        assert r.status_code == 200
+        kinds = [test_db.get(Operation, i).kind for i in r.json()["operations"]]
+        assert kinds == ["archive_sync", "history_merge", "stats"]
+
+    def test_path_history_reports_its_coverage(
+        self, test_client, test_db, admin_headers
+    ):
+        _pro(test_db)
+        agent = self._agent_repo(test_db)
+        _archive(test_db, agent, "a1", 1, state="skipped")
+        _archive(test_db, agent, "a2", 2, state="skipped")
+        r = test_client.get(
+            f"/api/repositories/{agent.id}/history",
+            params={"path": "etc/hosts"},
+            headers=admin_headers,
+        )
+        assert r.status_code == 200
+        assert r.json()["entries"] == []
+        # `skipped` archives are uncovered like `pending` ones; the
+        # capability says why they stay so
+        assert r.json()["coverage"] == {
+            "indexed": 0,
+            "exhausted": 0,
+            "total": 2,
+            "capability": "agent_unsupported",
+        }
+
+        server = _repo(test_db, name="server")
+        _archive(test_db, server, "b1", 1)
+        _archive(test_db, server, "b2", 2, state="pending")
+        retrying = _archive(test_db, server, "b3", 3, state="failed")
+        given_up = _archive(test_db, server, "b4", 4, state="failed")
+        given_up.history_attempts = 3
+        test_db.commit()
+        r = test_client.get(
+            f"/api/repositories/{server.id}/history",
+            params={"path": "etc/hosts"},
+            headers=admin_headers,
+        )
+        # one failure still has retries, one the executor gave up on
+        assert retrying.history_attempts in (None, 0)
+        assert r.json()["coverage"] == {
+            "indexed": 1,
+            "exhausted": 1,
+            "total": 4,
+            "capability": "available",
+        }

--- a/tests/unit/test_api_operations.py
+++ b/tests/unit/test_api_operations.py
@@ -305,6 +305,38 @@ class TestOperationsRepositories:
     """GET /api/operations/repositories: the derived-data hub, one row per
     repository whether or not anything is running."""
 
+    def test_rows_name_the_history_capability(
+        self, test_client, test_db, admin_headers
+    ):
+        """The executor first, then the plan: an agent's repository is
+        agent-unsupported on every plan; a server repository is plan-locked
+        on Community and has the stage on Pro."""
+        from app.database.models import LicensingState
+
+        _repo(test_db, "server")
+        agent = _repo(test_db, "agent")
+        agent.executor_type = "agent"
+        agent.execution_target = "agent"
+        test_db.commit()
+
+        r = test_client.get("/api/operations/repositories", headers=admin_headers)
+        rows = {row["repository_name"]: row for row in r.json()["repositories"]}
+        assert rows["server"]["history_capability"] == "plan_locked"
+        assert rows["agent"]["history_capability"] == "agent_unsupported"
+        assert r.json()["history_available"] is False
+
+        # the first request created the single licensing row; flip that one
+        # (lookups always read the first row in the table)
+        state = test_db.query(LicensingState).first()
+        state.plan = "pro"
+        state.status = "active"
+        test_db.commit()
+        r = test_client.get("/api/operations/repositories", headers=admin_headers)
+        rows = {row["repository_name"]: row for row in r.json()["repositories"]}
+        assert rows["server"]["history_capability"] == "available"
+        assert rows["agent"]["history_capability"] == "agent_unsupported"
+        assert r.json()["history_available"] is True
+
     def test_rows_cover_every_repository_with_index_totals(
         self, test_client, test_db, admin_headers
     ):

--- a/tests/unit/test_api_repositories.py
+++ b/tests/unit/test_api_repositories.py
@@ -2424,6 +2424,348 @@ class TestRepositoriesUpdate:
 
         assert response.status_code == 200
 
+    def test_moving_a_repository_back_to_the_server_reopens_its_history(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """An agent's archives carry `skipped` (no history run reaches them);
+        once the server executes the repository the history stage exists
+        again, so they go back to `pending` for the next index run, a
+        `failed` one the listing had not marked yet with them."""
+        from app.database.models import Archive
+
+        repo = Repository(
+            name="Moved Back",
+            path="/repos/moved-back",
+            encryption="none",
+            repository_type="local",
+            executor_type="agent",
+            execution_target="agent",
+        )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+        for i, state in enumerate(("skipped", "failed", "indexed")):
+            test_db.add(
+                Archive(
+                    repository_id=repo.id,
+                    borg_id=f"id-{i}",
+                    name=f"a{i}",
+                    series="nas",
+                    start=datetime(2026, 9, 1 + i, 2),
+                    history_state=state,
+                    history_attempts=3,
+                )
+            )
+        test_db.commit()
+
+        from app.services.operations.executors import load_default_executors
+
+        load_default_executors()  # the queued run needs registered kinds
+        with patch("app.api.repositories.mqtt_service.sync_state_with_db"):
+            response = test_client.put(
+                f"/api/repositories/{repo.id}",
+                json={"executor_type": "server"},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200, response.text
+        test_db.expire_all()
+        rows = test_db.query(Archive).filter_by(repository_id=repo.id).all()
+        assert sorted(a.history_state for a in rows) == [
+            "indexed",
+            "pending",
+            "pending",
+        ]
+        assert all(
+            a.history_attempts == 0 for a in rows if a.history_state == "pending"
+        )
+
+    def test_moving_back_to_the_server_queues_the_history_despite_a_running_listing(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """The agent's listing may still be in flight when the repository
+        moves back, and its chain has no history stage: the reopened
+        archives would wait for the hourly reconcile. The run is queued
+        anyway (the runner serialises it on the repository)."""
+        from app.database.models import Archive, Operation
+
+        repo = Repository(
+            name="Moved Back Busy",
+            path="/repos/moved-back-busy",
+            encryption="none",
+            repository_type="local",
+            executor_type="agent",
+            execution_target="agent",
+        )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+        test_db.add(
+            Archive(
+                repository_id=repo.id,
+                borg_id="id-busy",
+                name="busy",
+                series="nas",
+                start=datetime(2026, 9, 1, 2),
+                history_state="skipped",
+            )
+        )
+        listing = Operation(
+            repository_id=repo.id,
+            kind="archive_sync",
+            category="index",
+            status="running",
+            trigger="followup",
+            run_id="run-busy",
+        )
+        test_db.add(listing)
+        test_db.commit()
+        listing_id = listing.id
+
+        from app.services.operations.executors import load_default_executors
+
+        load_default_executors()
+        with patch("app.api.repositories.mqtt_service.sync_state_with_db"):
+            response = test_client.put(
+                f"/api/repositories/{repo.id}",
+                json={"executor_type": "server"},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200, response.text
+        test_db.expire_all()
+        run = (
+            test_db.query(Operation)
+            .filter(
+                Operation.repository_id == repo.id, Operation.trigger == "reconcile"
+            )
+            .order_by(Operation.id)
+            .all()
+        )
+        assert run, "a reconcile run was queued despite the listing"
+        # its own chain, not one hung behind the listing
+        assert run[0].depends_on_id is None
+        assert listing_id not in [op.depends_on_id for op in run]
+        assert "history_index" in [op.kind for op in run]
+
+    def test_moving_back_to_the_server_reopens_but_does_not_index_a_narrower_mode(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """A mode without the history stage keeps the reopened archives
+        `pending`, the state every archive of such a repository has, and
+        queues no run for them: a later return to `full` catches up."""
+        from app.database.models import Archive, Operation
+
+        repo = Repository(
+            name="Moved Back Archives",
+            path="/repos/moved-back-archives",
+            encryption="none",
+            repository_type="local",
+            executor_type="agent",
+            execution_target="agent",
+            index_mode="archives",
+        )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+        test_db.add(
+            Archive(
+                repository_id=repo.id,
+                borg_id="id-narrow",
+                name="narrow",
+                series="nas",
+                start=datetime(2026, 9, 1, 2),
+                history_state="skipped",
+                history_attempts=3,
+            )
+        )
+        test_db.commit()
+
+        from app.services.operations.executors import load_default_executors
+
+        load_default_executors()
+        with patch("app.api.repositories.mqtt_service.sync_state_with_db"):
+            response = test_client.put(
+                f"/api/repositories/{repo.id}",
+                json={"executor_type": "server"},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200, response.text
+        test_db.expire_all()
+        archive = test_db.query(Archive).filter_by(repository_id=repo.id).one()
+        assert archive.history_state == "pending"
+        assert archive.history_attempts == 0
+        assert (
+            test_db.query(Operation).filter(Operation.repository_id == repo.id).count()
+            == 0
+        )
+
+    def test_moving_back_to_the_server_with_a_mode_change_queues_one_run(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """An update that both returns the repository to the server and
+        sets its mode to `full` has one catch-up run, not one per reason."""
+        from app.database.models import Archive, Operation
+
+        repo = Repository(
+            name="Moved Back Full",
+            path="/repos/moved-back-full",
+            encryption="none",
+            repository_type="local",
+            executor_type="agent",
+            execution_target="agent",
+            index_mode="archives",
+        )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+        test_db.add(
+            Archive(
+                repository_id=repo.id,
+                borg_id="id-full",
+                name="full",
+                series="nas",
+                start=datetime(2026, 9, 1, 2),
+                history_state="skipped",
+            )
+        )
+        test_db.commit()
+
+        from app.services.operations.executors import load_default_executors
+
+        load_default_executors()
+        with patch("app.api.repositories.mqtt_service.sync_state_with_db"):
+            response = test_client.put(
+                f"/api/repositories/{repo.id}",
+                json={"executor_type": "server", "index_mode": "full"},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200, response.text
+        test_db.expire_all()
+        listings = (
+            test_db.query(Operation)
+            .filter(
+                Operation.repository_id == repo.id, Operation.kind == "archive_sync"
+            )
+            .all()
+        )
+        assert len(listings) == 1
+        kinds = {
+            op.kind
+            for op in test_db.query(Operation).filter(
+                Operation.repository_id == repo.id
+            )
+        }
+        assert "history_index" in kinds
+        archive = test_db.query(Archive).filter_by(repository_id=repo.id).one()
+        assert archive.history_state == "pending"
+
+    def test_moving_back_to_the_server_keeps_the_reopen_when_the_queueing_fails(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """The reopen is stored with the executor change; the index run is
+        a convenience the hourly reconcile makes up for."""
+        from app.database.models import Archive
+
+        repo = Repository(
+            name="Moved Back Unqueued",
+            path="/repos/moved-back-unqueued",
+            encryption="none",
+            repository_type="local",
+            executor_type="agent",
+            execution_target="agent",
+        )
+        test_db.add(repo)
+        test_db.commit()
+        test_db.refresh(repo)
+        test_db.add(
+            Archive(
+                repository_id=repo.id,
+                borg_id="id-unqueued",
+                name="unqueued",
+                series="nas",
+                start=datetime(2026, 9, 1, 2),
+                history_state="skipped",
+            )
+        )
+        test_db.commit()
+
+        with (
+            patch("app.api.repositories.mqtt_service.sync_state_with_db"),
+            patch(
+                "app.api.repositories.enqueue_reconcile_run",
+                side_effect=RuntimeError("queue closed"),
+            ),
+        ):
+            response = test_client.put(
+                f"/api/repositories/{repo.id}",
+                json={"executor_type": "server"},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200, response.text
+        test_db.expire_all()
+        archive = test_db.query(Archive).filter_by(repository_id=repo.id).one()
+        assert archive.history_state == "pending"
+        test_db.refresh(repo)
+        assert repo.executor_type == "server"
+
+    def test_moving_a_repository_to_an_agent_leaves_its_archive_states_alone(
+        self, test_client: TestClient, admin_headers, test_db
+    ):
+        """The other direction changes nothing on the rows: an index built on
+        the server stays (the Changes tab still serves it), and `pending`
+        archives are marked `skipped` by the next listing, not here."""
+        from app.database.models import Archive
+
+        agent = AgentMachine(
+            name="Taker",
+            agent_id="agt_taker",
+            token_hash=get_password_hash("borgui_agent_secret"),
+            token_prefix="borgui_agent_secret"[:20],
+            status="online",
+            capabilities=["repository.init"],
+        )
+        repo = Repository(
+            name="Moved Out",
+            path="/repos/moved-out",
+            encryption="none",
+            repository_type="local",
+        )
+        test_db.add_all([agent, repo])
+        test_db.commit()
+        test_db.refresh(repo)
+        for i, state in enumerate(("indexed", "pending")):
+            test_db.add(
+                Archive(
+                    repository_id=repo.id,
+                    borg_id=f"id-{i}",
+                    name=f"a{i}",
+                    series="nas",
+                    start=datetime(2026, 9, 1 + i, 2),
+                    history_state=state,
+                )
+            )
+        test_db.commit()
+
+        with patch("app.api.repositories.mqtt_service.sync_state_with_db"):
+            response = test_client.put(
+                f"/api/repositories/{repo.id}",
+                json={"executor_type": "agent", "agent_machine_id": agent.id},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 200, response.text
+        test_db.expire_all()
+        assert test_db.get(Repository, repo.id).executor_type == "agent"
+        states = sorted(
+            a.history_state
+            for a in test_db.query(Archive).filter_by(repository_id=repo.id)
+        )
+        assert states == ["indexed", "pending"]
+
     def test_update_repository_clear_source_connection_id(
         self, test_client: TestClient, admin_headers, test_db
     ):

--- a/tests/unit/test_api_repositories_import_operations.py
+++ b/tests/unit/test_api_repositories_import_operations.py
@@ -25,6 +25,47 @@ def test_record_import_connect_creates_completed_row_and_followups(test_db):
 
 
 @pytest.mark.unit
+def test_record_import_connect_gives_an_agent_repository_no_history_stage(test_db):
+    """The import chain carries `history_index` on a plan with the feature,
+    but not for a repository executed by an agent (the server cannot diff
+    it); the other stages are unchanged."""
+    from app.database.models import LicensingState
+    from app.services.operations.enqueue import record_import_connect
+    import app.services.operations.executors.index  # noqa: F401
+    import app.services.operations.executors.history  # noqa: F401
+
+    test_db.add(
+        LicensingState(instance_id="t-import-agent", plan="pro", status="active")
+    )
+    server = Repository(name="s", path="/tmp/s", encryption="none", compression="lz4")
+    agent = Repository(
+        name="a",
+        path="/tmp/a",
+        encryption="none",
+        compression="lz4",
+        executor_type="agent",
+        execution_target="agent",
+    )
+    test_db.add_all([server, agent])
+    test_db.commit()
+
+    for_server = record_import_connect(test_db, server, user_id=None)
+    for_agent = record_import_connect(test_db, agent, user_id=None)
+
+    def chain(op):
+        return [
+            r.kind
+            for r in test_db.query(Operation)
+            .filter(Operation.run_id == op.run_id, Operation.id != op.id)
+            .order_by(Operation.id)
+            .all()
+        ]
+
+    assert chain(for_server) == ["stats", "archive_sync", "history_index"]
+    assert chain(for_agent) == ["stats", "archive_sync"]
+
+
+@pytest.mark.unit
 def test_import_repository_records_operation_and_skips_inline_stats(
     test_client, test_db, admin_headers, tmp_path
 ):

--- a/tests/unit/test_history_index.py
+++ b/tests/unit/test_history_index.py
@@ -361,12 +361,23 @@ async def test_cap_collapses_overflow_into_summary_rows(db, repo, monkeypatch):
 
 @pytest.mark.unit
 async def test_agent_repository_skips_all_pending(db, repo):
+    """Every archive not indexed is marked, the exhausted failures too:
+    the same rule the listing applies, so the two never disagree."""
     a1 = _archive(db, repo, "first", 1)
+    given_up = _archive(db, repo, "given-up", 2, state="failed")
+    given_up.history_attempts = history.MAX_HISTORY_ATTEMPTS
+    done = _archive(db, repo, "done", 3, state="indexed")
+    db.commit()
     with patch.object(history, "is_agent_executor", return_value=True):
         out = await history.run_history_index(_ctx(db, repo))
     assert out.status == "skipped" and out.skip_reason == "agent_diff_unsupported"
+    assert out.result == {"archives": 2}
     db.refresh(a1)
+    db.refresh(given_up)
+    db.refresh(done)
     assert a1.history_state == "skipped"
+    assert given_up.history_state == "skipped"
+    assert done.history_state == "indexed"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_history_merge.py
+++ b/tests/unit/test_history_merge.py
@@ -167,6 +167,25 @@ async def test_unindexed_removed_archive_resets_indexed_successor(db, repo):
 
 
 @pytest.mark.unit
+async def test_reset_successor_of_an_agent_repository_is_skipped_not_pending(db, repo):
+    """No history run comes for an agent's repository on any plan, so a
+    successor that loses its base takes the state the listing writes there;
+    `pending` would read as "not yet" for good."""
+    repo.executor_type = "agent"
+    repo.execution_target = "agent"
+    db.commit()
+    r = _archive(db, repo, "r", 2, state="skipped")
+    s = _archive(db, repo, "s", 3)
+    _row(db, s, "a", "added", after=1)
+    op = _ops(db, repo, [r.id])
+    out = await history.run_history_merge(_ctx(db, repo, op))
+    assert out.result["reset"] == 1
+    db.refresh(s)
+    assert s.history_state == "skipped" and s.history_rows is None
+    assert db.query(ArchiveChange).filter_by(archive_id=s.id).count() == 0
+
+
+@pytest.mark.unit
 async def test_pending_successor_or_no_successor_just_drops(db, repo):
     r1 = _archive(db, repo, "r1", 1)
     _row(db, r1, "a", "added", after=1)

--- a/tests/unit/test_operations_followups.py
+++ b/tests/unit/test_operations_followups.py
@@ -350,3 +350,105 @@ async def test_backup_followup_chain_deletes_removed_archive_and_keeps_survivor(
     assert repo.archive_count == 1
     assert repo.last_backup == datetime(2026, 9, 1)
     assert all(db.get(Operation, op.id).status == "completed" for op in ops)
+
+
+@pytest.mark.unit
+def test_history_capability_names_the_reason(db_session):
+    """The executor first, then the plan: an agent's repository reads as
+    agent-unsupported on every plan (an upgrade would not change it), a
+    Community install's server repository as plan-locked, and only a Pro
+    server-side repository has the history stage."""
+    from app.database.models import LicensingState
+    from app.services.operations.followups import (
+        history_capability,
+        history_possible,
+        history_possible_for,
+    )
+
+    server = Repository(name="server", path="/repo/server", borg_version=1)
+    agent = Repository(
+        name="agent",
+        path="/repo/agent",
+        borg_version=1,
+        executor_type="agent",
+        execution_target="agent",
+    )
+    db_session.add_all([server, agent])
+    db_session.commit()
+
+    assert history_capability(db_session, server) == "plan_locked"
+    assert history_capability(db_session, agent) == "agent_unsupported"
+    state = db_session.query(LicensingState).first()
+    state.plan = "pro"
+    state.status = "active"
+    db_session.commit()
+    assert history_capability(db_session, server) == "available"
+    assert history_capability(db_session, agent) == "agent_unsupported"
+    assert history_possible(db_session, server) is True
+    assert history_possible(db_session, agent) is False
+    # the plan gate can be handed in by a caller that already read it
+    assert history_capability(db_session, agent, history=False) == "agent_unsupported"
+    assert history_capability(db_session, server, history=False) == "plan_locked"
+    assert history_possible_for(db_session, agent.id, history=True) is False
+    assert history_possible_for(db_session, server.id, history=True) is True
+    # a missing repository keeps the plan answer
+    assert history_possible_for(db_session, 999_999, history=True) is True
+    assert history_possible_for(db_session, None, history=True) is True
+
+
+@pytest.mark.unit
+def test_enqueue_backup_followups_omits_history_index_for_an_agent_repository(db):
+    agent = Repository(
+        name="agent",
+        path="/repo/agent",
+        borg_version=1,
+        executor_type="agent",
+        execution_target="agent",
+    )
+    db.add(agent)
+    db.commit()
+    load_default_executors()
+    ops = enqueue_backup_followups(db, agent.id, history=True)
+    assert [o.kind for o in ops] == ["archive_sync", "history_merge", "stats"]
+
+
+@pytest.mark.unit
+def test_chain_for_repository_gives_an_agent_repository_no_history_stage(
+    db, monkeypatch
+):
+    """The one place every follow-up site reads its gates: with the plan
+    open and the mode `full`, a repository executed by an agent still gets
+    no `history_index`, since the server cannot diff it."""
+    from app.services.operations.followups import chain_for_repository
+
+    monkeypatch.setattr(
+        "app.services.operations.followups.history_enabled", lambda db: True
+    )
+    server = Repository(name="server", path="/repo/server", borg_version=1)
+    agent = Repository(
+        name="agent",
+        path="/repo/agent",
+        borg_version=1,
+        executor_type="agent",
+        execution_target="agent",
+    )
+    db.add_all([server, agent])
+    db.commit()
+    load_default_executors()
+
+    assert chain_for_repository(db, "backup", server.id) == [
+        "archive_sync",
+        "history_merge",
+        "history_index",
+        "stats",
+    ]
+    assert chain_for_repository(db, "backup", agent.id) == [
+        "archive_sync",
+        "history_merge",
+        "stats",
+    ]
+    # the mode still applies on top: an `archives` agent repository keeps
+    # the listing and the size only
+    agent.index_mode = "archives"
+    db.commit()
+    assert chain_for_repository(db, "backup", agent.id) == ["archive_sync", "stats"]

--- a/tests/unit/test_operations_index_executors.py
+++ b/tests/unit/test_operations_index_executors.py
@@ -196,6 +196,113 @@ async def test_run_archive_sync_updates_repository_columns(db, repo, monkeypatch
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "agent, plan_has_history, expected_state",
+    [
+        (True, True, "skipped"),  # no history run reaches it: say so
+        (
+            True,
+            False,
+            "skipped",
+        ),  # on Community too: the executor's reason outlasts the plan
+        (False, True, "pending"),  # server-side: the history run decides
+        (False, False, "pending"),  # Community: the stage is absent, nothing is touched
+    ],
+)
+async def test_run_archive_sync_marks_agent_archives_skipped(
+    db, repo, monkeypatch, agent, plan_has_history, expected_state
+):
+    """No history run reaches an agent's repository on any plan, so the
+    listing writes the state that run used to write: a new archive is
+    `skipped`, not a `pending` that reads as "not yet"; an indexed one is
+    left alone. On a server's repository `pending` stays, so the history
+    run (or a later plan change) finds it."""
+    monkeypatch.setattr(
+        index_exec,
+        "list_archives_for_repository",
+        AsyncMock(return_value=(True, [BORG1_ENTRY], "UTC")),
+    )
+    monkeypatch.setattr(index_exec, "fill_archive_info", AsyncMock(return_value=0))
+    monkeypatch.setattr(
+        index_exec, "_prepare_repository_borg_env", lambda repository, db: ({}, None)
+    )
+    monkeypatch.setattr(
+        "app.services.repository_executor.is_agent_executor", lambda repository: agent
+    )
+    monkeypatch.setattr(index_exec, "is_agent_executor", lambda repository: agent)
+    monkeypatch.setattr(
+        "app.services.operations.followups.history_enabled",
+        lambda db: plan_has_history,
+    )
+    # a Borg 1 listing needs a way to resolve archive ends; not this test's point
+    monkeypatch.setattr(
+        index_exec, "archive_end_resolvable", lambda db, repository: True
+    )
+    earlier = Archive(
+        repository_id=repo.id,
+        borg_id="earlier",
+        name="earlier",
+        series="nas",
+        start=datetime(2026, 9, 1, 2),
+        history_state="indexed",
+    )
+    given_up = Archive(
+        repository_id=repo.id,
+        borg_id="given-up",
+        name="given-up",
+        series="nas",
+        start=datetime(2026, 9, 1, 3),
+        history_state="failed",
+    )
+    leftover = Archive(
+        repository_id=repo.id,
+        borg_id="leftover",
+        name="leftover",
+        series="nas",
+        start=datetime(2026, 9, 1, 4),
+        history_state="skipped",
+        history_attempts=3,
+    )
+    other_repo = Repository(
+        name="other", path="/tmp/other", encryption="none", compression="lz4"
+    )
+    db.add_all([earlier, given_up, leftover, other_repo])
+    db.flush()
+    db.add(
+        Archive(
+            repository_id=other_repo.id,
+            borg_id="elsewhere",
+            name="elsewhere",
+            series="nas",
+            start=datetime(2026, 9, 1, 2),
+            history_state="pending",
+        )
+    )
+    db.commit()
+
+    await index_exec.run_archive_sync(_ctx(db, repo))
+
+    db.expire_all()
+    states = {a.name: a.history_state for a in db.query(Archive).all()}
+    assert states.pop("earlier") == "indexed"
+    assert states.pop("elsewhere") == "pending"  # another repository's row
+    # a failure is marked with the rest where the listing marks, kept otherwise
+    assert states.pop("given-up") == (
+        "skipped" if expected_state == "skipped" else "failed"
+    )
+    # a `skipped` row on a server's repository is left over from an
+    # agent-executed past: reopened with a fresh budget where the history
+    # stage exists, left alone everywhere else
+    reopened = not agent and plan_has_history
+    assert states.pop("leftover") == ("pending" if reopened else "skipped")
+    assert db.query(Archive).filter_by(name="leftover").one().history_attempts == (
+        0 if reopened else 3
+    )
+    assert states and all(state == expected_state for state in states.values())
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_run_archive_sync_clears_last_backup_when_no_archives_remain(
     db, repo, monkeypatch
 ):

--- a/tests/unit/test_operations_reconcile.py
+++ b/tests/unit/test_operations_reconcile.py
@@ -67,6 +67,31 @@ def test_enqueue_reconcile_runs_skips_repos_with_active_index_work(
 
 
 @pytest.mark.unit
+def test_enqueue_reconcile_run_can_be_forced_past_active_index_work(
+    db, repos, monkeypatch
+):
+    """A caller whose run the in-flight work cannot replace (the mode
+    catch-up, the reopen after an executor change) queues anyway; the
+    runner's admission serialises the two on the repository."""
+    monkeypatch.setattr(
+        reconcile, "registered_kinds", lambda: {"stats", "archive_sync"}
+    )
+    a, _ = repos
+    syncing = enqueue(db, "archive_sync", repository_id=a.id)
+    syncing.status = "running"
+    enqueue(db, "stats", repository_id=a.id, depends_on_id=syncing.id)
+    db.commit()
+
+    assert reconcile.enqueue_reconcile_run(db, a.id) == []
+
+    rows = reconcile.enqueue_reconcile_run(db, a.id, force=True)
+    assert [r.kind for r in rows] == ["archive_sync", "stats"]
+    assert rows[0].depends_on_id is None
+    assert rows[1].depends_on_id == rows[0].id
+    assert all(r.trigger == "reconcile" and r.status == "queued" for r in rows)
+
+
+@pytest.mark.unit
 def test_enqueue_reconcile_runs_despite_a_running_history_index(db, repos, monkeypatch):
     """A history index can run for hours. It must not block the hourly
     archive sync, or the repository reads as stale while nothing is wrong."""
@@ -289,3 +314,37 @@ def test_a_failed_bootstrap_releases_its_claim(db, repos, monkeypatch):
         reconcile.bootstrap_history_once(db)
 
     assert db.query(SystemSettings).first().history_bootstrap_at is None
+
+
+@pytest.mark.unit
+def test_enqueue_reconcile_run_omits_history_index_for_an_agent_repository(
+    db, monkeypatch
+):
+    """The history stage does not exist for an agent's repository (the
+    server cannot diff it), so the reconcile chain never creates it there,
+    while a server-side repository on the same install keeps it."""
+    monkeypatch.setattr(
+        reconcile,
+        "registered_kinds",
+        lambda: {"archive_sync", "history_merge", "history_index", "stats"},
+    )
+    server = Repository(name="server", path="/repo/server", borg_version=1)
+    agent = Repository(
+        name="agent",
+        path="/repo/agent",
+        borg_version=1,
+        executor_type="agent",
+        execution_target="agent",
+    )
+    db.add_all([server, agent])
+    db.commit()
+
+    kinds_server = [
+        o.kind for o in reconcile.enqueue_reconcile_run(db, server.id, history=True)
+    ]
+    kinds_agent = [
+        o.kind for o in reconcile.enqueue_reconcile_run(db, agent.id, history=True)
+    ]
+
+    assert kinds_server == ["archive_sync", "history_merge", "history_index", "stats"]
+    assert kinds_agent == ["archive_sync", "history_merge", "stats"]

--- a/tests/unit/test_operations_runner.py
+++ b/tests/unit/test_operations_runner.py
@@ -301,6 +301,50 @@ async def test_followups_include_history_kinds_on_pro(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_followups_omit_history_index_for_an_agent_repository(
+    db, runner, registry, monkeypatch
+):
+    """Through the real per-repository gate (only the plan is stubbed): a
+    backup of a repository executed by an agent gets no history stage, since
+    the server cannot diff it."""
+
+    async def ok(ctx):
+        return Outcome()
+
+    registry["backup"] = ok
+    registry["archive_sync"] = ok
+    registry["history_merge"] = ok
+    registry["history_index"] = ok
+    registry["stats"] = ok
+    monkeypatch.setattr(
+        "app.services.operations.followups.history_enabled", lambda db: True
+    )
+    agent = Repository(
+        name="agent",
+        path="/tmp/agent",
+        encryption="none",
+        compression="lz4",
+        executor_type="agent",
+        execution_target="agent",
+    )
+    db.add(agent)
+    db.add(SystemSettings())
+    db.commit()
+
+    enqueue(db, "backup", repository_id=agent.id, trigger="manual")
+    await _drain(runner)
+    db.expire_all()
+    rows = db.query(Operation).order_by(Operation.id).all()
+    assert [r.kind for r in rows] == [
+        "backup",
+        "archive_sync",
+        "history_merge",
+        "stats",
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_no_followups_on_failure(db, repo, runner, registry):
     async def fail(ctx):
         return Outcome(status="failed", error_message="nope")


### PR DESCRIPTION
## Description

For a repository executed by a managed agent, `history_index` can only skip: the server runs `borg diff` and cannot reach the agent's repository, and the agent protocol has no diff job. On an install where every repository is agent-executed that produced 161 skipped `history_index` operations in twelve hours, a Changes tab that said "History indexing was skipped for this archive" with a rebuild link that queued the same outcome, and a Files tab that answered "No earlier archive contains this path." for paths present in every archive, from an index that was never built.

The repository now has a **history capability**, derived when read from the executor and the plan: `agent_unsupported`, `plan_locked` or `available`. The executor is read first: its reason outlasts any plan change, so an agent repository on Community names it rather than a plan chip that promises what an upgrade cannot deliver. It is a fact about the repository rather than about one run, so nothing is stored and there is no migration; the skip reason on the archive row (point 1 of the issue) is left for a follow-up, if it is still wanted.

What changes:

- **Nothing enqueues what cannot run.** `chain_for_repository` reads the three gates in one place: the plan, the repository's index mode (phase 10) and the executor (`history_possible_for` in `followups.py`); its call sites (backup and import follow-ups, wipe, inline maintenance, the runner) are phase 10's, untouched, and the reconcile run applies the same executor gate next to the mode. So an agent repository gets no `history_index` from any chain, the same way Community installs get none. The executor's `agent_diff_unsupported` skip stays as the safety net.
- **Responses say why.** The archive list, detail and changes responses carry `history_capability`; `history_available` keeps its meaning (the plan has the feature). The hub row carries the capability too, next to phase 10's `index_mode`. The plan lookup, which commits the session, is read before any rows are loaded so it cannot expire them. `POST /rebuild` with `from = history` on an agent repository answers 409 `historyUnavailableForAgent` instead of resetting every archive to `pending`, ahead of the plan gate; `from = archives` drops the history kind. `GET /history` reports `coverage: {indexed, exhausted, total, capability}`, where `total` counts every archive, `skipped` ones included (uncovered like `pending` ones; `capability` says whether a run will ever reach them), and `exhausted` the failures the executor gave up on.
- **The archive state agrees.** No history run reaches an agent repository any more, so `archive_sync` marks its `pending` archives `skipped` (the state the history run used to write), on every plan. A `failed` archive is marked too: nothing on an agent repository can retry it, and a row left `failed` would flag the repository and offer a rebuild that is refused. `history_merge` resets a successor to `skipped` rather than `pending` there. Moving a repository from an agent back to the server puts its `skipped` archives back to `pending` with a fresh retry budget in the same transaction as the executor change, and queues an index run where the mode indexes history, forced past the in-flight check like phase 10's mode catch-up (the agent's listing still queued carries no history stage); a mode change to `full` in the same update queues one run, not two. A server's `archive_sync` reopens rows an older release left `skipped` the same way, so existing installs need no migration. The other direction leaves the rows alone (an index built on the server stays, and the next listing marks the pending ones). A rebuild from the history stage resets the retry budget as well.
- **UI: "not available", never "not yet".** Changes tab: one message per reason; the rebuild control is rendered only where a rebuild can change the outcome (`pending`, `failed`, or `skipped` on a repository that can be indexed). Files tab: with nothing indexed the panel says the repository is not indexed yet (or could not be indexed, when the executor gave up on every archive), or that history is not available for agent repositories, and makes no statement about the path; with a partial index it says how many archives are covered and qualifies an empty history; "No earlier archive contains this path." is kept for a fully indexed series. Once the path's series is known, the panel scopes coverage to that series from the listing it already holds, since every statement it makes is about that series; on an agent repository the Changes tab says "not available" whatever the archive's own state, since the failed wording promises a rebuild the repository cannot have. Rebuild dialog, stage picker and pipeline board treat the capability like the plan lock, with their own wording instead of a Pro chip; the board's retry of a failed history segment on a repository without the history stage (its `history_merge`, on an agent repository or a plan-locked one) goes through the resync route, which re-runs the listing chain with the merge and invalidates nothing, since a rebuild from the history stage is refused there and one from the listing would wipe every archive's stored info. The hub cell and the rebuild dialog keep showing an index a repository built before it moved to an agent, and the dialog makes no "every archive has its file history" claim for a repository that never built one (agent or plan-locked); the file history panel names the agent as the reason next to such a partial index and keeps "No earlier archive contains this path." for an older index that is complete. The panel scopes coverage to the path's series only when its entries all belong to one; the hub row and the track dialog name a narrower index mode (`archives`, `off`) ahead of everything else, and the hub row names the agent reason ahead of the plan chip. A retry the resync yields on (index work already queued or running for the repository) says so instead of looking like a no-op. "Not present in N older archives" is stated only when those older archives of the path's series are indexed, ordered by archive time. Eight new strings in all four locales, plural forms for two existing ones, stories for every new state.

Acceptance from the issue, checked:

- An archive of an agent repository shows "Change history is not available for repositories executed by an agent." and no rebuild control; the Info tab and header are unaffected.
- The rebuild dialog and the pipeline board offer no history stage for agent repositories.
- `history_index` is not enqueued for agent repositories by backups, imports, reconcile or rebuild; `stats` runs after `archive_sync` as before.
- The Files tab of an agent repository shows the same "not available" wording for every path and never "No earlier archive contains this path."
- On a server-executed repository nothing changes: `pending` / `failed` / `indexed` behave as today, and Community installs read as `plan_locked` for a server repository (`agent_unsupported` for an agent one, on every plan).

## Related Issue
Fixes #953

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

Backend (new tests):

- `test_operations_followups.py`: capability per plan and executor, `history_possible_for` with and without the plan gate, a missing repository; the backup follow-up chain of an agent repository has no `history_index`.
- `test_operations_reconcile.py`: the reconcile run omits `history_index` for an agent repository while a server repository on the same install keeps it.
- `test_api_archive_index.py`: list, detail and changes name the capability (`agent_unsupported` on every plan, `available`, `plan_locked` for a server repository on Community); rebuild from history is refused for an agent repository and leaves the archives alone; rebuild from archives drops the history kind; path history reports its coverage, `skipped` archives counted, for an unindexed agent repository and a partially indexed server one.
- `test_operations_index_executors.py`: the listing marks an agent repository's `pending` and `failed` archives `skipped` on every plan, keeps an indexed one, leaves another repository's rows alone, leaves `pending` alone for a server repository, and reopens a server repository's leftover `skipped` rows where the history stage exists. `test_api_operations.py`: the hub rows name the capability per plan and executor. `test_api_repositories.py`: moving a repository back to the server reopens its skipped archives with a fresh retry budget and queues an index run, despite a listing in flight; queues nothing under a narrower mode; keeps the reopen when the queueing fails; queues one run when the same update also returns the mode to `full`; leaves another repository alone; moving it to an agent leaves the states alone. `test_operations_reconcile.py`: a forced run queues past in-flight work. `test_history_merge.py`: a reset successor of an agent repository is `skipped`. `test_history_index.py`: a stale agent run marks the exhausted failures too, the same rule as the listing. `test_api_repositories_import_operations.py`: the import chain of an agent repository has no history stage. `test_operations_runner.py`: through the real gate, a backup of an agent repository enqueues no history stage.

Frontend (new tests): the Changes tab says history is not available for an agent repository (whatever the archive's own state) and offers no rebuild, and still offers it for a skipped archive of a repository that can be indexed; the file history panel says "not available" for an agent repository (with no index, or a partial one), says no archive contains the path when its older index is complete, shows the entries such a repository indexed before it moved with their coverage, keeps the repository-wide coverage across several series, says "not indexed yet" with nothing indexed, keeps entries a series reset left behind, qualifies an empty history by its partial coverage, and counts older archives without the path only when those are indexed; the pipeline board says the stage is not available for an agent repository, retries a failed history segment through the resync route, on an agent repository and on a plan-locked one, and says so when the resync yields to index work in flight; the hub row names the agent reason ahead of the Pro chip, with and without an older index; the rebuild dialog says history is not available for an agent repository without an index and locks the stage with that reason, keeps showing an index built before the move, says how far an agent repository got and why the rest stays uncovered, describes a narrower index mode as the choice made, and makes no claim for a plan-locked repository that never built one. Stories: `ArchiveChangesTab/AgentUnsupported`, `FileHistoryPanel/AgentUnsupported`, `PartiallyIndexed` and `AgentWithOlderIndex`, `RepositoryHubRow/AgentRepository`, `RebuildStagePicker/HistoryUnsupportedForAgent`, `RepositoryTrackDialog/AgentRepository` and `ArchivesOnlyMode`.

```
pytest tests/unit -q
4086 passed, 14 skipped, 3985 warnings in 663.63s   (head 370ae031 on main 7df23469, after three local review rounds of the port)
ruff check app tests && ruff format --check app tests
All checks passed!
npm run format:check && npm run typecheck && npm run lint && npm run check:locales
all clean; locale parity 4 files, same 5110 keys
vitest run
Test Files 230 passed, Tests 2689 passed
npm run build-storybook
exit 0
```

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

The new states are in the stories listed above.

## Additional Context

Rebuilt on main after phase 10 (#1021): the capability is the third input of `chain_for_repository` next to the plan and the index mode, and the call sites are untouched. No migration, and no change of meaning for `history_available` anywhere. The maintenance follow-up chains (prune, compact, delete, wipe) never carried `history_index`, so their callers changed only in the gate they pass. Path-history `coverage` counts the repository's archives across series while the panel's "not present in N older archives" is per series; both are stated with their own scope, and the panel gates the latter on the series' own archive states. When the agent protocol gains a `repository.diff` job, the `skipped` archives of agent repositories are the set to flip back to `pending`, the same way the executor switch does it here.

