### PR TITLE
fix(agents): queue a plan's agent script job again after phase 9

### DIFF
--- a/app/api/activity.py
+++ b/app/api/activity.py
@@ -42,9 +42,16 @@ router = APIRouter(prefix="/api/activity", tags=["activity"])
 
 
 def _get_agent_job_for_backup(db: Session, operation_id: int) -> Optional[AgentJob]:
+    from app.services.repository_executor import BACKUP_AGENT_JOB_TYPE
+
+    # The same question `repository_executor.get_agent_job_for_backup` asks,
+    # and the same answer: only the transport row speaks for the backup.
     return (
         db.query(AgentJob)
-        .filter(AgentJob.operation_id == operation_id)
+        .filter(
+            AgentJob.operation_id == operation_id,
+            AgentJob.job_type == BACKUP_AGENT_JOB_TYPE,
+        )
         .order_by(AgentJob.id.desc())
         .first()
     )

--- a/app/api/managed_machines.py
+++ b/app/api/managed_machines.py
@@ -758,9 +758,11 @@ async def create_agent_backup_job(
         )
 
     now = _now_utc()
+    from app.services.repository_executor import BACKUP_AGENT_JOB_TYPE
+
     job = AgentJob(
         agent_machine_id=agent.id,
-        job_type="backup",
+        job_type=BACKUP_AGENT_JOB_TYPE,
         status="queued",
         payload=_build_backup_job_payload(payload),
         created_at=now,

--- a/app/services/repository_executor.py
+++ b/app/services/repository_executor.py
@@ -21,7 +21,6 @@ from app.services.job_admission import (
 from app.services.operations.backup_facade import (
     admission_ignore_for,
     backup_job_link_columns,
-    is_backup_operation,
     resolve_backup_job,
 )
 
@@ -444,6 +443,13 @@ async def wait_for_agent_repository_operation_job(
     )
 
 
+# `agent_jobs.job_type` of the row that carries a backup to its agent. Named
+# once: the writers set it and `get_agent_job_for_backup` reads it, and a
+# mismatch between them fails silently — the cancel route would find no job
+# and refuse, the log endpoints would serve nothing.
+BACKUP_AGENT_JOB_TYPE = "backup"
+
+
 def queue_agent_backup_job(
     db: Session,
     backup_job,
@@ -479,7 +485,7 @@ def queue_agent_backup_job(
     now = datetime.utcnow()
     agent_job = AgentJob(
         agent_machine_id=agent.id,
-        job_type="backup",
+        job_type=BACKUP_AGENT_JOB_TYPE,
         status="queued",
         payload=build_agent_backup_payload(
             repository,
@@ -544,15 +550,23 @@ def queue_agent_script_job(
     *,
     script_name: str,
     env: Optional[dict[str, str]] = None,
-    backup_job_id: Optional[int] = None,
 ) -> AgentJob:
     """Enqueue a ``script.run`` job for a resolved agent. Not a borg operation, so
-    it carries no repository admission — it wraps a plan run, not the borg call."""
+    it carries no repository admission — it wraps a plan run, not the borg call.
+
+    It carries no backup link either. `agent_jobs` has one link column,
+    `operation_id`, and every reader of it — the agent's own reports, the
+    reaper, the cancel path — takes the row it points at to *be* that
+    operation's transport job: a script row wearing the same link would
+    fail a finished backup, overwrite its log and be cancelled in its
+    place. What ties a hook to the run it belongs to is its
+    `script_executions` row, through the plan run and the `agent_job_id`
+    the caller writes back onto it.
+    """
     validate_agent_script(agent)
     now = datetime.utcnow()
     agent_job = AgentJob(
         agent_machine_id=agent.id,
-        backup_job_id=backup_job_id,
         job_type="script",
         status="queued",
         payload=build_agent_script_payload(script_name, env),
@@ -635,15 +649,19 @@ async def wait_for_agent_script_job(
 
 
 def get_agent_job_for_backup(db: Session, backup_job: Any) -> Optional[AgentJob]:
-    """The transport job for a backup, whichever shape the backup has."""
-    column = (
-        AgentJob.operation_id
-        if is_backup_operation(backup_job)
-        else AgentJob.backup_job_id
-    )
+    """The transport job that carries a backup to its agent.
+
+    `agent_jobs` has one link column, so the lookup names the kind it wants
+    rather than trusting the link alone: the caller cancels this job, reads
+    its logs and decides the backup's fate from its status, none of which
+    may land on a row that merely belongs to the same run.
+    """
     return (
         db.query(AgentJob)
-        .filter(column == backup_job.id)
+        .filter(
+            AgentJob.operation_id == backup_job.id,
+            AgentJob.job_type == BACKUP_AGENT_JOB_TYPE,
+        )
         .order_by(AgentJob.id.desc())
         .first()
     )

--- a/tests/unit/test_agent_script_job_queueing.py
+++ b/tests/unit/test_agent_script_job_queueing.py
@@ -1,0 +1,159 @@
+"""A plan's agent hook must reach the agent, and must not be mistaken for
+the backup it runs beside.
+
+Phase 9 dropped `agent_jobs.backup_job_id`; `queue_agent_script_job` kept
+passing it and raised `TypeError` at construction, so every agent pre/post
+backup hook failed at once. A pre-backup hook that cannot be queued aborts
+the plan run before the backup, which is what makes this worth pinning.
+
+The column it was tempting to move the link to, `operation_id`, is the one
+every reader treats as "this agent job *is* that operation": a script row
+wearing it would let a failing hook fail a finished backup. So a script job
+carries no backup link at all, and the lookups that want the backup's
+transport job say so.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.core.security import get_password_hash
+from app.database.models import AgentJob, AgentMachine, Repository, ScriptExecution
+from app.services.backup_plan_execution_service import BackupPlanExecutionService
+from app.services.operations.backup_facade import create_backup_operation
+from app.services.repository_executor import (
+    BACKUP_AGENT_JOB_TYPE,
+    SCRIPT_RUN_CAPABILITY,
+    get_agent_job_for_backup,
+    queue_agent_script_job,
+)
+
+
+@pytest.fixture()
+def agent(db_session):
+    machine = AgentMachine(
+        name="Agent",
+        agent_id="agt_queue_script",
+        token_hash=get_password_hash("agent-secret"),
+        token_prefix="agent-se",
+        status="online",
+        capabilities=[SCRIPT_RUN_CAPABILITY],
+    )
+    db_session.add(machine)
+    db_session.commit()
+    return machine
+
+
+def _agent_repository(db_session, agent, name="nas"):
+    repository = Repository(
+        name=name,
+        path=f"/repos/{name}",
+        encryption="none",
+        repository_type="local",
+        executor_type="agent",
+        agent_machine_id=agent.id,
+    )
+    db_session.add(repository)
+    db_session.commit()
+    return repository
+
+
+@pytest.mark.unit
+def test_script_job_is_queued_and_carries_no_backup_link(db_session, agent):
+    job = queue_agent_script_job(
+        db_session, agent, script_name="pre-db-dump.sh", env={"A": "b"}
+    )
+
+    assert job.id is not None
+    assert job.job_type == "script"
+    assert job.status == "queued"
+    assert job.payload["job_kind"] == "script.run"
+    # the link column means "transport job of this operation"; a hook is not that
+    assert job.operation_id is None
+
+
+@pytest.mark.unit
+def test_the_transport_job_wins_over_a_script_row_of_the_same_run(db_session, agent):
+    """`get_agent_job_for_backup` drives the backup: it cancels that job,
+    reads its logs and takes the backup's outcome from its status. A row
+    that merely shares the operation must never be handed back, not even
+    when it is the newer one."""
+    repository = _agent_repository(db_session, agent)
+    backup = create_backup_operation(
+        db_session, repository, trigger="plan", executor="agent"
+    )
+    transport = AgentJob(
+        agent_machine_id=agent.id,
+        operation_id=backup.id,
+        # the constant the writers use, so a rename cannot part reader
+        # from writer without this test noticing
+        job_type=BACKUP_AGENT_JOB_TYPE,
+        status="running",
+        payload={"schema_version": 1, "job_kind": "backup.create"},
+    )
+    db_session.add(transport)
+    db_session.commit()
+    impostor = AgentJob(
+        agent_machine_id=agent.id,
+        operation_id=backup.id,
+        job_type="script",
+        status="queued",
+        payload={"schema_version": 1, "job_kind": "script.run"},
+    )
+    db_session.add(impostor)
+    db_session.commit()
+
+    assert impostor.id > transport.id
+    assert get_agent_job_for_backup(db_session, backup).id == transport.id
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_plan_hook_gets_past_queueing_and_records_its_execution(
+    db_session, agent, monkeypatch
+):
+    """The caller the regression actually broke: the plan's hook step. It
+    must queue the job, keep a `ScriptExecution` for it and report success
+    to the run, instead of dying in `AgentJob(...)`."""
+    from app.services import backup_plan_execution_service as module
+
+    monkeypatch.setattr(module, "SessionLocal", lambda: db_session)
+    monkeypatch.setattr(db_session, "close", lambda: None)
+    service = BackupPlanExecutionService()
+    monkeypatch.setattr(
+        service, "_resolve_plan_agent", lambda db, plan_id: (agent, None)
+    )
+    monkeypatch.setattr(
+        service, "_build_agent_script_env", lambda *a, **k: {"BORG_UI_RUN_ID": "1"}
+    )
+    context = SimpleNamespace(plan_id=7)
+
+    with (
+        patch.object(module, "dispatch_agent_job_best_effort", new=AsyncMock()),
+        patch.object(
+            module,
+            "wait_for_agent_script_job",
+            new=AsyncMock(
+                return_value={"status": "completed", "result": {"return_code": 0}}
+            ),
+        ),
+    ):
+        ok, error = await service._execute_agent_plan_script(
+            run_id=1,
+            context=context,
+            hook_type="pre-backup",
+            backup_result=None,
+            agent_script_name="pre-db-dump.sh",
+        )
+
+    assert (ok, error) == (True, None)
+    queued = db_session.query(AgentJob).filter(AgentJob.job_type == "script").all()
+    assert len(queued) == 1
+    assert queued[0].operation_id is None
+    execution = db_session.query(ScriptExecution).one()
+    assert execution.agent_script_name == "pre-db-dump.sh"
+    assert execution.status == "completed"
+    # what replaces the link this change removed: the execution points at
+    # the job, which is how the activity feed streams a running hook's output
+    assert execution.agent_job_id == queued[0].id

--- a/tests/unit/test_api_activity.py
+++ b/tests/unit/test_api_activity.py
@@ -1216,7 +1216,7 @@ class TestActivityLogContracts:
 
         agent_job = AgentJob(
             agent_machine_id=1,
-            job_type="script.run",
+            job_type="script",
             status="running",
             payload={},
         )

--- a/tests/unit/test_api_backup.py
+++ b/tests/unit/test_api_backup.py
@@ -2007,7 +2007,7 @@ class TestBackupLogs:
         agent_job = AgentJob(
             agent_machine_id=agent.id,
             operation_id=backup_job.id,
-            job_type="backup.create",
+            job_type="backup",
             status="completed",
             payload={},
             completed_at=datetime.now(),
@@ -2071,7 +2071,7 @@ class TestBackupLogs:
         agent_job = AgentJob(
             agent_machine_id=agent.id,
             operation_id=backup_job.id,
-            job_type="backup.create",
+            job_type="backup",
             status="completed",
             payload={},
             completed_at=datetime.now(),


### PR DESCRIPTION
## Description

Phase 9 (#1010) dropped `agent_jobs.backup_job_id` (migration `d0e1f2a3b4c5`), but `queue_agent_script_job` kept passing it, so the row could not be constructed at all:

```
TypeError: 'backup_job_id' is an invalid keyword argument for AgentJob
```

It is unconditional, not a matter of which id is passed: the plan's own call site passes none, and `AgentJob(backup_job_id=None, ...)` raises just the same. **Every agent pre/post-backup hook has failed the moment it was queued since phase 9**, after 0 seconds, with no exit code and no output.

A failing pre-backup hook aborts the plan run before the backup. On an install whose plan carries a database dump as its pre-hook, that repository stopped being backed up at all, one missed run per hour from the moment the build arrived, and because the run dies before `create_backup_operation`, its history shows no row for those cycles rather than a failure. Six hours passed before anyone noticed, for reasons that are themselves findings; see #1026.

**The parameter is not moved to `operation_id`, it goes.** It has no caller, and that column is the one every reader takes to mean "this agent job *is* that operation". Had a caller ever used it, a failing post-backup hook would have flipped the finished backup to `failed` and overwritten its log with the hook's transcript (`_finish_linked_backup_job`), the reaper would have failed a completed backup when the hook job went stale, and the cancel path would have killed the hook instead of `borg create`. What ties a hook to its run is the `script_executions` row, through the plan run and the `agent_job_id` written back onto it.

The two readers that would have been fooled first now name the kind they want, since both take the newest row for the operation and a post-backup hook is queued after the transport job.

## Side findings

All of these came out of one two-line fix, and they share a root: phase 9 moved a link column that many call sites read, and nothing in the suite reads the column that tells those rows apart. Listing them because the pattern may be more useful than the individual fixes.

1. **`get_agent_job_for_backup` still named `AgentJob.backup_job_id`** in its legacy branch, an attribute the model no longer has. Unreachable while `resolve_backup_job` returns only operations, so it never raised, which is also why nothing flagged it.
2. **The transport lookup existed twice, and only one copy was reachable from tests.** `api/activity.py::_get_agent_job_for_backup` answers the same question with a second query; it is now guarded the same way. Two copies of an invariant drift by definition; worth deciding which one survives.
3. **Three fixtures write `job_type` values the application never writes**: `"backup.create"` twice and `"script.run"` once (the domain is `backup`, `script`, `repository`, `agent_upgrade`; those two are payload `job_kind`s). They passed for as long as nothing read `job_type` and broke the moment a reader did, which is how I found them. Corrected here.
4. **No shared constant for the transport job's type.** Two writers and now two readers agree on a bare `"backup"`, and a mismatch is silent: the cancel route finds no job and refuses with `canOnlyCancelRunningJobs`, and the log endpoints serve nothing. Hoisted to `BACKUP_AGENT_JOB_TYPE`.
5. **The plan's agent hook step had no test at all.** `_execute_agent_plan_script` is the caller the regression broke, and the suite stayed green (4089 tests) through a build in which it could not construct its job. There is one now.
6. **The upgrade path would have carried the hazard into existing data.** `legacy_job_collapse._rewrite_backup_links` rewrites `backup_job_id → operation_id` for every `agent_jobs` row regardless of `job_type`, so any historical script row with a link would now read as a transport job. Checked on two upgraded installs: zero script rows carry `operation_id`, because the parameter never had a caller. The guard makes the readers immune either way.
7. **The failure was invisible where people look** (#1026, left out of this PR on purpose): no backup row is created at all, `dashboard.py` has no script lane, and `maintenance_jobs_started_since` filters `started_at >= since`, which drops exactly the rows that failed before starting.

## Related Issue

Fixes #1026.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

New `tests/unit/test_agent_script_job_queueing.py`, three cases: a hook queued outside a backup run, the plan's own hook step driven end to end (queued, `ScriptExecution` written, `agent_job_id` linked back, success reported to the run), and the transport lookup pinned against a newer script row carrying the same `operation_id`. Each was run against the defect it exists for, reintroduced in place: all three fail with the production error, including the plan step's own log line.

```
pytest tests/unit -q                (on upstream main 631edd58)
4089 passed, 14 skipped
ruff check app tests && ruff format --check app tests
All checks passed! / 638 files already formatted
```

Suites around the changed functions (`test_api_backup_plans`, `test_api_backup`, `test_api_activity`, `test_activity_union`, `test_api_agents`, `test_api_managed_machines`, `test_operations_backup_facade`, `test_operations_backup_executor`, the agent-script modules, `test_agent_job_abandon`): 399 passed.

Not covered, and worth saying plainly: nothing exercises `cancel_agent_backup_job`, `backup_job_has_logs` or the reaper under the new filter. They cannot see a script row today because none carries the link, but the tests do not state that.

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none needed; `docs/managed-agent-spec.md` already gives `backup` as the wire value)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

n/a; the visible effect is that an agent hook runs again instead of failing after 0 seconds.

## Additional Context

No frontend change. Two rounds of an isolated blind review plus the CodeRabbit CLI before opening; round one's blocker was my own first attempt, which moved the script job's link to `operation_id` instead of dropping it and would have armed exactly the aliasing described above.
