### PR TITLE
fix(background-work): name the operation that holds a repository's lane

### DIFF
--- a/app/api/operations.py
+++ b/app/api/operations.py
@@ -36,7 +36,7 @@ from app.services.operations.followups import (
     history_capability,
     history_enabled,
 )
-from app.services.operations.lanes import lane_free, running_count
+from app.services.operations.lanes import running_count
 from app.services.operations.models import is_terminal, serialize_operation
 from app.services.operations.index_mode import mode_of as index_mode_of
 from app.services.operations.reconcile import (
@@ -44,7 +44,7 @@ from app.services.operations.reconcile import (
     enqueue_reconcile_runs,
 )
 from app.services.operations.runner import operation_runner
-from app.services.operations.vocab import INDEX_KINDS, SUCCESS_STATUSES
+from app.services.operations.vocab import INDEX_KINDS, KINDS, SUCCESS_STATUSES
 
 router = APIRouter()
 
@@ -116,10 +116,20 @@ class QueueLimits(BaseModel):
     max_concurrent_scheduled_checks: int
 
 
+class LaneHolder(BaseModel):
+    """The running exclusive operation a repository's lane is taken by."""
+
+    kind: str
+    id: int
+
+
 class QueueRepository(BaseModel):
     repository_id: Optional[int]
     repository_name: str
     lane_busy: bool
+    # Which operation holds the lane, so the waiting stages can name it.
+    # Set exactly when `lane_busy` is true: both come from one lookup.
+    lane_holder: Optional[LaneHolder] = None
     operations: list[OperationItem]
 
 
@@ -474,19 +484,48 @@ async def get_queue(
     repos = _repositories_by_id(db, ops)
     policy = get_log_save_policy(db)
     groups: dict[Optional[int], list[dict]] = {}
+    # Which operation holds each repository's lane. Taken from the rows this
+    # response already carries rather than a query per repository: the
+    # listing holds every running operation, so the holder is always one of
+    # the operations the same row lists, and the two cannot drift apart
+    # between two queries.
+    holders: dict[int, Operation] = {}
     for op in ops:
         groups.setdefault(op.repository_id, []).append(_item(op, repos, policy))
+        if op.repository_id is None or op.status != "running":
+            continue
+        # A kind this build does not know (a row left by a newer one) is
+        # passed over here rather than raised on: it stays in `operations`
+        # and only loses its claim to the lane, so the stages under it read
+        # "next in line" instead of the whole board failing to load.
+        # `is_exclusive` would raise on it.
+        spec = KINDS.get(op.kind)
+        if spec is None or not spec.exclusive:
+            continue
+        current = holders.get(op.repository_id)
+        # The one that took the lane: the earliest start, the lowest id
+        # when two rows share one. A row the plan created already running
+        # carries no start (`start_inline_maintenance`) and cannot be
+        # placed on that timeline, so those sort behind the rows that can
+        # and by id among themselves.
+        if current is None or (op.started_at or datetime.max, op.id) < (
+            current.started_at or datetime.max,
+            current.id,
+        ):
+            holders[op.repository_id] = op
     repositories = []
     for repository_id, items in groups.items():
         repo = repos.get(repository_id) if repository_id is not None else None
+        holder = holders.get(repository_id) if repository_id is not None else None
         repositories.append(
             QueueRepository(
                 repository_id=repository_id,
                 repository_name=repo.name if repo else "System",
-                lane_busy=(
-                    (not lane_free(db, repository_id))
-                    if repository_id is not None
-                    else False
+                lane_busy=holder is not None,
+                lane_holder=(
+                    LaneHolder(kind=holder.kind, id=holder.id)
+                    if holder is not None
+                    else None
                 ),
                 operations=items,
             )

--- a/frontend/src/components/background-work/PipelineBoard.stories.tsx
+++ b/frontend/src/components/background-work/PipelineBoard.stories.tsx
@@ -5,7 +5,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Box } from '@mui/material'
 import PipelineBoard from './PipelineBoard'
 import api from '../../services/api'
-import { busyQueue, emptyQueue, hubDetail, hubResponse } from './storyFixtures'
+import {
+  busyQueue,
+  emptyQueue,
+  hubDetail,
+  hubResponse,
+  maintenanceLaneQueue,
+  unnamedLaneQueue,
+} from './storyFixtures'
 import type { HubResponse, QueueResponse } from '../../types/operations'
 
 function StoryProviders({
@@ -60,6 +67,26 @@ type Story = StoryObj<typeof meta>
 export const Busy: Story = {
   render: () => (
     <StoryProviders queue={busyQueue} hub={hubResponse}>
+      <PipelineBoard canManage />
+    </StoryProviders>
+  ),
+}
+
+// A prune holds the lane: the queued stages name it instead of claiming a
+// backup is running.
+export const MaintenanceHoldsTheLane: Story = {
+  render: () => (
+    <StoryProviders queue={maintenanceLaneQueue} hub={hubResponse}>
+      <PipelineBoard canManage />
+    </StoryProviders>
+  ),
+}
+
+// The lane is taken by something this payload does not name: the caption
+// says so instead of picking a kind.
+export const LaneHolderUnnamed: Story = {
+  render: () => (
+    <StoryProviders queue={unnamedLaneQueue} hub={hubResponse}>
       <PipelineBoard canManage />
     </StoryProviders>
   ),

--- a/frontend/src/components/background-work/StageTrack.tsx
+++ b/frontend/src/components/background-work/StageTrack.tsx
@@ -39,9 +39,18 @@ function StageSegment({
   if (stage.status === 'done') caption = t('operations.background.stageDone')
   else if (stage.status === 'failed') caption = t('operations.background.stageFailed')
   else if (stage.status === 'skipped') caption = t('operations.background.stageSkipped')
-  else if (stage.status === 'waiting' && stage.reason)
-    caption = t(`operations.background.reason.${stage.reason}`)
-  else if (stage.status === 'running') {
+  else if (stage.status === 'waiting' && stage.reason) {
+    // `lane_busy` is the only reason with a placeholder; without a kind to
+    // fill it the unnamed wording is used, so the raw `{{kind}}` can never
+    // reach the page however a caller built the stage.
+    const named = stage.reason === 'lane_busy' && stage.reasonKind
+    caption = t(
+      `operations.background.reason.${named ? 'lane_busy' : stage.reason === 'lane_busy' ? 'lane_busy_unnamed' : stage.reason}`,
+      named
+        ? { kind: t(`operations.kind.${stage.reasonKind}`, { defaultValue: stage.reasonKind }) }
+        : {}
+    )
+  } else if (stage.status === 'running') {
     const elapsed = elapsedSince(stage.operation?.started_at ?? null, now)
     const counted =
       stage.operation?.progress_current != null && stage.operation?.progress_total != null

--- a/frontend/src/components/background-work/__tests__/PipelineBoard.test.tsx
+++ b/frontend/src/components/background-work/__tests__/PipelineBoard.test.tsx
@@ -186,6 +186,92 @@ describe('PipelineBoard', () => {
     expect(within(row).getByRole('link', { name: /view runs/i })).toBeInTheDocument()
   })
 
+  it('names the operation a waiting stage is held up by', async () => {
+    // the lane belongs to whichever exclusive operation runs; saying
+    // "backup" while a prune holds it contradicts the row above
+    mockQueue([
+      {
+        repository_id: 1,
+        repository_name: 'nas',
+        lane_busy: true,
+        lane_holder: { kind: 'prune', id: 5 },
+        operations: [
+          queueOp({
+            id: 5,
+            kind: 'prune',
+            category: 'maintenance',
+            status: 'running',
+            started_at: new Date().toISOString(),
+          }),
+          queueOp({ id: 6, kind: 'stats', category: 'index', status: 'queued' }),
+        ],
+      },
+    ])
+    renderBoard()
+    const row = (await screen.findAllByTestId('repository-row'))[0]
+    expect(within(row).getByText(/prune still running/i)).toBeInTheDocument()
+    // backup is the kind the old wording named whatever held the lane
+    expect(within(row).queryByText(/backup still running/i)).not.toBeInTheDocument()
+    expect(within(row).queryByText(/\{\{kind\}\}/)).not.toBeInTheDocument()
+  })
+
+  it('falls back to the unnamed wording when the payload carries no holder', async () => {
+    mockQueue([
+      {
+        repository_id: 1,
+        repository_name: 'nas',
+        lane_busy: true,
+        operations: [
+          queueOp({
+            id: 5,
+            kind: 'backup',
+            category: 'backup',
+            status: 'running',
+            started_at: new Date().toISOString(),
+          }),
+          queueOp({ id: 6, kind: 'stats', category: 'index', status: 'queued' }),
+        ],
+      },
+    ])
+    renderBoard()
+    const row = (await screen.findAllByTestId('repository-row'))[0]
+    expect(within(row).getByText(/another operation is still running/i)).toBeInTheDocument()
+  })
+
+  it('stops naming a holder the same payload shows as finished', async () => {
+    // an event can mark the holder completed in the cache before the queue
+    // is refetched; the row must not wait for an operation it lists as
+    // done, while the backup that is still running keeps it waiting
+    mockQueue([
+      {
+        repository_id: 1,
+        repository_name: 'nas',
+        lane_busy: true,
+        lane_holder: { kind: 'prune', id: 5 },
+        operations: [
+          queueOp({
+            id: 5,
+            kind: 'prune',
+            category: 'maintenance',
+            status: 'completed',
+          }),
+          queueOp({
+            id: 7,
+            kind: 'backup',
+            category: 'backup',
+            status: 'running',
+            started_at: new Date().toISOString(),
+          }),
+          queueOp({ id: 6, kind: 'stats', category: 'index', status: 'queued' }),
+        ],
+      },
+    ])
+    renderBoard()
+    const row = (await screen.findAllByTestId('repository-row'))[0]
+    expect(within(row).getByText(/another operation is still running/i)).toBeInTheDocument()
+    expect(within(row).queryByText(/prune still running/i)).not.toBeInTheDocument()
+  })
+
   it('adds a system lane below the repositories for work with no repository', async () => {
     mockQueue([
       {

--- a/frontend/src/components/background-work/__tests__/repositoryTrack.test.ts
+++ b/frontend/src/components/background-work/__tests__/repositoryTrack.test.ts
@@ -51,12 +51,32 @@ const limits: QueueLimits = {
   max_concurrent_scheduled_checks: 4,
 }
 
-const repo = (operations: OperationItem[], lane_busy = false): QueueRepository => ({
+const repo = (
+  operations: OperationItem[],
+  lane_busy = false,
+  lane_holder: QueueRepository['lane_holder'] = null
+): QueueRepository => ({
   repository_id: 1,
   repository_name: 'nas',
   lane_busy,
+  lane_holder,
   operations,
 })
+
+// A busy lane and the operation holding it, as the queue sends the pair:
+// the holder is one of the repository's own running rows.
+const held = (
+  kind: 'backup' | 'prune' | 'compact' | 'check',
+  queued: OperationItem[]
+): QueueRepository => {
+  const holder = op({
+    id: 99,
+    kind,
+    category: kind === 'backup' ? 'backup' : 'maintenance',
+    status: 'running',
+  })
+  return repo([...queued, holder], true, { kind, id: holder.id })
+}
 
 describe('deriveTrack', () => {
   it('maps each stage to its latest operation status', () => {
@@ -79,13 +99,142 @@ describe('deriveTrack', () => {
   })
 
   it('explains a queued stage with the paused state first', () => {
-    const track = deriveTrack(repo([op({ kind: 'stats', status: 'queued' })], true), limits, true)
+    const track = deriveTrack(
+      held('backup', [op({ kind: 'stats', status: 'queued' })]),
+      limits,
+      true
+    )
     expect(track.stages[3].reason).toBe('paused')
   })
 
   it('explains a queued stage with the busy lane', () => {
-    const track = deriveTrack(repo([op({ kind: 'stats', status: 'queued' })], true), limits, false)
+    const track = deriveTrack(
+      held('backup', [op({ kind: 'stats', status: 'queued' })]),
+      limits,
+      false
+    )
     expect(track.stages[3].reason).toBe('lane_busy')
+    expect(track.stages[3].reasonKind).toBe('backup')
+  })
+
+  it('names whichever exclusive operation holds the lane', () => {
+    // a prune, a compact or a check hold it as much as a backup does
+    for (const kind of ['prune', 'compact', 'check'] as const) {
+      const track = deriveTrack(
+        held(kind, [op({ kind: 'stats', status: 'queued' })]),
+        limits,
+        false
+      )
+      expect(track.stages[3].reason).toBe('lane_busy')
+      expect(track.stages[3].reasonKind).toBe(kind)
+    }
+  })
+
+  it('falls back to the unnamed wording when the payload carries no holder', () => {
+    // a page loaded before the server sent the holder: the lane is busy,
+    // something runs, but nothing names it, and "the backup" would be a guess
+    const track = deriveTrack(
+      repo(
+        [
+          op({ kind: 'stats', status: 'queued' }),
+          op({ id: 99, kind: 'backup', category: 'backup', status: 'running' }),
+        ],
+        true,
+        null
+      ),
+      limits,
+      false
+    )
+    expect(track.stages[3].reason).toBe('lane_busy_unnamed')
+    expect(track.stages[3].reasonKind).toBeNull()
+  })
+
+  it('stops naming a holder the same payload shows as finished', () => {
+    // an event marked the holder completed in the cache before the queue
+    // was refetched, while another operation still runs: the stage waits,
+    // but for something it can no longer name
+    const track = deriveTrack(
+      repo(
+        [
+          op({ kind: 'stats', status: 'queued' }),
+          op({ id: 99, kind: 'prune', category: 'maintenance', status: 'completed' }),
+          op({ id: 100, kind: 'backup', category: 'backup', status: 'running' }),
+        ],
+        true,
+        { kind: 'prune', id: 99 }
+      ),
+      limits,
+      false
+    )
+    expect(track.stages[3].reason).toBe('lane_busy_unnamed')
+    expect(track.stages[3].reasonKind).toBeNull()
+  })
+
+  it('leaves the worker limit to explain a stage once the holder is gone', () => {
+    // bypass_lock lets index work run beside a lane holder; when that
+    // holder finishes in the cache, an archive_sync still running is not
+    // evidence of a taken lane, and the real answer is the worker pool
+    const track = deriveTrack(
+      repo(
+        [
+          op({ id: 10, kind: 'history_index', status: 'queued' }),
+          op({ id: 99, kind: 'prune', category: 'maintenance', status: 'completed' }),
+          op({ id: 9, kind: 'archive_sync', category: 'index', status: 'running' }),
+        ],
+        true,
+        { kind: 'prune', id: 99 }
+      ),
+      { ...limits, index_running: 2 },
+      false
+    )
+    expect(track.stages[2].reason).toBe('workers')
+    expect(track.stages[2].reasonKind).toBeNull()
+  })
+
+  it('does not let a kind it cannot place keep the lane busy', () => {
+    // an operation from a newer build carries a category all the same; the
+    // server refuses it the lane, and so does the track rather than
+    // reporting a holder it cannot name
+    const track = deriveTrack(
+      repo(
+        [
+          op({ id: 10, kind: 'history_index', status: 'queued' }),
+          op({ id: 99, kind: 'prune', category: 'maintenance', status: 'completed' }),
+          op({
+            id: 11,
+            kind: 'teleport' as OperationItem['kind'],
+            category: 'maintenance',
+            status: 'running',
+          }),
+        ],
+        true,
+        { kind: 'prune', id: 99 }
+      ),
+      { ...limits, index_running: 2 },
+      false
+    )
+    expect(track.stages[2].reason).toBe('workers')
+    expect(track.stages[2].reasonKind).toBeNull()
+  })
+
+  it('does not claim a busy lane while the payload shows nothing running', () => {
+    // the lane flag is the server's word and the rows are this payload's;
+    // with every operation finished in the cache the stage is simply next
+    // in line, not waiting for a phantom
+    const track = deriveTrack(
+      repo(
+        [
+          op({ kind: 'stats', status: 'queued' }),
+          op({ id: 99, kind: 'prune', category: 'maintenance', status: 'completed' }),
+        ],
+        true,
+        { kind: 'prune', id: 99 }
+      ),
+      limits,
+      false
+    )
+    expect(track.stages[3].reason).toBe('queued')
+    expect(track.stages[3].reasonKind).toBeNull()
   })
 
   it('explains a queued history stage with the worker limit', () => {

--- a/frontend/src/components/background-work/repositoryTrack.ts
+++ b/frontend/src/components/background-work/repositoryTrack.ts
@@ -1,5 +1,6 @@
 import type {
   OperationItem,
+  OperationKind,
   QueueLimits,
   QueueRepository,
   RebuildStage,
@@ -59,13 +60,20 @@ export type StageStatus = 'idle' | 'done' | 'running' | 'waiting' | 'failed' | '
 // Why a queued stage has not started, in the order a person would want to
 // hear it: the whole queue is paused, a foreground job owns this
 // repository, every index worker is busy, or it is simply next in line.
-export type WaitReason = 'paused' | 'lane_busy' | 'workers' | 'queued'
+// `lane_busy` names the operation that holds the lane; `lane_busy_unnamed`
+// is the same state from a payload that did not carry it.
+export type WaitReason = 'paused' | 'lane_busy' | 'lane_busy_unnamed' | 'workers' | 'queued'
 
 export interface StageState {
   key: StageKey
   status: StageStatus
   operation: OperationItem | null
   reason: WaitReason | null
+  // The lane holder's kind, for the `lane_busy` wording. Any exclusive
+  // kind can hold a lane: a backup, but also a prune, a compact, a check
+  // or the file-history index. Optional so the partial stage literals in
+  // tests and stories stay valid; `deriveTrack` always sets it.
+  reasonKind?: OperationKind | null
 }
 
 export interface RepositoryTrack {
@@ -74,6 +82,22 @@ export interface RepositoryTrack {
   foreground: OperationItem | null
   stages: StageState[]
 }
+
+// The kinds the server admits one at a time (its exclusive set). The track
+// only needs them to tell "the lane is taken" apart from "the index workers
+// are busy", so it names them rather than reading a category: a kind this
+// build does not know carries a category all the same, and the server
+// already refuses it the lane. A drift against the server's table costs
+// wording, never a stage.
+const LANE_KINDS = new Set<OperationItem['kind']>([
+  'backup',
+  'check',
+  'prune',
+  'compact',
+  'delete_archive',
+  'wipe',
+  'history_index',
+])
 
 const FOREGROUND_CATEGORIES = new Set<OperationItem['category']>([
   'backup',
@@ -131,18 +155,33 @@ export function deriveTrack(
       (operation) => FOREGROUND_CATEGORIES.has(operation.category) && operation.status === 'running'
     ) ?? null
 
+  const holdingLane = repository.operations.filter(
+    (operation) => operation.status === 'running' && LANE_KINDS.has(operation.kind)
+  )
+
   const stages = STAGE_ORDER.map<StageState>((key) => {
     const operation = latest.get(key) ?? null
-    if (!operation) return { key, status: 'idle', operation: null, reason: null }
+    if (!operation) return { key, status: 'idle', operation: null, reason: null, reasonKind: null }
     const status = stageStatus(operation.status)
     let reason: WaitReason | null = null
+    let reasonKind: OperationKind | null = null
     if (status === 'waiting') {
       if (paused) reason = 'paused'
-      else if (repository.lane_busy) reason = 'lane_busy'
-      else if (key === 'history' && limits.index_running >= limits.index_workers) reason = 'workers'
+      else if (repository.lane_busy && holdingLane.length > 0) {
+        // The lane is the server's word, the operations are this payload's:
+        // an event can mark the holder finished in the cache before the
+        // queue is refetched. Only name a holder this payload still shows
+        // running, and only claim the lane is taken while it shows
+        // something running at all, or the caption contradicts the row it
+        // sits in.
+        const holder = repository.lane_holder ?? null
+        reasonKind = holdingLane.some((o) => o.id === holder?.id) ? (holder?.kind ?? null) : null
+        reason = reasonKind ? 'lane_busy' : 'lane_busy_unnamed'
+      } else if (key === 'history' && limits.index_running >= limits.index_workers)
+        reason = 'workers'
       else reason = 'queued'
     }
-    return { key, status, operation, reason }
+    return { key, status, operation, reason, reasonKind }
   })
 
   return {

--- a/frontend/src/components/background-work/storyFixtures.ts
+++ b/frontend/src/components/background-work/storyFixtures.ts
@@ -155,6 +155,7 @@ export const busyQueue: QueueResponse = {
       repository_id: 2,
       repository_name: 'nas',
       lane_busy: true,
+      lane_holder: { kind: 'backup', id: 3 },
       operations: [
         op({
           id: 2,
@@ -231,4 +232,58 @@ export const emptyQueue: QueueResponse = {
     max_concurrent_scheduled_checks: 4,
   },
   paused: false,
+}
+
+// The same queue with a prune holding the lane instead of a backup: the
+// waiting stages name the prune (issue: the wording used to say "backup"
+// whatever held the lane).
+export const maintenanceLaneQueue: QueueResponse = {
+  ...busyQueue,
+  repositories: busyQueue.repositories.map((repository) =>
+    repository.repository_id === 2
+      ? {
+          ...repository,
+          lane_holder: { kind: 'prune' as const, id: 3 },
+          operations: [
+            // the prune that holds the lane, and an index stage queued
+            // behind it: the caption under that stage names the prune
+            ...repository.operations.map((operation) =>
+              operation.id === 3
+                ? { ...operation, kind: 'prune' as const, category: 'maintenance' as const }
+                : // admission holds index work back while a prune runs, so
+                  // the stats row of the busy fixture waits here too
+                  { ...operation, status: 'queued' as const, started_at: null }
+            ),
+            op({
+              id: 31,
+              kind: 'archive_sync',
+              status: 'queued',
+              repository: 'nas',
+              repository_id: 2,
+              started_at: null,
+            }),
+          ],
+        }
+      : repository
+  ),
+}
+
+// The lane is taken, but the payload does not say by what: a page loaded
+// before the server carried the holder, or one whose holder has finished
+// since. The caption stays generic rather than naming a guess.
+export const unnamedLaneQueue: QueueResponse = {
+  ...busyQueue,
+  repositories: busyQueue.repositories.map((repository) =>
+    repository.repository_id === 2
+      ? {
+          ...repository,
+          lane_holder: null,
+          operations: repository.operations.map((operation) =>
+            operation.id === 2
+              ? { ...operation, status: 'queued' as const, started_at: null }
+              : operation
+          ),
+        }
+      : repository
+  ),
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -3569,7 +3569,8 @@
       "pauseAdminOnly": "Nur Administratoren können Hintergrundarbeiten pausieren.",
       "reason": {
         "paused": "Pausiert",
-        "lane_busy": "Wartet, bis das Backup dieses Repositorys fertig ist",
+        "lane_busy": "{{kind}} läuft noch",
+        "lane_busy_unnamed": "Eine andere Operation läuft noch",
         "workers": "Wartet auf einen Index-Worker",
         "queued": "Als Nächstes dran"
       },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -3569,7 +3569,8 @@
       "pauseAdminOnly": "Only administrators can pause background work.",
       "reason": {
         "paused": "Paused",
-        "lane_busy": "Waiting for the backup on this repository to finish",
+        "lane_busy": "{{kind}} still running",
+        "lane_busy_unnamed": "Another operation is still running",
         "workers": "Waiting for an index worker",
         "queued": "Next in line"
       },

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -3569,7 +3569,8 @@
       "pauseAdminOnly": "Solo los administradores pueden pausar el trabajo en segundo plano.",
       "reason": {
         "paused": "En pausa",
-        "lane_busy": "Esperando a que termine la copia de este repositorio",
+        "lane_busy": "{{kind}} aún en ejecución",
+        "lane_busy_unnamed": "Otra operación aún en ejecución",
         "workers": "Esperando un worker de índice",
         "queued": "Siguiente en la cola"
       },

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -3569,7 +3569,8 @@
       "pauseAdminOnly": "Solo gli amministratori possono mettere in pausa il lavoro in background.",
       "reason": {
         "paused": "In pausa",
-        "lane_busy": "In attesa che il backup di questo repository finisca",
+        "lane_busy": "{{kind}} ancora in esecuzione",
+        "lane_busy_unnamed": "Un'altra operazione ancora in esecuzione",
         "workers": "In attesa di un worker di indicizzazione",
         "queued": "Prossimo in coda"
       },

--- a/frontend/src/types/operations.ts
+++ b/frontend/src/types/operations.ts
@@ -82,10 +82,20 @@ export interface QueueLimits {
   max_concurrent_scheduled_checks: number
 }
 
+/** The running exclusive operation a repository's lane is taken by. */
+export interface LaneHolder {
+  kind: OperationKind
+  id: number
+}
+
 export interface QueueRepository {
   repository_id: number | null
   repository_name: string
   lane_busy: boolean
+  // Sent whenever `lane_busy` is true; optional so a page loaded before
+  // the server carried it keeps working (it says the lane is busy without
+  // naming the operation).
+  lane_holder?: LaneHolder | null
   operations: OperationItem[]
 }
 

--- a/tests/unit/test_api_operations.py
+++ b/tests/unit/test_api_operations.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 import pytest
+from sqlalchemy import text
 
 from app.database.models import (
     Operation,
@@ -90,6 +91,129 @@ class TestOperationsList:
 
 @pytest.mark.unit
 class TestOperationsQueue:
+    def test_queue_names_the_maintenance_operation_that_holds_the_lane(
+        self, test_client, test_db, admin_headers
+    ):
+        """A prune holds the lane as much as a backup does; the payload says
+        which one it is, so the waiting stages do not have to guess."""
+        repo = _repo(test_db)
+        _settings(test_db)
+        prune = enqueue(test_db, "prune", repository_id=repo.id)
+        prune.status = "running"
+        waiting = enqueue(test_db, "stats", repository_id=repo.id)
+        test_db.commit()
+
+        body = test_client.get("/api/operations/queue", headers=admin_headers).json()
+        group = body["repositories"][0]
+
+        assert group["lane_busy"] is True
+        assert group["lane_holder"] == {"kind": "prune", "id": prune.id}
+        assert waiting.id in {o["id"] for o in group["operations"]}
+
+    def test_queue_reports_no_lane_holder_while_the_lane_is_free(
+        self, test_client, test_db, admin_headers
+    ):
+        """A running index operation shares the repository rather than
+        taking it, so it is not a holder and the lane stays free."""
+        repo = _repo(test_db)
+        _settings(test_db)
+        running = enqueue(test_db, "stats", repository_id=repo.id)
+        running.status = "running"
+        enqueue(test_db, "archive_sync", repository_id=repo.id)
+        test_db.commit()
+
+        body = test_client.get("/api/operations/queue", headers=admin_headers).json()
+        group = body["repositories"][0]
+
+        assert group["lane_busy"] is False
+        assert group["lane_holder"] is None
+
+    def test_queue_holder_is_the_operation_that_took_the_lane(
+        self, test_client, test_db, admin_headers
+    ):
+        """With two running exclusive rows the earliest start holds the
+        lane; a row without one falls behind it rather than winning on id."""
+        repo = _repo(test_db)
+        _settings(test_db)
+        later = enqueue(test_db, "check", repository_id=repo.id)
+        later.status = "running"
+        later.started_at = utc_now() - timedelta(minutes=1)
+        undated = enqueue(test_db, "compact", repository_id=repo.id)
+        undated.status = "running"
+        undated.started_at = None
+        earlier = enqueue(test_db, "prune", repository_id=repo.id)
+        earlier.status = "running"
+        earlier.started_at = utc_now() - timedelta(minutes=9)
+        test_db.commit()
+
+        body = test_client.get("/api/operations/queue", headers=admin_headers).json()
+        group = body["repositories"][0]
+
+        assert group["lane_holder"] == {"kind": "prune", "id": earlier.id}
+
+    def test_queue_holder_falls_back_to_the_lowest_id_without_starts(
+        self, test_client, test_db, admin_headers
+    ):
+        """A plan creates its post-backup prune and compact already running
+        and without a start, so two rows can tie on the sentinel; the
+        lowest id decides rather than the iteration order."""
+        repo = _repo(test_db)
+        _settings(test_db)
+        first = enqueue(test_db, "prune", repository_id=repo.id)
+        first.status = "running"
+        first.started_at = None
+        second = enqueue(test_db, "compact", repository_id=repo.id)
+        second.status = "running"
+        second.started_at = None
+        test_db.commit()
+
+        body = test_client.get("/api/operations/queue", headers=admin_headers).json()
+        group = body["repositories"][0]
+
+        assert first.id < second.id
+        assert group["lane_holder"] == {"kind": "prune", "id": first.id}
+
+    def test_queue_never_gives_the_system_group_a_lane_holder(
+        self, test_client, test_db, admin_headers
+    ):
+        """Work without a repository is listed under System, which has no
+        lane to take."""
+        _settings(test_db)
+        op = enqueue(test_db, "package_install")
+        op.status = "running"
+        test_db.commit()
+
+        body = test_client.get("/api/operations/queue", headers=admin_headers).json()
+        system = [g for g in body["repositories"] if g["repository_id"] is None][0]
+
+        assert system["lane_busy"] is False
+        assert system["lane_holder"] is None
+
+    def test_queue_survives_an_operation_kind_this_build_does_not_know(
+        self, test_client, test_db, admin_headers
+    ):
+        """A row left by a newer build costs its claim to the lane, not the
+        board: it stays in the listing, and the stages under it read as
+        merely queued rather than the whole page failing to load."""
+        repo = _repo(test_db)
+        _settings(test_db)
+        known = enqueue(test_db, "prune", repository_id=repo.id)
+        known.status = "running"
+        test_db.commit()
+        test_db.execute(
+            text("UPDATE operations SET kind = :kind WHERE id = :id"),
+            {"kind": "teleport", "id": known.id},
+        )
+        test_db.commit()
+
+        response = test_client.get("/api/operations/queue", headers=admin_headers)
+
+        assert response.status_code == 200
+        group = response.json()["repositories"][0]
+        assert known.id in {o["id"] for o in group["operations"]}
+        assert group["lane_busy"] is False
+        assert group["lane_holder"] is None
+
     def test_queue_groups_and_limits(self, test_client, test_db, admin_headers):
         repo = _repo(test_db)
         settings = _settings(test_db)
@@ -109,6 +233,8 @@ class TestOperationsQueue:
         assert group["repository_id"] == repo.id
         assert group["repository_name"] == "r"
         assert group["lane_busy"] is True
+        # the waiting stages name what holds the lane instead of guessing
+        assert group["lane_holder"] == {"kind": "history_index", "id": running.id}
         assert {o["id"] for o in group["operations"]} == {running.id, recent.id}
         assert body["limits"]["index_workers"] == 3
         assert body["limits"]["index_running"] == 1


### PR DESCRIPTION
## Description

On the Background work page, a queued stage of a busy repository read "Waiting for the backup on this repository to finish" whatever exclusive operation actually held the lane. Backup is one of seven exclusive kinds (`vocab.py`): a prune, a compact, a check, a delete, a wipe or the file-history index hold it just as well, and the same row shows that operation in its foreground line, so the two lines contradicted each other. The wording had no way to be right, because the payload never said which operation it was.

What changes:

- **The queue payload carries the holder.** `QueueRepository` gains `lane_holder: {kind, id} | null` next to `lane_busy`, and both come from one lookup, so they cannot disagree. It is taken from the rows the response already lists rather than a query per repository: the listing holds every running operation, so the holder is always one of the operations the same row shows, which removes an N+1 and the skew between two queries. A kind this build does not know (a row left by a newer one) is passed over instead of raised on; it keeps its line in the listing and only loses its claim to the lane.
- **The caption names it in the shape these labels are written for.** `operations.kind.*` entries are titles and verb phrases ("Index file history", "Archiv löschen", "Indexar historial de archivos"), which cannot be slotted mid-sentence — the Romance locales would need an article and the verb phrases stay ungrammatical whatever article you pick. The existing `foregroundRunning` puts the kind first for exactly that reason, and this follows it: "prune still running", "Sicherung läuft noch".
- **The track trusts the pair only as far as the payload backs it.** An event can mark the holder finished in the cache before the queue is refetched (the board refetches on its own schedule). So it names a holder that payload still lists as running, keeps the wording generic when it does not, and drops the busy reason altogether when no row that could hold a lane is running, which lets the worker-limit explanation surface instead. The caption falls back on its own as well, so the raw `{{kind}}` placeholder cannot reach the page however a stage was built, and an unknown kind renders as itself rather than as a translation key.

Not included: the issue's optional third point (a hint when a `running` row has neither a process nor an agent job). #1008 closed the way those orphans were created, so the hint would now describe a state that no longer occurs on its own.

## Related Issue

Fixes #1001.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

```
pytest tests/unit -q                (on upstream main 7df23469)
4068 passed, 14 skipped
vitest run                          (frontend)
2669 passed, 230 files
ruff check app tests && ruff format --check app tests
All checks passed! / 637 files already formatted
npm run typecheck && npm run lint && npm run format:check && npm run check:locales
clean, 4 locale files share the same 5098 keys
npm run build-storybook
Storybook build completed successfully
```

New backend tests: the holder named for a maintenance operation and for the history index; no holder while the lane is free, including a *running* non-exclusive kind; the earliest start wins the tie-break and a row without one falls behind it; two rows without a start fall back to the lowest id (the shape `start_inline_maintenance` produces for a plan's post-backup prune and compact); the System group never gets a holder; an operation kind this build does not know keeps its line and costs only the lane claim.

New frontend tests: each exclusive kind named in turn; the unnamed wording without a holder; the holder dropped once the same payload lists it finished; the busy reason dropped when nothing that could hold a lane is running, so the worker limit explains the stage; and the rendered captions on the board, including that "backup still running" is not shown while a prune holds the lane.

Story: `PipelineBoard/MaintenanceHoldsTheLane`, a prune holding the lane with an index stage queued behind it.

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none needed; the lane rules themselves are unchanged)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

The visible change is the caption under a waiting stage: where it said "Waiting for the backup on this repository to finish" it now says "prune still running" (or check, compact, delete archive, wipe, Index file history) and, with nothing to name, "Another operation is still running". The new story `BackgroundWork/PipelineBoard/MaintenanceHoldsTheLane` shows the case.

## Additional Context

Three rounds of an isolated blind review plus the CodeRabbit CLI before opening. Round one's blocker was the wording: the first attempt slotted the kind labels into "Waiting for {{kind}} to finish", which is ungrammatical for the verb-phrase labels and article-less in de/es/it. Round two and three had no blocker; their findings account for the unknown-kind guard, the holder being derived from the listing instead of a second query, the payload cross-checks above, and the tie-break test.

Two notes for whoever reviews this next to the other open work: `lanes.py` is deliberately untouched (an earlier draft added a helper there; deriving the holder from the listing made it unnecessary), and the change sits entirely beside #1016, which does not touch `app/api/operations.py`.


<!-- visual-regression:start -->
## Visual regression report
No visual changes detected: 0 changed, 0 added, 0 removed, 810 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-1023/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/34593265374
<details>
<summary>Changed files</summary>
- None
</details>
<details>
<summary>New screenshots</summary>
- None
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->