### PR TITLE
fix(operations): hand a runner-claimed maintenance row to the Borg 2 service in the shape it claims

### DIFF
--- a/app/services/operations/executors/maintenance.py
+++ b/app/services/operations/executors/maintenance.py
@@ -9,6 +9,7 @@ into an `Outcome` for the runner.
 """
 
 import asyncio
+from datetime import datetime
 from typing import Awaitable, Callable, Optional
 
 import structlog
@@ -18,6 +19,7 @@ from app.database.models import Operation, Repository, utc_now
 from app.services.operations import executors
 from app.services.operations.job_facade import MaintenanceJobFacade
 from app.services.operations.runner import Outcome
+from app.utils.db_retries import commit_with_retry
 
 logger = structlog.get_logger()
 
@@ -66,21 +68,166 @@ async def cancel_watcher(
         await asyncio.sleep(_CANCEL_POLL_SECONDS)
 
 
+# The kinds whose Borg 2 server services claim the row through
+# `claim_running` before they run.
+_CLAIMING_KINDS = ("check", "prune", "compact", "delete_archive")
+
+
+def _borg2_server_service(repository: Repository) -> bool:
+    """Whether `BorgRouter` sends this repository's maintenance to a Borg 2
+    server service (the v2 services), as opposed to a Borg 1 service or a
+    managed agent."""
+    from app.services.repository_executor import is_agent_executor
+
+    return (repository.borg_version or 1) == 2 and not is_agent_executor(repository)
+
+
+def _hands_over(ctx, repository: Repository) -> bool:
+    """Whether this dispatch goes to a Borg 2 server service, the one route
+    that claims the row through `claim_running`. The Borg 1 services write
+    their own start over the runner's, the agent path leaves the row to the
+    agent's report (which stamps the start from the job and would otherwise
+    end a run with no start at all), and `restore_check` never claims."""
+    return ctx.kind in _CLAIMING_KINDS and _borg2_server_service(repository)
+
+
+async def _hand_over_to_service(ctx, claimed_at: Optional[datetime]) -> None:
+    """Give the row the service the shape it claims. The runner's claim wrote
+    `running` with a `started_at`; the Borg 2 server services claim the row
+    again through `claim_running`, which takes a `running` row only without
+    a start (the manual-start shape, so two dispatches of one id cannot both
+    start), and skip the run otherwise. The runner is the one dispatcher
+    here, so the start is the service's to record: it stamps its own when
+    it claims. One guarded UPDATE, read from the table rather than this
+    session's copy: only a row still `running` and still carrying the
+    start this dispatch's claim wrote is cleared, so a cancel that landed
+    in between keeps its start and a row another claim has since stamped
+    is left alone. A row this dispatch did not claim with a start (the
+    inline shape) is not touched either: a start it carries is not this
+    dispatch's to clear. Committed with the retry every write on this path
+    uses; the service runs in its own session."""
+    if claimed_at is None:
+        return
+
+    cleared = 0
+
+    def clear_start():
+        nonlocal cleared
+        cleared = (
+            ctx.db.query(Operation)
+            .filter(
+                Operation.id == ctx.operation_id,
+                Operation.status == "running",
+                Operation.started_at == claimed_at,
+            )
+            .update({Operation.started_at: None}, synchronize_session=False)
+        )
+
+    await commit_with_retry(
+        ctx.db,
+        prepare=clear_start,
+        logger=logger,
+        action="maintenance_hand_over",
+        operation_id=ctx.operation_id,
+    )
+    if not cleared:
+        # A cancel landed since the claim, or the row is not this claim's:
+        # the service will decline it and the executor reports that.
+        logger.info(
+            "Maintenance row not handed over, left as found",
+            operation_id=ctx.operation_id,
+            kind=ctx.kind,
+        )
+
+
+async def _restore_start(ctx, claimed_at: Optional[datetime]) -> None:
+    """A service that never claimed the row (it ended the run before that
+    on a missing repository or a lock it gave up on, returned without a
+    verdict, or raised out of the call) left it with no start; the runner's
+    start is put back, whatever the status, so the run keeps its place in
+    the history and its duration. A start the service wrote stays."""
+    if claimed_at is None:
+        return
+
+    restored = 0
+
+    def restore():
+        nonlocal restored
+        restored = (
+            ctx.db.query(Operation)
+            .filter(
+                Operation.id == ctx.operation_id,
+                Operation.started_at.is_(None),
+            )
+            .update({Operation.started_at: claimed_at}, synchronize_session=False)
+        )
+
+    try:
+        await commit_with_retry(
+            ctx.db,
+            prepare=restore,
+            logger=logger,
+            action="maintenance_restore_start",
+            operation_id=ctx.operation_id,
+        )
+    except asyncio.CancelledError:
+        # A shutdown drain cancelled this task while the retry slept: the
+        # cancel must propagate, and the start stays lost, on record.
+        ctx.db.rollback()
+        logger.warning(
+            "Maintenance start not restored, task cancelled",
+            operation_id=ctx.operation_id,
+        )
+        raise
+    except Exception as exc:
+        # Runs in the executor's `finally`: the service's own failure, if
+        # any, must reach the runner, not this one.
+        ctx.db.rollback()
+        logger.warning(
+            "Maintenance start not restored",
+            operation_id=ctx.operation_id,
+            error=str(exc),
+        )
+        return
+    if restored:
+        logger.info(
+            "Maintenance start restored, the service never claimed the row",
+            operation_id=ctx.operation_id,
+            kind=ctx.kind,
+        )
+
+
 async def _run(
     ctx,
     call: Callable[[BorgRouter, int], Awaitable[None]],
     *,
     canceller: Optional[Callable[[int], Awaitable[bool]]] = None,
+    borg2_canceller: Optional[Callable[[int], Awaitable[bool]]] = None,
 ) -> Outcome:
+    """`canceller` is the Borg 1 service's, `borg2_canceller` the Borg 2
+    service's; the one the router's route tracks the process is the one the
+    watcher calls. The Borg 2 services also poll the row for `cancelled`,
+    which the runner's cooperative flag never writes, so without their own
+    canceller a cancel is not seen until the run finishes."""
     repository = _load_repository(ctx)
     if repository is None:
         return Outcome(status="skipped", skip_reason="repository_missing")
 
+    if borg2_canceller is not None and _borg2_server_service(repository):
+        canceller = borg2_canceller
+    handed_over = _hands_over(ctx, repository)
+    claimed_at = ctx.operation.started_at
+    if handed_over:
+        await _hand_over_to_service(ctx, claimed_at)
     watcher = asyncio.create_task(cancel_watcher(ctx, canceller))
     try:
         await call(BorgRouter(repository), ctx.operation_id)
     finally:
         watcher.cancel()
+        if handed_over:
+            # Also on a raise or a cancel out of the call: the runner then
+            # writes the verdict, and the row must not lose its start.
+            await _restore_start(ctx, claimed_at)
 
     # The service ran in its own session and committed there. Expire this
     # one so the verdict it wrote is read back rather than assumed.
@@ -109,6 +256,15 @@ async def _run(
             # result from this outcome, so it has to travel through it.
             result["stats"] = job.stats
         return Outcome(status=status, result=result)
+    if status == "failed" and ctx.cancelled():
+        # A killed process is a failure to the service: the row never read
+        # `cancelled` (the runner's flag does not write it), so it recorded
+        # the signal's exit code as the error. The service has returned, so
+        # the process is dead and the lane can go: the verdict is the user's
+        # cancel, which the runner keeps only when the row already says so.
+        operation.status = "cancelled"
+        ctx.db.commit()
+        return Outcome(status="failed", error_message="cancelled")
     if status == "cancelled":
         # `Outcome` has no cancelled status (spec 6.3 gives that to the row,
         # not to the executor's verdict), and the runner rewrites the row to
@@ -149,6 +305,7 @@ _PRUNE_DEFAULTS = {
 
 async def run_prune(ctx) -> Outcome:
     from app.services.prune_service import prune_service
+    from app.services.v2.prune_service import prune_v2_service
 
     params = ctx.params
     retention = tuple(
@@ -160,7 +317,12 @@ async def run_prune(ctx) -> Outcome:
     async def call(router, job_id):
         await router.prune(job_id, *retention, False, **kwargs)
 
-    return await _run(ctx, call, canceller=getattr(prune_service, "cancel_prune", None))
+    return await _run(
+        ctx,
+        call,
+        canceller=getattr(prune_service, "cancel_prune", None),
+        borg2_canceller=getattr(prune_v2_service, "cancel_prune", None),
+    )
 
 
 executors.register("prune", run_prune)
@@ -168,11 +330,13 @@ executors.register("prune", run_prune)
 
 async def run_compact(ctx) -> Outcome:
     from app.services.compact_service import compact_service
+    from app.services.v2.compact_service import compact_v2_service
 
     return await _run(
         ctx,
         lambda router, job_id: router.compact(job_id),
         canceller=getattr(compact_service, "cancel_compact", None),
+        borg2_canceller=getattr(compact_v2_service, "cancel_compact", None),
     )
 
 

--- a/app/services/operations/executors/maintenance.py
+++ b/app/services/operations/executors/maintenance.py
@@ -145,7 +145,9 @@ async def _restore_start(ctx, claimed_at: Optional[datetime]) -> None:
     on a missing repository or a lock it gave up on, returned without a
     verdict, or raised out of the call) left it with no start; the runner's
     start is put back, whatever the status, so the run keeps its place in
-    the history and its duration. A start the service wrote stays."""
+    the history and its duration. A start the service wrote stays. If the
+    first commit exhausts its retries, retry the guarded write in a fresh
+    transaction before returning control to the runner's finalization."""
     if claimed_at is None:
         return
 
