### PR TITLE
fix(ui): drop the 2.0 badge and settle on the Borg UI name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Borg Web UI - Environment Configuration
+# Borg UI - Environment Configuration
 # Copy this file to .env and customize as needed
 
 # =============================================================================

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Borg Web UI
+# Contributing to Borg UI
 
-Thank you for your interest in contributing to Borg Web UI!
+Thank you for your interest in contributing to Borg UI!
 
 ## Quick Start
 
@@ -182,4 +182,4 @@ Please read and follow the [Borg UI Code of Conduct](CODE_OF_CONDUCT.md).
 - **Issues**: [GitHub Issues](https://github.com/karanhudia/borg-ui/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/karanhudia/borg-ui/discussions)
 
-Thank you for contributing to Borg Web UI!
+Thank you for contributing to Borg UI!

--- a/.github/COPYRIGHT_NOTICE.md
+++ b/.github/COPYRIGHT_NOTICE.md
@@ -1,6 +1,6 @@
 # Copyright Notice
 
-## Borg Web UI
+## Borg UI
 
 **Copyright (c) 2025 Karan Hudia (ainullcode)**
 All Rights Reserved.

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,10 +122,10 @@ ENV APP_VERSION=${APP_VERSION}
 ARG PYTHON_VERSION
 
 # Docker image metadata
-LABEL org.opencontainers.image.title="Borg Web UI"
+LABEL org.opencontainers.image.title="Borg UI"
 LABEL org.opencontainers.image.description="A lightweight web interface for Borg backup management"
 LABEL org.opencontainers.image.version="${APP_VERSION}"
-LABEL org.opencontainers.image.vendor="Borg Web UI"
+LABEL org.opencontainers.image.vendor="Borg UI"
 LABEL org.opencontainers.image.url="https://github.com/karanhudia/borg-ui"
 LABEL org.opencontainers.image.documentation="https://github.com/karanhudia/borg-ui/blob/main/README.md"
 LABEL org.opencontainers.image.source="https://github.com/karanhudia/borg-ui"

--- a/app/config.py
+++ b/app/config.py
@@ -82,7 +82,7 @@ class Settings(BaseSettings):
     """Application settings"""
 
     # Application settings
-    app_name: str = "Borg Web UI"
+    app_name: str = "Borg UI"
     debug: bool = False
     environment: str = "production"  # Default to production for safety
 

--- a/app/main.py
+++ b/app/main.py
@@ -164,7 +164,7 @@ logger = structlog.get_logger()
 
 # Create FastAPI app
 app = FastAPI(
-    title="Borg Web UI",
+    title="Borg UI",
     description="A lightweight web interface for Borg backup management",
     version=get_runtime_app_version(),
     docs_url="/api/docs",
@@ -247,7 +247,7 @@ app.include_router(v2_router, prefix="/api/v2")  # Borg 2 versioned API
 @app.on_event("startup")
 async def startup_event():
     """Initialize application on startup"""
-    logger.info("Starting Borg Web UI")
+    logger.info("Starting Borg UI")
     _log_insecure_no_auth_warning()
     _log_proxy_auth_security_warnings()
 
@@ -500,13 +500,13 @@ async def startup_event():
     app.state.background_tasks.append(task6)
     logger.info("Job history retention scheduler started")
 
-    logger.info("Borg Web UI started successfully")
+    logger.info("Borg UI started successfully")
 
 
 @app.on_event("shutdown")
 async def shutdown_event():
     """Cleanup on application shutdown"""
-    logger.info("Shutting down Borg Web UI")
+    logger.info("Shutting down Borg UI")
 
     global licensing_refresh_task
     if licensing_refresh_task:
@@ -555,7 +555,7 @@ async def root():
     if _cached_index_html is not None:
         return HTMLResponse(content=_cached_index_html)
     return HTMLResponse(
-        content="<h1>Borg Web UI</h1><p>Frontend not built yet. Please run the build process.</p>"
+        content="<h1>Borg UI</h1><p>Frontend not built yet. Please run the build process.</p>"
     )
 
 
@@ -581,7 +581,7 @@ async def catch_all(full_path: str):
     if _cached_index_html is not None:
         return HTMLResponse(content=_cached_index_html)
     return HTMLResponse(
-        content="<h1>Borg Web UI</h1><p>Frontend not built yet. Please run the build process.</p>"
+        content="<h1>Borg UI</h1><p>Frontend not built yet. Please run the build process.</p>"
     )
 
 
@@ -595,7 +595,7 @@ async def health_check():
 async def api_info():
     """API information endpoint"""
     return {
-        "name": "Borg Web UI API",
+        "name": "Borg UI API",
         "version": get_runtime_app_version(),
         "docs": "/api/docs",
         "status": "running",

--- a/app/services/mqtt_service.py
+++ b/app/services/mqtt_service.py
@@ -1,5 +1,5 @@
 """
-MQTT service for Borg Web UI.
+MQTT service for Borg UI.
 
 Home Assistant sensor state is always published from database state so that:
 - state can be fully reconstructed from DB records

--- a/app/services/mqtt_sync_scheduler.py
+++ b/app/services/mqtt_sync_scheduler.py
@@ -1,5 +1,5 @@
 """
-MQTT Sync Scheduler for Borg Web UI.
+MQTT Sync Scheduler for Borg UI.
 
 Periodically synchronizes repository state with MQTT broker to ensure
 Home Assistant devices stay in sync with database changes.

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -1779,7 +1779,7 @@ class NotificationService:
             try:
                 success = apobj.notify(
                     title="🔔 Borg UI Test Notification",
-                    body="This is a test notification from Borg Web UI. If you received this, your notification service is configured correctly!",
+                    body="This is a test notification from Borg UI. If you received this, your notification service is configured correctly!",
                 )
             finally:
                 socket.setdefaulttimeout(old_timeout)

--- a/dev.sh
+++ b/dev.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Development helper script for Borg Web UI
+# Development helper script for Borg UI
 # Usage: ./dev.sh [command]
 
 set -e
@@ -177,7 +177,7 @@ cmd_init() {
 
 cmd_help() {
     cat << EOF
-Borg Web UI - Development Helper Script
+Borg UI - Development Helper Script
 
 Usage: ./dev.sh [command]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# Borg Web UI - Docker Compose Configuration
+# Borg UI - Docker Compose Configuration
 #
 # Zero-configuration setup with smart defaults:
 # - SECRET_KEY: Auto-generated and persisted to /data/.secret_key

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -13,7 +13,7 @@ const withBase = (path: string) => `${siteBase}${path.replace(/^\/+/, '')}`;
 
 export default defineConfig({
   base: siteBase,
-  title: 'Borg Web UI',
+  title: 'Borg UI',
   description: 'A modern web interface for Borg Backup management',
   cleanUrls: true,
   srcExclude: [
@@ -42,7 +42,7 @@ export default defineConfig({
     logo: {
       light: '/logo-light.png',
       dark: '/logo-dark.png',
-      alt: 'Borg Web UI',
+      alt: 'Borg UI',
     },
     siteTitle: false,
     nav: [

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 PUID=${PUID:-1001}
 PGID=${PGID:-1001}
 
-echo "[$(date)] Borg Web UI Entrypoint"
+echo "[$(date)] Borg UI Entrypoint"
 echo "[$(date)] PUID: $PUID | PGID: $PGID"
 
 # Get current borg user UID/GID
@@ -280,7 +280,7 @@ done
 cd /app
 
 # Switch to borg user and start the application
-echo "[$(date)] Starting Borg Web UI as user borg (${PUID}:${PGID})..."
+echo "[$(date)] Starting Borg UI as user borg (${PUID}:${PGID})..."
 PORT=${PORT:-8081}
 
 # Start package installation in background (non-blocking)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
-# Borg Web UI - Frontend
+# Borg UI - Frontend
 
-React frontend for the Borg Web UI application.
+React frontend for the Borg UI application.
 
 ## Development
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,7 @@
     <meta name="theme-color" content="#059669" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#065f46" media="(prefers-color-scheme: dark)" />
     <meta name="description" content="A lightweight web interface for Borg backup management" />
-    <title>Borg Web UI</title>
+    <title>Borg UI</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "borg-web-ui-frontend",
   "version": "2.3.0-alpha.1",
   "type": "module",
-  "description": "React frontend for Borg Web UI",
+  "description": "React frontend for Borg UI",
   "license": "AGPL-3.0",
   "private": true,
   "dependencies": {

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -453,24 +453,6 @@ export default function AppSidebar({ mobileOpen, onClose }: AppSidebarProps) {
                 >
                   Borg UI
                 </Typography>
-                <Box
-                  component="span"
-                  sx={{
-                    fontSize: '0.6rem',
-                    fontWeight: 700,
-                    letterSpacing: '0.04em',
-                    px: 0.6,
-                    py: 0.2,
-                    borderRadius: 0.75,
-                    bgcolor: 'rgba(5,150,105,0.15)',
-                    border: '1px solid rgba(5,150,105,0.35)',
-                    color: '#34d399',
-                    lineHeight: 1.5,
-                    userSelect: 'none',
-                  }}
-                >
-                  2.0
-                </Box>
               </Box>
             </Box>
           </Box>

--- a/frontend/src/components/AuthLayout.tsx
+++ b/frontend/src/components/AuthLayout.tsx
@@ -253,7 +253,7 @@ export default function AuthLayout({ children }: { children: ReactNode }) {
               </div>
             </div>
 
-            {/* App name + version badge */}
+            {/* App name */}
             <div
               style={{
                 display: 'flex',
@@ -276,22 +276,6 @@ export default function AuthLayout({ children }: { children: ReactNode }) {
               >
                 Borg UI
               </h1>
-              <span
-                style={{
-                  fontSize: '0.75rem',
-                  fontWeight: 700,
-                  letterSpacing: '0.04em',
-                  padding: '3px 7px',
-                  borderRadius: 6,
-                  background: 'rgba(5,150,105,0.15)',
-                  border: '1px solid rgba(5,150,105,0.35)',
-                  color: '#34d399',
-                  lineHeight: 1.5,
-                  userSelect: 'none',
-                }}
-              >
-                2.0
-              </span>
             </div>
 
             {/* Tagline — desktop only */}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -69,7 +69,7 @@
     }
   },
   "login": {
-    "title": "Borg Web UI",
+    "title": "Borg UI",
     "subtitle": "Zugangsdaten eingeben, um fortzufahren",
     "username": "Benutzername",
     "password": "Passwort",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -69,7 +69,7 @@
     }
   },
   "login": {
-    "title": "Borg Web UI",
+    "title": "Borg UI",
     "subtitle": "Enter your credentials to continue",
     "username": "Username",
     "password": "Password",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -69,7 +69,7 @@
     }
   },
   "login": {
-    "title": "Borg Web UI",
+    "title": "Borg UI",
     "subtitle": "Introduce tus credenciales para continuar",
     "username": "Usuario",
     "password": "Contraseña",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -69,7 +69,7 @@
     }
   },
   "login": {
-    "title": "Borg Web UI",
+    "title": "Borg UI",
     "subtitle": "Inserisci le credenziali per continuare",
     "username": "Nome utente",
     "password": "Password",

--- a/tests/manual/test.sh
+++ b/tests/manual/test.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# Borg Web UI Test Runner
+# Borg UI Test Runner
 # This script runs the comprehensive test suite for the application
 
 set -e  # Exit on any error
 
-echo "🧪 Borg Web UI Test Runner"
+echo "🧪 Borg UI Test Runner"
 echo "================================"
 
 # Check if Python 3 is available

--- a/tests/manual/test_app.py
+++ b/tests/manual/test_app.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Comprehensive test suite for Borg Web UI
+Comprehensive test suite for Borg UI
 Tests all core functionality including API endpoints, authentication, routing, and application health.
 """
 
@@ -433,7 +433,7 @@ class BorgWebUITester:
 
     def run_all_tests(self) -> Dict[str, Any]:
         """Run all tests and return results"""
-        print("🚀 Starting Borg Web UI Test Suite")
+        print("🚀 Starting Borg UI Test Suite")
         print("=" * 50)
 
         # Run tests in order
@@ -493,7 +493,7 @@ def main():
     """Main function to run the test suite"""
     import argparse
 
-    parser = argparse.ArgumentParser(description="Test Borg Web UI")
+    parser = argparse.ArgumentParser(description="Test Borg UI")
     parser.add_argument(
         "--url",
         default="http://localhost:7879",

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -40,7 +40,7 @@ def test_settings_environment():
     settings = Settings()
 
     assert settings.environment is not None
-    assert settings.app_name == "Borg Web UI"
+    assert settings.app_name == "Borg UI"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #912

The sidebar and login screen carried a hardcoded `2.0` badge. It reads as a version, drifts from the real one (2.2.6 stable, 2.3.0-alpha.1 now), and the actual version is already shown at the bottom of the sidebar. Removed rather than tied to the real version, per the discussion on the issue.

Also picked up @ioanalytica's follow-up: the remaining "Borg Web UI" strings are now "Borg UI", so the browser tab, login title, API title, Docker labels, docs site and contributor docs all use one name. Container names and the `borg-web-ui` service slug are untouched, renaming those would break existing deployments.

## Verification

- `npx tsc --noEmit` clean
- `vitest run AppSidebar.test.tsx SidebarVersionInfo.test.tsx` 21 passed
- `pytest tests/unit/test_config.py` 19 passed
- Sidebar header rendered in Storybook, badge gone, spacing intact
- Local CodeRabbit review against main: 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 2 changed, 0 added, 0 removed, 772 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-1017/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/34515231700
<details>
<summary>Changed files</summary>
- `components-appsidebar--community-plan.png` (0.05%)
- `components-appsidebar--with-remote-clients.png` (0.05%)
</details>
<details>
<summary>New screenshots</summary>
- None
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->