### PR TITLE
chore(lint): enable ruff F811 and F821 and clear their hits

### DIFF
--- a/app/api/ssh_keys.py
+++ b/app/api/ssh_keys.py
@@ -549,12 +549,6 @@ async def create_ssh_key(
         )
 
 
-class SSHKeyGenerate(BaseModel):
-    name: str
-    key_type: str = "rsa"
-    description: Optional[str] = None
-
-
 class SSHKeyImport(BaseModel):
     name: str
     private_key_path: str

--- a/app/services/backup_plan_execution_service.py
+++ b/app/services/backup_plan_execution_service.py
@@ -26,6 +26,7 @@ from app.database.models import (
     BackupPlanRun,
     BackupPlanRunRetryLineage,
     BackupPlanRunRepository,
+    Operation,
     Repository,
     Script,
     ScriptExecution,

--- a/app/services/check_service.py
+++ b/app/services/check_service.py
@@ -541,9 +541,11 @@ class CheckService:
             try:
                 completed_at = datetime.utcnow()
 
+                error_message = str(e)
+
                 def persist_failure_state():
                     job.status = "failed"
-                    job.error_message = str(e)
+                    job.error_message = error_message
                     job.completed_at = completed_at
 
                 await commit_with_retry(

--- a/app/services/compact_service.py
+++ b/app/services/compact_service.py
@@ -459,9 +459,11 @@ class CompactService:
             try:
                 completed_at = datetime.utcnow()
 
+                error_message = str(e)
+
                 def persist_failure_state():
                     job.status = "failed"
-                    job.error_message = str(e)
+                    job.error_message = error_message
                     job.completed_at = completed_at
 
                 await commit_with_retry(

--- a/app/services/delete_archive_service.py
+++ b/app/services/delete_archive_service.py
@@ -307,9 +307,11 @@ class DeleteArchiveService:
             try:
                 completed_at = datetime.utcnow()
 
+                error_message = str(e)
+
                 def persist_failure_state():
                     job.status = "failed"
-                    job.error_message = str(e)
+                    job.error_message = error_message
                     job.completed_at = completed_at
 
                 await commit_with_retry(

--- a/app/services/prune_service.py
+++ b/app/services/prune_service.py
@@ -408,9 +408,11 @@ class PruneService:
             try:
                 completed_at = datetime.utcnow()
 
+                error_message = str(e)
+
                 def persist_failure_state():
                     job.status = "failed"
-                    job.error_message = str(e)
+                    job.error_message = error_message
                     job.completed_at = completed_at
 
                 await commit_with_retry(

--- a/app/services/script_library_executor.py
+++ b/app/services/script_library_executor.py
@@ -18,7 +18,6 @@ import time
 import os
 import structlog
 import json
-import os
 
 from app.database.models import (
     Script,

--- a/app/services/v2/check_service.py
+++ b/app/services/v2/check_service.py
@@ -410,9 +410,11 @@ class CheckV2Service:
             try:
                 completed_at = datetime.utcnow()
 
+                error_message = str(e)
+
                 def persist_failure_state():
                     job.status = "failed"
-                    job.error_message = str(e)
+                    job.error_message = error_message
                     job.completed_at = completed_at
 
                 await commit_with_retry(

--- a/app/services/v2/compact_service.py
+++ b/app/services/v2/compact_service.py
@@ -521,9 +521,11 @@ class CompactV2Service:
             try:
                 completed_at = datetime.utcnow()
 
+                error_message = str(e)
+
                 def persist_failure_state():
                     job.status = "failed"
-                    job.error_message = str(e)
+                    job.error_message = error_message
                     job.completed_at = completed_at
 
                 await commit_with_retry(

--- a/app/services/v2/delete_archive_service.py
+++ b/app/services/v2/delete_archive_service.py
@@ -187,9 +187,11 @@ class DeleteArchiveV2Service:
                 if job:
                     completed_at = datetime.now(timezone.utc)
 
+                    error_message = str(e)
+
                     def persist_failure_state():
                         job.status = "failed"
-                        job.error_message = str(e)
+                        job.error_message = error_message
                         job.completed_at = completed_at
 
                     await commit_with_retry(

--- a/app/services/v2/prune_service.py
+++ b/app/services/v2/prune_service.py
@@ -278,9 +278,11 @@ class PruneV2Service:
                 if job:
                     completed_at = datetime.now(timezone.utc)
 
+                    error_message = str(e)
+
                     def persist_failure_state():
                         job.status = "failed"
-                        job.error_message = str(e)
+                        job.error_message = error_message
                         job.completed_at = completed_at
 
                     await commit_with_retry(

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,7 +1,7 @@
 target-version = "py311"
 
 [lint]
-select = ["F401"]
+select = ["F401", "F811", "F821"]
 
 [lint.per-file-ignores]
 "tests/fixtures/database.py" = ["F401"]


### PR DESCRIPTION
## Description

`ruff.toml` selected only `F401`, so neither `F811` (redefinition of an unused name) nor `F821` (undefined name) ran in CI. `F811` is the rule that would have caught the shadowed tests fixed in #920; `F821` would have caught the two `NameError`s of #922 and #923. This enables both and clears every hit they report on `main` today, so the lint job turns on clean.

`select = ["F401", "F811", "F821"]` in `ruff.toml`, and:

- **`F811`, two hits.** `app/api/ssh_keys.py` defined `SSHKeyGenerate` twice with identical fields; the second copy, the one the route bound to, is removed and the route keeps working on the first. `app/services/script_library_executor.py` imported `os` twice. (A third, a duplicate `Operation` in `job_history_retention.py`'s import list, was cleaned up by phase 9 in the meantime.)
- **`F821`, nine hits.** One arrived with phase 9: `backup_plan_execution_service.py` annotates `_run_inline_maintenance` with `Operation` without importing it, harmless under `from __future__ import annotations` and exactly what the rule is for; the import is added. The other eight are of one shape. In `check_service`, `compact_service`, `delete_archive_service`, `prune_service` and their `v2` counterparts, the `except Exception as e:` handler defines a nested `persist_failure_state()` that reads `e`, and pyflakes reports it because Python unbinds `e` when the handler exits. Not a runtime bug today (`commit_with_retry` calls `prepare()` synchronously inside the handler), but any deferred call would hit `NameError`. The text is now bound before the closure (`error_message = str(e)`), which is what the closure meant to capture.

No behaviour change. `F811` and `F821` cover only what pyflakes can see (imports, functions, classes, names); #920 was found by an AST scan, and `F811` would have flagged it too.

## Related Issue

Fixes #921. Related: #920 (the shadowed tests), #922 and #923 (the two `NameError`s `F821` would have caught, both fixed since).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🧪 Test addition/improvement
- [x] ♻️ Refactoring

## Testing

```
ruff check app tests agent        (with F401, F811, F821)
All checks passed!
ruff format --check app tests
624 files already formatted
pytest tests/unit -q              (on upstream main 44c2cc4a, after phase 9)
3976 passed, 14 skipped
```

The tests of the touched modules (`test_api_ssh_keys`, `test_delete_archive_service`, `test_job_history_retention`, `test_prune_service`, `test_script_library_executor`, `test_v2_services`) pass; the SSH key generation route still binds to the one remaining `SSHKeyGenerate`.

- [x] I have tested this locally
- [ ] I have added tests that prove my fix is effective or that my feature works (none: lint rules and a name binding, no behaviour to test; the rules themselves are the guard)
- [x] All existing tests pass

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (nothing new to explain)
- [ ] I have made corresponding changes to the documentation (none needed)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

n/a

## Additional Context

The CI lint step (`ruff check app tests`) picks the new rules up from `ruff.toml` without a workflow change. `agent/` is linted here too and is clean under the three rules.