@@ -162,32 +164,37 @@ async def _restore_start(ctx, claimed_at: Optional[datetime]) -> None:
             .update({Operation.started_at: claimed_at}, synchronize_session=False)
         )
 
-    try:
-        await commit_with_retry(
-            ctx.db,
-            prepare=restore,
-            logger=logger,
-            action="maintenance_restore_start",
-            operation_id=ctx.operation_id,
-        )
-    except asyncio.CancelledError:
-        # A shutdown drain cancelled this task while the retry slept: the
-        # cancel must propagate, and the start stays lost, on record.
-        ctx.db.rollback()
-        logger.warning(
-            "Maintenance start not restored, task cancelled",
-            operation_id=ctx.operation_id,
-        )
-        raise
-    except Exception as exc:
-        # Runs in the executor's `finally`: the service's own failure, if
-        # any, must reach the runner, not this one.
-        ctx.db.rollback()
-        logger.warning(
-            "Maintenance start not restored",
-            operation_id=ctx.operation_id,
-            error=str(exc),
-        )
+    for action in ("maintenance_restore_start", "maintenance_restore_start_recovery"):
+        try:
+            await commit_with_retry(
+                ctx.db,
+                prepare=restore,
+                logger=logger,
+                action=action,
+                operation_id=ctx.operation_id,
+            )
+            break
+        except asyncio.CancelledError:
+            # A shutdown drain must still be able to interrupt either retry.
+            ctx.db.rollback()
+            logger.warning(
+                "Maintenance start not restored, task cancelled",
+                operation_id=ctx.operation_id,
+            )
+            raise
+        except Exception as exc:
+            # Rollback discards the UPDATE as well as the failed transaction.
+            # Recovery must execute it again, keeping the NULL guard in case
+            # a service has since recorded its own start. Neither failure may
+            # replace the service's exception escaping the executor's finally.
+            ctx.db.rollback()
+            logger.warning(
+                "Maintenance start restore failed",
+                operation_id=ctx.operation_id,
+                action=action,
+                error=str(exc),
+            )
+    else:
         return
     if restored:
         logger.info(

--- a/app/services/operations/job_facade.py
+++ b/app/services/operations/job_facade.py
@@ -404,7 +404,10 @@ def claim_running(db: Session, job_id: int, kind: str, started_at: datetime) -> 
     with no `started_at` before this ever runs, so "running" alone isn't
     "already claimed" - only a "running" row that already has a `started_at`
     is, and matching it here would let two concurrent claims both report
-    success."""
+    success. The runner path produces the same shape on purpose: the
+    maintenance executor clears the start its claim wrote before it calls
+    the service (`executors/maintenance.py`), and there the single-dispatch
+    guarantee rests on the runner's own queued-to-running claim."""
     return (
         db.query(Operation)
         .filter(

--- a/tests/unit/test_operations_maintenance_executors.py
+++ b/tests/unit/test_operations_maintenance_executors.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import sessionmaker
 from app.database.models import Base, Operation, Repository
 from app.services.operations.executors import get_executor, load_default_executors
 from app.services.operations.job_facade import MaintenanceJobFacade
+from app.utils.datetime_utils import utc_now
 
 
 @pytest.fixture()
@@ -574,7 +575,7 @@ async def test_run_hands_the_runner_claimed_row_to_a_claiming_service(
     async def fake_service(self, job_id, *args, **kwargs):
         other = _other_session(db)
         try:
-            seen["started_at"] = datetime.utcnow()
+            seen["started_at"] = utc_now()
             seen["claimed"] = claim_running(other, job_id, kind, seen["started_at"])
             other.commit()
             job = MaintenanceJobFacade(other, other.get(Operation, job_id))
@@ -851,7 +852,7 @@ async def test_run_does_not_touch_a_row_dispatched_without_a_start(
     async def fake_compact(self, job_id):
         other = _other_session(db)
         try:
-            seen["started_at"] = datetime.utcnow()
+            seen["started_at"] = utc_now()
             assert claim_running(other, job_id, "compact", seen["started_at"]) == 1
             other.commit()
             job = MaintenanceJobFacade(other, other.get(Operation, job_id))
@@ -936,6 +937,142 @@ async def test_restore_failure_does_not_replace_the_services_error(
 
     with pytest.raises(RuntimeError, match="borg2 compact failed"):
         await maintenance.run_compact(FakeContext(db, op))
+
+    db.expire_all()
+    assert db.get(Operation, op.id).started_at == _RUNNER_CLAIMED_AT
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_result", ["raises", "failed", "completed", "no_verdict"]
+)
+async def test_restore_recovers_after_exhausting_commit_retries(
+    db, borg2_repository, monkeypatch, service_result
+):
+    """Recovery persists the start before returning the original service verdict."""
+    from sqlalchemy.exc import OperationalError
+
+    from app.services.operations.executors import maintenance
+    from app.utils import db_retries
+
+    op = _runner_claimed(db, borg2_repository)
+    operation_id = op.id
+    real_commit = db.commit
+    failed_commits = 0
+
+    def locked_commit():
+        nonlocal failed_commits
+        if failed_commits < 6:  # initial attempt plus all five retries
+            failed_commits += 1
+            raise OperationalError("COMMIT", {}, Exception("database is locked"))
+        real_commit()
+
+    async def no_sleep(delay):
+        return None
+
+    async def fake_compact(self, job_id):
+        with _other_session(db) as other:
+            job = MaintenanceJobFacade(other, other.get(Operation, job_id))
+            assert job.started_at is None
+            if service_result in ("failed", "completed"):
+                job.status = service_result
+                if service_result == "failed":
+                    job.error_message = "borg2 compact failed"
+                other.commit()
+        monkeypatch.setattr(db, "commit", locked_commit)
+        if service_result == "raises":
+            raise RuntimeError("borg2 compact failed")
+
+    monkeypatch.setattr(db_retries.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr("app.core.borg_router.BorgRouter.compact", fake_compact)
+
+    if service_result == "raises":
+        with pytest.raises(RuntimeError, match="borg2 compact failed"):
+            await maintenance.run_compact(FakeContext(db, op))
+    else:
+        outcome = await maintenance.run_compact(FakeContext(db, op))
+        assert outcome.status == (
+            "completed" if service_result == "completed" else "failed"
+        )
+        if service_result == "failed":
+            assert outcome.error_message == "borg2 compact failed"
+        elif service_result == "no_verdict":
+            assert outcome.error_message == "service returned no result"
+
+    assert failed_commits == 6
+    with _other_session(db) as other:
+        assert other.get(Operation, operation_id).started_at == _RUNNER_CLAIMED_AT
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel_recovery", [False, True])
+async def test_failed_restore_recovery_preserves_service_error_or_cancellation(
+    db, borg2_repository, monkeypatch, cancel_recovery
+):
+    """Recovery is bounded and does not mask service errors or shutdown cancellation."""
+    from app.services.operations.executors import maintenance
+
+    op = _runner_claimed(db, borg2_repository)
+    real = maintenance.commit_with_retry
+    actions = []
+
+    async def commit(session, **kwargs):
+        action = kwargs["action"]
+        if action.startswith("maintenance_restore_start"):
+            actions.append(action)
+            kwargs["prepare"]()
+            if len(actions) == 2 and cancel_recovery:
+                raise asyncio.CancelledError()
+            raise RuntimeError("restore unavailable")
+        return await real(session, **kwargs)
+
+    async def fake_compact(self, job_id):
+        raise RuntimeError("borg2 compact failed")
+
+    monkeypatch.setattr(maintenance, "commit_with_retry", commit)
+    monkeypatch.setattr("app.core.borg_router.BorgRouter.compact", fake_compact)
+
+    if cancel_recovery:
+        with pytest.raises(asyncio.CancelledError):
+            await maintenance.run_compact(FakeContext(db, op))
+    else:
+        with pytest.raises(RuntimeError, match="borg2 compact failed"):
+            await maintenance.run_compact(FakeContext(db, op))
+
+    assert len(actions) == 2
+    assert not db.in_transaction()
+
+
+@pytest.mark.asyncio
+async def test_restore_recovery_keeps_a_start_written_between_attempts(
+    db, borg2_repository, monkeypatch
+):
+    """The recovery UPDATE preserves a service start committed after the rollback."""
+    from app.services.operations.executors import maintenance
+
+    op = _runner_claimed(db, borg2_repository)
+    operation_id = op.id
+    service_start = utc_now()
+    real = maintenance.commit_with_retry
+
+    async def commit(session, **kwargs):
+        if kwargs["action"] == "maintenance_restore_start":
+            kwargs["prepare"]()
+            session.rollback()
+            with _other_session(db) as other:
+                other.get(Operation, operation_id).started_at = service_start
+                other.commit()
+            raise RuntimeError("restore commit failed")
+        return await real(session, **kwargs)
+
+    monkeypatch.setattr(maintenance, "commit_with_retry", commit)
+    monkeypatch.setattr("app.core.borg_router.BorgRouter.compact", _completing(db))
+
+    outcome = await maintenance.run_compact(FakeContext(db, op))
+
+    assert outcome.status == "completed"
+    with _other_session(db) as other:
+        assert other.get(Operation, operation_id).started_at == service_start
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_operations_maintenance_executors.py
+++ b/tests/unit/test_operations_maintenance_executors.py
@@ -1,6 +1,7 @@
 """Phase 5: the maintenance executors (spec 6.3, 7.4, section 13 phase 5)."""
 
 import asyncio
+from datetime import datetime
 
 import pytest
 from sqlalchemy import create_engine, event
@@ -236,6 +237,163 @@ async def test_check_cancellation_terminates_the_tracked_borg_process(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kind, router_method, v1_module, v2_module, v2_singleton",
+    [
+        ("prune", "prune", "prune_service", "v2.prune_service", "prune_v2_service"),
+        (
+            "compact",
+            "compact",
+            "compact_service",
+            "v2.compact_service",
+            "compact_v2_service",
+        ),
+    ],
+)
+async def test_borg2_cancellation_terminates_the_borg2_services_process(
+    db, monkeypatch, kind, router_method, v1_module, v2_module, v2_singleton
+):
+    """On a Borg 2 server repository the router runs the Borg 2 service,
+    which tracks its own process; the Borg 1 singleton the executor used to
+    hand the watcher knows nothing about it, so a cancel returned False for
+    the whole run and the row never read `cancelled` for the service to
+    poll. The watcher now calls the Borg 2 service's canceller there."""
+    import importlib
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.services.operations.executors import maintenance
+
+    v1 = getattr(importlib.import_module(f"app.services.{v1_module}"), v1_module)
+    v2 = getattr(importlib.import_module(f"app.services.{v2_module}"), v2_singleton)
+    repo = Repository(name=f"nas2-{kind}", path=f"/repo/nas2-{kind}", borg_version=2)
+    db.add(repo)
+    db.commit()
+    op = _operation(db, repo, kind=kind)
+    ctx = FakeContext(db, op)
+    ctx._cancelled = True
+
+    fake_process = MagicMock()
+    fake_process.pid = 4243
+    fake_process.wait = AsyncMock(return_value=None)
+    v2.running_processes[op.id] = fake_process
+    v1_cancel = AsyncMock(return_value=False)
+    monkeypatch.setattr(v1, f"cancel_{kind}", v1_cancel)
+
+    async def call(self, job_id, *args, **kwargs):
+        await asyncio.sleep(0.05)
+        job = MaintenanceJobFacade(db, db.get(Operation, job_id))
+        job.status = "cancelled"
+        db.commit()
+
+    monkeypatch.setattr(
+        f"app.core.borg_router.BorgRouter.{router_method}", call, raising=True
+    )
+    try:
+        await getattr(maintenance, f"run_{kind}")(ctx)
+        fake_process.terminate.assert_called_once()
+        v1_cancel.assert_not_awaited()
+    finally:
+        v2.running_processes.pop(op.id, None)
+
+
+@pytest.mark.asyncio
+async def test_a_killed_borg2_process_ends_the_row_cancelled_not_failed(
+    db, monkeypatch
+):
+    """The Borg 2 services record a killed process as `failed` with the
+    signal's exit as the error: they poll the row for `cancelled`, which the
+    runner's flag never writes. Once the service has returned the process is
+    dead, so the executor turns that failure into the user's cancel, and the
+    runner keeps `cancelled` because the row already says so."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.services.operations.executors import maintenance
+    from app.services.v2.prune_service import prune_v2_service
+
+    repo = Repository(name="nas2-killed", path="/repo/nas2-killed", borg_version=2)
+    db.add(repo)
+    db.commit()
+    op = _operation(db, repo, kind="prune")
+    ctx = FakeContext(db, op)
+    ctx._cancelled = True
+    fake_process = MagicMock()
+    fake_process.pid = 4245
+    fake_process.wait = AsyncMock(return_value=None)
+    prune_v2_service.running_processes[op.id] = fake_process
+
+    async def call(self, job_id, *args, **kwargs):
+        await asyncio.sleep(0.05)
+        # what the service writes after SIGTERM: not cancelled, failed
+        job = MaintenanceJobFacade(db, db.get(Operation, job_id))
+        job.status = "failed"
+        job.error_message = "Terminated"
+        db.commit()
+
+    monkeypatch.setattr("app.core.borg_router.BorgRouter.prune", call, raising=True)
+    try:
+        outcome = await maintenance.run_prune(ctx)
+    finally:
+        prune_v2_service.running_processes.pop(op.id, None)
+    fake_process.terminate.assert_called_once()
+    assert outcome.status == "failed" and outcome.error_message == "cancelled"
+    db.expire_all()
+    assert db.get(Operation, op.id).status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_a_failure_without_a_cancel_stays_a_failure(db, repository, monkeypatch):
+    """The mapping is for the cancel case only."""
+    from app.services.operations.executors import maintenance
+
+    op = _operation(db, repository, kind="prune")
+    ctx = FakeContext(db, op)
+    monkeypatch.setattr(
+        "app.core.borg_router.BorgRouter.prune", _completing(db, "failed", "boom")
+    )
+    outcome = await maintenance.run_prune(ctx)
+    assert outcome.status == "failed" and outcome.error_message == "boom"
+    db.expire_all()
+    assert db.get(Operation, op.id).status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_borg1_cancellation_keeps_the_borg1_canceller(
+    db, repository, monkeypatch
+):
+    """The Borg 1 route is unchanged: its own singleton tracks the process,
+    and the Borg 2 service is not consulted."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.services.operations.executors import maintenance
+    from app.services.prune_service import prune_service
+    from app.services.v2.prune_service import prune_v2_service
+
+    op = _operation(db, repository, kind="prune")
+    ctx = FakeContext(db, op)
+    ctx._cancelled = True
+    fake_process = MagicMock()
+    fake_process.pid = 4244
+    fake_process.wait = AsyncMock(return_value=None)
+    prune_service.running_processes[op.id] = fake_process
+    v2_cancel = AsyncMock(return_value=True)
+    monkeypatch.setattr(prune_v2_service, "cancel_prune", v2_cancel)
+
+    async def call(self, job_id, *args, **kwargs):
+        await asyncio.sleep(0.05)
+        job = MaintenanceJobFacade(db, db.get(Operation, job_id))
+        job.status = "cancelled"
+        db.commit()
+
+    monkeypatch.setattr("app.core.borg_router.BorgRouter.prune", call, raising=True)
+    try:
+        await maintenance.run_prune(ctx)
+        fake_process.terminate.assert_called_once()
+        v2_cancel.assert_not_awaited()
+    finally:
+        prune_service.running_processes.pop(op.id, None)
+
+
+@pytest.mark.asyncio
 async def test_cancel_watcher_retries_until_the_process_is_registered(
     db, repository, monkeypatch
 ):
@@ -344,6 +502,473 @@ async def test_prune_omits_keep_within_when_it_is_not_set(db, repository, monkey
     await maintenance.run_prune(ctx)
 
     assert "keep_within" not in seen["kwargs"]
+
+
+_RUNNER_CLAIMED_AT = datetime(2026, 1, 1, 12, 0, 0)
+
+
+def _runner_claimed(db, repository, kind="compact", params=None):
+    """A row the way `runner.tick` leaves it: queued, then claimed."""
+    op = _operation(db, repository, kind=kind, params=params)
+    op.status = "queued"
+    db.commit()
+    claimed = (
+        db.query(Operation)
+        .filter(Operation.id == op.id, Operation.status == "queued")
+        .update(
+            # a fixed past instant: the service's own stamp must differ from it
+            # on any clock resolution
+            {"status": "running", "started_at": _RUNNER_CLAIMED_AT},
+            synchronize_session=False,
+        )
+    )
+    assert claimed == 1
+    db.commit()
+    db.refresh(op)
+    assert op.started_at is not None
+    return op
+
+
+def _other_session(db):
+    """A second identity map on the test engine (the in-memory SQLite engine
+    shares one connection, so this is what `claim_running` in the service's
+    own session sees, not a second transaction)."""
+    return sessionmaker(bind=db.get_bind())()
+
+
+@pytest.fixture()
+def borg2_repository(db):
+    repo = Repository(name="nas2", path="/repo/nas2", borg_version=2)
+    db.add(repo)
+    db.commit()
+    return repo
+
+
+# kind -> (executor, router method, params)
+_CLAIMING = {
+    "check": ("run_check", "check", None),
+    "prune": ("run_prune", "prune", None),
+    "compact": ("run_compact", "compact", None),
+    "delete_archive": ("run_delete_archive", "delete_archive", {"archive_name": "a1"}),
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", sorted(_CLAIMING))
+async def test_run_hands_the_runner_claimed_row_to_a_claiming_service(
+    db, borg2_repository, monkeypatch, kind
+):
+    """The runner claims a row as `running` with a `started_at`; the Borg 2
+    server services claim it again through `claim_running`, which takes a
+    `running` row only without a start. The executor hands the row over in
+    that shape before the call, so the service's claim succeeds and the
+    stored start is the service's, not the runner's (#1005)."""
+    from app.services.operations.executors import maintenance
+    from app.services.operations.job_facade import claim_running
+
+    executor_name, router_method, params = _CLAIMING[kind]
+    op = _runner_claimed(db, borg2_repository, kind=kind, params=params)
+    runner_started_at = op.started_at
+    seen = {}
+
+    async def fake_service(self, job_id, *args, **kwargs):
+        other = _other_session(db)
+        try:
+            seen["started_at"] = datetime.utcnow()
+            seen["claimed"] = claim_running(other, job_id, kind, seen["started_at"])
+            other.commit()
+            job = MaintenanceJobFacade(other, other.get(Operation, job_id))
+            job.status = "completed"
+            other.commit()
+        finally:
+            other.close()
+
+    monkeypatch.setattr(
+        f"app.core.borg_router.BorgRouter.{router_method}", fake_service, raising=True
+    )
+
+    outcome = await getattr(maintenance, executor_name)(FakeContext(db, op))
+
+    assert outcome.status == "completed"
+    assert seen["claimed"] == 1
+    db.expire_all()
+    stored = db.get(Operation, op.id).started_at
+    assert stored == seen["started_at"]
+    assert stored != runner_started_at
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "borg_version, executor_type",
+    [(1, "server"), (2, "agent")],
+    ids=["borg1-server", "borg2-agent"],
+)
+async def test_run_keeps_the_runner_start_where_no_service_claims(
+    db, monkeypatch, borg_version, executor_type
+):
+    """A Borg 1 service writes its own start over the runner's and the agent
+    path stamps it from the agent's report; neither claims through
+    `claim_running`, so the runner's start is left in place (an agent that
+    never reports would otherwise end the run with no start at all)."""
+    from app.services.operations.executors import maintenance
+
+    repo = Repository(
+        name=f"r-{borg_version}-{executor_type}",
+        path=f"/repo/{executor_type}",
+        borg_version=borg_version,
+        executor_type=executor_type,
+    )
+    db.add(repo)
+    db.commit()
+    op = _runner_claimed(db, repo)
+    runner_started_at = op.started_at
+
+    async def fake_compact(self, job_id):
+        other = _other_session(db)
+        try:
+            assert other.get(Operation, job_id).started_at == runner_started_at
+            job = MaintenanceJobFacade(other, other.get(Operation, job_id))
+            job.status = "completed"
+            other.commit()
+        finally:
+            other.close()
+
+    monkeypatch.setattr(
+        "app.core.borg_router.BorgRouter.compact", fake_compact, raising=True
+    )
+
+    outcome = await maintenance.run_compact(FakeContext(db, op))
+
+    assert outcome.status == "completed"
+    db.expire_all()
+    assert db.get(Operation, op.id).started_at == runner_started_at
+
+
+@pytest.mark.asyncio
+async def test_run_leaves_a_row_a_cancel_made_terminal_alone(tmp_path, monkeypatch):
+    """A cancel that landed between the runner's claim and the hand-over
+    (committed by a request's session on its own connection, after the
+    runner's session loaded the row) made the row terminal; the guarded
+    UPDATE reads the table, not the runner session's copy, so its start
+    stays for the history. A file-backed database, so the two sessions
+    really are two connections."""
+    from app.services.operations.executors import maintenance
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'ops.db'}")
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine)
+    runner_db = factory()
+    repo = Repository(name="nas2", path="/repo/nas2", borg_version=2)
+    runner_db.add(repo)
+    runner_db.commit()
+    op = _runner_claimed(runner_db, repo)
+    started_at = op.started_at
+    ctx = FakeContext(runner_db, op)  # holds the row as `running`
+
+    request_db = factory()
+    request_db.query(Operation).filter(Operation.id == op.id).update(
+        {"status": "cancelled"}, synchronize_session=False
+    )
+    request_db.commit()
+    request_db.close()
+
+    async def fake_compact(self, job_id):
+        return None
+
+    monkeypatch.setattr(
+        "app.core.borg_router.BorgRouter.compact", fake_compact, raising=True
+    )
+
+    try:
+        await maintenance.run_compact(ctx)
+        runner_db.expire_all()
+        row = runner_db.get(Operation, op.id)
+        assert row.status == "cancelled"
+        assert row.started_at == started_at
+    finally:
+        runner_db.close()
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_run_restores_the_runner_start_when_the_service_never_claimed(
+    db, borg2_repository, monkeypatch
+):
+    """A service that ends the run before it claims (a missing repository, a
+    lock it gave up on) writes a terminal status with no start; the runner's
+    start is put back so the run keeps its place in the history."""
+    from app.services.operations.executors import maintenance
+
+    op = _runner_claimed(db, borg2_repository)
+    runner_started_at = op.started_at
+
+    async def fake_compact(self, job_id):
+        other = _other_session(db)
+        try:
+            assert other.get(Operation, job_id).started_at is None
+            job = MaintenanceJobFacade(other, other.get(Operation, job_id))
+            job.status = "failed"
+            job.error_message = "Repository not found"
+            other.commit()
+        finally:
+            other.close()
+
+    monkeypatch.setattr(
+        "app.core.borg_router.BorgRouter.compact", fake_compact, raising=True
+    )
+
+    outcome = await maintenance.run_compact(FakeContext(db, op))
+
+    assert outcome.status == "failed"
+    db.expire_all()
+    assert db.get(Operation, op.id).started_at == runner_started_at
+
+
+@pytest.mark.asyncio
+async def test_run_restores_the_runner_start_when_the_service_raises(
+    db, borg2_repository, monkeypatch
+):
+    """A service that raises out of the call (a cancel arriving while it
+    retries a lock, before it claimed) leaves the row with no start; the
+    restore runs in the executor's `finally`, so the runner's verdict that
+    follows lands on a row that still has one."""
+    from app.services.operations.executors import maintenance
+
+    op = _runner_claimed(db, borg2_repository)
+    runner_started_at = op.started_at
+
+    async def fake_compact(self, job_id):
+        other = _other_session(db)
+        try:
+            assert other.get(Operation, job_id).started_at is None
+        finally:
+            other.close()
+        raise RuntimeError("database is locked")
+
+    monkeypatch.setattr(
+        "app.core.borg_router.BorgRouter.compact", fake_compact, raising=True
+    )
+
+    with pytest.raises(RuntimeError):
+        await maintenance.run_compact(FakeContext(db, op))
+
+    db.expire_all()
+    row = db.get(Operation, op.id)
+    assert row.status == "running"  # the runner writes the verdict
+    assert row.started_at == runner_started_at
+
+
+@pytest.mark.asyncio
+async def test_run_restores_the_runner_start_when_the_service_gave_no_verdict(
+    db, borg2_repository, monkeypatch
+):
+    """A service that returns with the row still `running` (its own failure
+    write lost to a lock) never claimed it; the start comes back before the
+    executor reports the missing verdict."""
+    from app.services.operations.executors import maintenance
+
+    op = _runner_claimed(db, borg2_repository)
+    runner_started_at = op.started_at
+
+    async def fake_compact(self, job_id):
+        return None
+
+    monkeypatch.setattr(
+        "app.core.borg_router.BorgRouter.compact", fake_compact, raising=True
+    )
+
+    outcome = await maintenance.run_compact(FakeContext(db, op))
+
+    assert outcome.status == "failed"
+    assert outcome.error_message == "service returned no result"
+    db.expire_all()
+    assert db.get(Operation, op.id).started_at == runner_started_at
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_clear_a_start_another_claim_wrote(tmp_path, monkeypatch):
+    """Between this dispatch loading the row and the hand-over, another
+    session rewrote the start (a service claiming the row through its own
+    path); the guarded UPDATE matches only the start this dispatch's claim
+    wrote, so that start stays. Two connections on a file-backed database."""
+    from app.services.operations.executors import maintenance
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'ops.db'}")
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine)
+    runner_db = factory()
+    repo = Repository(name="nas2", path="/repo/nas2", borg_version=2)
+    runner_db.add(repo)
+    runner_db.commit()
+    op = _runner_claimed(runner_db, repo)
+    ctx = FakeContext(runner_db, op)  # holds the runner's start
+
+    other_start = datetime(2026, 1, 2, 8, 30, 0)
+    other = factory()
+    other.query(Operation).filter(Operation.id == op.id).update(
+        {"started_at": other_start}, synchronize_session=False
+    )
+    other.commit()
+    other.close()
+
+    async def fake_compact(self, job_id):
+        service = factory()
+        try:
+            assert service.get(Operation, job_id).started_at == other_start
+            job = MaintenanceJobFacade(service, service.get(Operation, job_id))
+            job.status = "completed"
+            service.commit()
+        finally:
+            service.close()
+
+    monkeypatch.setattr(
+        "app.core.borg_router.BorgRouter.compact", fake_compact, raising=True
+    )
+
+    try:
+        outcome = await maintenance.run_compact(ctx)
+        assert outcome.status == "completed"
+        runner_db.expire_all()
+        assert runner_db.get(Operation, op.id).started_at == other_start
+    finally:
+        runner_db.close()
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_touch_a_row_dispatched_without_a_start(
+    db, borg2_repository, monkeypatch
+):
+    """A row dispatched without a runner start (the inline shape) is not
+    the executor's to touch; the start the service writes stays."""
+    from app.services.operations.executors import maintenance
+    from app.services.operations.job_facade import claim_running
+
+    op = _operation(db, borg2_repository, kind="compact")  # running, no start
+    assert op.started_at is None
+    seen = {}
+
+    async def fake_compact(self, job_id):
+        other = _other_session(db)
+        try:
+            seen["started_at"] = datetime.utcnow()
+            assert claim_running(other, job_id, "compact", seen["started_at"]) == 1
+            other.commit()
+            job = MaintenanceJobFacade(other, other.get(Operation, job_id))
+            job.status = "completed"
+            other.commit()
+        finally:
+            other.close()
+
+    monkeypatch.setattr(
+        "app.core.borg_router.BorgRouter.compact", fake_compact, raising=True
+    )
+
+    outcome = await maintenance.run_compact(FakeContext(db, op))
+
+    assert outcome.status == "completed"
+    db.expire_all()
+    assert db.get(Operation, op.id).started_at == seen["started_at"]
+
+
+@pytest.mark.asyncio
+async def test_hand_over_commit_failure_propagates_before_the_service_runs(
+    db, borg2_repository, monkeypatch
+):
+    """A hand-over whose commit exhausts its retries raises out of `_run`
+    before the service is called; the row keeps the runner's start."""
+    from sqlalchemy.exc import OperationalError
+
+    from app.services.operations.executors import maintenance
+
+    op = _runner_claimed(db, borg2_repository)
+    started_at = op.started_at
+    called = []
+
+    async def failing_commit(session, **kwargs):
+        session.rollback()
+        raise OperationalError("UPDATE operations", {}, Exception("database is locked"))
+
+    monkeypatch.setattr(maintenance, "commit_with_retry", failing_commit)
+
+    async def fake_compact(self, job_id):
+        called.append(job_id)
+
+    monkeypatch.setattr(
+        "app.core.borg_router.BorgRouter.compact", fake_compact, raising=True
+    )
+
+    with pytest.raises(OperationalError):
+        await maintenance.run_compact(FakeContext(db, op))
+
+    assert called == []
+    db.expire_all()
+    assert db.get(Operation, op.id).started_at == started_at
+
+
+@pytest.mark.asyncio
+async def test_restore_failure_does_not_replace_the_services_error(
+    db, borg2_repository, monkeypatch
+):
+    """The restore runs in the executor's `finally`; when its own commit
+    fails, the service's failure is what reaches the runner."""
+    from sqlalchemy.exc import OperationalError
+
+    from app.services.operations.executors import maintenance
+
+    op = _runner_claimed(db, borg2_repository)
+    real = maintenance.commit_with_retry
+
+    async def commit(session, **kwargs):
+        if kwargs.get("action") == "maintenance_restore_start":
+            session.rollback()
+            raise OperationalError("UPDATE operations", {}, Exception("locked"))
+        return await real(session, **kwargs)
+
+    monkeypatch.setattr(maintenance, "commit_with_retry", commit)
+
+    async def fake_compact(self, job_id):
+        raise RuntimeError("borg2 compact failed")
+
+    monkeypatch.setattr(
+        "app.core.borg_router.BorgRouter.compact", fake_compact, raising=True
+    )
+
+    with pytest.raises(RuntimeError, match="borg2 compact failed"):
+        await maintenance.run_compact(FakeContext(db, op))
+
+
+@pytest.mark.parametrize(
+    "kind, borg_version, executor_type, handed_over",
+    [
+        ("check", 2, "server", True),
+        ("prune", 2, "server", True),
+        ("compact", 2, "server", True),
+        ("delete_archive", 2, "server", True),
+        ("restore_check", 2, "server", False),
+        ("compact", 1, "server", False),
+        ("compact", 2, "agent", False),
+    ],
+)
+def test_hands_over_only_to_a_claiming_borg2_server_service(
+    db, kind, borg_version, executor_type, handed_over
+):
+    """The hand-over is for the four kinds whose Borg 2 server service claims
+    through `claim_running`; restore_check runs its own service without a
+    claim, Borg 1 services and the agent path write or report their own
+    start."""
+    from app.services.operations.executors import maintenance
+
+    repo = Repository(
+        name=f"{kind}-{borg_version}-{executor_type}",
+        path=f"/repo/{kind}",
+        borg_version=borg_version,
+        executor_type=executor_type,
+    )
+    db.add(repo)
+    db.commit()
+    op = _operation(db, repo, kind=kind, params={"archive_name": "a"})
+    assert maintenance._hands_over(FakeContext(db, op), repo) is handed_over
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_v2_services.py
+++ b/tests/unit/test_v2_services.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -1104,3 +1105,260 @@ def test_server_compact_stats_support_is_probed_per_binary_file(monkeypatch):
     assert borg2_core.compact_stats_supported("/opt/borg2") is False
     _Probe.stdout = "borg2 2.0.0b24\n"
     assert borg2_core.compact_stats_supported("/opt/borg2") is True
+
+
+class _RunnerContext:
+    """The slice of OperationContext the maintenance executor uses, for a row
+    the runner has already claimed."""
+
+    def __init__(self, db, operation):
+        self.db = db
+        self.operation = operation
+        self.operation_id = operation.id
+        self.repository_id = operation.repository_id
+        self.kind = operation.kind
+        self.params = dict(operation.params or {})
+
+    def cancelled(self):
+        return False
+
+    def log(self, line):
+        return None
+
+    async def progress(self, **kwargs):
+        return None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_runner_claimed_compact_runs_the_borg2_service(
+    db_session, testing_session_local, borg_v2_repo_for_services, tmp_path
+):
+    """Regression for #1005: a compact the runner claimed (`running` with a
+    `started_at`) reaches the Borg 2 service through the maintenance
+    executor and runs, instead of the service skipping it as already
+    started and the executor reporting `service returned no result`."""
+    from app.services.operations.executors import maintenance
+
+    job = _runner_claimed_operation(db_session, borg_v2_repo_for_services, "compact")
+    runner_started_at = job.started_at
+
+    service = CompactV2Service()
+    service.log_dir = tmp_path
+    with (
+        patch("app.services.v2.compact_service.compact_v2_service", service),
+        patch("app.services.v2.compact_service.SessionLocal", testing_session_local),
+        patch(
+            "app.services.v2.compact_service.resolve_repo_ssh_key_file",
+            return_value=None,
+        ),
+        patch(
+            "app.services.v2.compact_service._get_borg2_binary", return_value="borg2"
+        ),
+        patch(
+            "app.services.v2.compact_service.compact_stats_supported",
+            return_value=False,
+        ),
+        patch(
+            "app.services.v2.compact_service._get_process_start_time", return_value=1
+        ),
+        patch(
+            "app.services.v2.compact_service.asyncio.create_subprocess_exec",
+            return_value=FakeProcess(returncode=0, stderr_lines=[]),
+        ) as spawn,
+    ):
+        outcome = await maintenance.run_compact(_RunnerContext(db_session, job))
+
+    assert spawn.called, "the service never ran borg"
+    assert outcome.status == "completed"
+    verification = testing_session_local()
+    refreshed = verification.get(Operation, job.id)
+    assert refreshed.status == "completed"
+    # the start is the service's own, recorded when it claimed the row
+    assert refreshed.started_at is not None
+    assert refreshed.started_at != runner_started_at
+    assert refreshed.completed_at is not None
+    verification.close()
+
+
+class _CommunicatingProcess:
+    """The process shape the prune service drives (`communicate`)."""
+
+    def __init__(self, returncode=0, stdout=b"", stderr=b""):
+        self.returncode = returncode
+        self.pid = 4321
+        self._out = (stdout, stderr)
+
+    async def communicate(self):
+        return self._out
+
+    async def wait(self):
+        return self.returncode
+
+    def terminate(self):
+        return None
+
+    def kill(self):
+        return None
+
+
+# a fixed past instant: the service's own stamp must differ from it on any
+# clock resolution
+_RUNNER_CLAIMED_AT = datetime(2026, 1, 1, 12, 0, 0)
+
+
+def _runner_claimed_operation(db_session, repository, kind, params=None):
+    job = Operation(
+        repository_id=repository.id,
+        kind=kind,
+        category="maintenance",
+        status="queued",
+        trigger="manual",
+        priority=10,
+        run_id=f"run-claimed-{kind}",
+        params=params or {},
+    )
+    db_session.add(job)
+    db_session.commit()
+    db_session.refresh(job)
+    db_session.query(Operation).filter(
+        Operation.id == job.id, Operation.status == "queued"
+    ).update(
+        {"status": "running", "started_at": _RUNNER_CLAIMED_AT},
+        synchronize_session=False,
+    )
+    db_session.commit()
+    db_session.refresh(job)
+    assert job.started_at == _RUNNER_CLAIMED_AT
+    return job
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_runner_claimed_check_runs_the_borg2_service(
+    db_session, testing_session_local, borg_v2_repo_for_services, tmp_path
+):
+    """Regression for #1005, check: the real Borg 2 check service claims
+    and runs a row the runner claimed."""
+    from app.services.operations.executors import maintenance
+
+    job = _runner_claimed_operation(db_session, borg_v2_repo_for_services, "check")
+    runner_started_at = job.started_at
+    service = CheckV2Service()
+    service.log_dir = tmp_path
+    with (
+        patch("app.services.v2.check_service.check_v2_service", service),
+        patch("app.services.v2.check_service.SessionLocal", testing_session_local),
+        patch(
+            "app.services.v2.check_service.resolve_repo_ssh_key_file",
+            return_value=None,
+        ),
+        patch("app.services.v2.check_service._get_borg2_binary", return_value="borg2"),
+        patch("app.services.v2.check_service._get_process_start_time", return_value=1),
+        patch(
+            "app.services.v2.check_service.asyncio.create_subprocess_exec",
+            return_value=FakeProcess(returncode=0, stderr_lines=[]),
+        ) as spawn,
+    ):
+        outcome = await maintenance.run_check(_RunnerContext(db_session, job))
+
+    assert spawn.called, "the service never ran borg"
+    assert outcome.status == "completed"
+    verification = testing_session_local()
+    refreshed = verification.get(Operation, job.id)
+    assert refreshed.status == "completed"
+    assert refreshed.started_at is not None
+    assert refreshed.started_at != runner_started_at
+    verification.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_runner_claimed_prune_runs_the_borg2_service(
+    db_session, testing_session_local, borg_v2_repo_for_services, tmp_path
+):
+    """Regression for #1005, prune: the real Borg 2 prune service claims and
+    runs a row the runner claimed."""
+    from unittest.mock import AsyncMock
+
+    from app.services.operations.executors import maintenance
+    from app.services.v2.prune_service import PruneV2Service
+
+    job = _runner_claimed_operation(
+        db_session, borg_v2_repo_for_services, "prune", params={"keep_daily": 7}
+    )
+    runner_started_at = job.started_at
+    service = PruneV2Service()
+    service.log_dir = tmp_path
+    spawn = AsyncMock(return_value=_CommunicatingProcess(0, stdout=b"pruned"))
+    with (
+        patch("app.services.v2.prune_service.prune_v2_service", service),
+        patch("app.services.v2.prune_service.SessionLocal", testing_session_local),
+        patch("app.services.v2.prune_service._get_borg2_binary", return_value="borg2"),
+        patch(
+            "app.services.v2.prune_service.build_repository_borg_env",
+            return_value=({}, None),
+        ),
+        patch(
+            "app.services.v2.prune_service.asyncio.create_subprocess_exec", new=spawn
+        ),
+    ):
+        outcome = await maintenance.run_prune(_RunnerContext(db_session, job))
+
+    assert spawn.called, "the service never ran borg"
+    assert outcome.status == "completed"
+    verification = testing_session_local()
+    refreshed = verification.get(Operation, job.id)
+    assert refreshed.status == "completed"
+    assert refreshed.started_at is not None
+    assert refreshed.started_at != runner_started_at
+    verification.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_runner_claimed_delete_archive_runs_the_borg2_service(
+    db_session, testing_session_local, borg_v2_repo_for_services
+):
+    """Regression for #1005, delete_archive: the real Borg 2 delete service
+    claims and runs a row the runner claimed (it is the one claiming
+    service without a cancellation poll)."""
+    from unittest.mock import AsyncMock
+
+    from app.services.operations.executors import maintenance
+    from app.services.v2.delete_archive_service import DeleteArchiveV2Service
+
+    job = _runner_claimed_operation(
+        db_session,
+        borg_v2_repo_for_services,
+        "delete_archive",
+        params={"archive_name": "aid:deadbeef"},
+    )
+    runner_started_at = job.started_at
+    service = DeleteArchiveV2Service()
+    delete = AsyncMock(return_value={"success": True, "stdout": "", "stderr": ""})
+    compact = AsyncMock(return_value={"success": True, "stdout": "", "stderr": ""})
+    with (
+        patch(
+            "app.services.v2.delete_archive_service.delete_archive_v2_service", service
+        ),
+        patch(
+            "app.services.v2.delete_archive_service.SessionLocal", testing_session_local
+        ),
+        patch(
+            "app.services.v2.delete_archive_service.build_repository_borg_env",
+            return_value=({}, None),
+        ),
+        patch("app.services.v2.delete_archive_service.borg2.delete_archive", delete),
+        patch("app.services.v2.delete_archive_service.borg2.compact", compact),
+    ):
+        outcome = await maintenance.run_delete_archive(_RunnerContext(db_session, job))
+
+    assert delete.await_count == 1, "the service never ran borg"
+    assert outcome.status == "completed"
+    verification = testing_session_local()
+    refreshed = verification.get(Operation, job.id)
+    assert refreshed.status == "completed"
+    assert refreshed.started_at is not None
+    assert refreshed.started_at != runner_started_at
+    verification.close()


### PR DESCRIPTION
## Description

Runner-dispatched check, prune, compact and delete-archive on a Borg 2 repository executed on the server never ran Borg. The runner's claim writes `running` with a `started_at`; the Borg 2 services claim the row again through `claim_running`, which takes a `running` row only without a start (the manual-start shape, so two dispatches of one id cannot both start). The claim matched nothing, the service logged "reached a terminal state before start, skipping", and the executor recorded `failed` with "service returned no result".

The maintenance executor now hands the row to a Borg 2 server service in the shape it claims:

- **Hand-over.** Before calling the service, one guarded UPDATE against the table clears `started_at` where the row is still `running` and still carries the start this dispatch's claim wrote. A cancel that landed in between keeps its start; a row dispatched without a runner start (the inline shape) or one another claim has since stamped is not touched. The service then claims and records its own start.
- **Restore.** After the call, in the executor's `finally`, a row the service never claimed (it ended the run before that, returned without a verdict, or raised) gets the runner's start put back, so the run keeps its place in the maintenance history and its duration. A start the service wrote stays. The restore never replaces the service's own failure.
- **Only that route.** Borg 1 services write their own start over the runner's; the agent path leaves the row to the agent's report, which stamps the start from the job (an agent that never reports would otherwise end a run with no start at all); `restore_check` never claims.
- Both writes use the SQLite lock retry every write on this path uses. The runner keeps its claim semantics and `claim_running` its guard; `claim_running`'s docstring now says the runner path produces the manual-start shape on purpose.

## Related Issue

Fixes #1005

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

Regression, before and after: a compact the runner claimed (`running` with `started_at`) run through `maintenance.run_compact` with the real `CompactV2Service` and a fake Borg process. Before the change the outcome is `failed` with "service returned no result" and Borg is never spawned; after it the service claims, runs and completes. The same end-to-end run exists for check, prune and delete_archive.

Unit tests on the executor shell: the hand-over for each of the four kinds (fake service claiming in its own session; the stored start is the service's, not the runner's); the runner's start stays for a Borg 1 repository, an agent repository and `restore_check`; a row cancelled from a second connection between claim and hand-over keeps its start (file-backed SQLite, two connections); a start another session wrote after this dispatch loaded the row is not cleared; a row dispatched without a runner start is not touched; the runner's start comes back when the service never claimed, returned no verdict or raised; a hand-over commit that fails propagates before the service runs; a restore commit that fails keeps the service's error; the routing predicate over seven kind/version/executor combinations.

```
tests/unit/test_operations_maintenance_executors.py  40 passed
tests/unit/test_v2_services.py + test_schedulers.py  green
full unit suite (last review round)                  4104 passed, 14 skipped
```

Seven local review rounds (blind reviewer plus the CodeRabbit CLI) before opening.

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Context

Left out on purpose, named here so they are not mistaken for oversights:

- **Cancelling a runner-dispatched Borg 2 check or delete_archive.** Prune and compact are covered here: on the Borg 2 server route the executor hands `cancel_watcher` the Borg 2 service's canceller (`prune_v2_service.cancel_prune`, `compact_v2_service.cancel_compact`, which terminate the tracked process), the service records the killed process as a failure since the row never read `cancelled`, and once it has returned the executor turns that failure into the user's cancel, which the runner keeps; the Borg 1 route keeps its singleton (tests for both routes, for the killed-process verdict and for a plain failure staying a failure). `check_v2_service` and `delete_archive_v2_service` have no canceller to hand over yet; that is #1028.
- **A process kill between the hand-over and the service's claim** leaves a `running` row with no start, which `recover_on_startup` closes as `failed` without one. A claim token that does not require clearing the column would remove that window; it changes `claim_running`'s contract, so it is not part of this fix.
- `_CLAIMING_KINDS` names the four services that claim through `claim_running`; a new service that adopts the claim has to be added there. The end-to-end tests for the four are what tie the list to the services.

