### PR TITLE
feat(repositories): one stored storage payload for every size reader

### DIFF
--- a/app/api/dashboard.py
+++ b/app/api/dashboard.py
@@ -30,6 +30,7 @@ from app.services.operations.job_facade import (
     latest_maintenance_jobs_by_repository,
     maintenance_jobs_started_since,
 )
+from app.services.storage_usage import stored_size_bytes
 from app.utils.datetime_utils import serialize_datetime
 from app.utils.schedule_time import (
     DEFAULT_SCHEDULE_TIMEZONE,
@@ -798,14 +799,14 @@ async def get_dashboard_overview(
 
         # Include all repos for size/archive totals
         for repo in repositories:
-            size_bytes = parse_size_to_bytes(repo.total_size)
+            size_bytes = repository_size_bytes(repo)
             total_size_bytes += size_bytes
             total_archives += repo.archive_count or 0
 
         # Show health for both repo modes, but with mode-specific semantics.
         for repo in full_mode_repos:
             # Parse size for this repo
-            size_bytes = parse_size_to_bytes(repo.total_size)
+            size_bytes = repository_size_bytes(repo)
             latest_restore_check = latest_restore_checks.get(repo.id)
             health = build_full_repository_health(
                 repo,
@@ -843,18 +844,6 @@ async def get_dashboard_overview(
                 repo_schedule = fallback_schedule
             repo_backup_plans = backup_plans_by_repo.get(repo.id, [])
 
-            # Calculate dedup ratio (if we have the data)
-            dedup_ratio = None
-            if (
-                hasattr(repo, "deduplicated_size")
-                and repo.deduplicated_size
-                and size_bytes > 0
-            ):
-                dedup_bytes = parse_size_to_bytes(repo.deduplicated_size)
-                dedup_ratio = (
-                    int((1 - (dedup_bytes / size_bytes)) * 100) if size_bytes > 0 else 0
-                )
-
             repo_health.append(
                 {
                     "id": repo.id,
@@ -877,7 +866,8 @@ async def get_dashboard_overview(
                         "latest_restore_check_status"
                     ],
                     "latest_restore_check_error": health["latest_restore_check_error"],
-                    "dedup_ratio": dedup_ratio,
+                    # nothing stores a per-repository deduplicated size
+                    "dedup_ratio": None,
                     "has_schedule": repo_schedule is not None,
                     "schedule_enabled": repo_schedule.enabled
                     if repo_schedule
@@ -896,7 +886,7 @@ async def get_dashboard_overview(
             )
 
         for repo in observe_only_repos:
-            size_bytes = parse_size_to_bytes(repo.total_size)
+            size_bytes = repository_size_bytes(repo)
             latest_restore_check = latest_restore_checks.get(repo.id)
             health = build_observe_repository_health(
                 repo,
@@ -1205,13 +1195,9 @@ async def get_dashboard_overview(
                         {
                             "name": repo.name,
                             "size": repo.total_size,
-                            "size_bytes": parse_size_to_bytes(repo.total_size),
+                            "size_bytes": repository_size_bytes(repo),
                             "percentage": round(
-                                (
-                                    parse_size_to_bytes(repo.total_size)
-                                    / total_size_bytes
-                                    * 100
-                                ),
+                                (repository_size_bytes(repo) / total_size_bytes * 100),
                                 1,
                             )
                             if total_size_bytes > 0
@@ -1264,39 +1250,10 @@ async def get_dashboard_overview(
         )
 
 
-def parse_size_to_bytes(size_str: str) -> int:
-    """Parse human-readable size string to bytes"""
-    if not size_str:
-        return 0
-
-    size_str = size_str.strip().upper()
-
-    # Remove spaces
-    size_str = size_str.replace(" ", "")
-
-    # Check units from longest to shortest to avoid matching 'B' in 'GB'
-    multipliers = [
-        ("PB", 1024**5),
-        ("TB", 1024**4),
-        ("GB", 1024**3),
-        ("MB", 1024**2),
-        ("KB", 1024),
-        ("B", 1),
-    ]
-
-    for unit, multiplier in multipliers:
-        if size_str.endswith(unit):
-            try:
-                number = float(size_str[: -len(unit)])
-                return int(number * multiplier)
-            except ValueError:
-                return 0
-
-    # Try parsing as plain number
-    try:
-        return int(float(size_str))
-    except ValueError:
-        return 0
+def repository_size_bytes(repo) -> int:
+    """The repository's measured size in bytes, by the one rule every size
+    reader applies (`storage_usage.stored_size_bytes`); 0 when unknown."""
+    return stored_size_bytes(repo) or 0
 
 
 def format_bytes(bytes_value: int) -> str:

--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -23,6 +23,7 @@ from app.database.models import (
 )
 from app.services.operations.backup_facade import latest_backup_job_for_repository
 from app.services.operations.job_facade import legacy_status
+from app.services.storage_usage import stored_size_bytes
 from app.utils.datetime_utils import serialize_datetime
 
 logger = structlog.get_logger()
@@ -114,32 +115,6 @@ def _extract_metrics_token(
     return None
 
 
-def parse_size_string(size_str: str) -> int:
-    """Convert size string like '1.5 GB' to bytes"""
-    if not size_str:
-        return 0
-
-    size_str = size_str.strip()
-    # Check longer units first to avoid matching 'B' in 'GB'
-    units = [
-        ("PB", 1024**5),
-        ("TB", 1024**4),
-        ("GB", 1024**3),
-        ("MB", 1024**2),
-        ("KB", 1024),
-        ("B", 1),
-    ]
-
-    try:
-        for unit, multiplier in units:
-            if unit in size_str:
-                number = float(size_str.replace(unit, "").strip())
-                return int(number * multiplier)
-        return int(float(size_str))
-    except:
-        return 0
-
-
 def timestamp_to_unix(dt: datetime) -> int:
     """Convert datetime to Unix timestamp"""
     if not dt:
@@ -200,7 +175,12 @@ async def get_metrics(
         lines.append("# HELP borg_repository_size_bytes Repository total size in bytes")
         lines.append("# TYPE borg_repository_size_bytes gauge")
         for repo in repositories:
-            size_bytes = parse_size_string(repo.total_size or "0")
+            # a repository nobody has measured yet gets no sample: 0 is the
+            # size of an emptied repository, and an alert on "dropped to
+            # zero" must not fire on an import that was never measured
+            size_bytes = stored_size_bytes(repo)
+            if size_bytes is None:
+                continue
             lines.append(
                 f'borg_repository_size_bytes{{repository="{repo.name}"}} {size_bytes}'
             )

--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -51,7 +51,12 @@ from app.services.operations.index_mode import MODE_KINDS, indexes_history
 from app.services.operations.index_mode import mode_of as index_mode_of
 from app.services.operations.reconcile import enqueue_reconcile_run
 from app.services.operations.runner import operation_runner
-from app.services.operations.repository_status import LastRuns, last_runs
+from app.services.operations.repository_status import (
+    LastRuns,
+    StorageSummary,
+    last_runs,
+    storage_summaries,
+)
 from app.core.authorization import authorize_request
 from app.core.security import get_current_user, check_repo_access
 from app.core.borg import BorgInterface
@@ -103,6 +108,8 @@ from app.services.repository_info_sync import sync_archive_stats_from_info
 from app.services.storage_usage import (
     SOURCE_BORG1_CACHE_STATS,
     SOURCE_STORAGE_USED,
+    format_bytes,
+    set_repository_size,
 )
 from app.services.repository_command_lock import run_serialized_repository_command
 from app.services.rclone_repository_service import (
@@ -923,6 +930,7 @@ async def _update_agent_repository_stats(
 
         encryption_mode = None
         total_size = None
+        total_size_bytes = None
         total_size_source = None
         borg_last_modified = None
         try:
@@ -949,6 +957,7 @@ async def _update_agent_repository_stats(
             size_bytes = stats.get("unique_csize") or stats.get("unique_size")
             if isinstance(size_bytes, (int, float)) and size_bytes > 0:
                 total_size = format_bytes(int(size_bytes))
+                total_size_bytes = int(size_bytes)
                 total_size_source = SOURCE_BORG1_CACHE_STATS
             # Both versions report the last manifest write; the agent renders
             # it in its reported zone (UTC since #889).
@@ -991,6 +1000,7 @@ async def _update_agent_repository_stats(
                     and usage.get("source")
                 ):
                     total_size = format_bytes(size_bytes)
+                    total_size_bytes = size_bytes
                     total_size_source = str(usage["source"])
             except Exception as e:
                 logger.warning(
@@ -1021,6 +1031,7 @@ async def _update_agent_repository_stats(
                     fields = first.split()
                     if fields and fields[0].isdigit() and int(fields[0]) > 0:
                         total_size = format_bytes(int(fields[0]))
+                        total_size_bytes = int(fields[0])
                         total_size_source = SOURCE_STORAGE_USED
             except Exception as e:
                 logger.warning(
@@ -1035,9 +1046,8 @@ async def _update_agent_repository_stats(
                 repository.last_backup = last_backup_time
         if encryption_mode:
             repository.encryption = encryption_mode
-        if total_size:
-            repository.total_size = total_size
-            repository.total_size_source = total_size_source
+        if total_size and total_size_bytes is not None:
+            set_repository_size(repository, total_size_bytes, total_size_source)
         if borg_last_modified:
             repository.borg_last_modified = borg_last_modified
         db.commit()
@@ -1060,13 +1070,11 @@ async def _update_agent_repository_stats(
 
 
 # Helper function to format bytes to human readable format
-def format_bytes(bytes_size: int) -> str:
-    """Format bytes to human readable string (e.g., '1.23 GB')"""
-    for unit in ["B", "KB", "MB", "GB", "TB", "PB"]:
-        if bytes_size < 1024.0:
-            return f"{bytes_size:.2f} {unit}"
-        bytes_size /= 1024.0
-    return f"{bytes_size:.2f} EB"
+# `format_bytes` now lives next to the parser that reads its output and the
+# writer that keeps the size columns in agreement (`storage_usage`); it is
+# imported above and re-exported here for the callers that have always
+# taken it from this module.
+__all__ = ["format_bytes"]
 
 
 def _decode_json_list_field(value):
@@ -1120,6 +1128,61 @@ def _normalize_repository_source_payload(
 def format_datetime(dt):
     """Format datetime to ISO8601 with UTC timezone indicator"""
     return serialize_datetime(dt)
+
+
+def _storage_summary_or_none(
+    db: Session, repository: Repository
+) -> Optional[StorageSummary]:
+    """The repository's storage summary, or None when it cannot be computed:
+    a decorative object must not take the repository detail down. The
+    detail carries the archive sums and the compact statistics; the list,
+    polled by every tab, carries the stored size columns only."""
+    repository_id = repository.id  # before a rollback could expire the row
+    try:
+        return storage_summaries(db, [repository], archives=True).get(repository_id)
+    except Exception as exc:
+        db.rollback()
+        logger.warning(
+            "Failed to compute storage summary",
+            repository_id=repository_id,
+            error=str(exc),
+            exc_info=True,
+        )
+        return None
+
+
+def storage_payload(summary: Optional[StorageSummary]) -> Optional[dict]:
+    """The `storage` object of a repository response (#981): the stored
+    size with its provenance and time, Borg's last manifest write, the
+    archive sums and the newest compact statistics. A None field is "not
+    measured yet" or "not reported by this Borg version"; a size of 0 is a
+    measurement (an emptied repository), so the two are distinct states. A
+    size with `measured_at` None comes from the formatted string (the
+    upgrade's backfill, or a row it did not reach), so its time is unknown;
+    `archives_consistent` False says the archive figures are withheld
+    because the rows and the count disagree, or because no listing has run
+    for the repository yet; None says the route did not compute them (the
+    list; the detail route does). `latest_archive_files` is the newest
+    archive's file count, not a sum. `compact` is the statistics of that
+    run as `parse_compact_stats` read them, including its
+    `size_precision`: `rounded` says its figures come from Borg's
+    formatted output, so they can differ from `size_bytes` by the rounding
+    of that text rather than by a change in the repository."""
+    if summary is None:
+        return None
+    return {
+        "size_bytes": summary.size_bytes,
+        "size_source": summary.size_source,
+        "measured_at": format_datetime(summary.measured_at),
+        "last_modified": format_datetime(summary.last_modified),
+        "archives_consistent": summary.archives_consistent,
+        "original_size": summary.original_size,
+        "compressed_size": summary.compressed_size,
+        "deduplicated_size": summary.deduplicated_size,
+        "latest_archive_files": summary.latest_archive_files,
+        "compact": summary.compact,
+        "compact_at": format_datetime(summary.compact_at),
+    }
 
 
 def _borg_result_error(result: Dict[str, Any]) -> Optional[str]:
@@ -2967,6 +3030,9 @@ async def get_repositories(
             repositories = (
                 db.query(Repository).filter(Repository.id.in_(repository_ids)).all()
             )
+        # the stored columns only, no query of its own (the archive figures
+        # come with the detail route, which guards its queries)
+        storage = storage_summaries(db, repositories, archives=False)
         for repo in repositories:
             # Running check, compact, or prune.
             running_kinds = {
@@ -3022,6 +3088,7 @@ async def get_repositories(
                     else {}
                 ),
                 "total_size": repo.total_size,
+                "storage": storage_payload(storage.get(repo.id)),
                 "archive_count": repo.archive_count,
                 "created_at": format_datetime(repo.created_at),
                 "updated_at": format_datetime(repo.updated_at),
@@ -4085,6 +4152,10 @@ async def get_repository(
         # Get repository statistics
         stats = await get_repository_stats(repository, db, bypass_lock=use_bypass_lock)
 
+        # computed before the payload is built: on a failure this rolls the
+        # session back, which would expire every row the payload still reads
+        storage = storage_payload(_storage_summary_or_none(db, repository))
+
         repository_payload = {
             "id": repository.id,
             "name": repository.name,
@@ -4097,6 +4168,7 @@ async def get_repository(
             **_agent_machine_summary(repository, db),
             "last_backup": format_datetime(repository.last_backup),
             "total_size": repository.total_size,
+            "storage": storage,
             "archive_count": repository.archive_count,
             "created_at": format_datetime(repository.created_at),
             "updated_at": format_datetime(repository.updated_at),

--- a/app/database/alembic/versions/a9b8c7d6e5f4_add_repository_size_bytes.py
+++ b/app/database/alembic/versions/a9b8c7d6e5f4_add_repository_size_bytes.py
@@ -1,0 +1,100 @@
+"""add repository size bytes and measured_at
+
+Revision ID: a9b8c7d6e5f4
+Revises: e1f2a3b4c5d6
+Create Date: 2026-09-11
+"""
+
+import re
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Optional
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "a9b8c7d6e5f4"
+down_revision = "e1f2a3b4c5d6"
+branch_labels = None
+depends_on = None
+
+# The units a stored size string may carry: what `format_bytes` prints
+# (base 1024, two decimals) and the shapes older releases wrote ("1.5GB",
+# "1 GiB", a bare byte count). A copy of `storage_usage.bytes_from_formatted`
+# (a migration imports no app code): keep the two in step.
+_SIZE_UNITS = {"": 0, "K": 1, "M": 2, "G": 3, "T": 4, "P": 5, "E": 6}
+_SIZE_TEXT = re.compile(
+    r"^\s*(?P<number>\d+(?:\.\d+)?)\s*(?P<unit>[KMGTPE]?)(?:I?B)?\s*$", re.IGNORECASE
+)
+
+
+def bytes_from_formatted(text: Optional[str]) -> Optional[int]:
+    """The byte count a stored size string stands for, as exact as its
+    digits allow; None for anything else ("Unknown", "N/A", empty)."""
+    if not text:
+        return None
+    match = _SIZE_TEXT.match(text)
+    if not match:
+        return None
+    # the pattern admits digits and one point only, so the value is finite
+    value = Decimal(match.group("number"))
+    exponent = _SIZE_UNITS[match.group("unit").upper()]
+    scaled = value * (Decimal(1024) ** exponent)
+    return int(scaled.to_integral_value(rounding=ROUND_HALF_UP))
+
+
+def upgrade() -> None:
+    # The size as measured, next to the formatted string the card shows:
+    # readers that need a number (the archive header, the info dialog, a
+    # storage total) no longer parse the string back. `measured_at` is when
+    # that value was written.
+    with op.batch_alter_table("repositories") as batch:
+        batch.add_column(sa.Column("total_size_bytes", sa.BigInteger(), nullable=True))
+        batch.add_column(
+            sa.Column("total_size_measured_at", sa.DateTime(), nullable=True)
+        )
+    # Backfill from the string every row already carries, so a repository
+    # that showed a size keeps showing one in the new field; the two
+    # decimals of the string are all the precision there is until the next
+    # measurement rewrites both. The time of that old measurement is not
+    # known, so `measured_at` stays NULL until then: a size with no time is
+    # the backfilled state, and the readers say so.
+    connection = op.get_bind()
+    rows = connection.execute(
+        sa.text("SELECT id, total_size FROM repositories WHERE total_size IS NOT NULL")
+    ).fetchall()
+    updates = [
+        {"size_bytes": size_bytes, "id": repository_id}
+        for repository_id, total_size in rows
+        if (size_bytes := bytes_from_formatted(total_size)) is not None
+    ]
+    if updates:
+        # one statement, not one round trip per repository
+        connection.execute(
+            sa.text(
+                "UPDATE repositories SET total_size_bytes = :size_bytes WHERE id = :id"
+            ),
+            updates,
+        )
+
+
+def downgrade() -> None:
+    # On SQLite a dropped column means a table recreate (copy, DROP TABLE,
+    # rename), and DROP TABLE with foreign keys enforced deletes through
+    # every ON DELETE CASCADE that points at `repositories`: the archive
+    # index and the operation history. The pragma cannot be changed inside
+    # the migration's transaction (a silent no-op), so it is switched in an
+    # autocommit block around the recreate.
+    # The pragma is not switched back: entering a second autocommit block
+    # after the recreate would commit the DDL before Alembic writes the
+    # version row, and a stop in between would leave a database without
+    # the columns that still claims this revision. The recreate and the
+    # version row commit together; the connection ends with the pragma
+    # off, which affects nothing beyond this run (the upgrade runner
+    # disposes its engine, and the application sets the pragma on
+    # connect).
+    if op.get_bind().dialect.name == "sqlite":
+        with op.get_context().autocommit_block():
+            op.execute("PRAGMA foreign_keys=OFF")
+    with op.batch_alter_table("repositories") as batch:
+        batch.drop_column("total_size_measured_at")
+        batch.drop_column("total_size_bytes")

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -306,6 +306,10 @@ class Repository(Base):
     # borg2_index (repository object size), storage_used (store file bytes),
     # compact_stats (pack file bytes as `borg compact --stats` reported them).
     total_size_source = Column(String, nullable=True)
+    # The same measurement as a number, and when it was written; NULL on a
+    # row no size write has touched since the columns arrived.
+    total_size_bytes = Column(BigInteger, nullable=True)
+    total_size_measured_at = Column(DateTime, nullable=True)
     # repository.last_modified as Borg reports it: the last manifest write.
     borg_last_modified = Column(DateTime, nullable=True)
     archive_count = Column(Integer, default=0)

--- a/app/services/maintenance_state.py
+++ b/app/services/maintenance_state.py
@@ -9,7 +9,11 @@ from app.services.borg2_compact_stats import (
     PRECISION_EXACT,
     PRECISION_ROUNDED,
 )
-from app.services.storage_usage import SOURCE_COMPACT_STATS, SOURCE_STORAGE_USED
+from app.services.storage_usage import (
+    SOURCE_COMPACT_STATS,
+    SOURCE_STORAGE_USED,
+    set_repository_size,
+)
 
 logger = structlog.get_logger()
 
@@ -57,10 +61,7 @@ def apply_compact_stats(job, repository, stats: Optional[dict]) -> bool:
         isinstance(size, int) and not isinstance(size, bool) and 0 <= size < MAX_COUNT
     ):
         return False
-    from app.api.repositories import format_bytes
-
-    repository.total_size = format_bytes(size)
-    repository.total_size_source = SOURCE_COMPACT_STATS
+    set_repository_size(repository, size, SOURCE_COMPACT_STATS)
     return True
 
 

--- a/app/services/mqtt_service.py
+++ b/app/services/mqtt_service.py
@@ -584,7 +584,7 @@ class RepositoryStatePublisher:
         """Publish all per-repository state topics from repository table."""
         try:
             success = True
-            size_bytes = stored_size_bytes(repository) or 0
+            size_bytes = stored_size_bytes(repository)
             if not self._mqtt_service.publish_repository_size(
                 repository.id,
                 size_bytes,
@@ -1118,7 +1118,7 @@ class MQTTService:
             payload["archive"] = archive
         return self.publish(f"repositories/{repository_id}/status", payload, qos=1)
 
-    def publish_repository_size(self, repository_id: int, total: int):
+    def publish_repository_size(self, repository_id: int, total: Optional[int]):
         if not self.config["enabled"]:
             return False
         return self.publish(

--- a/app/services/mqtt_service.py
+++ b/app/services/mqtt_service.py
@@ -22,6 +22,7 @@ from app.services.operations.backup_facade import (
     newest_backup_job,
 )
 from app.utils.datetime_utils import serialize_datetime
+from app.services.storage_usage import stored_size_bytes
 
 import paho.mqtt.client as mqtt
 
@@ -583,7 +584,7 @@ class RepositoryStatePublisher:
         """Publish all per-repository state topics from repository table."""
         try:
             success = True
-            size_bytes = self.parse_size_to_bytes(repository.total_size or "0")
+            size_bytes = stored_size_bytes(repository) or 0
             if not self._mqtt_service.publish_repository_size(
                 repository.id,
                 size_bytes,
@@ -709,35 +710,6 @@ class RepositoryStatePublisher:
                 exc_info=True,
             )
             return False
-
-    @staticmethod
-    def parse_size_to_bytes(size_str: str) -> int:
-        """Parse human-readable size string to bytes."""
-        if not size_str:
-            return 0
-
-        normalized = size_str.strip().upper().replace(" ", "")
-        multipliers = [
-            ("PB", 1024**5),
-            ("TB", 1024**4),
-            ("GB", 1024**3),
-            ("MB", 1024**2),
-            ("KB", 1024),
-            ("B", 1),
-        ]
-
-        for unit, multiplier in multipliers:
-            if normalized.endswith(unit):
-                try:
-                    number = float(normalized[: -len(unit)])
-                    return int(number * multiplier)
-                except ValueError:
-                    return 0
-
-        try:
-            return int(float(normalized))
-        except ValueError:
-            return 0
 
     @staticmethod
     def get_repository_status(
@@ -1448,10 +1420,6 @@ class MQTTService:
     def _fetch_running_backup_jobs_by_repository(self, db: Session) -> Dict[str, Any]:
         """Return latest running backup job row per repository path."""
         return self._job_query_service.fetch_running_backup_jobs_by_repository(db)
-
-    def _parse_size_to_bytes(self, size_str: str) -> int:
-        """Parse human-readable size string to bytes."""
-        return self._repository_state_publisher.parse_size_to_bytes(size_str)
 
     def _get_repository_status(
         self,

--- a/app/services/operations/executors/index.py
+++ b/app/services/operations/executors/index.py
@@ -530,10 +530,8 @@ async def run_stats(ctx) -> Outcome:
             ),
             scope="metadata",
         )
-        # `measure_repository_size` reports unknown as None and never 0, so
-        # this is "a size came back"; an emptied repository reads as unknown
-        # and keeps its stored size until a source can say "empty"
-        if measured.bytes:
+        # Preserve a successful empty measurement; only None is unknown.
+        if measured.bytes is not None:
             set_repository_size(repository, measured.bytes, measured.source)
         if measured.last_modified:
             repository.borg_last_modified = measured.last_modified

--- a/app/services/operations/executors/index.py
+++ b/app/services/operations/executors/index.py
@@ -16,7 +16,6 @@ from app.api.repositories import (
     _prepare_repository_borg_env,
     _repository_stats_borg_env,
     agent_timezone_for_repository,
-    format_bytes,
     get_operation_timeouts,
 )
 from app.config import settings
@@ -31,7 +30,7 @@ from app.services.operations.runner import Outcome, repository_busy
 from app.services.operations.series import infer_series, series_prefixes_for_repository
 from app.services.repository_command_lock import run_serialized_repository_command
 from app.services.repository_executor import is_agent_executor
-from app.services.storage_usage import measure_repository_size
+from app.services.storage_usage import measure_repository_size, set_repository_size
 from app.utils.borg_env import cleanup_temp_key_file, effective_repository_remote_path
 
 logger = structlog.get_logger()
@@ -531,9 +530,11 @@ async def run_stats(ctx) -> Outcome:
             ),
             scope="metadata",
         )
+        # `measure_repository_size` reports unknown as None and never 0, so
+        # this is "a size came back"; an emptied repository reads as unknown
+        # and keeps its stored size until a source can say "empty"
         if measured.bytes:
-            repository.total_size = format_bytes(measured.bytes)
-            repository.total_size_source = measured.source
+            set_repository_size(repository, measured.bytes, measured.source)
         if measured.last_modified:
             repository.borg_last_modified = measured.last_modified
         if system_settings is not None:

--- a/app/services/operations/repository_status.py
+++ b/app/services/operations/repository_status.py
@@ -22,7 +22,7 @@ from datetime import datetime, timedelta
 from math import ceil
 from typing import Iterable, Optional
 
-from sqlalchemy import and_, case, func, or_
+from sqlalchemy import String, and_, case, cast, func, or_
 from sqlalchemy.orm import Session, aliased
 
 from app.database.models import (
@@ -37,6 +37,7 @@ from app.database.models import (
 from app.services.operations import anomalies
 from app.services.operations.index_mode import mode_of as index_mode_of
 from app.services.operations.vocab import SUCCESS_STATUSES
+from app.services.storage_usage import SOURCE_BORG1_CACHE_STATS, stored_size_bytes
 
 TERMINAL = ("completed", "completed_with_warnings", "failed", "cancelled")
 FAILED = ("failed", "cancelled")
@@ -644,4 +645,276 @@ def last_runs(db: Session, repositories: Iterable[Repository]) -> dict[int, Last
         else:
             result[repository_id].last_prune = job
         result[repository_id].last_index = index_ops.get(repository_id)
+    return result
+
+
+# -- storage: the one payload every size reader takes ---------------------------
+
+
+@dataclass
+class StorageSummary:
+    """What is stored about a repository's size, in one place (#981): the
+    measured size with its provenance and time, Borg's last manifest write,
+    the sums over the archive index, and the newest compact statistics.
+    Every field can be None: not measured yet, or not reported by this Borg
+    version. A reader shows that state rather than a zero. Two more states
+    are named explicitly: a size whose `measured_at` is None comes from the
+    formatted string (the upgrade's backfill, or a row it did not reach,
+    read back on the way out), so its time is unknown; and the archive
+    figures are withheld (`archives_consistent` False) while the archive
+    rows and `archive_count` disagree, or while no listing has run for the
+    repository yet (nothing to be consistent with); `archives_consistent`
+    None says they were not computed at all (the list route).
+    `latest_archive_files` is the newest archive's file count, not a sum."""
+
+    size_bytes: Optional[int] = None
+    size_source: Optional[str] = None
+    measured_at: Optional[datetime] = None
+    last_modified: Optional[datetime] = None
+    archives_consistent: Optional[bool] = None
+    original_size: Optional[int] = None
+    compressed_size: Optional[int] = None
+    deduplicated_size: Optional[int] = None
+    latest_archive_files: Optional[int] = None
+    compact: Optional[dict] = None
+    compact_at: Optional[datetime] = None
+
+
+def _current_archives(db: Session, repository_ids: list[int]):
+    """A filter for the archive rows the newest listing still saw: every
+    listing stamps the rows it sees with one `last_seen_at`, so a row an
+    earlier listing stamped was reported removed and waits for
+    `history_merge` to drop it. `archive_count` excludes those rows, and so
+    do the sums."""
+    newest_seen = (
+        db.query(
+            Archive.repository_id.label("repository_id"),
+            func.max(Archive.last_seen_at).label("last_seen_at"),
+        )
+        .filter(Archive.repository_id.in_(repository_ids))
+        .group_by(Archive.repository_id)
+        .subquery()
+    )
+    return newest_seen, and_(
+        Archive.repository_id == newest_seen.c.repository_id,
+        Archive.last_seen_at == newest_seen.c.last_seen_at,
+    )
+
+
+def _archive_sums(db: Session, current) -> dict[int, tuple]:
+    """Per repository over the current archive rows: the rows, the rows
+    whose per-archive info has been filled (`fill_archive_info` writes
+    `original_size` and `compressed_size`; a listing alone leaves them
+    NULL), and the sums over the filled rows."""
+    newest_seen, current = current
+    rows = (
+        db.query(
+            Archive.repository_id,
+            func.count(Archive.id),
+            func.count(Archive.original_size),
+            func.sum(Archive.original_size),
+            func.count(Archive.compressed_size),
+            func.sum(Archive.compressed_size),
+        )
+        .join(newest_seen, current)
+        .group_by(Archive.repository_id)
+        .all()
+    )
+    return {row[0]: row[1:] for row in rows}
+
+
+def _latest_archive_files(db: Session, current) -> dict[int, int]:
+    """`nfiles` of each repository's newest current archive (by start, then
+    id), where that archive's info has been filled."""
+    newest_seen, current = current
+    newest = (
+        db.query(Archive.repository_id, func.max(Archive.start).label("start"))
+        .join(newest_seen, current)
+        .group_by(Archive.repository_id)
+        .subquery()
+    )
+    rows = (
+        db.query(Archive.repository_id, Archive.nfiles)
+        .join(newest_seen, current)
+        .join(
+            newest,
+            and_(
+                Archive.repository_id == newest.c.repository_id,
+                Archive.start == newest.c.start,
+            ),
+        )
+        .order_by(Archive.repository_id, Archive.id.desc())
+        .all()
+    )
+    files: dict[int, Optional[int]] = {}
+    for repository_id, nfiles in rows:
+        # the first row per repository is the newest (highest id among the
+        # rows tied on start); a newest archive without its info yet reports
+        # nothing rather than an older archive's count
+        files.setdefault(repository_id, nfiles)
+    return {repository_id: n for repository_id, n in files.items() if n is not None}
+
+
+# How many of a repository's newest successful compacts are read for their
+# statistics. The query keeps only rows whose serialized result mentions
+# the key, a textual filter; the window then tolerates a row that mentions
+# it without carrying a usable statistics dict. The newest is the one
+# wanted.
+_COMPACT_STATS_LOOKBACK = 3
+
+
+def _listed_repositories(db: Session, repository_ids: list[int]) -> set[int]:
+    """The repositories a listing (`archive_sync`) has completed for. A
+    repository without one has no archive rows and the count it was
+    created with, so "0 rows, count 0" says nothing about its archives;
+    with one, the same state is a measurement (an emptied repository)."""
+    rows = (
+        db.query(Operation.repository_id)
+        .filter(
+            Operation.repository_id.in_(repository_ids),
+            Operation.kind == "archive_sync",
+            Operation.status.in_(SUCCESS_STATUSES),
+        )
+        .distinct()
+        .all()
+    )
+    return {repository_id for (repository_id,) in rows}
+
+
+def _latest_compact_stats(
+    db: Session, repository_ids: list[int]
+) -> dict[int, tuple[dict, datetime]]:
+    """The statistics of each repository's newest successful compact that
+    reported any (`result["stats"]`, Borg 2 `compact --stats`), read from
+    the newest few rows per repository (a window, not the whole history)."""
+    ranked = (
+        db.query(
+            Operation.repository_id,
+            Operation.result,
+            Operation.completed_at,
+            func.row_number()
+            .over(
+                partition_by=Operation.repository_id,
+                order_by=(Operation.completed_at.desc(), Operation.id.desc()),
+            )
+            .label("rank"),
+        )
+        .filter(
+            Operation.repository_id.in_(repository_ids),
+            Operation.kind == "compact",
+            Operation.status.in_(SUCCESS_STATUSES),
+            Operation.completed_at.isnot(None),
+            # only rows that carry statistics rank: a run of compacts without
+            # them (an agent that predates the report) must not push the
+            # newest figure out of the window
+            cast(Operation.result, String).like('%"stats"%'),
+        )
+        .subquery()
+    )
+    rows = (
+        db.query(ranked.c.repository_id, ranked.c.result, ranked.c.completed_at)
+        .filter(ranked.c.rank <= _COMPACT_STATS_LOOKBACK)
+        .order_by(ranked.c.repository_id, ranked.c.rank)
+        .all()
+    )
+    found: dict[int, tuple[dict, datetime]] = {}
+    for repository_id, result, completed_at in rows:
+        if repository_id in found:
+            continue
+        stats = result.get("stats") if isinstance(result, dict) else None
+        if isinstance(stats, dict) and stats:
+            found[repository_id] = (stats, completed_at)
+    return found
+
+
+def storage_summaries(
+    db: Session, repositories: Iterable[Repository], *, archives: bool = True
+) -> dict[int, StorageSummary]:
+    """One `StorageSummary` per repository. With `archives`, three grouped
+    queries add the archive sums and the newest compact statistics (the
+    detail route); without, only the stored columns are read (the list,
+    which is polled and whose card shows the size alone). Borg 1's stored
+    size is its deduplicated size (`cache.stats`), Borg 2's deduplicated
+    size comes from the newest compact statistics; compressed size is a
+    Borg 1 figure (Borg 2 does not report it). The archive sums cover the
+    rows the newest listing still saw and are reported once every one of
+    them carries the figure; until then they would read as a total they
+    are not."""
+    repos = list(repositories)
+    ids = [repository.id for repository in repos]
+    if not ids:
+        return {}
+    if archives:
+        current = _current_archives(db, ids)
+        sums = _archive_sums(db, current)
+        files = _latest_archive_files(db, current)
+        compacts = _latest_compact_stats(db, ids)
+        listed = _listed_repositories(db, ids)
+    else:
+        sums, files, compacts, listed = {}, {}, {}, set()
+    result: dict[int, StorageSummary] = {}
+    for repository in repos:
+        count, filled_original, original, filled_compressed, compressed = sums.get(
+            repository.id, (0, 0, None, 0, None)
+        )
+        # The rows the newest listing stamped must be the archives it
+        # counted: a listing that found nothing stamps nothing, so the rows
+        # it reported removed would still read as current, and rows
+        # `history_merge` has not dropped yet drift the same way. On a
+        # mismatch the archive figures are not reported.
+        # `archive_count` also moves without the rows (an agent's own
+        # listing, an info sync), so the gate can close between a backup
+        # and its `archive_sync`; the flag tells a withheld figure from an
+        # absent one. Zero rows against a count of 0 is a measurement only
+        # once a listing has run: before that it is the row's initial state.
+        consistent = (
+            (
+                count == (repository.archive_count or 0)
+                and (count > 0 or repository.id in listed)
+            )
+            if archives
+            else None
+        )
+        compact = compacts.get(repository.id)
+        summary = StorageSummary(
+            size_bytes=stored_size_bytes(repository),
+            size_source=repository.total_size_source,
+            measured_at=repository.total_size_measured_at,
+            last_modified=repository.borg_last_modified,
+            archives_consistent=consistent,
+            # a consistent, empty repository has a measured original size
+            # of 0 (every archive pruned), which is not "not measured yet"
+            original_size=(
+                int(original or 0) if consistent and filled_original == count else None
+            ),
+            latest_archive_files=files.get(repository.id) if consistent else None,
+            compact=compact[0] if compact else None,
+            compact_at=compact[1] if compact else None,
+        )
+        borg2 = (repository.borg_version or 1) == 2
+        if not borg2:
+            # Borg 1's deduplicated size is its stored size when that came
+            # from `cache.stats`: a stored column, so both routes carry it
+            summary.deduplicated_size = (
+                summary.size_bytes
+                if repository.total_size_source == SOURCE_BORG1_CACHE_STATS
+                else None
+            )
+        if not archives:
+            # the light payload carries the stored columns only; the
+            # figures derived from the archive rows and the compact
+            # statistics come with the detail
+            result[repository.id] = summary
+            continue
+        if borg2:
+            summary.deduplicated_size = (
+                compact[0].get("deduplicated_size") if compact else None
+            )
+        else:
+            summary.compressed_size = (
+                int(compressed or 0)
+                if consistent and filled_compressed == count
+                else None
+            )
+        result[repository.id] = summary
     return result

--- a/app/services/storage_usage.py
+++ b/app/services/storage_usage.py
@@ -25,6 +25,8 @@ caller persists alongside.
 """
 
 import asyncio
+import re
+from decimal import ROUND_HALF_UP, Decimal
 import json
 import os
 import shutil
@@ -36,7 +38,7 @@ from urllib.parse import unquote, urlsplit
 
 import structlog
 
-from app.utils.datetime_utils import parse_borg_archive_time
+from app.utils.datetime_utils import parse_borg_archive_time, utc_now
 
 logger = structlog.get_logger()
 
@@ -45,6 +47,66 @@ SOURCE_BORG2_INDEX = "borg2_index"
 SOURCE_STORAGE_USED = "storage_used"
 # Written by the compact paths (maintenance_state), not measured here.
 SOURCE_COMPACT_STATS = "compact_stats"
+
+
+def format_bytes(bytes_size: int) -> str:
+    """Format bytes to human readable string (e.g., '1.23 GB')"""
+    for unit in ["B", "KB", "MB", "GB", "TB", "PB"]:
+        if bytes_size < 1024.0:
+            return f"{bytes_size:.2f} {unit}"
+        bytes_size /= 1024.0
+    return f"{bytes_size:.2f} EB"
+
+
+def set_repository_size(
+    repository, size_bytes: int, source: str, *, measured_at: Optional[datetime] = None
+) -> None:
+    """Write one size measurement to the four columns that carry it: the
+    formatted string the card shows, the number, its source and the time
+    it was written. Every writer goes through here so the four never
+    disagree."""
+    size_bytes = int(size_bytes)
+    repository.total_size = format_bytes(size_bytes)
+    repository.total_size_bytes = size_bytes
+    repository.total_size_source = source
+    repository.total_size_measured_at = measured_at or utc_now()
+
+
+# The units a stored size string may carry: what `format_bytes` prints
+# (base 1024, two decimals) and the shapes older releases wrote ("1.5GB",
+# "1 GiB", a bare byte count). The revision a9b8c7d6e5f4 backfill carries
+# its own copy of the strict form (a migration imports no app code).
+_SIZE_UNITS = {"": 0, "K": 1, "M": 2, "G": 3, "T": 4, "P": 5, "E": 6}
+_SIZE_TEXT = re.compile(
+    r"^\s*(?P<number>\d+(?:\.\d+)?)\s*(?P<unit>[KMGTPE]?)(?:I?B)?\s*$", re.IGNORECASE
+)
+
+
+def bytes_from_formatted(text: Optional[str]) -> Optional[int]:
+    """The byte count a stored size string stands for: a `format_bytes`
+    string as exact as its two decimals allow, or one of the older shapes
+    ("1.5GB", "1 GiB", "4096"); None for anything else ("Unknown", "N/A",
+    empty). For rows that predate `total_size_bytes`."""
+    if not text:
+        return None
+    match = _SIZE_TEXT.match(text)
+    if not match:
+        return None
+    # the pattern admits digits and one point only, so the value is finite
+    value = Decimal(match.group("number"))
+    exponent = _SIZE_UNITS[match.group("unit").upper()]
+    scaled = value * (Decimal(1024) ** exponent)
+    return int(scaled.to_integral_value(rounding=ROUND_HALF_UP))
+
+
+def stored_size_bytes(repository) -> Optional[int]:
+    """The one rule every size reader applies: the stored number where a
+    size write (or the backfill) has filled it, else the formatted string
+    parsed back, else None. Readers that need a number take `or 0`."""
+    size_bytes = repository.total_size_bytes
+    if size_bytes is not None:
+        return int(size_bytes)
+    return bytes_from_formatted(repository.total_size)
 
 
 def _port(parts) -> Optional[int]:

--- a/app/services/storage_usage.py
+++ b/app/services/storage_usage.py
@@ -556,7 +556,7 @@ async def measure_repository_size(
     use_bypass_lock: bool = False,
 ) -> SizeResult:
     """Best available size and `last_modified` for a server-executed
-    repository. Never returns 0 bytes: unknown is `None`."""
+    repository. An empty Borg 2 index is 0 bytes; unknown is `None`."""
     from app.utils.borg_env import effective_repository_remote_path
 
     remote_path = effective_repository_remote_path(repository)
@@ -620,9 +620,9 @@ async def measure_repository_size(
     )
     if indexed is not None:
         return SizeResult(
-            bytes=indexed[0] or None,
+            bytes=indexed[0],
             objects=indexed[1],
-            source=SOURCE_BORG2_INDEX if indexed[0] else None,
+            source=SOURCE_BORG2_INDEX,
             last_modified=last_modified,
         )
 

--- a/app/services/v2/compact_service.py
+++ b/app/services/v2/compact_service.py
@@ -485,8 +485,13 @@ class CompactV2Service:
             # A pre-phase-5 legacy row has no statistics attribute at all.
             final_stats = getattr(job, "stats", None)
             repository_last_compact = repository.last_compact
-            repository_total_size = repository.total_size
-            repository_total_size_source = repository.total_size_source
+            # the four size columns move together (`set_repository_size`)
+            repository_size_columns = (
+                repository.total_size,
+                repository.total_size_bytes,
+                repository.total_size_source,
+                repository.total_size_measured_at,
+            )
 
             def persist_final_state():
                 job.status = final_status
@@ -504,8 +509,12 @@ class CompactV2Service:
                     # Only a size this compact wrote is restored after a
                     # rolled-back attempt; one it left alone may have been
                     # measured by a follow-up in the meantime.
-                    repository.total_size = repository_total_size
-                    repository.total_size_source = repository_total_size_source
+                    (
+                        repository.total_size,
+                        repository.total_size_bytes,
+                        repository.total_size_source,
+                        repository.total_size_measured_at,
+                    ) = repository_size_columns
 
             await commit_with_retry(
                 db,

--- a/docs/architecture/job-system.md
+++ b/docs/architecture/job-system.md
@@ -345,7 +345,12 @@ Rules:
   suppresses a duplicate listing. `history_merge` follows the listing on
   every plan so removed archives leave the database as well.
 - `stats` measures the repository read-only through the best source Borg
-  offers and records it in `repositories.total_size_source`: Borg 1
+  offers and records it in `repositories.total_size` (formatted),
+  `total_size_bytes`, `total_size_source` and `total_size_measured_at`,
+  through one writer (`storage_usage.set_repository_size`); the repository
+  responses carry a `storage` object (the stored figures in the list; the
+  detail adds the archive sums and the newest compact statistics), so
+  every size reader shows the same value and names its source: Borg 1
   `cache.stats.unique_csize` (`borg1_cache_stats`, deduplicated); Borg 2 the
   chunk-index sum through Borg's Python API next to the configured binary
   (`borg2_index`, the bytes of every indexed object), else a store-level

--- a/tests/unit/test_api_dashboard.py
+++ b/tests/unit/test_api_dashboard.py
@@ -18,7 +18,6 @@ from app.api.dashboard import (
     build_restore_check_health,
     format_bytes,
     get_recent_jobs,
-    parse_size_to_bytes,
 )
 from app.database.models import (
     Operation,
@@ -288,22 +287,6 @@ class TestDashboardSummary:
 @pytest.mark.unit
 class TestDashboardHelpers:
     """Test dashboard helper functions directly."""
-
-    @pytest.mark.parametrize(
-        "size_string, expected",
-        [
-            ("0", 0),
-            ("512 B", 512),
-            ("1 KB", 1024),
-            ("1.5 MB", 1572864),
-            ("2 GB", 2147483648),
-            ("3 TB", 3298534883328),
-            ("bad-value", 0),
-            (None, 0),
-        ],
-    )
-    def test_parse_size_to_bytes(self, size_string, expected):
-        assert parse_size_to_bytes(size_string) == expected
 
     def test_maintenance_repository_name_falls_back_from_id_to_path(self):
         from types import SimpleNamespace
@@ -1326,3 +1309,18 @@ class TestDashboardScheduleAndOverview:
         assert repo_health["health_status"] == "warning"
         assert repo_health["dimension_health"]["backup"] == "warning"
         assert repo_health["warnings"] == ["Last backup 20 days ago"]
+
+
+@pytest.mark.unit
+def test_repository_size_bytes_prefers_the_stored_number():
+    from types import SimpleNamespace
+
+    from app.api.dashboard import repository_size_bytes
+
+    measured = SimpleNamespace(total_size="2.19 GB", total_size_bytes=2_350_000_000)
+    assert repository_size_bytes(measured) == 2_350_000_000
+    # a row from before the column: the string, rounded to its two decimals
+    legacy = SimpleNamespace(total_size="1.00 KB", total_size_bytes=None)
+    assert repository_size_bytes(legacy) == 1024
+    empty = SimpleNamespace(total_size=None, total_size_bytes=None)
+    assert repository_size_bytes(empty) == 0

--- a/tests/unit/test_api_metrics.py
+++ b/tests/unit/test_api_metrics.py
@@ -647,6 +647,8 @@ class TestMetricValues:
         content = response.text
 
         assert 'borg_repository_archive_count{repository="Empty Repo"} 0' in content
+        # "0" is not a size the parser accepts as measured... it is: a bare
+        # byte count, so the gauge carries it
         assert 'borg_repository_size_bytes{repository="Empty Repo"} 0' in content
 
     def test_metrics_sorted_consistently(self, test_client, test_db):
@@ -667,3 +669,31 @@ class TestMetricValues:
 
         # Should be in same order
         assert names1 == names2
+
+
+@pytest.mark.unit
+def test_repository_size_gauge_reports_the_stored_number(test_client, test_db):
+    """The gauge and the MQTT size topic read the same stored number; the
+    formatted string is only the fallback for a row without one."""
+    from app.database.models import Repository
+
+    measured = Repository(
+        name="measured",
+        path="/repos/measured",
+        total_size="2.19 GB",
+        total_size_bytes=2_350_000_000,
+    )
+    legacy = Repository(name="legacy", path="/repos/legacy", total_size="1.00 KB")
+    test_db.add_all([measured, legacy])
+    test_db.commit()
+
+    unmeasured = Repository(name="unmeasured", path="/repos/unmeasured")
+    test_db.add(unmeasured)
+    test_db.commit()
+
+    content = test_client.get("/metrics").text
+    assert 'borg_repository_size_bytes{repository="measured"} 2350000000' in content
+    assert 'borg_repository_size_bytes{repository="legacy"} 1024' in content
+    # a repository nobody measured has no sample at all, so an alert on a
+    # size of zero cannot fire on it
+    assert 'borg_repository_size_bytes{repository="unmeasured"}' not in content

--- a/tests/unit/test_api_repositories_routes.py
+++ b/tests/unit/test_api_repositories_routes.py
@@ -550,6 +550,8 @@ class TestRepositoryHelperContracts:
                 is True
             )
         assert repo.total_size == "4.00 KB" and repo.total_size_source == "storage_used"
+        assert repo.total_size_bytes == 4096
+        assert repo.total_size_measured_at is not None
         assert [c.kwargs["job_kind"] for c in mock_queue.call_args_list][-2:] == [
             "repository.storage_usage",
             "repository.disk_usage",

--- a/tests/unit/test_maintenance_state.py
+++ b/tests/unit/test_maintenance_state.py
@@ -93,6 +93,8 @@ def test_apply_compact_completion_persists_stats_and_fills_an_unmeasured_size():
 
     assert job.stats == stats
     assert repo.total_size == "490.23 KB"
+    assert repo.total_size_bytes == 502_000
+    assert repo.total_size_measured_at is not None
     # value and provenance move together: the label names pack file bytes
     assert repo.total_size_source == "compact_stats"
 

--- a/tests/unit/test_mqtt_service.py
+++ b/tests/unit/test_mqtt_service.py
@@ -542,29 +542,6 @@ class TestBackupJobQueryService:
 class TestRepositoryStatePublisher:
     """Tests for RepositoryStatePublisher."""
 
-    @pytest.mark.parametrize(
-        "size_str,expected",
-        [
-            ("0", 0),
-            ("100", 100),
-            ("1 KB", 1024),
-            ("1KB", 1024),
-            ("2 MB", 2 * 1024**2),
-            ("3 GB", 3 * 1024**3),
-            ("4 TB", 4 * 1024**4),
-            ("5 PB", 5 * 1024**5),
-            ("1.5 GB", int(1.5 * 1024**3)),
-            ("", 0),
-            ("invalid", 0),
-            ("  2.5 MB  ", int(2.5 * 1024**2)),
-        ],
-    )
-    def test_parse_size_to_bytes(self, size_str, expected):
-        """Should parse various size formats correctly."""
-        publisher = RepositoryStatePublisher(Mock())
-        result = publisher.parse_size_to_bytes(size_str)
-        assert result == expected
-
     def test_get_repository_status_failed(self, db_session):
         """Should return 'failed' for repositories in failed set."""
         repo = Repository(
@@ -668,6 +645,36 @@ class TestRepositoryStatePublisher:
         assert result is True
         # Verify all expected methods were called
         assert mqtt_service.publish.call_count >= 5  # At least 5 topics
+
+    def test_publish_repository_data_reports_the_stored_size_number(self, db_session):
+        """The size topic carries the stored number where a measurement wrote
+        it; the formatted string is only the fallback for a row without one."""
+        repo = Repository(
+            name="Measured",
+            path="/repo/measured",
+            total_size="2.19 GB",
+            total_size_bytes=2_350_000_000,
+            archive_count=1,
+        )
+        db_session.add(repo)
+        db_session.commit()
+        db_session.refresh(repo)
+
+        mqtt_service = _create_mqtt_service_configured()
+        publisher = RepositoryStatePublisher(mqtt_service)
+
+        assert publisher.publish_repository_data(
+            repo,
+            failed_repository_ids=set(),
+            latest_jobs_by_repository={},
+            running_jobs_by_repository={},
+        )
+        sizes = [
+            call.args[1]
+            for call in mqtt_service.publish.call_args_list
+            if call.args and call.args[0] == f"repositories/{repo.id}/size"
+        ]
+        assert sizes == [{"total": 2_350_000_000}]
 
     def test_publish_repository_data_with_running_job(self, db_session):
         """Should include running job data in progress payload."""
@@ -1586,11 +1593,6 @@ class TestMQTTServiceStateSync:
 @pytest.mark.unit
 class TestMQTTServiceEdgeCases:
     """Tests for edge cases and error handling."""
-
-    def test_parse_size_with_none(self):
-        """Should handle None size string."""
-        publisher = RepositoryStatePublisher(Mock())
-        assert publisher.parse_size_to_bytes(None) == 0
 
     def test_repository_status_with_none_id(self):
         """Should handle repository with no ID."""

--- a/tests/unit/test_mqtt_service.py
+++ b/tests/unit/test_mqtt_service.py
@@ -676,6 +676,27 @@ class TestRepositoryStatePublisher:
         ]
         assert sizes == [{"total": 2_350_000_000}]
 
+    @pytest.mark.parametrize("size_bytes", [None, 0])
+    def test_publish_repository_data_distinguishes_unknown_from_empty(
+        self, db_session, size_bytes
+    ):
+        repo = Repository(
+            name="Size state", path="/repo/size-state", total_size_bytes=size_bytes
+        )
+        db_session.add(repo)
+        db_session.commit()
+        mqtt_service = _create_mqtt_service_configured()
+        publisher = RepositoryStatePublisher(mqtt_service)
+
+        assert publisher.publish_repository_data(repo, set(), {}, {})
+
+        sizes = [
+            call.args[1]
+            for call in mqtt_service.publish.call_args_list
+            if call.args and call.args[0] == f"repositories/{repo.id}/size"
+        ]
+        assert sizes == [{"total": size_bytes}]
+
     def test_publish_repository_data_with_running_job(self, db_session):
         """Should include running job data in progress payload."""
         repo = Repository(name="Test", path="/repo")

--- a/tests/unit/test_operations_index_executors.py
+++ b/tests/unit/test_operations_index_executors.py
@@ -371,6 +371,8 @@ async def test_run_stats_writes_total_size(db, repo, monkeypatch):
     }
     db.refresh(repo)
     assert repo.total_size == "2.00 KB"
+    assert repo.total_size_bytes == 2048
+    assert repo.total_size_measured_at is not None
     assert repo.total_size_source == "borg2_index"
     assert repo.borg_last_modified == datetime(2026, 9, 6, 8, 57, 17)
 

--- a/tests/unit/test_operations_index_executors.py
+++ b/tests/unit/test_operations_index_executors.py
@@ -1440,3 +1440,46 @@ async def test_agent_listing_reports_the_timeout_when_the_cancel_fails(
     db.commit()
     db.expire_all()
     assert db.get(type(repo), repo.id).total_size == "1.0 GB"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("index_result", [None, (0, 0), (2048, 3)])
+async def test_run_stats_persists_an_empty_borg2_index_but_not_failed_measurement(
+    db, repo, monkeypatch, index_result
+):
+    from app.core.borg2 import borg2
+    from app.services import storage_usage
+
+    repo.borg_version = 2
+    repo.total_size = "42.00 B"
+    repo.total_size_bytes = 42
+    repo.total_size_source = "compact_stats"
+    previous_measurement = datetime(2026, 1, 1)
+    repo.total_size_measured_at = previous_measurement
+    db.commit()
+    monkeypatch.setattr(
+        index_exec, "_prepare_repository_borg_env", lambda repository, db: ({}, None)
+    )
+    monkeypatch.setattr(borg2, "rinfo", AsyncMock(return_value={"success": False}))
+    monkeypatch.setattr(
+        storage_usage, "borg2_index_size", AsyncMock(return_value=index_result)
+    )
+    monkeypatch.setattr(storage_usage, "storage_used", AsyncMock(return_value=None))
+
+    outcome = await index_exec.run_stats(_ctx(db, repo, kind="stats"))
+    db.expire_all()
+
+    assert outcome.status == "completed"
+    if index_result is None:
+        assert outcome.result["bytes"] is None
+        assert repo.total_size_bytes == 42
+        assert repo.total_size_measured_at == previous_measurement
+        assert repo.total_size_source == "compact_stats"
+    else:
+        assert outcome.result["bytes"] == index_result[0]
+        assert outcome.result["source"] == "borg2_index"
+        assert repo.total_size_bytes == index_result[0]
+        assert repo.total_size_source == "borg2_index"
+        assert repo.total_size_measured_at > previous_measurement
+        assert repo.total_size == ("0.00 B" if index_result[0] == 0 else "2.00 KB")

--- a/tests/unit/test_repository_size_bytes_migration.py
+++ b/tests/unit/test_repository_size_bytes_migration.py
@@ -1,0 +1,209 @@
+"""Tests for revision a9b8c7d6e5f4 (repository size bytes and measured_at)."""
+
+from alembic import command
+import pytest
+from sqlalchemy import inspect, text
+
+from app.database.db_upgrade import _alembic_config, _engine
+
+REVISION = "a9b8c7d6e5f4"
+PREVIOUS = "e1f2a3b4c5d6"
+COLUMNS = {"total_size_bytes", "total_size_measured_at"}
+
+
+def _migrate(url, target, *, down=False):
+    engine = _engine(url)
+    config = _alembic_config(url)
+    with engine.connect() as connection:
+        config.attributes["connection"] = connection
+        (command.downgrade if down else command.upgrade)(config, target)
+        connection.commit()
+    engine.dispose()
+
+
+def _columns(url):
+    engine = _engine(url)
+    try:
+        return {c["name"] for c in inspect(engine).get_columns("repositories")}
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.unit
+def test_upgrade_adds_and_downgrade_drops_the_columns(tmp_path):
+    """The DDL of both directions on an empty schema; the populated
+    downgrade is covered below."""
+    url = f"sqlite:///{tmp_path / 'borg.db'}"
+    _migrate(url, PREVIOUS)
+    assert not COLUMNS & _columns(url)
+    _migrate(url, REVISION)
+    assert COLUMNS <= _columns(url)
+    _migrate(url, PREVIOUS, down=True)
+    assert not COLUMNS & _columns(url)
+
+
+@pytest.mark.unit
+def test_revision_follows_the_index_mode_revision_and_the_graph_has_one_head():
+    from alembic.script import ScriptDirectory
+
+    script = ScriptDirectory.from_config(_alembic_config("sqlite://"))
+    assert script.get_revision(REVISION).down_revision == PREVIOUS
+    assert len(script.get_heads()) == 1
+
+
+def _required_columns(engine) -> dict:
+    """Placeholder values for every NOT NULL column of `repositories` that
+    has no default, so a row can be inserted whatever the schema demands."""
+    placeholders = {}
+    for column in inspect(engine).get_columns("repositories"):
+        if column["nullable"] or column.get("default") is not None:
+            continue
+        if column.get("autoincrement") is True or column["name"] == "id":
+            continue
+        kind = str(column["type"]).upper()
+        if "INT" in kind or "BOOL" in kind:
+            placeholders[column["name"]] = 0
+        elif "DATE" in kind or "TIME" in kind:
+            placeholders[column["name"]] = "2026-01-01 00:00:00"
+        else:
+            placeholders[column["name"]] = "x"
+    return placeholders
+
+
+@pytest.mark.unit
+def test_upgrade_backfills_bytes_from_the_formatted_size(tmp_path):
+    """A repository that showed a size keeps showing one in the new field:
+    the string's two decimals are all the precision there is, and the time
+    of that old measurement is unknown, so `measured_at` stays NULL."""
+    url = f"sqlite:///{tmp_path / 'borg.db'}"
+    _migrate(url, PREVIOUS)
+    engine = _engine(url)
+    required = _required_columns(engine)
+    with engine.begin() as connection:
+        for name, total_size in (
+            ("tb", "2.40 TB"),
+            ("kb", "490.23 KB"),
+            ("zero", "0.00 B"),
+            ("old-shape", "1.5GB"),
+            ("bare", "4096"),
+            ("unknown", "Unknown"),
+            ("none", None),
+        ):
+            values = {
+                **required,
+                "name": name,
+                "path": f"/repos/{name}",
+                "total_size": total_size,
+            }
+            columns = ", ".join(values)
+            marks = ", ".join(f":{column}" for column in values)
+            connection.execute(
+                text(f"INSERT INTO repositories ({columns}) VALUES ({marks})"), values
+            )
+    engine.dispose()
+
+    _migrate(url, REVISION)
+
+    engine = _engine(url)
+    with engine.connect() as connection:
+        rows = dict(
+            connection.execute(
+                text("SELECT name, total_size_bytes FROM repositories")
+            ).fetchall()
+        )
+        measured = connection.execute(
+            text(
+                "SELECT count(*) FROM repositories WHERE total_size_measured_at IS NOT NULL"
+            )
+        ).scalar()
+    engine.dispose()
+    assert rows == {
+        "tb": 2_638_827_906_662,
+        "kb": 501_996,
+        "zero": 0,
+        "old-shape": 1_610_612_736,
+        "bare": 4096,
+        "unknown": None,
+        "none": None,
+    }
+    assert measured == 0
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "text_value, expected",
+    [
+        ("2.40 TB", 2_638_827_906_662),
+        ("1.00 KB", 1024),
+        ("512.00 B", 512),
+        ("3.5 gb", 3_758_096_384),
+        ("Unknown", None),
+        ("N/A", None),
+        ("", None),
+        (None, None),
+        ("-1.00 KB", None),
+        ("1.00 XB", None),
+        ("1.5GB", 1_610_612_736),
+        ("1 GiB", 1_073_741_824),
+        ("4096", 4096),
+        ("NaN KB", None),
+        ("Infinity GB", None),
+    ],
+)
+def test_bytes_from_formatted(text_value, expected):
+    import importlib.util
+    from pathlib import Path
+
+    versions = Path(__file__).resolve().parents[2] / "app/database/alembic/versions"
+    path = next(versions.glob("a9b8c7d6e5f4_*.py"))
+    spec = importlib.util.spec_from_file_location("size_bytes_migration", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.bytes_from_formatted(text_value) == expected
+
+
+@pytest.mark.unit
+def test_downgrade_keeps_the_rows_that_reference_repositories(tmp_path):
+    """On SQLite the batch drop recreates `repositories` (copy, DROP TABLE,
+    rename); with foreign keys enforced the drop would cascade into the
+    archive index and the operation history. The downgrade switches the
+    pragma off around the recreate, so a populated database survives it."""
+    url = f"sqlite:///{tmp_path / 'borg.db'}"
+    _migrate(url, REVISION)
+    engine = _engine(url)
+    required = _required_columns(engine)
+    with engine.begin() as connection:
+        values = {**required, "name": "r", "path": "/repos/r", "total_size": "1.00 KB"}
+        columns = ", ".join(values)
+        marks = ", ".join(f":{column}" for column in values)
+        connection.execute(
+            text(f"INSERT INTO repositories ({columns}) VALUES ({marks})"), values
+        )
+        repository_id = connection.execute(text("SELECT id FROM repositories")).scalar()
+        connection.execute(
+            text(
+                "INSERT INTO archives (repository_id, borg_id, name, series, start, "
+                "history_state, history_truncated, history_attempts, first_seen_at, "
+                "last_seen_at) VALUES (:r, 'b1', 'a1', 's', '2026-01-01 00:00:00', "
+                "'pending', 0, 0, '2026-01-01 00:00:00', '2026-01-01 00:00:00')"
+            ),
+            {"r": repository_id},
+        )
+        connection.execute(
+            text(
+                "INSERT INTO operations (repository_id, kind, category, status, trigger, "
+                "priority, run_id, created_at) VALUES (:r, 'stats', 'index', 'completed', "
+                "'manual', 10, 'run-1', '2026-01-01 00:00:00')"
+            ),
+            {"r": repository_id},
+        )
+    engine.dispose()
+
+    _migrate(url, PREVIOUS, down=True)
+
+    engine = _engine(url)
+    with engine.connect() as connection:
+        assert connection.execute(text("SELECT count(*) FROM archives")).scalar() == 1
+        assert connection.execute(text("SELECT count(*) FROM operations")).scalar() == 1
+    engine.dispose()
+    assert not COLUMNS & _columns(url)

--- a/tests/unit/test_repository_storage_summary.py
+++ b/tests/unit/test_repository_storage_summary.py
@@ -1,0 +1,512 @@
+"""The one storage payload every size reader takes (#981)."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.database.models import Archive, Operation, Repository
+from app.services.operations.repository_status import storage_summaries
+
+
+def _repo(test_db, name, *, borg_version, **fields):
+    repo = Repository(
+        name=name, path=f"/repos/{name}", borg_version=borg_version, **fields
+    )
+    test_db.add(repo)
+    test_db.commit()
+    return repo
+
+
+# One listing stamps every row it sees with the same instant; the rows of
+# a test repository are "current" together unless a test says otherwise.
+SEEN_AT = datetime(2026, 9, 2, 0, 0, 0)
+
+
+def _archive(test_db, repo, name, start, **fields):
+    archive = Archive(
+        repository_id=repo.id,
+        borg_id=f"id-{name}",
+        name=name,
+        series="series",
+        start=start,
+        first_seen_at=SEEN_AT,
+        last_seen_at=fields.pop("last_seen_at", SEEN_AT),
+        **fields,
+    )
+    test_db.add(archive)
+    test_db.commit()
+    return archive
+
+
+def _compact(test_db, repo, completed_at, *, status="completed", stats=None, note=None):
+    op = Operation(
+        repository_id=repo.id,
+        kind="compact",
+        category="maintenance",
+        status=status,
+        trigger="manual",
+        priority=10,
+        run_id=f"run-{repo.id}-{completed_at.isoformat()}",
+        completed_at=completed_at,
+        result=(
+            {"stats": stats}
+            if stats is not None
+            else ({"note": note} if note is not None else None)
+        ),
+    )
+    test_db.add(op)
+    test_db.commit()
+    return op
+
+
+def _archive_sync(test_db, repo, completed_at, *, status="completed"):
+    op = Operation(
+        repository_id=repo.id,
+        kind="archive_sync",
+        category="index",
+        status=status,
+        trigger="scheduled",
+        priority=10,
+        run_id=f"sync-{repo.id}-{completed_at.isoformat()}",
+        completed_at=completed_at,
+    )
+    test_db.add(op)
+    test_db.commit()
+    return op
+
+
+@pytest.mark.unit
+def test_borg1_summary_reads_the_cache_size_and_the_archive_sums(test_db):
+    at = datetime(2026, 9, 1, 12, 0, 0)
+    repo = _repo(
+        test_db,
+        "b1",
+        borg_version=1,
+        total_size="2.40 TB",
+        total_size_bytes=2_400_000_000_000,
+        total_size_source="borg1_cache_stats",
+        total_size_measured_at=at,
+        borg_last_modified=at - timedelta(hours=1),
+        archive_count=2,
+    )
+    _archive(
+        test_db,
+        repo,
+        "a1",
+        at - timedelta(days=1),
+        original_size=100,
+        compressed_size=80,
+        deduplicated_size=10,
+        nfiles=5,
+    )
+    _archive(
+        test_db,
+        repo,
+        "a2",
+        at,
+        original_size=200,
+        compressed_size=150,
+        deduplicated_size=20,
+        nfiles=7,
+    )
+
+    summary = storage_summaries(test_db, [repo])[repo.id]
+
+    assert summary.size_bytes == 2_400_000_000_000
+    assert summary.size_source == "borg1_cache_stats"
+    assert summary.measured_at == at
+    assert summary.last_modified == at - timedelta(hours=1)
+    assert summary.original_size == 300
+    assert summary.compressed_size == 230
+    # Borg 1's stored size is its deduplicated size
+    assert summary.deduplicated_size == 2_400_000_000_000
+    assert summary.latest_archive_files == 7  # the newest archive
+    assert summary.compact is None and summary.compact_at is None
+
+
+@pytest.mark.unit
+def test_borg2_summary_takes_the_newest_successful_compact_statistics(test_db):
+    at = datetime(2026, 9, 1, 12, 0, 0)
+    repo = _repo(
+        test_db,
+        "b2",
+        borg_version=2,
+        total_size_bytes=2_350_000_000,
+        total_size_source="borg2_index",
+        archive_count=1,
+    )
+    _archive(test_db, repo, "a1", at, original_size=500, nfiles=922)
+    old_stats = {"repository_size": 1, "deduplicated_size": 1}
+    new_stats = {
+        "repository_size": 2_350_000_000,
+        "deduplicated_size": 2_300_000_000,
+        "source_size": 10_830_000_000,
+        "compression_factor": 1.5,
+    }
+    _compact(test_db, repo, at - timedelta(days=2), stats=old_stats)
+    _compact(test_db, repo, at - timedelta(days=1), stats=new_stats)
+    _compact(test_db, repo, at, status="failed", stats={"repository_size": 9})
+    _compact(test_db, repo, at + timedelta(hours=1))  # newest, but no statistics
+
+    summary = storage_summaries(test_db, [repo])[repo.id]
+
+    assert summary.compact == new_stats
+    assert summary.compact_at == at - timedelta(days=1)
+    assert summary.deduplicated_size == 2_300_000_000
+    assert summary.compressed_size is None  # Borg 2 does not report it
+    assert summary.original_size == 500
+    assert summary.latest_archive_files == 922
+
+
+@pytest.mark.unit
+def test_archive_sums_wait_until_every_archive_carries_its_info(test_db):
+    """A listing creates archive rows without sizes; `fill_archive_info`
+    fills a few per run. A sum over the filled ones would read as a total,
+    so the sums are reported only once every archive has its info."""
+    at = datetime(2026, 9, 1, 12, 0, 0)
+    repo = _repo(test_db, "partial", borg_version=1, archive_count=2)
+    _archive(
+        test_db,
+        repo,
+        "filled",
+        at - timedelta(days=1),
+        original_size=100,
+        compressed_size=90,
+        nfiles=3,
+    )
+    newest = _archive(test_db, repo, "listed-only", at)  # no info yet
+
+    summary = storage_summaries(test_db, [repo])[repo.id]
+    assert summary.original_size is None
+    assert summary.compressed_size is None
+    assert summary.latest_archive_files is None  # the newest archive has no info yet
+
+    newest.original_size = 50
+    newest.compressed_size = 40
+    newest.nfiles = 9
+    test_db.commit()
+    summary = storage_summaries(test_db, [repo])[repo.id]
+    assert summary.original_size == 150
+    assert summary.compressed_size == 130
+    assert summary.latest_archive_files == 9
+
+
+@pytest.mark.unit
+def test_unmeasured_repository_reports_nothing_not_zero(test_db):
+    repo = _repo(test_db, "fresh", borg_version=2)
+
+    summary = storage_summaries(test_db, [repo])[repo.id]
+
+    assert summary.size_bytes is None
+    assert summary.size_source is None
+    assert summary.measured_at is None
+    # no rows against the count it was created with: no listing has run,
+    # so there is nothing to sum, not a sum of 0
+    assert summary.archives_consistent is False
+    assert summary.original_size is None
+    assert summary.deduplicated_size is None
+    assert summary.latest_archive_files is None
+    assert storage_summaries(test_db, []) == {}
+
+
+@pytest.mark.unit
+class TestStorageInResponses:
+    def test_list_and_single_routes_carry_the_storage_object(
+        self, test_client, test_db, admin_headers
+    ):
+        at = datetime(2026, 9, 1, 12, 0, 0)
+        repo = _repo(
+            test_db,
+            "listed",
+            borg_version=2,
+            total_size="2.35 GB",
+            total_size_bytes=2_350_000_000,
+            total_size_source="borg2_index",
+            total_size_measured_at=at,
+        )
+        _compact(test_db, repo, at, stats={"repository_size": 2_350_000_000})
+
+        listed = test_client.get("/api/repositories/", headers=admin_headers)
+        assert listed.status_code == 200, listed.text
+        rows = listed.json()["repositories"]
+        row = next(r for r in rows if r["id"] == repo.id)
+        assert row["total_size"] == "2.35 GB"
+        assert row["storage"]["size_bytes"] == 2_350_000_000
+        assert row["storage"]["size_source"] == "borg2_index"
+        assert row["storage"]["measured_at"] is not None
+        # the polled list carries the stored columns only
+        assert row["storage"]["archives_consistent"] is None
+        assert row["storage"]["compact"] is None
+
+        single = test_client.get(f"/api/repositories/{repo.id}", headers=admin_headers)
+        assert single.status_code == 200, single.text
+        storage = single.json()["repository"]["storage"]
+        assert storage["size_bytes"] == 2_350_000_000
+        assert storage["compact"] == {"repository_size": 2_350_000_000}
+        assert storage["compact_at"] is not None
+        assert storage["compressed_size"] is None
+
+    def test_storage_failure_does_not_take_the_detail_down(
+        self, test_client, test_db, admin_headers, monkeypatch
+    ):
+        """The detail route runs the archive queries; a failure there logs
+        and leaves `storage` null. (The list reads stored columns only and
+        runs no query of its own.)"""
+        repo = _repo(test_db, "still-served", borg_version=1)
+        import app.api.repositories as repositories_api
+
+        from sqlalchemy import text
+
+        def boom(db, repositories, *, archives=True):
+            # a real statement failure, so the session is in the state the
+            # handler's rollback exists for
+            db.execute(text("SELECT nothing FROM no_such_table"))
+
+        monkeypatch.setattr(repositories_api, "storage_summaries", boom)
+        single = test_client.get(f"/api/repositories/{repo.id}", headers=admin_headers)
+        assert single.status_code == 200, single.text
+        assert single.json()["repository"]["storage"] is None
+
+
+@pytest.mark.unit
+def test_sums_leave_out_archives_the_newest_listing_no_longer_saw(test_db):
+    """A prune drops archives; the next listing stamps the rows it still
+    sees and leaves the removed ones for `history_merge`. Until then those
+    rows are not part of the sums, as they are not part of `archive_count`."""
+    at = datetime(2026, 9, 1, 12, 0, 0)
+    repo = _repo(test_db, "pruned", borg_version=1, archive_count=1)
+    kept = _archive(
+        test_db, repo, "kept", at, original_size=100, compressed_size=80, nfiles=4
+    )
+    _archive(
+        test_db,
+        repo,
+        "removed",
+        at + timedelta(hours=1),
+        original_size=900,
+        compressed_size=700,
+        nfiles=99,
+    )
+    # the listing after the prune saw only `kept`
+    kept.last_seen_at = SEEN_AT + timedelta(days=1)
+    test_db.commit()
+
+    summary = storage_summaries(test_db, [repo])[repo.id]
+    assert summary.original_size == 100
+    assert summary.compressed_size == 80
+    assert summary.latest_archive_files == 4
+
+
+@pytest.mark.unit
+def test_compressed_sum_needs_every_archive_to_carry_it(test_db):
+    """Borg 1 fills `compressed_size` next to `original_size`; a payload
+    that carried one without the other leaves the compressed sum unreported
+    rather than short."""
+    at = datetime(2026, 9, 1, 12, 0, 0)
+    repo = _repo(test_db, "half", borg_version=1, archive_count=2)
+    _archive(test_db, repo, "a1", at, original_size=100, compressed_size=80, nfiles=1)
+    _archive(test_db, repo, "a2", at + timedelta(hours=1), original_size=50, nfiles=1)
+
+    summary = storage_summaries(test_db, [repo])[repo.id]
+    assert summary.original_size == 150
+    assert summary.compressed_size is None
+
+
+@pytest.mark.unit
+def test_summaries_group_by_repository(test_db):
+    """One page, several repositories: each summary carries its own rows
+    and its own newest compact."""
+    at = datetime(2026, 9, 1, 12, 0, 0)
+    one = _repo(test_db, "one", borg_version=2, archive_count=1)
+    two = _repo(test_db, "two", borg_version=2, archive_count=2)
+    _archive(test_db, one, "o1", at, original_size=10, nfiles=1)
+    _archive(test_db, two, "t1", at, original_size=20, nfiles=2)
+    _archive(test_db, two, "t2", at + timedelta(hours=1), original_size=30, nfiles=3)
+    _compact(test_db, one, at, stats={"repository_size": 1})
+    _compact(test_db, two, at, stats={"repository_size": 2})
+
+    summaries = storage_summaries(test_db, [one, two])
+    assert summaries[one.id].original_size == 10
+    assert summaries[one.id].latest_archive_files == 1
+    assert summaries[one.id].compact == {"repository_size": 1}
+    assert summaries[two.id].original_size == 50
+    assert summaries[two.id].latest_archive_files == 3
+    assert summaries[two.id].compact == {"repository_size": 2}
+
+
+@pytest.mark.unit
+def test_archive_figures_are_withheld_when_the_rows_do_not_match_the_count(test_db):
+    """A listing that found nothing stamps nothing, so the rows it reported
+    removed still look current; `archive_count` says 0. The archive figures
+    are not reported until the rows and the count agree again."""
+    at = datetime(2026, 9, 1, 12, 0, 0)
+    repo = _repo(test_db, "wiped", borg_version=1, archive_count=0)
+    _archive(test_db, repo, "gone", at, original_size=100, compressed_size=80, nfiles=4)
+
+    summary = storage_summaries(test_db, [repo])[repo.id]
+    assert summary.archives_consistent is False
+    assert summary.original_size is None
+    assert summary.compressed_size is None
+    assert summary.latest_archive_files is None
+
+    repo.archive_count = 1
+    test_db.commit()
+    summary = storage_summaries(test_db, [repo])[repo.id]
+    assert summary.archives_consistent is True
+    assert summary.original_size == 100
+    assert summary.latest_archive_files == 4
+
+
+@pytest.mark.unit
+def test_files_come_from_a_current_archive_only(test_db):
+    """Two archives started in the same second; the newer row was pruned
+    and waits for `history_merge`: the file count is the surviving one's."""
+    at = datetime(2026, 9, 1, 12, 0, 0)
+    repo = _repo(test_db, "same-second", borg_version=1, archive_count=1)
+    _archive(
+        test_db,
+        repo,
+        "kept",
+        at,
+        original_size=1,
+        compressed_size=1,
+        nfiles=4,
+        last_seen_at=SEEN_AT + timedelta(days=1),
+    )
+    _archive(test_db, repo, "pruned", at, original_size=1, compressed_size=1, nfiles=99)
+
+    summary = storage_summaries(test_db, [repo])[repo.id]
+    assert summary.latest_archive_files == 4
+
+
+@pytest.mark.unit
+def test_files_are_withheld_while_the_newest_archive_has_no_info(test_db):
+    """Two current archives tied on start; the newest (highest id) is not
+    filled yet: no older archive's count stands in for it."""
+    at = datetime(2026, 9, 1, 12, 0, 0)
+    repo = _repo(test_db, "tied", borg_version=1, archive_count=2)
+    _archive(test_db, repo, "older", at, original_size=1, compressed_size=1, nfiles=4)
+    _archive(test_db, repo, "newest", at)  # listed, not filled
+
+    summary = storage_summaries(test_db, [repo])[repo.id]
+    assert summary.latest_archive_files is None
+
+
+@pytest.mark.unit
+def test_the_list_reads_the_stored_columns_only(test_db):
+    at = datetime(2026, 9, 1, 12, 0, 0)
+    repo = _repo(test_db, "listed", borg_version=2, total_size_bytes=5, archive_count=1)
+    _archive(test_db, repo, "a1", at, original_size=100, nfiles=3)
+    _compact(test_db, repo, at, stats={"repository_size": 5})
+
+    light = storage_summaries(test_db, [repo], archives=False)[repo.id]
+    assert light.size_bytes == 5
+    assert light.archives_consistent is None  # not computed, not withheld
+    assert (
+        light.original_size is None
+        and light.latest_archive_files is None
+        and light.compact is None
+    )
+    full = storage_summaries(test_db, [repo])[repo.id]
+    assert full.original_size == 100 and full.latest_archive_files == 3
+    assert full.compact == {"repository_size": 5}
+
+
+@pytest.mark.unit
+def test_compacts_without_statistics_do_not_hide_the_newest_figure(test_db):
+    """An agent that predates the report runs compacts without statistics;
+    however many of them land, the newest figure that exists is served."""
+    at = datetime(2026, 9, 1, 12, 0, 0)
+    repo = _repo(test_db, "lookback", borg_version=2)
+    _compact(test_db, repo, at - timedelta(days=9), stats={"repository_size": 3})
+    for days in range(8):
+        _compact(test_db, repo, at - timedelta(days=days))  # no statistics
+
+    summary = storage_summaries(test_db, [repo])[repo.id]
+    assert summary.compact == {"repository_size": 3}
+    assert summary.compact_at == at - timedelta(days=9)
+
+
+@pytest.mark.unit
+def test_only_the_newest_few_compacts_that_mention_statistics_are_read(test_db):
+    """The rows are filtered in SQL on the text of the serialized result,
+    so one that mentions the key without carrying a usable dict still
+    ranks; the window is what keeps a few of those from hiding the
+    figure, and what bounds the rows read per repository."""
+    at = datetime(2026, 9, 1, 12, 0, 0)
+    repo = _repo(test_db, "window", borg_version=2)
+    _compact(test_db, repo, at - timedelta(days=4), stats={"repository_size": 7})
+    for days in (3, 2):
+        _compact(test_db, repo, at - timedelta(days=days), stats=None, note="stats")
+
+    summary = storage_summaries(test_db, [repo])[repo.id]
+    assert summary.compact == {"repository_size": 7}
+
+    # a third such row fills the window and the figure drops out
+    _compact(test_db, repo, at - timedelta(days=1), stats=None, note="stats")
+    assert storage_summaries(test_db, [repo])[repo.id].compact is None
+
+
+@pytest.mark.unit
+def test_an_emptied_repository_measures_zero_not_nothing(test_db):
+    """Every archive pruned and the rows dropped: once a listing has run,
+    zero rows against a count of 0 are a measurement, unlike the same
+    state of a repository whose listing never ran (a fresh import, or one
+    whose index mode runs no listing)."""
+    at = datetime(2026, 9, 1, 12, 0, 0)
+    repo = _repo(test_db, "emptied", borg_version=1, archive_count=0)
+    _archive_sync(test_db, repo, at, status="failed")
+    summary = storage_summaries(test_db, [repo])[repo.id]
+    assert summary.archives_consistent is False
+    assert summary.original_size is None
+
+    _archive_sync(test_db, repo, at + timedelta(hours=1))
+    summary = storage_summaries(test_db, [repo])[repo.id]
+    assert summary.archives_consistent is True
+    assert summary.original_size == 0
+    assert summary.compressed_size == 0
+    assert summary.latest_archive_files is None
+
+
+@pytest.mark.unit
+def test_borg1_deduplicated_size_needs_the_cache_source(test_db):
+    """A Borg 1 size from a store walk is not a deduplicated size."""
+    repo = _repo(
+        test_db,
+        "walked",
+        borg_version=1,
+        total_size_bytes=4096,
+        total_size_source="storage_used",
+    )
+    summary = storage_summaries(test_db, [repo])[repo.id]
+    assert summary.size_bytes == 4096
+    assert summary.deduplicated_size is None
+
+
+@pytest.mark.unit
+def test_a_row_before_the_column_still_reports_its_size(test_db):
+    """A row the backfill did not reach (an unparseable string then, a real
+    one now) is read through the same rule as the dashboard and the
+    gauges: the string parsed back, with no `measured_at`."""
+    repo = _repo(
+        test_db,
+        "legacy",
+        borg_version=1,
+        total_size="1.00 KB",
+        total_size_source="borg1_cache_stats",
+    )
+    summary = storage_summaries(test_db, [repo])[repo.id]
+    assert summary.size_bytes == 1024
+    assert summary.deduplicated_size == 1024  # the same figure, by the same rule
+    assert summary.measured_at is None
+
+
+@pytest.mark.unit
+def test_route_carries_the_consistency_flag(test_client, test_db, admin_headers):
+    repo = _repo(test_db, "flagged", borg_version=1, archive_count=2)
+    _archive(test_db, repo, "only", datetime(2026, 9, 1), original_size=1, nfiles=1)
+    single = test_client.get(f"/api/repositories/{repo.id}", headers=admin_headers)
+    assert single.status_code == 200, single.text
+    storage = single.json()["repository"]["storage"]
+    assert storage["archives_consistent"] is False
+    assert storage["original_size"] is None

--- a/tests/unit/test_repository_storage_usage.py
+++ b/tests/unit/test_repository_storage_usage.py
@@ -862,3 +862,110 @@ def test_interpreter_is_the_venv_python_behind_the_wrapper(tmp_path):
     assert storage_usage.borg2_interpreter(
         str(wrapper_dir / "borg2"), {"BORG2_BINARY": str(current)}
     ) == str(venv / "bin" / "python")
+
+
+@pytest.mark.unit
+def test_set_repository_size_writes_the_four_columns_together():
+    """Every size writer goes through one helper, so the formatted string,
+    the number, the source and the time never disagree."""
+    from datetime import datetime
+    from types import SimpleNamespace
+
+    from app.services.storage_usage import set_repository_size
+
+    repo = SimpleNamespace(
+        total_size=None,
+        total_size_bytes=None,
+        total_size_source=None,
+        total_size_measured_at=None,
+    )
+    before = datetime.utcnow()
+    set_repository_size(repo, 2048, "borg2_index")
+    assert repo.total_size == "2.00 KB"
+    assert repo.total_size_bytes == 2048
+    assert repo.total_size_source == "borg2_index"
+    assert repo.total_size_measured_at >= before
+
+    at = datetime(2026, 1, 1, 12, 0, 0)
+    set_repository_size(repo, 0, "compact_stats", measured_at=at)
+    assert repo.total_size == "0.00 B"
+    assert repo.total_size_bytes == 0
+    assert repo.total_size_source == "compact_stats"
+    assert repo.total_size_measured_at == at
+
+
+@pytest.mark.unit
+def test_stored_size_bytes_is_the_one_rule_every_reader_applies():
+    from types import SimpleNamespace
+
+    from app.services.storage_usage import bytes_from_formatted, stored_size_bytes
+
+    assert (
+        stored_size_bytes(
+            SimpleNamespace(total_size="2.19 GB", total_size_bytes=2_350_000_000)
+        )
+        == 2_350_000_000
+    )
+    assert (
+        stored_size_bytes(SimpleNamespace(total_size="1.00 KB", total_size_bytes=None))
+        == 1024
+    )
+    assert (
+        stored_size_bytes(SimpleNamespace(total_size="Unknown", total_size_bytes=None))
+        is None
+    )
+    assert (
+        stored_size_bytes(SimpleNamespace(total_size=None, total_size_bytes=None))
+        is None
+    )
+    assert bytes_from_formatted("2.40 TB") == 2_638_827_906_662
+    # the shapes older releases wrote
+    assert bytes_from_formatted("1.5GB") == 1_610_612_736
+    assert bytes_from_formatted("1 GiB") == 1_073_741_824
+    assert bytes_from_formatted("4096") == 4096
+    assert bytes_from_formatted("512 b") == 512
+    assert bytes_from_formatted("NaN KB") is None
+    assert bytes_from_formatted("-1.00 KB") is None
+    assert bytes_from_formatted("1.00 XB") is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "text_value",
+    [
+        "2.40 TB",
+        "490.23 KB",
+        "0.00 B",
+        "1.5GB",
+        "1 GiB",
+        "4096",
+        "512 b",
+        "Unknown",
+        "N/A",
+        "",
+        None,
+        "-1 KB",
+        "1.00 XB",
+    ],
+)
+def test_the_migration_backfill_parses_like_the_service(text_value):
+    """The backfill carries its own copy of the parser (a migration imports
+    no app code); the two must agree, or `measured_at is None` stops
+    meaning what the docstrings say."""
+    import importlib.util
+    from pathlib import Path
+
+    from app.services import storage_usage
+    from app.services.storage_usage import bytes_from_formatted
+
+    versions = Path(__file__).resolve().parents[2] / "app/database/alembic/versions"
+    path = next(versions.glob("a9b8c7d6e5f4_*.py"))
+    spec = importlib.util.spec_from_file_location("size_bytes_migration", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.bytes_from_formatted(text_value) == bytes_from_formatted(text_value)
+    # a widened service pattern must be widened in the copy as well; the
+    # table above cannot know a shape added later
+    assert module._SIZE_TEXT.pattern == storage_usage._SIZE_TEXT.pattern
+    assert module._SIZE_TEXT.flags == storage_usage._SIZE_TEXT.flags
+    assert module._SIZE_UNITS == storage_usage._SIZE_UNITS

--- a/tests/unit/test_storage_usage.py
+++ b/tests/unit/test_storage_usage.py
@@ -312,7 +312,7 @@ async def test_measure_borg2_prefers_the_index_and_keeps_last_modified(monkeypat
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_measure_borg2_falls_back_to_the_store_and_never_reports_zero(
+async def test_measure_borg2_distinguishes_failed_measurements_from_an_empty_index(
     monkeypatch,
 ):
     repo = _repo()
@@ -328,13 +328,15 @@ async def test_measure_borg2_falls_back_to_the_store_and_never_reports_zero(
     assert used.call_args.kwargs["key_file"] == "/tmp/k"
     assert used.call_args.kwargs["env"] is None
 
-    monkeypatch.setattr(storage_usage, "storage_used", AsyncMock(return_value=None))
+    unavailable_store = AsyncMock(return_value=None)
+    monkeypatch.setattr(storage_usage, "storage_used", unavailable_store)
     with (
         patch("app.core.borg2.borg2.rinfo", AsyncMock(return_value={"success": False})),
         patch("app.core.borg2._get_borg2_binary", return_value="borg2"),
     ):
         assert await measure_repository_size(repo) == SizeResult()
 
+    unavailable_store.reset_mock()
     monkeypatch.setattr(
         storage_usage, "borg2_index_size", AsyncMock(return_value=(0, 0))
     )
@@ -343,7 +345,8 @@ async def test_measure_borg2_falls_back_to_the_store_and_never_reports_zero(
         patch("app.core.borg2._get_borg2_binary", return_value="borg2"),
     ):
         empty = await measure_repository_size(repo)
-    assert empty.bytes is None and empty.source is None and empty.objects == 0
+    assert empty == SizeResult(bytes=0, objects=0, source=SOURCE_BORG2_INDEX)
+    unavailable_store.assert_not_awaited()
 
 
 @pytest.mark.unit

--- a/tests/unit/test_v2_services.py
+++ b/tests/unit/test_v2_services.py
@@ -717,6 +717,9 @@ class TestCompactV2Service:
         assert refreshed.result["stats"]["repository_size"] == 502_000
         assert refreshed_repo.total_size == "490.23 KB"
         assert refreshed_repo.total_size_source == "compact_stats"
+        # the four size columns are restored together after the retry
+        assert refreshed_repo.total_size_bytes == 502_000
+        assert refreshed_repo.total_size_measured_at is not None
         verification.close()
 
     @pytest.mark.unit


### PR DESCRIPTION
## Description

Backend half of #981. A repository's size is shown in four places and read from three different sources: the stored `total_size` string, the live `repo-info` `unique_csize` that the v2 info route fills only for local paths (so every remote Borg 2 repository shows `0 B` in the archive header), and Borg's raw `cache.stats` or per-archive blocks. After this change everything a size reader needs is stored and served in one shape, so the frontend can stop measuring. The component that reads it is the second half and follows in its own PR.

- **The size as a number.** `repositories.total_size_bytes` and `total_size_measured_at` next to the formatted string and its source, written by one function (`storage_usage.set_repository_size`) on every size path: the `stats` executor, the agent stats refresh (cache statistics, `storage_usage`, `du`) and the compact statistics. Revision `a9b8c7d6e5f4` adds the columns and backfills the number from the string every row already carries; a backfilled row keeps `measured_at` NULL, because the time of that old measurement is not known, until its next size write. The dashboard total, the Prometheus gauge and the MQTT size topic read it through one helper (`stored_size_bytes`), which falls back to the string for a row whose number is not filled yet.
- **One summary per repository.** `storage_summaries` (`repository_status.py`) builds a `StorageSummary` from three grouped queries: the stored size with its source, time and Borg's last manifest write; the sums over the archive rows the newest listing saw (original size, compressed size on Borg 1, the newest archive's file count); the newest successful compact's statistics with its time. Borg 1's deduplicated size is its stored `cache.stats` size, Borg 2's comes from the compact statistics.
- **The states are distinct.** A field this Borg version does not report is null, as is one not measured yet; a size of 0 is a measurement (an emptied repository). The archive figures are reported only while the archive rows and `archive_count` agree and a listing has actually run (`archives_consistent`): between a backup and its `archive_sync`, while rows reported removed wait for `history_merge`, or before the first listing, they are withheld rather than summed into a total they are not.
- **Routes.** `GET /repositories/{id}` carries the full object as `storage`; `GET /repositories` carries the stored columns only, so the list runs no archive query per row. A failure of the detail's summary logs and leaves `storage` null instead of taking the response down.

```
storage: {
  size_bytes, size_source, measured_at, last_modified,
  archives_consistent,
  original_size, compressed_size, deduplicated_size, latest_archive_files,
  compact, compact_at
}
```

## Related Issue

Part of #981 (backend half). Builds on #950 (stored size with provenance), #974 (compact statistics) and #948 (per-archive sizes).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🧪 Test addition/improvement
- [ ] ♻️ Refactoring

## Testing

Review follow-up `c2648d37`, rebased onto main `172d7574`: 368 affected tests passed (367 in the sandbox plus the local HTTP-listing test rerun with permission to bind its test socket). Full Ruff lint and format checks passed. New regressions distinguish MQTT unknown from measured zero and exercise successful empty/nonempty Borg 2 index measurements versus failed measurements through the stats persistence path.

New tests: the migration up, down and its place in the graph, the backfill from the formatted string (rounding, the shapes older releases wrote, unparseable text stays NULL), a populated downgrade that keeps the rows referencing `repositories`; the service parser and the migration's copy agree over one table of inputs and over their pattern itself; the writer sets the four columns together; the summaries for a Borg 1 repository (cache size, archive sums, the newest archive's files), a Borg 2 repository (the newest successful compact with statistics wins over a failed one and over newer ones without), an unmeasured one, an emptied one (0, not null, and only once a listing has run), partial sums, rows the newest listing no longer saw, the consistency gate, the grouping over several repositories, the compact finalize snapshot; `stats` writing a measured zero; the dashboard total, the metrics gauge and the MQTT size topic reading the stored number; both routes carrying the object, and the detail surviving a failing summary query.

```
tests/unit/test_repository_storage_summary.py
tests/unit/test_repository_size_bytes_migration.py
tests/unit/test_repository_storage_usage.py
tests/unit/test_operations_index_executors.py
tests/unit/test_api_repositories_routes.py
tests/unit/test_api_metrics.py
tests/unit/test_api_dashboard.py
tests/unit/test_mqtt_service.py
tests/unit/test_maintenance_state.py
tests/unit/test_v2_services.py           364 passed

full unit suite                          4122 passed, 14 skipped
```

- [x] I have tested this locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Side findings

Defects found while building this, named so they are not mistaken for oversights.

**Fixed here, because they are what this change is about and each is a few lines.**

1. **Four size-string parsers with three behaviours.** `metrics.parse_size_string`, `dashboard.parse_size_to_bytes`, `RepositoryStatePublisher.parse_size_to_bytes` and `MQTTService._parse_size_to_bytes` each parsed the formatted size back on their own. Two of them return 0 for shapes older releases wrote: `"1 GiB"` loses its `B`, and `float("1 GI")` raises. All four are gone; every reader goes through `stored_size_bytes`, whose fallback accepts those shapes.
2. **A dashboard branch that never ran.** The per-repository deduplication ratio was computed under `hasattr(repo, "deduplicated_size")`, an attribute `Repository` does not have, so the ratio was always null. Nothing stores a per-repository deduplicated size to compute it from, so the branch is removed rather than left as a permanent no-op.
3. **Unknown and empty sizes:** MQTT preserves null for unmeasured sizes while retaining a measured zero. A successful empty Borg 2 index now retains its zero-byte value and source, and the stats executor persists it. The separate MQTT publication behavior in that executor is unchanged.

**Not fixed here. Each is its own change, and the first is not in this PR's area at all.**

4. **The phase 9 migration deletes the agent job logs on SQLite.** On SQLite a `batch_alter_table(...).drop_column` recreates the table (copy, `DROP TABLE`, rename), and the upgrade runner enforces foreign keys, so dropping `agent_jobs.backup_job_id` in `d0e1f2a3b4c5` fires the `ON DELETE CASCADE` from `agent_job_logs`. Measured: seed one machine, one job and one log at `c9d0e1f2a3b4`, upgrade one revision, and the job survives while the log is gone. That table is the largest one in a typical install. This PR's own downgrade switches the pragma off around its recreate for the same reason; the merged upgrade needs the same treatment, and the downgrades of the other revisions that recreate a table with children (`repositories`, `archives`, `agent_machines`, `agent_jobs`) are in the same class. A shared helper would be better than the same block in each.
5. **Zero semantics for other measurement sources remain separate.** The successful empty Borg 2 index case is fixed here. Borg 1 cache statistics and store-level fallback measurements still need source-specific rules for distinguishing a genuine empty store from an unsuccessful measurement; those contracts are unchanged.

6. **A Borg 2 deduplicated size can be much older than the size next to it.** It comes from the newest compact, so after twenty backups on top of one compact the two figures describe different moments. `compact_at` is in the payload and the frontend half will show it, but the rule for when the figure is too old to show is not written down anywhere.

**Known limitations of this PR**

- The storage queries are exercised on SQLite only. The `cast(result AS VARCHAR) LIKE` filter and the `row_number()` window compile for PostgreSQL, but nothing runs them there.
- `archives_consistent` proves "a listing has run" from the operation history, which job-history retention prunes. A repository that is empty, runs no further listing and outlives its retention window flips from "measured, empty" to "withheld" without anything having happened to it. A durable per-repository last-listed timestamp would settle it.
- The three queries behind one summary are three statements, so under `READ COMMITTED` a listing that commits between them can leave the archive sums and the newest archive's file count describing different moments.
- The archive figures are withheld whenever the archive rows and `archive_count` disagree, and that column is also written by a path that does not touch the rows. Withheld is the deliberate choice over a sum that is quietly short of an archive.

## Additional Context

`chunks` from the issue's sketch is not carried: Borg 1's chunk counts exist only in the live `cache.stats`, nothing stores them, and the frontend half does not show them.
