### PR TITLE
fix(operations): run the index operations of one repository one at a time

### DIFF
--- a/app/api/operations.py
+++ b/app/api/operations.py
@@ -36,7 +36,11 @@ from app.services.operations.followups import (
     history_capability,
     history_enabled,
 )
-from app.services.operations.lanes import lane_free, running_count
+from app.services.operations.lanes import (
+    lane_free,
+    repositories_with_running_index_work,
+    running_count,
+)
 from app.services.operations.models import is_terminal, serialize_operation
 from app.services.operations.index_mode import mode_of as index_mode_of
 from app.services.operations.reconcile import (
@@ -120,6 +124,10 @@ class QueueRepository(BaseModel):
     repository_id: Optional[int]
     repository_name: str
     lane_busy: bool
+    # A listing, merge or stats of the repository is running: the next index
+    # operation waits for it (one at a time per repository), whatever the
+    # lane and the worker count say.
+    index_busy: bool
     operations: list[OperationItem]
 
 
@@ -476,6 +484,11 @@ async def get_queue(
     groups: dict[Optional[int], list[dict]] = {}
     for op in ops:
         groups.setdefault(op.repository_id, []).append(_item(op, repos, policy))
+    # only the repositories in the response, which the query above already
+    # scoped to the caller's access
+    index_busy_ids = repositories_with_running_index_work(
+        db, repository_ids=[r for r in groups if r is not None]
+    )
     repositories = []
     for repository_id, items in groups.items():
         repo = repos.get(repository_id) if repository_id is not None else None
@@ -488,6 +501,7 @@ async def get_queue(
                     if repository_id is not None
                     else False
                 ),
+                index_busy=repository_id in index_busy_ids,
                 operations=items,
             )
         )

--- a/app/services/operations/lanes.py
+++ b/app/services/operations/lanes.py
@@ -13,6 +13,10 @@ from app.database.models import (
 from app.services.operations.vocab import INDEX_KINDS, KINDS, is_exclusive
 
 _EXCLUSIVE_KINDS = tuple(k for k, spec in KINDS.items() if spec.exclusive)
+# The index kinds that share the repository lane: listing, merge and stats.
+# `history_index` is exclusive and holds the lane itself. Sorted, so the
+# `IN (...)` literal is the same text in every process.
+_SHARED_INDEX_KINDS = tuple(sorted(k for k in INDEX_KINDS if not KINDS[k].exclusive))
 
 _DEFAULTS = {
     "max_concurrent_backups": 1,
@@ -82,6 +86,47 @@ def lane_free(
     return not running_exclusive_operation(db, repository_id, exclude_id=exclude_id)
 
 
+def running_index_operation(db: Session, repository_id: int) -> bool:
+    """True while a listing, merge or stats of the repository is running.
+
+    No two of those overlap on one repository (spec 7.2): two chains of one
+    run (the backup's follow-ups and the prune's) otherwise start their
+    stats side by side, and on an agent's repository a listing started next
+    to the stats' `rinfo` dies with rc 2, since Borg 1 holds the cache lock
+    during `info` and `list` and the agent's calls are not serialised the
+    way the server's own are (`run_serialized_repository_command`, scope
+    `metadata`). A running `history_index` is not counted: it is exclusive
+    and holds the lane, which the bypass setting may cross so an hours-long
+    index does not hold the hourly listing; the server's metadata scope
+    keeps its `borg diff` and the listing apart, and an agent's repository
+    has no history stage.
+
+    A row a dead task left `running` would hold the repository for good;
+    the runner requeues such rows at every tick (as it does at startup),
+    so the answer here is the state the runner is actually in."""
+    return repository_id in repositories_with_running_index_work(
+        db, repository_ids=(repository_id,)
+    )
+
+
+def repositories_with_running_index_work(
+    db: Session, *, repository_ids: Optional[Iterable[int]] = None
+) -> set[int]:
+    """The repositories with a listing, merge or stats running, in one
+    query; `repository_ids` narrows it. See `running_index_operation`."""
+    q = db.query(Operation.repository_id).filter(
+        Operation.status == "running",
+        Operation.kind.in_(_SHARED_INDEX_KINDS),
+        Operation.repository_id.isnot(None),
+    )
+    if repository_ids is not None:
+        ids = tuple(repository_ids)
+        if not ids:
+            return set()
+        q = q.filter(Operation.repository_id.in_(ids))
+    return {row.repository_id for row in q.distinct()}
+
+
 def running_count(
     db: Session,
     *,
@@ -135,15 +180,20 @@ def can_start(db: Session, op: Operation, settings: Optional[SystemSettings]) ->
         return False
     if op.repository_id is None:
         return True
+    if op.kind in INDEX_KINDS and running_index_operation(db, op.repository_id):
+        # No second index operation next to a running listing, merge or
+        # stats of the repository, bypass or not: that setting reads past
+        # a backup's lock, not past another index job.
+        return False
     if is_exclusive(op.kind):
         return lane_free(db, op.repository_id, exclude_id=op.id)
     if op.kind in INDEX_KINDS:
         # Admission refuses a listing while prune, compact, delete or wipe
         # is pending or running, whatever the lane says (a pending job holds
         # no lane yet) and whatever bypass_lock says (that reads past a
-        # running backup's lock, not past admission). Checked first: the
-        # backup follow-up chain otherwise fails with 409 against the plan's
-        # own post-backup prune.
+        # running backup's lock, not past admission). Checked before the
+        # lane and bypass decision: the backup follow-up chain otherwise
+        # fails with 409 against the plan's own post-backup prune.
         if write_maintenance_running(db, op.repository_id):
             return False
         if lane_free(db, op.repository_id, exclude_id=op.id):

--- a/app/services/operations/reconcile.py
+++ b/app/services/operations/reconcile.py
@@ -37,9 +37,12 @@ POLL_INTERVAL_WHEN_DISABLED_MINUTES = 5
 def has_active_index_work(db: Session, repository_id: int) -> bool:
     """True when a reconcile run for the repository would only pile up: index
     work is already waiting to start, or an archive sync is in flight. A
-    running history index or stats refresh does not count. History can take
-    hours, and holding the hourly sync behind it would leave the archive
-    list stale while nothing is wrong."""
+    running history index, merge or stats refresh does not count. History
+    can take hours, and holding the hourly sync behind it would leave the
+    archive list stale while nothing is wrong; a merge or stats is bounded
+    by the info timeout, and the run queued behind it starts once it is
+    done (the tick runs the index operations of one repository one at a
+    time)."""
     waiting = db.query(Operation.id).filter(
         Operation.repository_id == repository_id,
         Operation.category == "index",

--- a/app/services/operations/runner.py
+++ b/app/services/operations/runner.py
@@ -47,6 +47,10 @@ _OUTCOME_STATUSES = (
 # prune row exists and admission then refuses the listing. Bounded, so a
 # repository that never frees up still ends in a visible failure.
 MAX_DEFERRALS = 20
+# How often an index row left `running` without a live task is put back to
+# `queued` before it fails: a terminal commit that keeps failing (a locked
+# database, a full disk) would otherwise re-run the listing every tick.
+MAX_REQUEUES = 3
 # Each deferral waits before the next attempt, doubling from 5 s to 5 min.
 # The runner is woken by every completion anywhere in the system, so without
 # the delay a busy install would spend the whole deferral budget in seconds
@@ -77,6 +81,17 @@ def deferral_count(op: Operation) -> int:
         count = int((op.params or {}).get("deferrals", 0))
     except (TypeError, ValueError, OverflowError):
         # inf overflows int(), nan and text are ValueErrors
+        return 0
+    return max(count, 0)
+
+
+def requeue_count(op: Operation) -> int:
+    """How often the tick has requeued the abandoned row; unreadable
+    bookkeeping counts as none, like `deferral_count`."""
+    params = op.params if isinstance(op.params, dict) else {}
+    try:
+        count = int(params.get("requeues", 0))
+    except (TypeError, ValueError, OverflowError):
         return 0
     return max(count, 0)
 
@@ -295,10 +310,102 @@ class OperationRunner:
 
     # -- scheduling ------------------------------------------------------------
 
+    async def requeue_abandoned_index_rows(self, db: Session) -> int:
+        """Index rows left `running` by a task this runner no longer has (a
+        task that died before its terminal commit, or none at all). The row
+        holds no lock, but it would count as running index work for its
+        repository and against `index_workers` until the next restart; it
+        goes back to `queued` the way `recover_on_startup` puts it, and runs
+        again, after the deferral path's backoff so a transient condition
+        (a locked database) does not spend the budget in seconds. Bounded:
+        after `MAX_REQUEUES` the row fails instead, keeping its start time
+        and progress, so a condition that kills the task every time ends in
+        a visible failure rather than a listing re-run every tick. The
+        caller guards the sweep: a failure in it must not cost the dispatch
+        pass. Every index kind is covered, `history_index`
+        included, as at startup; the other exclusive kinds are not: their
+        process may still be alive, which startup checks and the tick does
+        not. An entry that is not a future (a test's patched task) is left
+        alone: it cannot be told apart from live work."""
+        changed: list[Operation] = []
+        for op in (
+            db.query(Operation)
+            .filter(
+                Operation.status == "running",
+                Operation.kind.in_(tuple(sorted(INDEX_KINDS))),
+            )
+            .all()
+        ):
+            task = self.running_tasks.get(op.id)
+            if task is not None and (not asyncio.isfuture(task) or not task.done()):
+                continue
+            requeues = requeue_count(op) + 1
+            if requeues > MAX_REQUEUES:
+                # the row keeps its start time and progress: the only
+                # evidence of how far the work got
+                op.status = "failed"
+                op.error_message = (
+                    f"lost by the runner again after {MAX_REQUEUES} requeues: the "
+                    "operation kept ending without a result"
+                )
+                op.completed_at = utc_now()
+            else:
+                self._reset_index_row(op)
+                params = op.params if isinstance(op.params, dict) else {}
+                # the deferral path's gate; a row deferred a few times and then
+                # swept keeps the larger of the two backoffs
+                backoff = self.deferral_delay_for(max(requeues, deferral_count(op)))
+                op.params = {
+                    **params,
+                    "requeues": requeues,
+                    "deferred_until": time.time() + backoff,
+                }
+            self.running_tasks.pop(op.id, None)
+            changed.append(op)
+        if not changed:
+            return 0
+        db.commit()
+        logger.warning(
+            "Swept abandoned index operations",
+            requeued=sum(1 for op in changed if op.status == "queued"),
+            failed=sum(1 for op in changed if op.status == "failed"),
+        )
+        for op in changed:
+            try:
+                await broadcast_operation_updated(op, db)
+            except Exception as exc:  # the row is stored; the board refetches
+                logger.warning(
+                    "Could not broadcast a requeued operation",
+                    operation_id=op.id,
+                    error=str(exc),
+                )
+        return len(changed)
+
+    @staticmethod
+    def _reset_index_row(op: Operation) -> None:
+        op.status = "queued"
+        op.error_message = None
+        op.started_at = None
+        op.process_pid = None
+        op.process_start_time = None
+        op.progress_percent = None
+        op.progress_current = None
+        op.progress_total = None
+        op.progress_message = None
+
     async def tick(self) -> int:
         dispatched = 0
         db: Session = self._session()
         try:
+            try:
+                await self.requeue_abandoned_index_rows(db)
+            except Exception as exc:
+                # the sweep is housekeeping; the dispatch pass must not
+                # depend on it (a locked database, an unreadable row)
+                db.rollback()
+                logger.warning(
+                    "Sweep of abandoned index operations failed", error=str(exc)
+                )
             system_settings = db.query(SystemSettings).first()
             queued = (
                 db.query(Operation)
@@ -579,14 +686,7 @@ class OperationRunner:
         counts = {"requeued": 0, "failed": 0, "kept": 0}
         for op in db.query(Operation).filter(Operation.status == "running").all():
             if op.kind in INDEX_KINDS:
-                op.status = "queued"
-                op.started_at = None
-                op.process_pid = None
-                op.process_start_time = None
-                op.progress_percent = None
-                op.progress_current = None
-                op.progress_total = None
-                op.progress_message = None
+                self._reset_index_row(op)
                 counts["requeued"] += 1
             elif op.process_pid and is_process_alive(
                 op.process_pid, int(op.process_start_time or 0)

--- a/docs/architecture/job-system.md
+++ b/docs/architecture/job-system.md
@@ -324,6 +324,23 @@ Rules:
   exclusive operations wait. Index operations wait too unless
   `bypass_lock_on_list` or the repository's bypass setting allows them to
   run alongside.
+- No two of the shared index kinds (`archive_sync`, `history_merge`,
+  `stats`) run on one repository at the same time, and no `history_index`
+  starts next to one of them. The bypass settings do not change that: they
+  read past a backup's lock, not past another index job. Two chains of one
+  run (the backup's follow-ups and the prune's) otherwise started their
+  stats side by side, and on an agent's repository a listing next to the
+  stats' `rinfo` failed with rc 2, since Borg 1 holds the cache lock during
+  `info` and `list` and only the server's own Borg calls are serialised by
+  the metadata scope. A running `history_index` is governed by the lane
+  and bypass as above, so an hours-long index does not hold the hourly
+  listing; the metadata scope keeps its diff and the listing apart. Lane
+  capacity (`index_workers`) stays global. An index row left `running` by
+  a task the runner no longer has is requeued at the next tick, as at
+  startup, so it holds neither the repository nor a worker; after three
+  such requeues it fails instead, so a task that keeps dying ends in a
+  visible failure. `GET /queue` reports the state as `index_busy` per
+  repository.
 - Lower priority number runs first: manual and plan work at 0, scheduled at
   5, follow-ups at 10, reconcile at 20.
 - A failed or cancelled operation skips everything that depends on it with

--- a/docs/engineering/specs/2026-09-03-repository-operations-and-archive-history.md
+++ b/docs/engineering/specs/2026-09-03-repository-operations-and-archive-history.md
@@ -482,6 +482,15 @@ SSE event, a `log()` sink writing to `log_file_path`, and a
   `legacy_running_exclusive(repository_id)`, which is deleted in phase 9.
 - Non-exclusive index kinds may run alongside an exclusive operation only if
   `bypass_lock_on_list` is enabled; otherwise they wait too.
+- No two of the non-exclusive index kinds (`archive_sync`, `history_merge`,
+  `stats`) run on one repository at the same time, and no `history_index`
+  starts next to one of them; the bypass settings do not change that (#1003:
+  two chains of one run started their stats side by side, and on an agent's
+  repository a listing next to the stats' `rinfo` failed with rc 2 on the
+  Borg 1 cache lock). A running `history_index` holds the lane as before.
+  An index row left `running` by a task the runner no longer has is
+  requeued at the next tick, as at startup (bounded: it fails after three
+  requeues), so it holds neither the repository nor a worker.
 - `rclone_sync` uses `run_serialized_repository_command(scope="rclone")` as
   it does today and ignores the lane.
 - Executors also wrap Borg calls in

--- a/frontend/src/components/background-work/PipelineBoard.tsx
+++ b/frontend/src/components/background-work/PipelineBoard.tsx
@@ -140,6 +140,9 @@ export default function PipelineBoard({ canManage }: PipelineBoardProps) {
             repo.repository_id === updated.repository_id ||
             repo.operations.some((op) => op.id === updated.id)
         )
+        // Only the operations change here; `lane_busy` and `index_busy`
+        // keep their fetched values, and the track reads them against the
+        // operations at hand (see deriveTrack).
         const repositories = current.repositories.map((repo) => ({
           ...repo,
           operations: repo.operations.some((op) => op.id === updated.id)
@@ -160,6 +163,7 @@ export default function PipelineBoard({ canManage }: PipelineBoardProps) {
                   repository_id: updated.repository_id,
                   repository_name: updated.repository ?? 'System',
                   lane_busy: false,
+                  index_busy: false,
                   operations: [updated],
                 },
               ],

--- a/frontend/src/components/background-work/RepositoryHubRow.stories.tsx
+++ b/frontend/src/components/background-work/RepositoryHubRow.stories.tsx
@@ -67,6 +67,13 @@ export const BackupHoldsTheLane: Story = {
   args: { repository: hubRepositories[1], track: trackFor(2) },
 }
 
+// A stats refresh of the repository is still running: its queued listing
+// waits for it (one index operation per repository) although a worker is
+// free, and the stage says so.
+export const IndexWorkHoldsTheRepository: Story = {
+  args: { repository: hubRepositories[5], track: trackFor(6) },
+}
+
 export const FailedStage: Story = {
   args: { repository: hubRepositories[3], track: trackFor(4) },
 }

--- a/frontend/src/components/background-work/__tests__/PipelineBoard.test.tsx
+++ b/frontend/src/components/background-work/__tests__/PipelineBoard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 import PipelineBoard from '../PipelineBoard'
@@ -19,6 +19,8 @@ vi.mock('../../../services/api', () => ({
     resync: vi.fn(),
   },
 }))
+
+import { useOperationEvents } from '../../../hooks/useOperationEvents'
 
 vi.mock('../../../hooks/useOperationEvents', () => ({
   useOperationEvents: vi.fn(),
@@ -153,6 +155,7 @@ describe('PipelineBoard', () => {
         repository_id: 2,
         repository_name: 'photos',
         lane_busy: false,
+        index_busy: false,
         operations: [queueOp({ id: 2, repository_id: 2, repository: 'photos', status: 'running' })],
       },
     ])
@@ -171,6 +174,7 @@ describe('PipelineBoard', () => {
         repository_id: 1,
         repository_name: 'nas',
         lane_busy: true,
+        index_busy: false,
         operations: [
           queueOp({
             kind: 'backup',
@@ -192,6 +196,7 @@ describe('PipelineBoard', () => {
         repository_id: null,
         repository_name: 'System',
         lane_busy: false,
+        index_busy: false,
         operations: [
           queueOp({
             id: 9,
@@ -237,6 +242,7 @@ describe('PipelineBoard', () => {
         repository_id: 1,
         repository_name: 'nas',
         lane_busy: false,
+        index_busy: false,
         operations: [queueOp({ id: 9, repository_id: 1, kind: 'archive_sync', status: 'failed' })],
       },
     ])
@@ -297,6 +303,7 @@ describe('PipelineBoard', () => {
         repository_id: 1,
         repository_name: 'nas',
         lane_busy: false,
+        index_busy: false,
         operations: [queueOp({ id: 9, repository_id: 1, kind: 'history_merge', status: 'failed' })],
       },
     ])
@@ -317,6 +324,7 @@ describe('PipelineBoard', () => {
         repository_id: 1,
         repository_name: 'nas',
         lane_busy: false,
+        index_busy: false,
         operations: [queueOp({ id: 9, repository_id: 1, kind: 'history_merge', status: 'failed' })],
       },
     ])
@@ -337,6 +345,7 @@ describe('PipelineBoard', () => {
         repository_id: 1,
         repository_name: 'nas',
         lane_busy: false,
+        index_busy: false,
         operations: [queueOp({ id: 9, repository_id: 1, kind: 'history_merge', status: 'failed' })],
       },
     ])
@@ -348,6 +357,39 @@ describe('PipelineBoard', () => {
     fireEvent.click(await screen.findByRole('button', { name: /retry/i }))
     await waitFor(() => expect(archivesAPI.resync).toHaveBeenCalledWith(1))
     expect(archivesAPI.rebuild).not.toHaveBeenCalled()
+  })
+
+  it('follows the running index work through SSE updates between two fetches', async () => {
+    mockQueue([
+      {
+        repository_id: 1,
+        repository_name: 'nas',
+        lane_busy: false,
+        index_busy: true,
+        operations: [
+          queueOp({ id: 9, repository_id: 1, kind: 'stats', status: 'running' }),
+          // another chain's listing: the running stats is foreign work to it
+          queueOp({
+            id: 10,
+            repository_id: 1,
+            kind: 'archive_sync',
+            status: 'queued',
+            run_id: 'r2',
+          }),
+        ],
+      },
+    ])
+    renderBoard()
+    expect(await screen.findByText(/other index work to finish/i)).toBeInTheDocument()
+    const calls = vi.mocked(useOperationEvents).mock.calls
+    const onUpdated = calls[calls.length - 1]?.[0]
+    expect(onUpdated).toBeDefined()
+    act(() => {
+      onUpdated?.(queueOp({ id: 9, repository_id: 1, kind: 'stats', status: 'completed' }) as never)
+    })
+    await waitFor(() =>
+      expect(screen.queryByText(/other index work to finish/i)).not.toBeInTheDocument()
+    )
   })
 
   it('has no rebuild form below the table, only the per-row menus', async () => {

--- a/frontend/src/components/background-work/__tests__/repositoryTrack.test.ts
+++ b/frontend/src/components/background-work/__tests__/repositoryTrack.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { deriveTrack } from '../repositoryTrack'
+import { deriveTrack, indexBusyFrom } from '../repositoryTrack'
 import type { OperationItem, QueueLimits, QueueRepository } from '../../../types/operations'
 
 const op = (overrides: Partial<OperationItem>): OperationItem =>
@@ -51,11 +51,16 @@ const limits: QueueLimits = {
   max_concurrent_scheduled_checks: 4,
 }
 
-const repo = (operations: OperationItem[], lane_busy = false): QueueRepository => ({
+const repo = (
+  operations: OperationItem[],
+  overrides: Partial<QueueRepository> = {}
+): QueueRepository => ({
   repository_id: 1,
   repository_name: 'nas',
-  lane_busy,
+  lane_busy: false,
+  index_busy: false,
   operations,
+  ...overrides,
 })
 
 describe('deriveTrack', () => {
@@ -79,13 +84,69 @@ describe('deriveTrack', () => {
   })
 
   it('explains a queued stage with the paused state first', () => {
-    const track = deriveTrack(repo([op({ kind: 'stats', status: 'queued' })], true), limits, true)
+    const track = deriveTrack(
+      repo([op({ kind: 'stats', status: 'queued' })], { lane_busy: true }),
+      limits,
+      true
+    )
     expect(track.stages[3].reason).toBe('paused')
   })
 
   it('explains a queued stage with the busy lane', () => {
-    const track = deriveTrack(repo([op({ kind: 'stats', status: 'queued' })], true), limits, false)
+    const track = deriveTrack(
+      repo([op({ kind: 'stats', status: 'queued' })], { lane_busy: true }),
+      limits,
+      false
+    )
     expect(track.stages[3].reason).toBe('lane_busy')
+  })
+
+  it("explains a queued stage with the repository's running index work", () => {
+    const track = deriveTrack(
+      repo(
+        [
+          op({ id: 1, kind: 'stats', status: 'running', run_id: 'r1' }),
+          op({ id: 2, kind: 'archive_sync', status: 'queued', run_id: 'r2' }),
+        ],
+        { index_busy: true }
+      ),
+      limits,
+      false
+    )
+    expect(track.stages[1].reason).toBe('index_busy')
+  })
+
+  it("calls a stage behind its own run's predecessor next in line, not foreign work", () => {
+    const track = deriveTrack(
+      repo(
+        [
+          op({ id: 1, kind: 'archive_sync', status: 'running' }),
+          op({ id: 2, kind: 'stats', status: 'queued', depends_on_id: 1 }),
+        ],
+        { index_busy: true }
+      ),
+      limits,
+      false
+    )
+    expect(track.stages[3].reason).toBe('queued')
+  })
+
+  it('names the busy lane before the running index work', () => {
+    const track = deriveTrack(
+      repo([op({ kind: 'stats', status: 'queued' })], { lane_busy: true, index_busy: true }),
+      limits,
+      false
+    )
+    expect(track.stages[3].reason).toBe('lane_busy')
+  })
+
+  it('derives the index flag from the operations at hand', () => {
+    for (const kind of ['archive_sync', 'history_merge', 'stats'] as const) {
+      expect(indexBusyFrom([op({ kind, status: 'running' })])).toBe(true)
+    }
+    expect(indexBusyFrom([op({ kind: 'stats', status: 'completed' })])).toBe(false)
+    // history_index holds the lane, not the index slot
+    expect(indexBusyFrom([op({ kind: 'history_index', status: 'running' })])).toBe(false)
   })
 
   it('explains a queued history stage with the worker limit', () => {
@@ -171,7 +232,9 @@ describe('deriveTrack', () => {
 
   it('surfaces a running foreground operation separately from the stages', () => {
     const track = deriveTrack(
-      repo([op({ id: 7, kind: 'backup', category: 'backup', status: 'running' })], true),
+      repo([op({ id: 7, kind: 'backup', category: 'backup', status: 'running' })], {
+        lane_busy: true,
+      }),
       limits,
       false
     )

--- a/frontend/src/components/background-work/repositoryTrack.ts
+++ b/frontend/src/components/background-work/repositoryTrack.ts
@@ -59,7 +59,24 @@ export type StageStatus = 'idle' | 'done' | 'running' | 'waiting' | 'failed' | '
 // Why a queued stage has not started, in the order a person would want to
 // hear it: the whole queue is paused, a foreground job owns this
 // repository, every index worker is busy, or it is simply next in line.
-export type WaitReason = 'paused' | 'lane_busy' | 'workers' | 'queued'
+export type WaitReason = 'paused' | 'lane_busy' | 'index_busy' | 'workers' | 'queued'
+
+// The index kinds that share a repository's index slot; `history_index`
+// holds the lane instead. A copy of what lanes.py derives (INDEX_KINDS
+// minus the exclusive one): keep the two in step when a kind is added.
+const SHARED_INDEX_KINDS = new Set<OperationItem['kind']>([
+  'archive_sync',
+  'history_merge',
+  'stats',
+])
+
+// Whether one of `operations` is running index work of the shared kind. The
+// track reads the server's `index_busy` against the operations it holds: an
+// SSE update that finishes that work clears the wait reason before the next
+// fetch, the same way the lane's holder is checked against them.
+export function indexBusyFrom(operations: OperationItem[]): boolean {
+  return operations.some((op) => op.status === 'running' && SHARED_INDEX_KINDS.has(op.kind))
+}
 
 export interface StageState {
   key: StageKey
@@ -131,6 +148,12 @@ export function deriveTrack(
       (operation) => FOREGROUND_CATEGORIES.has(operation.category) && operation.status === 'running'
     ) ?? null
 
+  // A stage queued behind its own run's predecessor is next in line, not
+  // waiting for foreign work: the repository-wide flag is read only while
+  // index work of another run is still running in the operations at hand.
+  const foreignIndexRunning =
+    repository.index_busy &&
+    indexBusyFrom(repository.operations.filter((operation) => !chosen.includes(operation)))
   const stages = STAGE_ORDER.map<StageState>((key) => {
     const operation = latest.get(key) ?? null
     if (!operation) return { key, status: 'idle', operation: null, reason: null }
@@ -139,6 +162,7 @@ export function deriveTrack(
     if (status === 'waiting') {
       if (paused) reason = 'paused'
       else if (repository.lane_busy) reason = 'lane_busy'
+      else if (foreignIndexRunning) reason = 'index_busy'
       else if (key === 'history' && limits.index_running >= limits.index_workers) reason = 'workers'
       else reason = 'queued'
     }

--- a/frontend/src/components/background-work/storyFixtures.ts
+++ b/frontend/src/components/background-work/storyFixtures.ts
@@ -97,6 +97,12 @@ export const hubRepositories: HubRepository[] = [
     archives: 15,
     history: { indexed: 15, pending: 0, failed: 0, skipped: 0, truncated: 0, rows: 62 },
   }),
+  hubRepository({
+    repository_id: 6,
+    repository_name: 'media',
+    archives: 22,
+    history: { indexed: 22, pending: 0, failed: 0, skipped: 0, truncated: 0, rows: 3140 },
+  }),
 ]
 
 export const hubResponse: HubResponse = {
@@ -147,6 +153,7 @@ export const busyQueue: QueueResponse = {
       repository_id: 1,
       repository_name: 'offsite',
       lane_busy: false,
+      index_busy: false,
       operations: [
         op({ id: 1, kind: 'import_connect', category: 'import', repository: 'offsite' }),
       ],
@@ -155,6 +162,9 @@ export const busyQueue: QueueResponse = {
       repository_id: 2,
       repository_name: 'nas',
       lane_busy: true,
+      // a stats is running here too; the lane's backup is what the stage
+      // names, since the lane wins over the index flag
+      index_busy: true,
       operations: [
         op({
           id: 2,
@@ -180,6 +190,7 @@ export const busyQueue: QueueResponse = {
       repository_id: 3,
       repository_name: 'photos',
       lane_busy: false,
+      index_busy: false,
       operations: [
         op({
           id: 4,
@@ -198,6 +209,7 @@ export const busyQueue: QueueResponse = {
       repository_id: 4,
       repository_name: 'laptop',
       lane_busy: false,
+      index_busy: false,
       operations: [
         op({ id: 5, status: 'completed', repository: 'laptop', repository_id: 4 }),
         op({
@@ -207,6 +219,34 @@ export const busyQueue: QueueResponse = {
           repository: 'laptop',
           repository_id: 4,
           error_message: 'borg list timed out',
+        }),
+      ],
+    },
+    {
+      // a stats of the repository still running: the next listing waits
+      // for it (one index operation per repository), with a worker to
+      // spare. The listing is another chain's, or the flag would not apply.
+      repository_id: 6,
+      repository_name: 'media',
+      lane_busy: false,
+      index_busy: true,
+      operations: [
+        op({
+          id: 7,
+          kind: 'stats',
+          status: 'running',
+          repository: 'media',
+          repository_id: 6,
+          started_at: minutesAgo(1),
+        }),
+        op({
+          id: 8,
+          kind: 'archive_sync',
+          status: 'queued',
+          repository: 'media',
+          repository_id: 6,
+          run_id: 'r2',
+          trigger: 'followup',
         }),
       ],
     },

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -3570,6 +3570,7 @@
       "reason": {
         "paused": "Pausiert",
         "lane_busy": "Wartet, bis das Backup dieses Repositorys fertig ist",
+        "index_busy": "Wartet, bis die andere Index-Arbeit dieses Repositorys fertig ist",
         "workers": "Wartet auf einen Index-Worker",
         "queued": "Als Nächstes dran"
       },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -3570,6 +3570,7 @@
       "reason": {
         "paused": "Paused",
         "lane_busy": "Waiting for the backup on this repository to finish",
+        "index_busy": "Waiting for this repository's other index work to finish",
         "workers": "Waiting for an index worker",
         "queued": "Next in line"
       },

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -3570,6 +3570,7 @@
       "reason": {
         "paused": "En pausa",
         "lane_busy": "Esperando a que termine la copia de este repositorio",
+        "index_busy": "Esperando a que termine el otro trabajo de índice de este repositorio",
         "workers": "Esperando un worker de índice",
         "queued": "Siguiente en la cola"
       },

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -3570,6 +3570,7 @@
       "reason": {
         "paused": "In pausa",
         "lane_busy": "In attesa che il backup di questo repository finisca",
+        "index_busy": "In attesa che termini l'altro lavoro di indice di questo repository",
         "workers": "In attesa di un worker di indicizzazione",
         "queued": "Prossimo in coda"
       },

--- a/frontend/src/types/operations.ts
+++ b/frontend/src/types/operations.ts
@@ -86,6 +86,9 @@ export interface QueueRepository {
   repository_id: number | null
   repository_name: string
   lane_busy: boolean
+  // A listing, merge or stats of the repository is running: the next index
+  // operation waits for it, whatever the lane and the worker count say.
+  index_busy: boolean
   operations: OperationItem[]
 }
 

--- a/tests/unit/test_api_operations.py
+++ b/tests/unit/test_api_operations.py
@@ -90,6 +90,28 @@ class TestOperationsList:
 
 @pytest.mark.unit
 class TestOperationsQueue:
+    def test_queue_reports_running_index_work_of_a_repository(
+        self, test_client, test_db, admin_headers
+    ):
+        """A running listing, merge or stats holds the repository's index
+        slot, not the lane; the board needs the difference to explain a
+        queued index stage next to free workers."""
+        repo = _repo(test_db)
+        _settings(test_db)
+        running = enqueue(test_db, "stats", repository_id=repo.id)
+        running.status = "running"
+        enqueue(test_db, "archive_sync", repository_id=repo.id)
+        test_db.commit()
+        system = enqueue(test_db, "package_install", repository_id=None)
+        system.status = "running"
+        test_db.commit()
+        body = test_client.get("/api/operations/queue", headers=admin_headers).json()
+        groups = {g["repository_id"]: g for g in body["repositories"]}
+        assert groups[repo.id]["lane_busy"] is False
+        assert groups[repo.id]["index_busy"] is True
+        # the system lane has no repository, so nothing of the sort
+        assert groups[None]["index_busy"] is False
+
     def test_queue_groups_and_limits(self, test_client, test_db, admin_headers):
         repo = _repo(test_db)
         settings = _settings(test_db)
@@ -109,6 +131,8 @@ class TestOperationsQueue:
         assert group["repository_id"] == repo.id
         assert group["repository_name"] == "r"
         assert group["lane_busy"] is True
+        # history_index holds the lane, not the shared index slot
+        assert group["index_busy"] is False
         assert {o["id"] for o in group["operations"]} == {running.id, recent.id}
         assert body["limits"]["index_workers"] == 3
         assert body["limits"]["index_running"] == 1

--- a/tests/unit/test_operations_lanes.py
+++ b/tests/unit/test_operations_lanes.py
@@ -98,6 +98,49 @@ def test_index_kind_waits_without_bypass_and_runs_with_bypass(db, repo, settings
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("running_kind", ["archive_sync", "history_merge", "stats"])
+@pytest.mark.parametrize("waiting_kind", ["archive_sync", "history_merge", "stats"])
+def test_index_kinds_of_one_repository_run_one_at_a_time(
+    db, repo, settings, running_kind, waiting_kind
+):
+    """A listing next to a stats refresh of the same repository dies with
+    rc 2 on Borg 1 (the cache lock), and two chains of one run otherwise
+    start their stats side by side: while one of them runs, the next waits,
+    and bypass does not change that (it reads past a backup's lock, not past
+    another index job). Another repository is unaffected."""
+    _running(db, running_kind, repo)
+    op = enqueue(db, waiting_kind, repository_id=repo.id)
+    assert lanes.can_start(db, op, settings) is False
+    settings.bypass_lock_on_list = True
+    repo.bypass_lock = True
+    db.commit()
+    assert lanes.can_start(db, op, settings) is False
+    other = enqueue(db, waiting_kind, repository_id=_other_repo(db).id)
+    assert lanes.can_start(db, other, settings) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("running_kind", ["archive_sync", "history_merge", "stats"])
+def test_history_index_waits_for_running_index_work_of_its_repository(
+    db, repo, settings, running_kind
+):
+    """The exclusive index kind is held back the same way."""
+    _running(db, running_kind, repo)
+    op = enqueue(db, "history_index", repository_id=repo.id)
+    assert lanes.can_start(db, op, settings) is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("kind", ["backup", "check", "prune", "restore"])
+def test_running_index_work_leaves_the_other_kinds_alone(db, repo, settings, kind):
+    """The rule is index against index; a backup or maintenance job of the
+    repository is governed by the lane as before."""
+    _running(db, "stats", repo)
+    op = enqueue(db, kind, repository_id=repo.id)
+    assert lanes.can_start(db, op, settings) is True
+
+
+@pytest.mark.unit
 def test_index_workers_limit(db, repo, settings):
     settings.index_workers = 1
     db.commit()

--- a/tests/unit/test_operations_runner.py
+++ b/tests/unit/test_operations_runner.py
@@ -7,7 +7,7 @@ from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from app.database.models import Base, Operation, Repository, SystemSettings
+from app.database.models import Base, Operation, Repository, SystemSettings, utc_now
 from app.services.operations.enqueue import enqueue, enqueue_chain
 from app.services.operations.runner import (
     OperationContext,
@@ -109,8 +109,13 @@ async def test_tick_does_not_dispatch_a_row_cancelled_while_it_awaited(
         return Outcome()
 
     registry["stats"] = record
+    # two repositories: on one, the second stats would wait for the first
+    # (one index operation per repository) and never reach the claim
+    other = Repository(name="o", path="/tmp/o", encryption="none", compression="lz4")
+    db.add(other)
+    db.commit()
     first = enqueue(db, "stats", repository_id=repo.id, priority=0)
-    second = enqueue(db, "stats", repository_id=repo.id, priority=5)
+    second = enqueue(db, "stats", repository_id=other.id, priority=5)
 
     import app.services.operations.runner as runner_module
 
@@ -120,11 +125,11 @@ async def test_tick_does_not_dispatch_a_row_cancelled_while_it_awaited(
     async def broadcast_then_cancel(op, session):
         calls.append(op.id)
         if len(calls) == 1:
-            other = session_factory()
-            row = other.get(Operation, second.id)
+            aside = session_factory()
+            row = aside.get(Operation, second.id)
             row.status = "cancelled"
-            other.commit()
-            other.close()
+            aside.commit()
+            aside.close()
         return await real_broadcast(op, session)
 
     monkeypatch.setattr(
@@ -355,6 +360,289 @@ async def test_no_followups_on_failure(db, repo, runner, registry):
     db.expire_all()
     assert db.query(Operation).count() == 1
     assert db.query(Operation).first().error_message == "nope"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_index_operations_of_one_repository_start_one_at_a_time(
+    db, repo, runner, registry
+):
+    """Two chains of one run (the backup's follow-ups and the prune's) each
+    queue index work for the same repository: the tick starts the second
+    operation only once the first has finished, with index_workers=2 (the
+    default)."""
+    gate = asyncio.Event()
+    reached = asyncio.Event()
+    started = []
+
+    async def wait(ctx):
+        started.append(ctx.operation_id)
+        reached.set()
+        await gate.wait()
+        return Outcome()
+
+    registry["stats"] = wait
+    registry["archive_sync"] = wait
+    enqueue(db, "stats", repository_id=repo.id, trigger="followup")
+    enqueue(db, "archive_sync", repository_id=repo.id, trigger="followup")
+    assert await runner.tick() == 1
+    await asyncio.wait_for(reached.wait(), 5)
+    assert await runner.tick() == 0
+    assert len(started) == 1
+    gate.set()
+    await asyncio.gather(*runner.running_tasks.values())
+    assert await runner.tick() == 1
+    await asyncio.gather(*runner.running_tasks.values())
+    assert len(started) == 2
+    db.expire_all()
+    assert {o.status for o in db.query(Operation)} == {"completed"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_row_left_running_by_a_dead_task_is_requeued_by_the_tick(
+    db, repo, runner, registry
+):
+    """A `running` index row whose task is gone (died before its terminal
+    commit) or never existed holds no lock; left alone it would hold every
+    index operation of the repository and a worker until the next restart.
+    The tick puts it back to `queued`, as startup does, and it runs again."""
+    seen = []
+
+    async def ok(ctx):
+        seen.append(ctx.kind)
+        return Outcome()
+
+    registry["stats"] = ok
+    registry["archive_sync"] = ok
+    no_task = enqueue(db, "stats", repository_id=repo.id)
+    no_task.status = "running"
+    dead_task = enqueue(db, "archive_sync", repository_id=repo.id)
+    dead_task.status = "running"
+    dead_task.started_at = utc_now()
+    db.commit()
+    finished = asyncio.ensure_future(asyncio.sleep(0))
+    await finished
+    runner.running_tasks[dead_task.id] = finished
+
+    assert await runner.requeue_abandoned_index_rows(db) == 2
+    db.expire_all()
+    for op in (no_task, dead_task):
+        row = db.get(Operation, op.id)
+        assert row.status == "queued" and row.started_at is None
+        assert row.params["requeues"] == 1
+    assert dead_task.id not in runner.running_tasks
+    # abandoned again: the count is what bounds the loop
+    for op in (no_task, dead_task):
+        db.get(Operation, op.id).status = "running"
+    db.commit()
+    assert await runner.requeue_abandoned_index_rows(db) == 2
+    db.expire_all()
+    assert {
+        db.get(Operation, op.id).params["requeues"] for op in (no_task, dead_task)
+    } == {2}
+    await _drain(runner)
+    db.expire_all()
+    assert {o.status for o in db.query(Operation)} == {"completed"}
+    assert sorted(seen) == ["archive_sync", "stats"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_tick_requeues_the_abandoned_row_before_it_dispatches(
+    db, repo, runner, registry
+):
+    """The wiring: an abandoned row holds the repository under the new
+    rule, so the tick must clear it before it looks at the queue. With the
+    backoff the requeued row itself may wait a moment; what the tick must
+    do is sweep first and then dispatch something."""
+
+    async def ok(ctx):
+        return Outcome()
+
+    registry["stats"] = ok
+    registry["archive_sync"] = ok
+    orphan = enqueue(db, "stats", repository_id=repo.id)
+    orphan.status = "running"
+    db.commit()
+    enqueue(db, "archive_sync", repository_id=repo.id)
+    assert await runner.tick() == 1
+    db.expire_all()
+    swept = db.get(Operation, orphan.id)
+    assert swept.params["requeues"] == 1
+    assert swept.status in ("queued", "running")  # requeued, or already re-run
+    await _drain(runner)
+    db.expire_all()
+    assert {o.status for o in db.query(Operation)} == {"completed"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_requeued_row_waits_out_the_backoff(
+    db, repo, session_factory, registry, monkeypatch, tmp_path
+):
+    """The deferral path's backoff applies: the row is not re-run in the
+    same pass, and a third requeue still requeues (the cap is four)."""
+    monkeypatch.setattr("app.config.settings.data_dir", str(tmp_path))
+    slow = OperationRunner(
+        session_factory=session_factory,
+        registry=registry,
+        poll_interval=0.01,
+        deferral_delay=2.0,
+    )
+    op = enqueue(db, "stats", repository_id=repo.id)
+    op.status = "running"
+    op.params = {"requeues": 2}
+    db.commit()
+    before = time.time()
+    assert await slow.requeue_abandoned_index_rows(db) == 1
+    db.expire_all()
+    row = db.get(Operation, op.id)
+    assert row.status == "queued" and row.params["requeues"] == 3
+    assert row.params["deferred_until"] >= before + slow.deferral_delay_for(3)
+    assert await slow.tick() == 0  # waiting out the backoff
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_index_row_abandoned_again_and_again_fails(db, repo, runner):
+    """Bounded: a task that keeps dying (a terminal commit that keeps
+    failing) must not re-run the listing every tick forever."""
+    from app.services.operations.runner import MAX_REQUEUES
+
+    op = enqueue(db, "history_index", repository_id=repo.id)  # the exclusive one too
+    op.status = "running"
+    op.started_at = utc_now()
+    op.progress_percent = 40
+    op.params = {"requeues": MAX_REQUEUES}
+    db.commit()
+    assert await runner.requeue_abandoned_index_rows(db) == 1
+    db.expire_all()
+    row = db.get(Operation, op.id)
+    assert row.status == "failed"
+    assert row.completed_at is not None
+    # how far it got stays on the row
+    assert row.started_at is not None and row.progress_percent == 40
+    assert f"after {MAX_REQUEUES} requeues" in row.error_message
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_failing_sweep_does_not_cost_the_dispatch_pass(
+    db, repo, runner, registry, monkeypatch
+):
+    """The sweep is housekeeping: a row whose bookkeeping cannot be read,
+    or a commit that fails, must not stop the tick from dispatching."""
+    seen = []
+
+    async def ok(ctx):
+        seen.append(ctx.kind)
+        return Outcome()
+
+    registry["stats"] = ok
+
+    async def dirty_then_boom(db_):
+        # the sweep has touched a row when its commit fails: the dirty
+        # session must be rolled back before the dispatch pass uses it
+        row = db_.query(Operation).first()
+        row.error_message = "half-swept"
+        raise RuntimeError("database is locked")
+
+    monkeypatch.setattr(runner, "requeue_abandoned_index_rows", dirty_then_boom)
+    op = enqueue(db, "stats", repository_id=repo.id)
+    assert await runner.tick() == 1
+    await asyncio.gather(*runner.running_tasks.values())
+    assert seen == ["stats"]
+    db.expire_all()
+    assert db.get(Operation, op.id).error_message is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_sweep_leaves_running_rows_of_other_kinds_alone(db, repo, runner):
+    """Inline maintenance (`start_inline_maintenance`) records prune, compact
+    and check rows as `running` with no task in this runner; the sweep is
+    for index kinds only and must never touch them."""
+    for kind in ("prune", "compact", "check", "backup"):
+        row = enqueue(db, kind, repository_id=repo.id)
+        row.status = "running"
+    db.commit()
+    assert await runner.requeue_abandoned_index_rows(db) == 0
+    db.expire_all()
+    assert {o.status for o in db.query(Operation)} == {"running"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_task_entry_that_is_not_a_future_is_left_alone(db, repo, runner):
+    """A patched `create_task` can land a mock in `running_tasks`; that
+    row cannot be told apart from live work and stays running."""
+    from unittest.mock import MagicMock
+
+    op = enqueue(db, "stats", repository_id=repo.id)
+    op.status = "running"
+    db.commit()
+    runner.running_tasks[op.id] = MagicMock()
+    assert await runner.requeue_abandoned_index_rows(db) == 0
+    db.expire_all()
+    assert db.get(Operation, op.id).status == "running"
+    runner.running_tasks.pop(op.id)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_tick_leaves_a_running_index_task_alone(db, repo, runner, registry):
+    """The requeue is for rows without a live task; a row with one is
+    running index work and stays so."""
+    gate = asyncio.Event()
+    reached = asyncio.Event()
+
+    async def wait(ctx):
+        reached.set()
+        await gate.wait()
+        return Outcome()
+
+    registry["stats"] = wait
+    op = enqueue(db, "stats", repository_id=repo.id)
+    assert await runner.tick() == 1
+    await asyncio.wait_for(reached.wait(), 5)
+    assert await runner.requeue_abandoned_index_rows(db) == 0
+    db.expire_all()
+    assert db.get(Operation, op.id).status == "running"
+    gate.set()
+    await asyncio.gather(*runner.running_tasks.values())
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_history_index_waits_for_running_index_work_through_the_tick(
+    db, repo, runner, registry
+):
+    """The exclusive index kind is held back by a running listing of its
+    repository too, and the tick reaches that rule before the lane one."""
+    gate = asyncio.Event()
+    reached = asyncio.Event()
+    started = []
+
+    async def wait(ctx):
+        started.append(ctx.kind)
+        reached.set()
+        await gate.wait()
+        return Outcome()
+
+    registry["archive_sync"] = wait
+    registry["history_index"] = wait
+    enqueue(db, "archive_sync", repository_id=repo.id, priority=5)
+    enqueue(db, "history_index", repository_id=repo.id, priority=10)
+    assert await runner.tick() == 1
+    await asyncio.wait_for(reached.wait(), 5)
+    assert started == ["archive_sync"]
+    assert await runner.tick() == 0
+    gate.set()
+    await asyncio.gather(*runner.running_tasks.values())
+    assert await runner.tick() == 1
+    await asyncio.gather(*runner.running_tasks.values())
+    assert started == ["archive_sync", "history_index"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Description

The runner tick started a listing, a merge or a stats refresh of a repository next to another one already running on it: the lane holds only exclusive kinds, and the index kinds are not. Two chains of one plan run (the backup's follow-ups and the prune's) queued their stats side by side, and with an agent repository on Borg 1 a listing started next to the stats' `rinfo` died with `repository.list_archives exited with code 2`, since Borg 1 holds the cache lock during `info` and `list` and only the server's own Borg calls are serialised by the metadata scope. The follow-up index of that backup was then lost until the next reconcile. (Seen again after #1012 landed: the deferral now catches the duplicate stats once, and the second attempt collides with the listing.)

What changes:

- **One index operation per repository at a time.** `can_start` refuses an index operation while an `archive_sync`, `history_merge` or `stats` of the same repository is running, `history_index` included, and the bypass settings do not cross that rule: they read past a backup's lock, not past another index job. A running `history_index` keeps holding the lane as before, so an hours-long index does not hold the hourly listing where bypass allows it. Lane capacity (`index_workers`) stays global; the constraint is per repository only.
- **Abandoned index rows no longer hold anything.** A row a dead task left `running` would now hold the repository (and a worker) until the next restart requeued it, so the tick sweeps such rows itself, the way `recover_on_startup` does: an index row whose task the runner no longer has goes back to `queued` behind the deferral path's backoff and runs again; after three such requeues it fails instead, keeping its start time and progress, so a task that keeps dying ends in a visible failure rather than a listing re-run every tick. The sweep is housekeeping the dispatch pass does not depend on; prune, compact, check and backup rows (inline maintenance records them `running` without a task) are never touched.
- **The queue explains the wait.** `GET /queue` reports `index_busy` per repository (one grouped query), the board explains a queued index stage with it ("Waiting for this repository's other index work to finish", four locales) instead of showing free workers next to work that cannot start, reading the flag against the operations it holds (the same way #1023 checks the lane's holder), so an SSE update that finishes that work clears the reason before the next fetch. Story `RepositoryHubRow/IndexWorkHoldsTheRepository` with a matching fixture.
- Spec 7.2 and the architecture notes carry the rule.

Not changed: the admission rules for manual jobs through the API (as the issue says), and the lane's own wording for a queued listing behind a running `history_index` (the separate work on the lane holder covers that).

## Related Issue
Fixes #1003. Related: #982, #983, #1012 (the stats deferral this rule closes the remaining gap of).

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

Backend (new tests):

- `test_operations_lanes.py`: every pair of the shared index kinds waits on one repository (3×3), bypass changes nothing, another repository is unaffected; `history_index` waits for each running shared kind; backup, check, prune and restore are left alone by the rule; a running `history_index` keeps the lane and bypass rule for the listing.
- `test_operations_runner.py`: two index operations of one repository start one at a time through `tick()`; `history_index` waits for a running listing through `tick()`; the tick sweeps an abandoned row (no task, dead task) before it dispatches, counts the requeues with backoff, fails the row after `MAX_REQUEUES` keeping its progress, leaves a live task and a non-future entry alone, never touches running rows of other kinds, and a failing sweep does not cost the dispatch pass; the pre-existing cancel-race test now runs over two repositories, since the new rule had made its claim path unreachable.
- `test_api_operations.py`: `/queue` reports `index_busy` for a running listing, merge or stats, not for a running `history_index`, and never for the system lane.

Frontend (new tests): the track explains a queued index stage with the repository's running index work, names the busy lane first, does not blame index work for a queued connect stage, derives the flag from the operations at hand, and the board follows the flag through an SSE update.

```
pytest tests/unit -q
4089 passed, 14 skipped, 3959 warnings in 696.99s   (after six local review rounds, on main 7df23469; rebased onto 631edd58 afterwards, with the operations, archive-index and repositories suites rerun: 374 passed)
ruff check app tests && ruff format --check app tests
All checks passed!
npm run format:check && npm run typecheck && npm run lint && npm run check:locales
all clean; locale parity 4 files, same keys
vitest run
Test Files 230 passed, Tests 2694 passed   (rebased tree)
npm run build-storybook
exit 0
```

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

The new wait state is in the story listed above.

## Additional Context

The runner is one instance per process (its module docstring), and startup recovery already treats every `running` index row as its own; the sweep makes the same assumption at runtime. Multiple runner instances sharing one database are outside that design and unchanged by this PR. `can_start` still issues one point query per queued index operation per tick; a batched form is possible but was left out to keep the tick's logic as it is.
