### PR TITLE
fix(operations): combine index serialization and accurate repository lane waits

### DIFF
--- a/app/api/operations.py
+++ b/app/api/operations.py
@@ -36,7 +36,10 @@ from app.services.operations.followups import (
     history_capability,
     history_enabled,
 )
-from app.services.operations.lanes import lane_free, running_count
+from app.services.operations.lanes import (
+    repositories_with_running_index_work,
+    running_count,
+)
 from app.services.operations.models import is_terminal, serialize_operation
 from app.services.operations.index_mode import mode_of as index_mode_of
 from app.services.operations.reconcile import (
@@ -44,7 +47,7 @@ from app.services.operations.reconcile import (
     enqueue_reconcile_runs,
 )
 from app.services.operations.runner import operation_runner
-from app.services.operations.vocab import INDEX_KINDS, SUCCESS_STATUSES
+from app.services.operations.vocab import INDEX_KINDS, KINDS, SUCCESS_STATUSES
 
 router = APIRouter()
 
@@ -116,10 +119,24 @@ class QueueLimits(BaseModel):
     max_concurrent_scheduled_checks: int
 
 
+class LaneHolder(BaseModel):
+    """The running exclusive operation a repository's lane is taken by."""
+
+    kind: str
+    id: int
+
+
 class QueueRepository(BaseModel):
     repository_id: Optional[int]
     repository_name: str
     lane_busy: bool
+    # Which operation holds the lane, so the waiting stages can name it.
+    # Set exactly when `lane_busy` is true: both come from one lookup.
+    lane_holder: Optional[LaneHolder] = None
+    # A listing, merge or stats of the repository is running: the next index
+    # operation waits for it (one at a time per repository), whatever the
+    # lane and the worker count say.
+    index_busy: bool
     operations: list[OperationItem]
 
 
@@ -474,20 +491,55 @@ async def get_queue(
     repos = _repositories_by_id(db, ops)
     policy = get_log_save_policy(db)
     groups: dict[Optional[int], list[dict]] = {}
+    # Which operation holds each repository's lane. Taken from the rows this
+    # response already carries rather than a query per repository: the
+    # listing holds every running operation, so the holder is always one of
+    # the operations the same row lists, and the two cannot drift apart
+    # between two queries.
+    holders: dict[int, Operation] = {}
     for op in ops:
         groups.setdefault(op.repository_id, []).append(_item(op, repos, policy))
+        if op.repository_id is None or op.status != "running":
+            continue
+        # A kind this build does not know (a row left by a newer one) is
+        # passed over here rather than raised on: it stays in `operations`
+        # and only loses its claim to the lane, so the stages under it read
+        # "next in line" instead of the whole board failing to load.
+        # `is_exclusive` would raise on it.
+        spec = KINDS.get(op.kind)
+        if spec is None or not spec.exclusive:
+            continue
+        current = holders.get(op.repository_id)
+        # The one that took the lane: the earliest start, the lowest id
+        # when two rows share one. A row the plan created already running
+        # carries no start (`start_inline_maintenance`) and cannot be
+        # placed on that timeline, so those sort behind the rows that can
+        # and by id among themselves.
+        if current is None or (op.started_at or datetime.max, op.id) < (
+            current.started_at or datetime.max,
+            current.id,
+        ):
+            holders[op.repository_id] = op
+    # only the repositories in the response, which the query above already
+    # scoped to the caller's access
+    index_busy_ids = repositories_with_running_index_work(
+        db, repository_ids=[r for r in groups if r is not None]
+    )
     repositories = []
     for repository_id, items in groups.items():
         repo = repos.get(repository_id) if repository_id is not None else None
+        holder = holders.get(repository_id) if repository_id is not None else None
         repositories.append(
             QueueRepository(
                 repository_id=repository_id,
                 repository_name=repo.name if repo else "System",
-                lane_busy=(
-                    (not lane_free(db, repository_id))
-                    if repository_id is not None
-                    else False
+                lane_busy=holder is not None,
+                lane_holder=(
+                    LaneHolder(kind=holder.kind, id=holder.id)
+                    if holder is not None
+                    else None
                 ),
+                index_busy=repository_id in index_busy_ids,
                 operations=items,
             )
         )

--- a/app/database/alembic/versions/f2a3b4c5d6e7_add_archive_generation_id.py
+++ b/app/database/alembic/versions/f2a3b4c5d6e7_add_archive_generation_id.py
@@ -1,0 +1,25 @@
+"""Add an archive row identity independent of reusable IDs and wall time.
+
+Revision ID: f2a3b4c5d6e7
+Revises: e1f2a3b4c5d6
+Create Date: 2026-09-12
+
+Existing rows remain NULL until their next listing initializes identities.
+Old merge results without an identity cannot delete rows.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "f2a3b4c5d6e7"
+down_revision = "e1f2a3b4c5d6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("archives", sa.Column("generation_id", sa.String(36), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("archives", "generation_id")

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from sqlalchemy import (
     Column,
     Integer,
@@ -1341,6 +1343,9 @@ class Archive(Base):
         index=True,
     )
     borg_id = Column(String(64), nullable=False)
+    # Distinguishes recreated rows even if SQLite IDs and timestamps repeat.
+    # Migrated rows receive an identity on their next listing.
+    generation_id = Column(String(36), nullable=True, default=lambda: str(uuid4()))
     name = Column(String, nullable=False)
     series = Column(String, nullable=False, index=True)
     start = Column(DateTime, nullable=False, index=True)

--- a/app/services/operations/executors/history.py
+++ b/app/services/operations/executors/history.py
@@ -458,7 +458,9 @@ async def run_history_index(ctx) -> Outcome:
 # -- executor: history_merge ----------------------------------------------------
 
 
-def removed_archive_ids_from_dependency(db: Session, operation) -> list[int]:
+def removed_archive_targets_from_dependency(
+    db: Session, operation
+) -> list[tuple[int, str | None, str | None, str | None]]:
     """archive_sync reports removed archives in its result; history_merge
     always directly depends on it (spec 7.4 and 7.5 chains)."""
     depends_on_id = getattr(operation, "depends_on_id", None)
@@ -467,8 +469,20 @@ def removed_archive_ids_from_dependency(db: Session, operation) -> list[int]:
     parent = db.get(Operation, depends_on_id)
     if parent is None or parent.kind != "archive_sync":
         return []
-    ids = (parent.result or {}).get("removed_archive_ids") or []
-    return [int(i) for i in ids]
+    result = parent.result or {}
+    ids = result.get("removed_archive_ids") or []
+    identities = result.get("removed_archive_borg_ids") or {}
+    observations = result.get("removed_archive_last_seen_at") or {}
+    generations = result.get("removed_archive_generations") or {}
+    return [
+        (
+            int(i),
+            identities.get(str(i)),
+            observations.get(str(i)),
+            generations.get(str(i)),
+        )
+        for i in ids
+    ]
 
 
 def _delete_rows(db: Session, archive_id: int) -> None:
@@ -477,10 +491,28 @@ def _delete_rows(db: Session, archive_id: int) -> None:
     )
 
 
+def _checkpoint_merge(operation: Operation, archive_id: int, outcome: str) -> None:
+    params = operation.params or {}
+    operation.params = {
+        **params,
+        "history_merge_completed": {
+            **params.get("history_merge_completed", {}),
+            str(archive_id): outcome,
+        },
+    }
+
+
 def merge_removed_archive(
-    db: Session, removed: Archive, *, reset_state: str = "pending"
+    db: Session,
+    removed: Archive,
+    *,
+    reset_state: str = "pending",
+    operation: Operation | None = None,
 ) -> str:
     """Fold `removed` into its successor and delete it, in one transaction.
+
+    When run by an operation, checkpoint the deletion in that same commit:
+    a replay must never mistake a reused SQLite ID for the removed archive.
 
     Returns "folded" when both archives were indexed, "reset" when the
     successor was indexed against an archive that never was (its delta is
@@ -534,6 +566,8 @@ def merge_removed_archive(
         # foreign_keys=ON, which the app does not guarantee.
         _delete_rows(db, removed.id)
         db.delete(removed)
+        if operation is not None:
+            _checkpoint_merge(operation, removed.id, outcome)
         db.commit()
     except Exception:
         db.rollback()
@@ -547,24 +581,56 @@ async def run_history_merge(ctx) -> Outcome:
         return Outcome(status="skipped", skip_reason="repository_missing")
     db = ctx.db
     counts = {"merged": 0, "folded": 0, "reset": 0, "dropped": 0}
-    ids = removed_archive_ids_from_dependency(db, ctx.operation)
+    targets = removed_archive_targets_from_dependency(db, ctx.operation)
     # A reset successor reads as "not yet"; on an agent's repository no run
     # comes on any plan (the capability is the executor's), so it takes the
     # state the listing writes there.
     reset_state = "skipped" if is_agent_executor(repository) else "pending"
-    for position, archive_id in enumerate(ids):
+    for position, (archive_id, borg_id, last_seen_at, generation_id) in enumerate(
+        targets
+    ):
         if ctx.cancelled():
             break
+        completed = (ctx.operation.params or {}).get("history_merge_completed", {})
+        if str(archive_id) in completed:
+            outcome = completed[str(archive_id)]
+            if outcome != "skipped":
+                counts[outcome] += 1
+                counts["merged"] += 1
+            continue
         removed = db.get(Archive, archive_id)
-        if removed is None or removed.repository_id != repository.id:
+        if (
+            removed is None
+            or removed.repository_id != repository.id
+            or borg_id is None
+            or removed.borg_id != borg_id
+            or generation_id is None
+            or removed.generation_id != generation_id
+            or last_seen_at is None
+            or removed.last_seen_at.isoformat() != last_seen_at
+        ):
+            # IDs can be reused between chains, even before our first run.
+            # A later listing may also rediscover the same Borg archive.
+            # Recreated rows may reuse IDs and timestamps, but not the nonce.
+            # Results without all identities cannot safely delete:
+            # leave them for the next listing to rediscover with identities.
+            # Checkpoint skipped targets as final decisions on replay too.
+            try:
+                _checkpoint_merge(ctx.operation, archive_id, "skipped")
+                db.commit()
+            except Exception:
+                db.rollback()
+                raise
             continue
         # The row is gone (and expired) after the merge commits.
         name = removed.name
-        outcome = merge_removed_archive(db, removed, reset_state=reset_state)
+        outcome = merge_removed_archive(
+            db, removed, reset_state=reset_state, operation=ctx.operation
+        )
         counts[outcome] += 1
         counts["merged"] += 1
         ctx.log(f"{name}: {outcome}")
-        await ctx.progress(current=position + 1, total=len(ids), message=name)
+        await ctx.progress(current=position + 1, total=len(targets), message=name)
         await asyncio.sleep(0)
     return Outcome(result=counts)
 

--- a/app/services/operations/executors/index.py
+++ b/app/services/operations/executors/index.py
@@ -4,7 +4,9 @@ Series inference follows spec 6.6 through `app.services.operations.series`.
 
 import json
 import re
+from datetime import timedelta
 from typing import Iterable, Optional, Sequence
+from uuid import uuid4
 
 import structlog
 from fastapi import HTTPException, status
@@ -103,6 +105,11 @@ def apply_listing(
         a.borg_id: a
         for a in db.query(Archive).filter(Archive.repository_id == repository.id).all()
     }
+    # Initialize migrated rows, including absent targets a fresh merge will
+    # consume. Never replace an existing row's recreation identity.
+    for archive in existing.values():
+        if archive.generation_id is None:
+            archive.generation_id = str(uuid4())
     seen: set[str] = set()
     new_rows: list[Archive] = []
     now = utc_now()
@@ -134,7 +141,13 @@ def apply_listing(
                 if key == "series" and value != row.series:
                     row.history_state = "pending"
                 setattr(row, key, value)
-        row.last_seen_at = now
+        # This also identifies the observation used by a delayed merge.
+        # Always advance it, including when the wall clock moves backward.
+        row.last_seen_at = (
+            max(now, row.last_seen_at + timedelta(microseconds=1))
+            if row.last_seen_at is not None
+            else now
+        )
     removed = [a.id for borg_id, a in existing.items() if borg_id not in seen]
     db.commit()
     for row in new_rows:
@@ -592,6 +605,24 @@ async def run_archive_sync(ctx) -> Outcome:
         new_rows, removed_ids = apply_listing(
             db, repository, entries, timezone_name=timezone_name
         )
+        # Capture identities while this sync still owns the metadata lane.
+        # A delayed merge must not delete a new archive that reuses an ID
+        # after another chain has already removed the original archive.
+        removed_id_set = set(removed_ids)
+        removed_rows = [
+            row
+            for row in db.query(
+                Archive.id, Archive.borg_id, Archive.last_seen_at, Archive.generation_id
+            )
+            .filter(Archive.repository_id == repository.id)
+            .all()
+            if row.id in removed_id_set
+        ]
+        removed_borg_ids = {str(row.id): row.borg_id for row in removed_rows}
+        removed_generations = {str(row.id): row.generation_id for row in removed_rows}
+        removed_last_seen_at = {
+            str(row.id): row.last_seen_at.isoformat() for row in removed_rows
+        }
         if is_agent_executor(repository):
             # No history run ever reaches an agent's repository (the server
             # cannot diff it), so the listing records the state the history
@@ -659,6 +690,9 @@ async def run_archive_sync(ctx) -> Outcome:
                 "new": len(new_rows),
                 "info_filled": filled,
                 "removed_archive_ids": removed_ids,
+                "removed_archive_borg_ids": removed_borg_ids,
+                "removed_archive_last_seen_at": removed_last_seen_at,
+                "removed_archive_generations": removed_generations,
             }
         )
     finally:

--- a/app/services/operations/lanes.py
+++ b/app/services/operations/lanes.py
@@ -13,6 +13,10 @@ from app.database.models import (
 from app.services.operations.vocab import INDEX_KINDS, KINDS, is_exclusive
 
 _EXCLUSIVE_KINDS = tuple(k for k, spec in KINDS.items() if spec.exclusive)
+# The index kinds that share the repository lane: listing, merge and stats.
+# `history_index` is exclusive and holds the lane itself. Sorted, so the
+# `IN (...)` literal is the same text in every process.
+_SHARED_INDEX_KINDS = tuple(sorted(k for k in INDEX_KINDS if not KINDS[k].exclusive))
 
 _DEFAULTS = {
     "max_concurrent_backups": 1,
@@ -82,6 +86,47 @@ def lane_free(
     return not running_exclusive_operation(db, repository_id, exclude_id=exclude_id)
 
 
+def running_index_operation(db: Session, repository_id: int) -> bool:
+    """True while a listing, merge or stats of the repository is running.
+
+    No two of those overlap on one repository (spec 7.2): two chains of one
+    run (the backup's follow-ups and the prune's) otherwise start their
+    stats side by side, and on an agent's repository a listing started next
+    to the stats' `rinfo` dies with rc 2, since Borg 1 holds the cache lock
+    during `info` and `list` and the agent's calls are not serialised the
+    way the server's own are (`run_serialized_repository_command`, scope
+    `metadata`). A running `history_index` is not counted: it is exclusive
+    and holds the lane, which the bypass setting may cross so an hours-long
+    index does not hold the hourly listing; the server's metadata scope
+    keeps its `borg diff` and the listing apart, and an agent's repository
+    has no history stage.
+
+    A row a dead task left `running` would hold the repository for good;
+    the runner requeues such rows at every tick (as it does at startup),
+    so the answer here is the state the runner is actually in."""
+    return repository_id in repositories_with_running_index_work(
+        db, repository_ids=(repository_id,)
+    )
+
+
+def repositories_with_running_index_work(
+    db: Session, *, repository_ids: Optional[Iterable[int]] = None
+) -> set[int]:
+    """The repositories with a listing, merge or stats running, in one
+    query; `repository_ids` narrows it. See `running_index_operation`."""
+    q = db.query(Operation.repository_id).filter(
+        Operation.status == "running",
+        Operation.kind.in_(_SHARED_INDEX_KINDS),
+        Operation.repository_id.isnot(None),
+    )
+    if repository_ids is not None:
+        ids = tuple(repository_ids)
+        if not ids:
+            return set()
+        q = q.filter(Operation.repository_id.in_(ids))
+    return {row.repository_id for row in q.distinct()}
+
+
 def running_count(
     db: Session,
     *,
@@ -135,15 +180,20 @@ def can_start(db: Session, op: Operation, settings: Optional[SystemSettings]) ->
         return False
     if op.repository_id is None:
         return True
+    if op.kind in INDEX_KINDS and running_index_operation(db, op.repository_id):
+        # No second index operation next to a running listing, merge or
+        # stats of the repository, bypass or not: that setting reads past
+        # a backup's lock, not past another index job.
+        return False
     if is_exclusive(op.kind):
         return lane_free(db, op.repository_id, exclude_id=op.id)
     if op.kind in INDEX_KINDS:
         # Admission refuses a listing while prune, compact, delete or wipe
         # is pending or running, whatever the lane says (a pending job holds
         # no lane yet) and whatever bypass_lock says (that reads past a
-        # running backup's lock, not past admission). Checked first: the
-        # backup follow-up chain otherwise fails with 409 against the plan's
-        # own post-backup prune.
+        # running backup's lock, not past admission). Checked before the
+        # lane and bypass decision: the backup follow-up chain otherwise
+        # fails with 409 against the plan's own post-backup prune.
         if write_maintenance_running(db, op.repository_id):
             return False
         if lane_free(db, op.repository_id, exclude_id=op.id):

--- a/app/services/operations/reconcile.py
+++ b/app/services/operations/reconcile.py
@@ -37,9 +37,12 @@ POLL_INTERVAL_WHEN_DISABLED_MINUTES = 5
 def has_active_index_work(db: Session, repository_id: int) -> bool:
     """True when a reconcile run for the repository would only pile up: index
     work is already waiting to start, or an archive sync is in flight. A
-    running history index or stats refresh does not count. History can take
-    hours, and holding the hourly sync behind it would leave the archive
-    list stale while nothing is wrong."""
+    running history index, merge or stats refresh does not count. History
+    can take hours, and holding the hourly sync behind it would leave the
+    archive list stale while nothing is wrong; a merge or stats is bounded
+    by the info timeout, and the run queued behind it starts once it is
+    done (the tick runs the index operations of one repository one at a
+    time)."""
     waiting = db.query(Operation.id).filter(
         Operation.repository_id == repository_id,
         Operation.category == "index",

--- a/app/services/operations/runner.py
+++ b/app/services/operations/runner.py
@@ -46,6 +46,10 @@ _OUTCOME_STATUSES = (
 # prune row exists and admission then refuses the listing. Bounded, so a
 # repository that never frees up still ends in a visible failure.
 MAX_DEFERRALS = 20
+# How often an index row left `running` without a live task is put back to
+# `queued` before it fails: a terminal commit that keeps failing (a locked
+# database, a full disk) would otherwise re-run the listing every tick.
+MAX_REQUEUES = 3
 # Each deferral waits before the next attempt, doubling from 5 s to 5 min.
 # The runner is woken by every completion anywhere in the system, so without
 # the delay a busy install would spend the whole deferral budget in seconds
@@ -76,6 +80,17 @@ def deferral_count(op: Operation) -> int:
         count = int((op.params or {}).get("deferrals", 0))
     except (TypeError, ValueError, OverflowError):
         # inf overflows int(), nan and text are ValueErrors
+        return 0
+    return max(count, 0)
+
+
+def requeue_count(op: Operation) -> int:
+    """How often recovery has requeued the abandoned row; unreadable
+    bookkeeping counts as none, like `deferral_count`."""
+    params = op.params if isinstance(op.params, dict) else {}
+    try:
+        count = int(params.get("requeues", 0))
+    except (TypeError, ValueError, OverflowError):
         return 0
     return max(count, 0)
 
@@ -294,10 +309,116 @@ class OperationRunner:
 
     # -- scheduling ------------------------------------------------------------
 
+    async def requeue_abandoned_index_rows(self, db: Session) -> int:
+        """Index rows left `running` by a task this runner no longer has (a
+        task that died before its terminal commit, or none at all). The row
+        holds no lock, but it would count as running index work for its
+        repository and against `index_workers` until the next restart; it
+        goes back to `queued` the way `recover_on_startup` puts it, and runs
+        again, after the deferral path's backoff so a transient condition
+        (a locked database) does not spend the budget in seconds. Bounded:
+        after `MAX_REQUEUES` the row fails instead, keeping its start time
+        and progress, so a condition that kills the task every time ends in
+        a visible failure rather than a listing re-run every tick. The
+        caller guards the sweep: a failure in it must not cost the dispatch
+        pass. Every index kind is covered, `history_index`
+        included, as at startup; the other exclusive kinds are not: their
+        process may still be alive, which startup checks and the tick does
+        not. An entry that is not a future (a test's patched task) is left
+        alone: it cannot be told apart from live work."""
+        changed: list[Operation] = []
+        for op in (
+            db.query(Operation)
+            .filter(
+                Operation.status == "running",
+                Operation.kind.in_(tuple(sorted(INDEX_KINDS))),
+            )
+            .all()
+        ):
+            task = self.running_tasks.get(op.id)
+            if task is not None and (not asyncio.isfuture(task) or not task.done()):
+                continue
+            if op.id in self.cancel_requested:
+                # The executor observed an accepted cancel but could not
+                # commit its terminal state. Finish that cancellation rather
+                # than starting the work again after the database recovers.
+                op.status = "cancelled"
+                op.completed_at = utc_now()
+            else:
+                self._recover_index_row(op)
+            self.running_tasks.pop(op.id, None)
+            changed.append(op)
+        if not changed:
+            return 0
+        db.commit()
+        logger.warning(
+            "Swept abandoned index operations",
+            requeued=sum(1 for op in changed if op.status == "queued"),
+            failed=sum(1 for op in changed if op.status == "failed"),
+            cancelled=sum(1 for op in changed if op.status == "cancelled"),
+        )
+        for op in changed:
+            if op.status == "cancelled":
+                self.cancel_requested.discard(op.id)
+            try:
+                await broadcast_operation_updated(op, db)
+            except Exception as exc:  # the row is stored; the board refetches
+                logger.warning(
+                    "Could not broadcast a requeued operation",
+                    operation_id=op.id,
+                    error=str(exc),
+                )
+        return len(changed)
+
+    def _recover_index_row(self, op: Operation) -> None:
+        """Apply one retry budget and backoff at startup and during the tick."""
+        requeues = requeue_count(op) + 1
+        if requeues > MAX_REQUEUES:
+            # the row keeps its start time and progress: the only
+            # evidence of how far the work got
+            op.status = "failed"
+            op.error_message = (
+                f"lost by the runner again after {MAX_REQUEUES} requeues: the "
+                "operation kept ending without a result"
+            )
+            op.completed_at = utc_now()
+        else:
+            self._reset_index_row(op)
+            params = op.params if isinstance(op.params, dict) else {}
+            # the deferral path's gate; a row deferred a few times and then
+            # swept keeps the larger of the two backoffs
+            backoff = self.deferral_delay_for(max(requeues, deferral_count(op)))
+            op.params = {
+                **params,
+                "requeues": requeues,
+                "deferred_until": time.time() + backoff,
+            }
+
+    @staticmethod
+    def _reset_index_row(op: Operation) -> None:
+        op.status = "queued"
+        op.error_message = None
+        op.started_at = None
+        op.process_pid = None
+        op.process_start_time = None
+        op.progress_percent = None
+        op.progress_current = None
+        op.progress_total = None
+        op.progress_message = None
+
     async def tick(self) -> int:
         dispatched = 0
         db: Session = self._session()
         try:
+            try:
+                await self.requeue_abandoned_index_rows(db)
+            except Exception as exc:
+                # the sweep is housekeeping; the dispatch pass must not
+                # depend on it (a locked database, an unreadable row)
+                db.rollback()
+                logger.warning(
+                    "Sweep of abandoned index operations failed", error=str(exc)
+                )
             system_settings = db.query(SystemSettings).first()
             queued = (
                 db.query(Operation)
@@ -374,6 +495,7 @@ class OperationRunner:
         db: Session = self._session()
         ctx: Optional[OperationContext] = None
         deferred = False
+        terminal_committed = False
         try:
             op = db.get(Operation, operation_id)
             if op is None or op.status != "running":
@@ -388,6 +510,7 @@ class OperationRunner:
                 op.status = "cancelled"
                 op.completed_at = utc_now()
                 db.commit()
+                terminal_committed = True
                 await broadcast_operation_updated(op, db)
                 raise
             except Exception as exc:
@@ -469,6 +592,7 @@ class OperationRunner:
             op.error_message = outcome.error_message
             op.completed_at = utc_now()
             db.commit()
+            terminal_committed = True
             await broadcast_operation_updated(op, db)
             if op.status in SUCCESS_STATUSES:
                 enqueue_followups(
@@ -479,7 +603,10 @@ class OperationRunner:
                 ctx.close()
             db.close()
             self.running_tasks.pop(operation_id, None)
-            self.cancel_requested.discard(operation_id)
+            # Recovery needs the accepted request if the terminal write
+            # failed; only a committed terminal state consumes it.
+            if terminal_committed:
+                self.cancel_requested.discard(operation_id)
             if not deferred:
                 self.wake()
 
@@ -563,15 +690,8 @@ class OperationRunner:
         counts = {"requeued": 0, "failed": 0, "kept": 0}
         for op in db.query(Operation).filter(Operation.status == "running").all():
             if op.kind in INDEX_KINDS:
-                op.status = "queued"
-                op.started_at = None
-                op.process_pid = None
-                op.process_start_time = None
-                op.progress_percent = None
-                op.progress_current = None
-                op.progress_total = None
-                op.progress_message = None
-                counts["requeued"] += 1
+                self._recover_index_row(op)
+                counts["requeued" if op.status == "queued" else "failed"] += 1
             elif op.process_pid and is_process_alive(
                 op.process_pid, int(op.process_start_time or 0)
             ):

--- a/docs/architecture/job-system.md
+++ b/docs/architecture/job-system.md
@@ -324,6 +324,39 @@ Rules:
   exclusive operations wait. Index operations wait too unless
   `bypass_lock_on_list` or the repository's bypass setting allows them to
   run alongside.
+- No two of the shared index kinds (`archive_sync`, `history_merge`,
+  `stats`) run on one repository at the same time, and no `history_index`
+  starts next to one of them. The bypass settings do not change that: they
+  read past a backup's lock, not past another index job. Two chains of one
+  run (the backup's follow-ups and the prune's) otherwise started their
+  stats side by side, and on an agent's repository a listing next to the
+  stats' `rinfo` failed with rc 2, since Borg 1 holds the cache lock during
+  `info` and `list` and only the server's own Borg calls are serialised by
+  the metadata scope. A running `history_index` is governed by the lane
+  and bypass as above, so an hours-long index does not hold the hourly
+  listing; the metadata scope keeps its diff and the listing apart. Lane
+  capacity (`index_workers`) stays global. An index row left `running` by
+  a task the runner no longer has is requeued at the next tick, as at
+  startup, so it holds neither the repository nor a worker; after three
+  such requeues it fails instead, so a task that keeps dying ends in a
+  visible failure. `GET /queue` reports the state as `index_busy` per
+  repository.
+- The queue also reports `lane_holder` with the exclusive operation's kind
+  and ID. The board names that holder only while its operation is still
+  running in the current cache. SSE updates replace operation rows; both
+  busy flags keep their fetched values, and the track validates them against
+  those rows. A transition into `running` refetches the queue so newly
+  acquired lanes and index slots are reported together. While a shared
+  queue fetch is active, status events request one follow-up fetch instead of
+  racing optimistic updates against a snapshot of unknown age. The active
+  request finishes even during continuous progress events; progress ticks
+  do not request further fetches. Its follow-up supplies authoritative
+  state. Independent index
+  branches can contend even when they share a run ID; only a stage's actual
+  dependency ancestors are treated as expected predecessors. Without a
+  live named holder, the wait reason falls through to
+  other index work, the worker limit, or next in line. The frontend does not
+  maintain a second copy of the server's exclusive operation kinds.
 - Lower priority number runs first: manual and plan work at 0, scheduled at
   5, follow-ups at 10, reconcile at 20.
 - A failed or cancelled operation skips everything that depends on it with
@@ -436,7 +469,17 @@ Two more index kinds fill and maintain `archive_changes`:
   (the table in the spec, section 8.4), or the successor is reset to
   pending when the removed archive was never indexed, or the rows are
   simply dropped when there is no successor. The archive row is deleted
-  afterwards.
+  afterwards. Each deletion and its outcome are checkpointed in the
+  operation's parameters in the same transaction. Replayed operations
+  skip completed or previously missing IDs, so an ID reused by SQLite
+  cannot cause a replacement archive to be deleted. Targets also carry the
+  Borg identity and last-seen observation; a later listing that rediscovers
+  the same archive invalidates a delayed deletion. Last-seen timestamps
+  advance on every sighting, even across wall-clock rollback. Legacy
+  results missing required identities wait for a fresh listing. A persisted
+  `generation_id` UUID also distinguishes recreated archive rows when SQLite
+  IDs, Borg IDs, and timestamps all repeat. The migration adds a nullable
+  column; the next listing initializes existing rows, including absent ones.
 
 Only `history_index` is gated on the plan including `archive_history`; on
 Community installs the follow-up chains and the reconcile run omit it, and

--- a/docs/engineering/plans/2026-09-11-combined-lane-and-index-fixes.md
+++ b/docs/engineering/plans/2026-09-11-combined-lane-and-index-fixes.md
@@ -1,0 +1,69 @@
+# Combined Lane and Index Fixes Implementation Plan
+
+**Goal:** Replace #1023 and #1024 with one PR on current main, including their maintainer feedback.
+
+**Architecture:** Preserve runner admission and recovery from #1024 and the holder payload from #1023. Derive wait reasons in `deriveTrack` from fetched flags and current operation rows; name only the supplied holder while it is running. Remove the copied exclusive-kind set and unnamed-lane state.
+
+**Tech stack:** Python, SQLAlchemy, FastAPI, React, TypeScript, pytest, Vitest, Storybook.
+
+**Spec:** `docs/engineering/specs/2026-09-03-repository-operations-and-archive-history.md`, sections 7.2 and 10.1, and maintainer comments on #1023 and #1024.
+
+## Constraints
+
+Preserve upstream #1027, the accumulated deferral backoff, access-scoped index query, and both original PRs' regression coverage. Keep both SSE busy flags fetched and interpret them in the track. Use existing components and all four locales.
+
+## Steps
+
+- [x] Apply both diffs and reconcile overlapping payload, fixture, locale, and test changes.
+- [x] Change missing/completed-holder expectations to `queued` and prove they fail. Cover a valid server holder unknown locally and lane completion revealing index contention.
+- [x] Replace `LANE_KINDS` with a holder ID/status check against current operations. Preserve precedence: paused, named holder, foreign index work, worker limit, queued. Remove `lane_busy_unnamed`; use queued wording for an incomplete named stage. Update stories.
+- [x] Run affected backend tests, frontend tests, typecheck, lint, formatting, locale parity, and Storybook build. Render and inspect affected stories.
+- [x] Review against both source diffs; no actionable findings.
+
+## Verification
+
+- Affected backend suites: 186 passed.
+- Full frontend suite: 231 files, 2,725 tests passed with `NODE_OPTIONS=--no-experimental-webstorage` on Node 26.
+- Ruff, frontend typecheck/lint/formatting, locale parity, and Storybook build passed.
+- Four affected stories rendered at desktop and mobile sizes; local screenshots are not committed.
+
+**Delivery:** Open the replacement PR in the fork after local review. Wait for CodeRabbit approval and green non-visual CI before opening the upstream replacement; the fork's protected visual-state branch causes an accepted Storybook publication failure. Then close #1023 and #1024 and the unmerged fork validation PR with references to the upstream replacement. Never merge the fork PR.
+
+## Review round 1 corrections
+
+- Checkpoint history merge deletions atomically with each outcome so retrying an abandoned operation cannot delete a replacement archive whose SQLite ID was reused. Regressions use the existing migration's non-AUTOINCREMENT schema.
+- Refresh authoritative queue ownership when SSE reports an operation starting.
+- Treat independent index branches within one run as contenders; exclude only actual dependency ancestors from the waiting reason.
+- Verification: 168 targeted backend tests and all 2,729 frontend tests passed. Typecheck, lint, formatting, and Storybook build passed; the sibling-branch story was inspected at desktop and mobile sizes.
+
+## Review round 2 corrections
+
+- Preserve Borg archive identities in the listing result and verify them before merging history. This also protects unvisited targets when another chain overtakes a delayed merge; legacy ID-only targets wait for a fresh listing.
+- Preserve newer completion and progress updates when a queue response arrives late.
+- Verification: 172 targeted backend tests and all 2,730 frontend tests passed; typecheck and lint passed.
+- Original #1024 side finding: startup recovery now shares the runtime retry budget and backoff. Seven startup regressions failed before the correction; 183 targeted backend tests pass afterward.
+
+## Review round 3 corrections
+
+- Cover parent-triggered queue requests and newer authoritative responses without replaying older buffered events onto them.
+- Both event-order regressions failed before the correction; all 37 board and parent-tab tests pass afterward.
+
+## Review round 4 corrections
+
+- Coalesce events received during an active shared queue request into one follow-up fetch. Keep optimistic row updates only between requests, avoiding both event/response ordering guesses and starvation under continuous progress events.
+- Strengthen the completion-race test with a completed replacement snapshot and a visible `done` stage assertion.
+- The progress-burst regression failed with eleven requests before the correction and passes with one initial request and one follow-up; all 38 board and parent-tab tests, typecheck, and lint pass.
+
+## Fork validation follow-ups
+
+- Progress received during a fetch relies on that response instead of scheduling another fetch; only status events request the coalesced follow-up. A sustained-progress regression proves that progress during the follow-up cannot start a third request.
+- Preserve accepted cancellation intent when a terminal database commit fails. Recovery must commit cancellation before dropping the request, preventing an unintended retry or dependant execution.
+- Give both operations in the same-run serialization regression the same run ID.
+
+- Fork full-review finding: bind removed archive targets to their last-seen observation as well as repository, database ID, and Borg ID. Advance the existing observation timestamp monotonically on every sighting, so a delayed or retried merge cannot delete an archive rediscovered by a newer listing. Legacy results without observation identities wait for another listing. Regression coverage includes first execution and interrupted replay, with advancing, frozen, and backward wall clocks.
+
+## Upstream review correction
+
+- Reproduce deletion and recreation with identical repository, SQLite ID, Borg ID, and captured timestamp, both before first execution and after partial replay. Both regressions fail before the fix.
+- Add a persisted UUID generation to each archive row, carry it in removal targets, and require it at merge time. A nullable additive migration preserves existing rows; each listing initializes missing generations even for absent archives. Legacy results without all required identities wait for a new listing.
+- Verify upgrade and downgrade preserve archive history, plus legacy-target, replay, queue, runner, and migration suites.

--- a/docs/engineering/specs/2026-09-03-repository-operations-and-archive-history.md
+++ b/docs/engineering/specs/2026-09-03-repository-operations-and-archive-history.md
@@ -482,6 +482,15 @@ SSE event, a `log()` sink writing to `log_file_path`, and a
   `legacy_running_exclusive(repository_id)`, which is deleted in phase 9.
 - Non-exclusive index kinds may run alongside an exclusive operation only if
   `bypass_lock_on_list` is enabled; otherwise they wait too.
+- No two of the non-exclusive index kinds (`archive_sync`, `history_merge`,
+  `stats`) run on one repository at the same time, and no `history_index`
+  starts next to one of them; the bypass settings do not change that (#1003:
+  two chains of one run started their stats side by side, and on an agent's
+  repository a listing next to the stats' `rinfo` failed with rc 2 on the
+  Borg 1 cache lock). A running `history_index` holds the lane as before.
+  An index row left `running` by a task the runner no longer has is
+  requeued at the next tick, as at startup (bounded: it fails after three
+  requeues), so it holds neither the repository nor a worker.
 - `rclone_sync` uses `run_serialized_repository_command(scope="rclone")` as
   it does today and ignores the lane.
 - Executors also wrap Borg calls in
@@ -556,7 +565,12 @@ On startup, before the runner starts:
   `failed` with `error_message = "interrupted by restart"`. Local
   repositories get the existing lock-break attempt; remote ones do not, as
   documented in `job-system.md`.
-- `running` index operations: set back to `queued`. They are idempotent.
+- `running` index operations: use the same recovery budget as the runtime
+  sweep of abandoned tasks. Each retry increments `params.requeues`; an
+  operation is requeued at most three times, with backoff based on the larger
+  of the requeue and admission-deferral counts. A further interruption marks the
+  operation failed while retaining its start time and progress. Restarting
+  cannot bypass this retry budget; executor checkpoints remain in params.
 - `queued` operations are left alone.
 
 This replaces the per-table startup cleanup for each kind as it migrates.
@@ -569,6 +583,11 @@ via `ctx.cancelled()`; Borg executors also terminate the child process, as
 the existing cancel paths do. Dependants become `skipped`. A cancel that
 arrives while the admission is refusing the operation wins over the
 deferral (7.1 step 5): the row ends `cancelled` instead of being requeued.
+
+If the terminal database write fails, the runner retains an accepted cancel
+request. The runtime sweep completes that cancellation after the database
+recovers, without restarting the index executor or dispatching its dependants.
+It clears the request only after committing the terminal state.
 
 ### 7.8 Retention
 
@@ -591,8 +610,10 @@ as today. Replaces the size half of `update_repository_stats`.
 2. Upsert rows into `archives` by `(repository_id, borg_id)`. Update
    `last_seen_at`. Compute `series`.
 3. Rows in `archives` not present in the list are collected as
-   `result["removed_archive_ids"]` and left in place; `history_merge`
-   consumes and deletes them.
+   `result["removed_archive_ids"]` and left in place. The result also carries
+   `removed_archive_borg_ids`, mapping each row ID (as a JSON object key) to
+   its Borg ID, captured while the listing owns the metadata lane.
+   `history_merge` consumes and deletes matching rows.
 4. For up to `INDEX_ARCHIVE_INFO_PER_RUN` archives, oldest first, run
    per-archive `borg info` and fill sizes, `end`, and duration: archives
    without stats first, archives missing only `end` into the slots left
@@ -631,8 +652,15 @@ with the `borg-live-debug` skill.
 
 ### 8.4 `history_merge`
 
-Input: archives that `archive_sync` reported removed. For each removed
-archive `R`, find its successor `S` in the same series by `start`.
+Input: archives that `archive_sync` reported removed. A target must match
+both its row ID and Borg ID in the listing result, within the same repository.
+Another chain can delete the original and SQLite can reuse its row ID before
+this merge starts or retries. Missing or mismatching identities are skipped.
+Legacy results containing only row IDs are also skipped: the next listing
+rediscovers remaining stale rows and supplies their identities for cleanup.
+
+For each matching removed archive `R`, find its successor `S` in the same
+series by `start`.
 
 If `S` exists, fold `R`'s rows into `S`:
 
@@ -652,8 +680,20 @@ If `S` does not exist (the newest archive was removed), `R`'s rows are
 simply deleted.
 
 Then delete the `archives` row for `R`, which cascades to its remaining
-rows. All of this is SQL inside one transaction per removed archive. No
-Borg call, no lane.
+rows. All of this is SQL inside one transaction per removed archive,
+including a completion checkpoint in the operation's params. Replay preserves
+completed outcome counts and never revisits checkpointed targets, including
+skipped targets. This stage makes no Borg call and uses the repository's
+metadata lane. Removal targets must match the repository, database ID,
+Borg ID, persisted row-generation UUID, and last-seen observation captured
+by the parent listing. Each
+sighting advances the observation timestamp even if the wall clock does
+not advance, protecting archives rediscovered before a delayed merge.
+The row-generation UUID remains independent of SQLite ID reuse and wall time,
+so deleting and recreating the same Borg archive cannot revive an old target.
+The next listing initializes migrated rows whose generation is NULL, including
+absent rows. Legacy results missing any required identity skip deletion until
+a fresh listing can report the missing rows safely.
 
 The visible effect is honest: a change that happened in a pruned archive now
 shows at the next surviving archive, which is the earliest place the user can

--- a/frontend/src/components/background-work/PipelineBoard.stories.tsx
+++ b/frontend/src/components/background-work/PipelineBoard.stories.tsx
@@ -5,7 +5,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Box } from '@mui/material'
 import PipelineBoard from './PipelineBoard'
 import api from '../../services/api'
-import { busyQueue, emptyQueue, hubDetail, hubResponse } from './storyFixtures'
+import {
+  busyQueue,
+  emptyQueue,
+  hubDetail,
+  hubResponse,
+  maintenanceLaneQueue,
+  missingLaneHolderQueue,
+} from './storyFixtures'
 import type { HubResponse, QueueResponse } from '../../types/operations'
 
 function StoryProviders({
@@ -60,6 +67,26 @@ type Story = StoryObj<typeof meta>
 export const Busy: Story = {
   render: () => (
     <StoryProviders queue={busyQueue} hub={hubResponse}>
+      <PipelineBoard canManage />
+    </StoryProviders>
+  ),
+}
+
+// A prune holds the lane: the queued stages name it instead of claiming a
+// backup is running.
+export const MaintenanceHoldsTheLane: Story = {
+  render: () => (
+    <StoryProviders queue={maintenanceLaneQueue} hub={hubResponse}>
+      <PipelineBoard canManage />
+    </StoryProviders>
+  ),
+}
+
+// Without a current holder, queued stages stay next in line until the
+// next fetch supplies one.
+export const LaneHolderMissing: Story = {
+  render: () => (
+    <StoryProviders queue={missingLaneHolderQueue} hub={hubResponse}>
       <PipelineBoard canManage />
     </StoryProviders>
   ),

--- a/frontend/src/components/background-work/PipelineBoard.tsx
+++ b/frontend/src/components/background-work/PipelineBoard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Alert, Box, Button, IconButton, Stack, Tooltip, Typography, useTheme } from '@mui/material'
 import { HardDrive, Minus, Plus, SearchX } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -120,6 +120,7 @@ export default function PipelineBoard({ canManage }: PipelineBoardProps) {
     setWindowSize(WINDOW_SIZE)
   }
 
+  const refetchAfterEvents = useRef(false)
   const queue = useQuery({
     queryKey: QUEUE_KEY,
     queryFn: () => operationsAPI.getQueue().then((r) => r.data),
@@ -131,15 +132,42 @@ export default function PipelineBoard({ canManage }: PipelineBoardProps) {
     refetchInterval: 30000,
   })
 
+  // Do not race optimistic events against a response whose snapshot time is
+  // unknown. Let active requests finish, then coalesce intervening events into
+  // one fresh read. Progress bursts cannot starve a slow initial request.
+  useEffect(() => {
+    if (!queue.isFetching && refetchAfterEvents.current) {
+      refetchAfterEvents.current = false
+      queryClient.invalidateQueries({ queryKey: QUEUE_KEY }, { cancelRefetch: false })
+    }
+  }, [queue.isFetching, queryClient])
+
   const onUpdated = useCallback(
     (updated: OperationItem) => {
-      queryClient.setQueryData<QueueResponse | undefined>(QUEUE_KEY, (current) => {
-        if (!current) return current
+      if (updated.category === 'index' && updated.status !== 'running') {
+        queryClient.invalidateQueries({ queryKey: HUB_KEY })
+      }
+      if (queryClient.isFetching({ queryKey: QUEUE_KEY }) > 0) {
+        refetchAfterEvents.current = true
+        return
+      }
+      const cached = queryClient.getQueryData<QueueResponse>(QUEUE_KEY)
+      const started =
+        updated.status === 'running' &&
+        !cached?.repositories.some((repository) =>
+          repository.operations.some(
+            (operation) => operation.id === updated.id && operation.status === 'running'
+          )
+        )
+      const applyUpdate = (current: QueueResponse): QueueResponse => {
         const known = current.repositories.some(
           (repo) =>
             repo.repository_id === updated.repository_id ||
             repo.operations.some((op) => op.id === updated.id)
         )
+        // Only the operations change here; `lane_busy` and `index_busy`
+        // keep their fetched values, and the track reads them against the
+        // operations at hand (see deriveTrack).
         const repositories = current.repositories.map((repo) => ({
           ...repo,
           operations: repo.operations.some((op) => op.id === updated.id)
@@ -160,25 +188,31 @@ export default function PipelineBoard({ canManage }: PipelineBoardProps) {
                   repository_id: updated.repository_id,
                   repository_name: updated.repository ?? 'System',
                   lane_busy: false,
+                  index_busy: false,
                   operations: [updated],
                 },
               ],
         }
-      })
-      // A finished index stage changes the numbers at rest, so refresh
-      // the hub once the queue has settled rather than on every progress
-      // tick.
-      if (updated.category === 'index' && updated.status !== 'running') {
-        queryClient.invalidateQueries({ queryKey: HUB_KEY })
       }
+      queryClient.setQueryData<QueueResponse | undefined>(QUEUE_KEY, (current) =>
+        current ? applyUpdate(current) : current
+      )
+      // A newly running operation can take either the exclusive lane or the
+      // shared index slot. Fetch both authoritative flags and the holder;
+      // subsequent running/progress events only update the cached rows.
+      if (started) queryClient.invalidateQueries({ queryKey: QUEUE_KEY })
     },
     [queryClient]
   )
 
   const onProgress = useCallback(
     (progress: OperationProgressEvent['data']) => {
-      queryClient.setQueryData<QueueResponse | undefined>(QUEUE_KEY, (current) => {
-        if (!current) return current
+      // The active response will supply progress. Unlike status transitions,
+      // progress ticks must not sustain a chain of follow-up requests.
+      if (queryClient.isFetching({ queryKey: QUEUE_KEY }) > 0) {
+        return
+      }
+      const applyProgress = (current: QueueResponse): QueueResponse => {
         return {
           ...current,
           repositories: current.repositories.map((repo) => ({
@@ -188,7 +222,10 @@ export default function PipelineBoard({ canManage }: PipelineBoardProps) {
             ),
           })),
         }
-      })
+      }
+      queryClient.setQueryData<QueueResponse | undefined>(QUEUE_KEY, (current) =>
+        current ? applyProgress(current) : current
+      )
     },
     [queryClient]
   )

--- a/frontend/src/components/background-work/RepositoryHubRow.stories.tsx
+++ b/frontend/src/components/background-work/RepositoryHubRow.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Box } from '@mui/material'
 import RepositoryHubRow from './RepositoryHubRow'
 import { deriveTrack } from './repositoryTrack'
-import { busyQueue, hubRepositories, hubRepository } from './storyFixtures'
+import { busyQueue, hubRepositories, hubRepository, op } from './storyFixtures'
 
 const trackFor = (repositoryId: number) => {
   const group = busyQueue.repositories.find((r) => r.repository_id === repositoryId)
@@ -65,6 +65,50 @@ export const Running: Story = {
 
 export const BackupHoldsTheLane: Story = {
   args: { repository: hubRepositories[1], track: trackFor(2) },
+}
+
+// A stats refresh of the repository is still running: its queued listing
+// waits for it (one index operation per repository) although a worker is
+// free, and the stage says so.
+export const IndexWorkHoldsTheRepository: Story = {
+  args: { repository: hubRepositories[5], track: trackFor(6) },
+}
+
+// Backup and prune follow-ups share a run, but their stats jobs are siblings.
+// The queued sibling must name the index contention even when it hides the
+// older running stats job in the one-cell-per-stage display.
+export const SiblingBranchesWaitWithinOneRun: Story = {
+  args: {
+    repository: hubRepositories[5],
+    track: deriveTrack(
+      {
+        repository_id: 6,
+        repository_name: 'media',
+        lane_busy: false,
+        index_busy: true,
+        operations: [
+          op({
+            id: 7,
+            kind: 'stats',
+            status: 'running',
+            repository_id: 6,
+            repository: 'media',
+            depends_on_id: 5,
+          }),
+          op({
+            id: 8,
+            kind: 'stats',
+            status: 'queued',
+            repository_id: 6,
+            repository: 'media',
+            depends_on_id: 6,
+          }),
+        ],
+      },
+      busyQueue.limits,
+      false
+    ),
+  },
 }
 
 export const FailedStage: Story = {

--- a/frontend/src/components/background-work/StageTrack.tsx
+++ b/frontend/src/components/background-work/StageTrack.tsx
@@ -39,9 +39,18 @@ function StageSegment({
   if (stage.status === 'done') caption = t('operations.background.stageDone')
   else if (stage.status === 'failed') caption = t('operations.background.stageFailed')
   else if (stage.status === 'skipped') caption = t('operations.background.stageSkipped')
-  else if (stage.status === 'waiting' && stage.reason)
-    caption = t(`operations.background.reason.${stage.reason}`)
-  else if (stage.status === 'running') {
+  else if (stage.status === 'waiting' && stage.reason) {
+    // `lane_busy` is the only reason with a placeholder; without a kind to
+    // fill it the queued wording is used, so the raw `{{kind}}` can never
+    // reach the page however a caller built the stage.
+    const named = stage.reason === 'lane_busy' && stage.reasonKind
+    caption = t(
+      `operations.background.reason.${named ? 'lane_busy' : stage.reason === 'lane_busy' ? 'queued' : stage.reason}`,
+      named
+        ? { kind: t(`operations.kind.${stage.reasonKind}`, { defaultValue: stage.reasonKind }) }
+        : {}
+    )
+  } else if (stage.status === 'running') {
     const elapsed = elapsedSince(stage.operation?.started_at ?? null, now)
     const counted =
       stage.operation?.progress_current != null && stage.operation?.progress_total != null

--- a/frontend/src/components/background-work/__tests__/PipelineBoard.test.tsx
+++ b/frontend/src/components/background-work/__tests__/PipelineBoard.test.tsx
@@ -1,14 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 import PipelineBoard from '../PipelineBoard'
+import BackgroundWorkTab from '../../BackgroundWorkTab'
 import { archivesAPI, operationsAPI } from '../../../services/api'
 import type { HubRepository } from '../../../types/operations'
 
 vi.mock('../../../services/api', () => ({
   operationsAPI: {
     getQueue: vi.fn(),
+    pause: vi.fn().mockResolvedValue({ data: { paused: true } }),
+    resume: vi.fn(),
     getRepositories: vi.fn(),
     getRepositoryDetail: vi.fn(),
     reconcileNow: vi.fn(),
@@ -19,6 +22,8 @@ vi.mock('../../../services/api', () => ({
     resync: vi.fn(),
   },
 }))
+
+import { useOperationEvents } from '../../../hooks/useOperationEvents'
 
 vi.mock('../../../hooks/useOperationEvents', () => ({
   useOperationEvents: vi.fn(),
@@ -32,12 +37,22 @@ vi.mock('../../shared/PlanGate', () => ({
   default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
 
-function renderBoard(props: Partial<React.ComponentProps<typeof PipelineBoard>> = {}) {
+vi.mock('../../../hooks/useAuthorization', () => ({
+  useAuthorization: () => ({
+    globalRoleRank: new Map([['admin', 3]]),
+    currentGlobalRole: 'admin',
+  }),
+}))
+
+function renderBoard(
+  props: Partial<React.ComponentProps<typeof PipelineBoard>> = {},
+  withParent = false
+) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter>
-        <PipelineBoard canManage {...props} />
+        {withParent ? <BackgroundWorkTab /> : <PipelineBoard canManage {...props} />}
       </MemoryRouter>
     </QueryClientProvider>
   )
@@ -153,6 +168,7 @@ describe('PipelineBoard', () => {
         repository_id: 2,
         repository_name: 'photos',
         lane_busy: false,
+        index_busy: false,
         operations: [queueOp({ id: 2, repository_id: 2, repository: 'photos', status: 'running' })],
       },
     ])
@@ -171,6 +187,7 @@ describe('PipelineBoard', () => {
         repository_id: 1,
         repository_name: 'nas',
         lane_busy: true,
+        index_busy: false,
         operations: [
           queueOp({
             kind: 'backup',
@@ -186,12 +203,99 @@ describe('PipelineBoard', () => {
     expect(within(row).getByRole('link', { name: /view runs/i })).toBeInTheDocument()
   })
 
+  it('names the operation a waiting stage is held up by', async () => {
+    // the lane belongs to whichever exclusive operation runs; saying
+    // "backup" while a prune holds it contradicts the row above
+    mockQueue([
+      {
+        repository_id: 1,
+        repository_name: 'nas',
+        lane_busy: true,
+        lane_holder: { kind: 'prune', id: 5 },
+        operations: [
+          queueOp({
+            id: 5,
+            kind: 'prune',
+            category: 'maintenance',
+            status: 'running',
+            started_at: new Date().toISOString(),
+          }),
+          queueOp({ id: 6, kind: 'stats', category: 'index', status: 'queued' }),
+        ],
+      },
+    ])
+    renderBoard()
+    const row = (await screen.findAllByTestId('repository-row'))[0]
+    expect(within(row).getByText(/prune still running/i)).toBeInTheDocument()
+    // backup is the kind the old wording named whatever held the lane
+    expect(within(row).queryByText(/backup still running/i)).not.toBeInTheDocument()
+    expect(within(row).queryByText(/\{\{kind\}\}/)).not.toBeInTheDocument()
+  })
+
+  it('falls through to next in line when the payload carries no holder', async () => {
+    mockQueue([
+      {
+        repository_id: 1,
+        repository_name: 'nas',
+        lane_busy: true,
+        operations: [
+          queueOp({
+            id: 5,
+            kind: 'backup',
+            category: 'backup',
+            status: 'running',
+            started_at: new Date().toISOString(),
+          }),
+          queueOp({ id: 6, kind: 'stats', category: 'index', status: 'queued' }),
+        ],
+      },
+    ])
+    renderBoard()
+    const row = (await screen.findAllByTestId('repository-row'))[0]
+    expect(within(row).getByText(/next in line/i)).toBeInTheDocument()
+  })
+
+  it('stops naming a holder the same payload shows as finished', async () => {
+    // an event can mark the holder completed in the cache before the queue
+    // is refetched; the row must not wait for an operation it lists as
+    // done; a different running backup is not evidence that it holds the lane
+    mockQueue([
+      {
+        repository_id: 1,
+        repository_name: 'nas',
+        lane_busy: true,
+        lane_holder: { kind: 'prune', id: 5 },
+        operations: [
+          queueOp({
+            id: 5,
+            kind: 'prune',
+            category: 'maintenance',
+            status: 'completed',
+          }),
+          queueOp({
+            id: 7,
+            kind: 'backup',
+            category: 'backup',
+            status: 'running',
+            started_at: new Date().toISOString(),
+          }),
+          queueOp({ id: 6, kind: 'stats', category: 'index', status: 'queued' }),
+        ],
+      },
+    ])
+    renderBoard()
+    const row = (await screen.findAllByTestId('repository-row'))[0]
+    expect(within(row).getByText(/next in line/i)).toBeInTheDocument()
+    expect(within(row).queryByText(/prune still running/i)).not.toBeInTheDocument()
+  })
+
   it('adds a system lane below the repositories for work with no repository', async () => {
     mockQueue([
       {
         repository_id: null,
         repository_name: 'System',
         lane_busy: false,
+        index_busy: false,
         operations: [
           queueOp({
             id: 9,
@@ -237,6 +341,7 @@ describe('PipelineBoard', () => {
         repository_id: 1,
         repository_name: 'nas',
         lane_busy: false,
+        index_busy: false,
         operations: [queueOp({ id: 9, repository_id: 1, kind: 'archive_sync', status: 'failed' })],
       },
     ])
@@ -297,6 +402,7 @@ describe('PipelineBoard', () => {
         repository_id: 1,
         repository_name: 'nas',
         lane_busy: false,
+        index_busy: false,
         operations: [queueOp({ id: 9, repository_id: 1, kind: 'history_merge', status: 'failed' })],
       },
     ])
@@ -317,6 +423,7 @@ describe('PipelineBoard', () => {
         repository_id: 1,
         repository_name: 'nas',
         lane_busy: false,
+        index_busy: false,
         operations: [queueOp({ id: 9, repository_id: 1, kind: 'history_merge', status: 'failed' })],
       },
     ])
@@ -337,6 +444,7 @@ describe('PipelineBoard', () => {
         repository_id: 1,
         repository_name: 'nas',
         lane_busy: false,
+        index_busy: false,
         operations: [queueOp({ id: 9, repository_id: 1, kind: 'history_merge', status: 'failed' })],
       },
     ])
@@ -348,6 +456,301 @@ describe('PipelineBoard', () => {
     fireEvent.click(await screen.findByRole('button', { name: /retry/i }))
     await waitFor(() => expect(archivesAPI.resync).toHaveBeenCalledWith(1))
     expect(archivesAPI.rebuild).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { kind: 'stats', category: 'index', caption: /other index work to finish/i },
+    { kind: 'prune', category: 'maintenance', caption: /prune still running/i },
+  ])('refreshes queue ownership when SSE starts $kind', async ({ kind, category, caption }) => {
+    const starting = queueOp({ id: 9, kind, category, status: 'queued', run_id: 'r1' })
+    const waiting = queueOp({ id: 10, kind: 'archive_sync', status: 'queued', run_id: 'r2' })
+    const repository = {
+      repository_id: 1,
+      repository_name: 'nas',
+      lane_busy: false,
+      lane_holder: null,
+      index_busy: false,
+      operations: [starting, waiting],
+    }
+    mockQueue([repository])
+    renderBoard()
+    expect(await screen.findByText(/next in line/i)).toBeInTheDocument()
+
+    const running = { ...starting, status: 'running' }
+    mockQueue([
+      {
+        ...repository,
+        lane_busy: kind === 'prune',
+        lane_holder: kind === 'prune' ? { id: 9, kind } : null,
+        index_busy: kind === 'stats',
+        operations: [running, waiting],
+      },
+    ])
+    const calls = vi.mocked(useOperationEvents).mock.calls
+    const onUpdated = calls[calls.length - 1]?.[0]
+    act(() => onUpdated?.(running as never))
+
+    expect(await screen.findByText(caption)).toBeInTheDocument()
+  })
+
+  it('keeps an SSE completion when an older running queue response arrives later', async () => {
+    const starting = queueOp({ id: 9, kind: 'stats', status: 'queued', run_id: 'r1' })
+    const waiting = queueOp({ id: 10, kind: 'archive_sync', status: 'queued', run_id: 'r1' })
+    const repository = {
+      repository_id: 1,
+      repository_name: 'nas',
+      lane_busy: false,
+      index_busy: false,
+      operations: [starting, waiting],
+    }
+    mockQueue([repository])
+    renderBoard()
+    expect(await screen.findByTestId('stage-stats')).toHaveAttribute('data-status', 'waiting')
+    const running = { ...starting, status: 'running' }
+    const staleResponse = {
+      data: {
+        repositories: [{ ...repository, index_busy: true, operations: [running, waiting] }],
+        limits,
+        paused: false,
+      },
+    }
+    let finishRequest!: (value: typeof staleResponse) => void
+    vi.mocked(operationsAPI.getQueue).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishRequest = resolve as typeof finishRequest
+        }) as never
+    )
+    const calls = vi.mocked(useOperationEvents).mock.calls
+    const onUpdated = calls[calls.length - 1]?.[0]
+    act(() => onUpdated?.(running as never))
+    await waitFor(() => expect(operationsAPI.getQueue).toHaveBeenCalledTimes(2))
+    mockQueue([{ ...repository, operations: [{ ...running, status: 'completed' }, waiting] }])
+    act(() => onUpdated?.({ ...running, status: 'completed' } as never))
+    await act(async () => {
+      finishRequest(staleResponse)
+    })
+    await waitFor(() => expect(screen.getByText(/next in line/i)).toBeInTheDocument())
+    await waitFor(() =>
+      expect(screen.getByTestId('stage-stats')).toHaveAttribute('data-status', 'done')
+    )
+    expect(screen.queryByText(/other index work to finish/i)).not.toBeInTheDocument()
+  })
+
+  it('keeps an SSE completion during a refetch started by the parent pause control', async () => {
+    const running = queueOp({ id: 9, kind: 'stats', status: 'running', run_id: 'r1' })
+    const waiting = queueOp({ id: 10, kind: 'archive_sync', status: 'queued', run_id: 'r2' })
+    const repository = {
+      repository_id: 1,
+      repository_name: 'nas',
+      lane_busy: false,
+      index_busy: true,
+      operations: [running, waiting],
+    }
+    mockQueue([repository])
+    renderBoard({}, true)
+    expect(await screen.findByText(/other index work to finish/i)).toBeInTheDocument()
+    const staleResponse = { data: { repositories: [repository], limits, paused: false } }
+    let finishRequest!: (value: typeof staleResponse) => void
+    vi.mocked(operationsAPI.getQueue).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishRequest = resolve as typeof finishRequest
+        }) as never
+    )
+    fireEvent.click(screen.getByRole('button', { name: /^pause$/i }))
+    await waitFor(() => expect(finishRequest).toBeDefined())
+    mockQueue([
+      {
+        ...repository,
+        index_busy: false,
+        operations: [{ ...running, status: 'completed' }, waiting],
+      },
+    ])
+    const calls = vi.mocked(useOperationEvents).mock.calls
+    act(() => calls[calls.length - 1]?.[0]({ ...running, status: 'completed' } as never))
+    await act(async () => {
+      finishRequest(staleResponse)
+    })
+    await waitFor(() =>
+      expect(screen.queryByText(/other index work to finish/i)).not.toBeInTheDocument()
+    )
+  })
+
+  it('accepts a completed server snapshot newer than a running event received during the fetch', async () => {
+    const starting = queueOp({ id: 9, kind: 'stats', status: 'queued' })
+    const repository = {
+      repository_id: 1,
+      repository_name: 'nas',
+      lane_busy: false,
+      index_busy: false,
+      operations: [starting],
+    }
+    mockQueue([repository])
+    renderBoard()
+    expect(await screen.findByTestId('stage-stats')).toHaveAttribute('data-status', 'waiting')
+    const completedResponse = {
+      data: {
+        repositories: [{ ...repository, operations: [{ ...starting, status: 'completed' }] }],
+        limits,
+        paused: false,
+      },
+    }
+    let finishRequest!: (value: typeof completedResponse) => void
+    vi.mocked(operationsAPI.getQueue)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishRequest = resolve as typeof finishRequest
+          }) as never
+      )
+      .mockResolvedValue(completedResponse as never)
+    const calls = vi.mocked(useOperationEvents).mock.calls
+    const onUpdated = calls[calls.length - 1]?.[0]
+    act(() => onUpdated?.({ ...starting, status: 'running' } as never))
+    await waitFor(() => expect(finishRequest).toBeDefined())
+    act(() => onUpdated?.({ ...starting, status: 'running' } as never))
+    await act(async () => {
+      finishRequest(completedResponse)
+    })
+    await waitFor(() =>
+      expect(screen.getByTestId('stage-stats')).toHaveAttribute('data-status', 'done')
+    )
+  })
+
+  it('lets a slow initial queue fetch finish during a burst of progress events', async () => {
+    const running = queueOp({ id: 9, kind: 'stats', status: 'running', progress_percent: 50 })
+    const repository = {
+      repository_id: 1,
+      repository_name: 'nas',
+      lane_busy: false,
+      index_busy: true,
+      operations: [running],
+    }
+    const response = { data: { repositories: [repository], limits, paused: false } }
+    let finishRequest!: (value: typeof response) => void
+    vi.mocked(operationsAPI.getQueue)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishRequest = resolve as typeof finishRequest
+          }) as never
+      )
+      .mockResolvedValue(response as never)
+    renderBoard({}, true)
+    await waitFor(() => expect(finishRequest).toBeDefined())
+    const calls = vi.mocked(useOperationEvents).mock.calls
+    const onProgress = calls[calls.length - 1]?.[1]
+    for (let current = 1; current <= 10; current++) {
+      act(() =>
+        onProgress?.({
+          id: 9,
+          progress_current: current,
+          progress_total: 20,
+          progress_percent: current * 5,
+          progress_message: `Archive ${current}`,
+        })
+      )
+    }
+    expect(operationsAPI.getQueue).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      finishRequest(response)
+    })
+    expect(await screen.findByTestId('stage-stats')).toHaveAttribute('data-status', 'running')
+    expect(operationsAPI.getQueue).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not chain more refetches when progress continues during the follow-up request', async () => {
+    const running = queueOp({ id: 9, kind: 'stats', status: 'running' })
+    const response = {
+      data: {
+        repositories: [
+          {
+            repository_id: 1,
+            repository_name: 'nas',
+            lane_busy: false,
+            index_busy: true,
+            operations: [running],
+          },
+        ],
+        limits,
+        paused: false,
+      },
+    }
+    let finishInitial!: (value: typeof response) => void
+    let finishFollowup!: (value: typeof response) => void
+    vi.mocked(operationsAPI.getQueue)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishInitial = resolve as typeof finishInitial
+          }) as never
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishFollowup = resolve as typeof finishFollowup
+          }) as never
+      )
+      .mockResolvedValue(response as never)
+    renderBoard({}, true)
+    await waitFor(() => expect(finishInitial).toBeDefined())
+    const calls = vi.mocked(useOperationEvents).mock.calls
+    const handlers = calls[calls.length - 1]
+    act(() => handlers?.[0](running as never))
+    await act(async () => {
+      finishInitial(response)
+    })
+    await waitFor(() => expect(finishFollowup).toBeDefined())
+    for (let current = 1; current <= 10; current++) {
+      act(() =>
+        handlers?.[1]({
+          id: 9,
+          progress_current: current,
+          progress_total: 20,
+          progress_percent: current * 5,
+          progress_message: `Archive ${current}`,
+        })
+      )
+    }
+    await act(async () => {
+      finishFollowup(response)
+    })
+    expect(await screen.findByTestId('stage-stats')).toHaveAttribute('data-status', 'running')
+    expect(operationsAPI.getQueue).toHaveBeenCalledTimes(2)
+  })
+
+  it('follows the running index work through SSE updates between two fetches', async () => {
+    mockQueue([
+      {
+        repository_id: 1,
+        repository_name: 'nas',
+        lane_busy: false,
+        index_busy: true,
+        operations: [
+          queueOp({ id: 9, repository_id: 1, kind: 'stats', status: 'running' }),
+          // another chain's listing: the running stats is foreign work to it
+          queueOp({
+            id: 10,
+            repository_id: 1,
+            kind: 'archive_sync',
+            status: 'queued',
+            run_id: 'r2',
+          }),
+        ],
+      },
+    ])
+    renderBoard()
+    expect(await screen.findByText(/other index work to finish/i)).toBeInTheDocument()
+    const calls = vi.mocked(useOperationEvents).mock.calls
+    const onUpdated = calls[calls.length - 1]?.[0]
+    expect(onUpdated).toBeDefined()
+    act(() => {
+      onUpdated?.(queueOp({ id: 9, repository_id: 1, kind: 'stats', status: 'completed' }) as never)
+    })
+    await waitFor(() =>
+      expect(screen.queryByText(/other index work to finish/i)).not.toBeInTheDocument()
+    )
   })
 
   it('has no rebuild form below the table, only the per-row menus', async () => {

--- a/frontend/src/components/background-work/__tests__/repositoryTrack.test.ts
+++ b/frontend/src/components/background-work/__tests__/repositoryTrack.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { deriveTrack } from '../repositoryTrack'
+import { deriveTrack, indexBusyFrom } from '../repositoryTrack'
 import type { OperationItem, QueueLimits, QueueRepository } from '../../../types/operations'
 
 const op = (overrides: Partial<OperationItem>): OperationItem =>
@@ -51,12 +51,34 @@ const limits: QueueLimits = {
   max_concurrent_scheduled_checks: 4,
 }
 
-const repo = (operations: OperationItem[], lane_busy = false): QueueRepository => ({
+const repo = (
+  operations: OperationItem[],
+  busy: boolean | Partial<QueueRepository> = false,
+  lane_holder: QueueRepository['lane_holder'] = null
+): QueueRepository => ({
   repository_id: 1,
   repository_name: 'nas',
-  lane_busy,
+  lane_busy: typeof busy === 'boolean' ? busy : false,
+  index_busy: false,
+  lane_holder,
+  ...(typeof busy === 'object' ? busy : {}),
   operations,
 })
+
+// A busy lane and the operation holding it, as the queue sends the pair:
+// the holder is one of the repository's own running rows.
+const held = (
+  kind: 'backup' | 'prune' | 'compact' | 'check',
+  queued: OperationItem[]
+): QueueRepository => {
+  const holder = op({
+    id: 99,
+    kind,
+    category: kind === 'backup' ? 'backup' : 'maintenance',
+    status: 'running',
+  })
+  return repo([...queued, holder], true, { kind, id: holder.id })
+}
 
 describe('deriveTrack', () => {
   it('maps each stage to its latest operation status', () => {
@@ -79,13 +101,138 @@ describe('deriveTrack', () => {
   })
 
   it('explains a queued stage with the paused state first', () => {
-    const track = deriveTrack(repo([op({ kind: 'stats', status: 'queued' })], true), limits, true)
+    const track = deriveTrack(
+      held('backup', [op({ kind: 'stats', status: 'queued' })]),
+      limits,
+      true
+    )
     expect(track.stages[3].reason).toBe('paused')
   })
 
   it('explains a queued stage with the busy lane', () => {
-    const track = deriveTrack(repo([op({ kind: 'stats', status: 'queued' })], true), limits, false)
+    const track = deriveTrack(
+      held('backup', [op({ kind: 'stats', status: 'queued' })]),
+      limits,
+      false
+    )
     expect(track.stages[3].reason).toBe('lane_busy')
+    expect(track.stages[3].reasonKind).toBe('backup')
+  })
+
+  it('names whichever exclusive operation holds the lane', () => {
+    // a prune, a compact or a check hold it as much as a backup does
+    for (const kind of ['prune', 'compact', 'check'] as const) {
+      const track = deriveTrack(
+        held(kind, [op({ kind: 'stats', status: 'queued' })]),
+        limits,
+        false
+      )
+      expect(track.stages[3].reason).toBe('lane_busy')
+      expect(track.stages[3].reasonKind).toBe(kind)
+    }
+  })
+
+  it('falls through to queued when the payload carries no holder', () => {
+    // A missing holder cannot establish which running operation owns the lane.
+    const track = deriveTrack(
+      repo(
+        [
+          op({ kind: 'stats', status: 'queued' }),
+          op({ id: 99, kind: 'backup', category: 'backup', status: 'running' }),
+        ],
+        true,
+        null
+      ),
+      limits,
+      false
+    )
+    expect(track.stages[3].reason).toBe('queued')
+    expect(track.stages[3].reasonKind).toBeNull()
+  })
+
+  it('stops naming a holder the same payload shows as finished', () => {
+    // an event marked the holder completed in the cache before the queue
+    // was refetched. Another running row cannot stand in for that holder.
+    const track = deriveTrack(
+      repo(
+        [
+          op({ kind: 'stats', status: 'queued' }),
+          op({ id: 99, kind: 'prune', category: 'maintenance', status: 'completed' }),
+          op({ id: 100, kind: 'backup', category: 'backup', status: 'running' }),
+        ],
+        true,
+        { kind: 'prune', id: 99 }
+      ),
+      limits,
+      false
+    )
+    expect(track.stages[3].reason).toBe('queued')
+    expect(track.stages[3].reasonKind).toBeNull()
+  })
+
+  it('leaves the worker limit to explain a stage once the holder is gone', () => {
+    // The holder has finished in the cache and no shared index work is
+    // running on this repository, so the global worker pool explains the wait.
+    const track = deriveTrack(
+      repo(
+        [
+          op({ id: 10, kind: 'history_index', status: 'queued' }),
+          op({ id: 99, kind: 'prune', category: 'maintenance', status: 'completed' }),
+        ],
+        true,
+        { kind: 'prune', id: 99 }
+      ),
+      { ...limits, index_running: 2 },
+      false
+    )
+    expect(track.stages[2].reason).toBe('workers')
+    expect(track.stages[2].reasonKind).toBeNull()
+  })
+
+  it('does not let a kind it cannot place keep the lane busy', () => {
+    // an operation from a newer build carries a category all the same; the
+    // server refuses it the lane, and so does the track rather than
+    // reporting a holder it cannot name
+    const track = deriveTrack(
+      repo(
+        [
+          op({ id: 10, kind: 'history_index', status: 'queued' }),
+          op({ id: 99, kind: 'prune', category: 'maintenance', status: 'completed' }),
+          op({
+            id: 11,
+            kind: 'teleport' as OperationItem['kind'],
+            category: 'maintenance',
+            status: 'running',
+          }),
+        ],
+        true,
+        { kind: 'prune', id: 99 }
+      ),
+      { ...limits, index_running: 2 },
+      false
+    )
+    expect(track.stages[2].reason).toBe('workers')
+    expect(track.stages[2].reasonKind).toBeNull()
+  })
+
+  it('does not claim a busy lane while the payload shows nothing running', () => {
+    // the lane flag is the server's word and the rows are this payload's;
+    // with every operation finished in the cache the stage is simply next
+    // in line, not waiting for a phantom
+    const track = deriveTrack(
+      repo(
+        [
+          op({ kind: 'stats', status: 'queued' }),
+          op({ id: 99, kind: 'prune', category: 'maintenance', status: 'completed' }),
+        ],
+        true,
+        { kind: 'prune', id: 99 }
+      ),
+      limits,
+      false
+    )
+    expect(track.stages[3].reason).toBe('queued')
+    expect(track.stages[3].reasonKind).toBeNull()
   })
 
   it('explains a queued history stage with the worker limit', () => {
@@ -177,5 +324,119 @@ describe('deriveTrack', () => {
     )
     expect(track.foreground?.id).toBe(7)
     expect(track.stages.every((s) => s.status === 'idle')).toBe(true)
+  })
+  it("explains a queued stage with the repository's running index work", () => {
+    const track = deriveTrack(
+      repo(
+        [
+          op({ id: 1, kind: 'stats', status: 'running', run_id: 'r1' }),
+          op({ id: 2, kind: 'archive_sync', status: 'queued', run_id: 'r2' }),
+        ],
+        { index_busy: true }
+      ),
+      limits,
+      false
+    )
+    expect(track.stages[1].reason).toBe('index_busy')
+  })
+
+  it("calls a stage behind its own run's predecessor next in line, not foreign work", () => {
+    const track = deriveTrack(
+      repo(
+        [
+          op({ id: 1, kind: 'archive_sync', status: 'running' }),
+          op({ id: 2, kind: 'stats', status: 'queued', depends_on_id: 1 }),
+        ],
+        { index_busy: true }
+      ),
+      limits,
+      false
+    )
+    expect(track.stages[3].reason).toBe('queued')
+  })
+
+  it('names the busy lane before the running index work', () => {
+    const track = deriveTrack(
+      { ...held('backup', [op({ kind: 'stats', status: 'queued' })]), index_busy: true },
+      limits,
+      false
+    )
+    expect(track.stages[3].reason).toBe('lane_busy')
+  })
+
+  it('derives the index flag from the operations at hand', () => {
+    for (const kind of ['archive_sync', 'history_merge', 'stats'] as const) {
+      expect(indexBusyFrom([op({ kind, status: 'running' })])).toBe(true)
+    }
+    expect(indexBusyFrom([op({ kind: 'stats', status: 'completed' })])).toBe(false)
+    // history_index holds the lane, not the index slot
+    expect(indexBusyFrom([op({ kind: 'history_index', status: 'running' })])).toBe(false)
+  })
+
+  it('names a running server holder even when its kind is unknown locally', () => {
+    const kind = 'future_maintenance' as OperationItem['kind']
+    const track = deriveTrack(
+      repo(
+        [
+          op({ id: 1, kind: 'stats', status: 'queued' }),
+          op({ id: 99, kind, category: 'maintenance', status: 'running' }),
+        ],
+        true,
+        { id: 99, kind }
+      ),
+      limits,
+      false
+    )
+    expect(track.stages[3].reason).toBe('lane_busy')
+    expect(track.stages[3].reasonKind).toBe(kind)
+  })
+
+  it('reveals foreign index work once the named lane holder has finished', () => {
+    const track = deriveTrack(
+      repo(
+        [
+          op({ id: 99, kind: 'prune', category: 'maintenance', status: 'completed' }),
+          op({ id: 1, kind: 'stats', status: 'running', run_id: 'old' }),
+          op({ id: 2, kind: 'archive_sync', status: 'queued', run_id: 'new' }),
+        ],
+        { lane_busy: true, index_busy: true, lane_holder: { id: 99, kind: 'prune' } }
+      ),
+      limits,
+      false
+    )
+    expect(track.stages[1].reason).toBe('index_busy')
+    expect(track.stages[1].reasonKind).toBeNull()
+  })
+  it('reports index contention from sibling branches sharing a run ID', () => {
+    const track = deriveTrack(
+      repo(
+        [
+          op({ id: 1, kind: 'stats', status: 'running', depends_on_id: 20 }),
+          op({ id: 2, kind: 'stats', status: 'queued', depends_on_id: 21 }),
+        ],
+        { index_busy: true }
+      ),
+      limits,
+      false
+    )
+    expect(track.stages[3].operation?.id).toBe(2)
+    expect(track.stages[3].reason).toBe('index_busy')
+  })
+
+  it('keeps a queued descendant next in line behind its running ancestor', () => {
+    const track = deriveTrack(
+      repo(
+        [
+          op({ id: 1, kind: 'archive_sync', status: 'running' }),
+          op({ id: 2, kind: 'history_merge', status: 'queued', depends_on_id: 1 }),
+          op({ id: 3, kind: 'stats', status: 'queued', depends_on_id: 2 }),
+        ],
+        { index_busy: true }
+      ),
+      limits,
+      false
+    )
+    expect(track.stages[2].reason).toBe('queued')
+    expect(track.stages[3].reason).toBe('queued')
   })
 })

--- a/frontend/src/components/background-work/repositoryTrack.ts
+++ b/frontend/src/components/background-work/repositoryTrack.ts
@@ -1,5 +1,6 @@
 import type {
   OperationItem,
+  OperationKind,
   QueueLimits,
   QueueRepository,
   RebuildStage,
@@ -59,13 +60,35 @@ export type StageStatus = 'idle' | 'done' | 'running' | 'waiting' | 'failed' | '
 // Why a queued stage has not started, in the order a person would want to
 // hear it: the whole queue is paused, a foreground job owns this
 // repository, every index worker is busy, or it is simply next in line.
-export type WaitReason = 'paused' | 'lane_busy' | 'workers' | 'queued'
+// `lane_busy` names the server-reported holder while it is still running.
+export type WaitReason = 'paused' | 'lane_busy' | 'index_busy' | 'workers' | 'queued'
+// The index kinds that share a repository's index slot; `history_index`
+// holds the lane instead. A copy of what lanes.py derives (INDEX_KINDS
+// minus the exclusive one): keep the two in step when a kind is added.
+const SHARED_INDEX_KINDS = new Set<OperationItem['kind']>([
+  'archive_sync',
+  'history_merge',
+  'stats',
+])
+
+// Whether one of `operations` is running index work of the shared kind. The
+// track reads the server's `index_busy` against the operations it holds: an
+// SSE update that finishes that work clears the wait reason before the next
+// fetch, the same way the lane's holder is checked against them.
+export function indexBusyFrom(operations: OperationItem[]): boolean {
+  return operations.some((op) => op.status === 'running' && SHARED_INDEX_KINDS.has(op.kind))
+}
 
 export interface StageState {
   key: StageKey
   status: StageStatus
   operation: OperationItem | null
   reason: WaitReason | null
+  // The lane holder's kind, for the `lane_busy` wording. Any exclusive
+  // kind can hold a lane: a backup, but also a prune, a compact, a check
+  // or the file-history index. Optional so the partial stage literals in
+  // tests and stories stay valid; `deriveTrack` always sets it.
+  reasonKind?: OperationKind | null
 }
 
 export interface RepositoryTrack {
@@ -131,18 +154,46 @@ export function deriveTrack(
       (operation) => FOREGROUND_CATEGORIES.has(operation.category) && operation.status === 'running'
     ) ?? null
 
+  // The server chooses the holder. SSE may finish it before the next fetch;
+  // another running row cannot establish a replacement holder on its own.
+  const holder = repository.lane_holder ?? null
+  const holderRunning =
+    repository.lane_busy &&
+    holder !== null &&
+    repository.operations.some(
+      (operation) => operation.id === holder.id && operation.status === 'running'
+    )
+
+  const operationsById = new Map(
+    repository.operations.map((operation) => [operation.id, operation])
+  )
   const stages = STAGE_ORDER.map<StageState>((key) => {
     const operation = latest.get(key) ?? null
-    if (!operation) return { key, status: 'idle', operation: null, reason: null }
+    if (!operation) return { key, status: 'idle', operation: null, reason: null, reasonKind: null }
     const status = stageStatus(operation.status)
     let reason: WaitReason | null = null
+    let reasonKind: OperationKind | null = null
     if (status === 'waiting') {
+      // A running dependency is the expected predecessor, but independent
+      // branches can share a run ID and still compete for the index slot.
+      const predecessors = new Set<number>()
+      let dependencyId = operation.depends_on_id
+      while (dependencyId != null && !predecessors.has(dependencyId)) {
+        predecessors.add(dependencyId)
+        dependencyId = operationsById.get(dependencyId)?.depends_on_id ?? null
+      }
+      const otherIndexRunning =
+        repository.index_busy &&
+        indexBusyFrom(repository.operations.filter((candidate) => !predecessors.has(candidate.id)))
       if (paused) reason = 'paused'
-      else if (repository.lane_busy) reason = 'lane_busy'
+      else if (holderRunning) {
+        reasonKind = holder.kind
+        reason = 'lane_busy'
+      } else if (otherIndexRunning) reason = 'index_busy'
       else if (key === 'history' && limits.index_running >= limits.index_workers) reason = 'workers'
       else reason = 'queued'
     }
-    return { key, status, operation, reason }
+    return { key, status, operation, reason, reasonKind }
   })
 
   return {

--- a/frontend/src/components/background-work/storyFixtures.ts
+++ b/frontend/src/components/background-work/storyFixtures.ts
@@ -97,6 +97,12 @@ export const hubRepositories: HubRepository[] = [
     archives: 15,
     history: { indexed: 15, pending: 0, failed: 0, skipped: 0, truncated: 0, rows: 62 },
   }),
+  hubRepository({
+    repository_id: 6,
+    repository_name: 'media',
+    archives: 22,
+    history: { indexed: 22, pending: 0, failed: 0, skipped: 0, truncated: 0, rows: 3140 },
+  }),
 ]
 
 export const hubResponse: HubResponse = {
@@ -147,6 +153,7 @@ export const busyQueue: QueueResponse = {
       repository_id: 1,
       repository_name: 'offsite',
       lane_busy: false,
+      index_busy: false,
       operations: [
         op({ id: 1, kind: 'import_connect', category: 'import', repository: 'offsite' }),
       ],
@@ -155,6 +162,10 @@ export const busyQueue: QueueResponse = {
       repository_id: 2,
       repository_name: 'nas',
       lane_busy: true,
+      lane_holder: { kind: 'backup', id: 3 },
+      // a stats is running here too; the lane's backup is what the stage
+      // names, since the lane wins over the index flag
+      index_busy: true,
       operations: [
         op({
           id: 2,
@@ -180,6 +191,7 @@ export const busyQueue: QueueResponse = {
       repository_id: 3,
       repository_name: 'photos',
       lane_busy: false,
+      index_busy: false,
       operations: [
         op({
           id: 4,
@@ -198,6 +210,7 @@ export const busyQueue: QueueResponse = {
       repository_id: 4,
       repository_name: 'laptop',
       lane_busy: false,
+      index_busy: false,
       operations: [
         op({ id: 5, status: 'completed', repository: 'laptop', repository_id: 4 }),
         op({
@@ -207,6 +220,34 @@ export const busyQueue: QueueResponse = {
           repository: 'laptop',
           repository_id: 4,
           error_message: 'borg list timed out',
+        }),
+      ],
+    },
+    {
+      // a stats of the repository still running: the next listing waits
+      // for it (one index operation per repository), with a worker to
+      // spare. The listing is another chain's, or the flag would not apply.
+      repository_id: 6,
+      repository_name: 'media',
+      lane_busy: false,
+      index_busy: true,
+      operations: [
+        op({
+          id: 7,
+          kind: 'stats',
+          status: 'running',
+          repository: 'media',
+          repository_id: 6,
+          started_at: minutesAgo(1),
+        }),
+        op({
+          id: 8,
+          kind: 'archive_sync',
+          status: 'queued',
+          repository: 'media',
+          repository_id: 6,
+          run_id: 'r2',
+          trigger: 'followup',
         }),
       ],
     },
@@ -231,4 +272,58 @@ export const emptyQueue: QueueResponse = {
     max_concurrent_scheduled_checks: 4,
   },
   paused: false,
+}
+
+// The same queue with a prune holding the lane instead of a backup: the
+// waiting stages name the prune (issue: the wording used to say "backup"
+// whatever held the lane).
+export const maintenanceLaneQueue: QueueResponse = {
+  ...busyQueue,
+  repositories: busyQueue.repositories.map((repository) =>
+    repository.repository_id === 2
+      ? {
+          ...repository,
+          lane_holder: { kind: 'prune' as const, id: 3 },
+          operations: [
+            // the prune that holds the lane, and an index stage queued
+            // behind it: the caption under that stage names the prune
+            ...repository.operations.map((operation) =>
+              operation.id === 3
+                ? { ...operation, kind: 'prune' as const, category: 'maintenance' as const }
+                : // admission holds index work back while a prune runs, so
+                  // the stats row of the busy fixture waits here too
+                  { ...operation, status: 'queued' as const, started_at: null }
+            ),
+            op({
+              id: 31,
+              kind: 'archive_sync',
+              status: 'queued',
+              repository: 'nas',
+              repository_id: 2,
+              started_at: null,
+            }),
+          ],
+        }
+      : repository
+  ),
+}
+
+// The lane is taken, but the payload does not say by what: a page loaded
+// before the server carried the holder, or one whose holder has finished
+// since. The caption falls through to next in line until the next fetch.
+export const missingLaneHolderQueue: QueueResponse = {
+  ...busyQueue,
+  repositories: busyQueue.repositories.map((repository) =>
+    repository.repository_id === 2
+      ? {
+          ...repository,
+          lane_holder: null,
+          operations: repository.operations.map((operation) =>
+            operation.id === 2
+              ? { ...operation, status: 'queued' as const, started_at: null }
+              : operation
+          ),
+        }
+      : repository
+  ),
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -3621,7 +3621,8 @@
       "pauseAdminOnly": "Nur Administratoren können Hintergrundarbeiten pausieren.",
       "reason": {
         "paused": "Pausiert",
-        "lane_busy": "Wartet, bis das Backup dieses Repositorys fertig ist",
+        "lane_busy": "{{kind}} läuft noch",
+        "index_busy": "Wartet, bis die andere Index-Arbeit dieses Repositorys fertig ist",
         "workers": "Wartet auf einen Index-Worker",
         "queued": "Als Nächstes dran"
       },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -3621,7 +3621,8 @@
       "pauseAdminOnly": "Only administrators can pause background work.",
       "reason": {
         "paused": "Paused",
-        "lane_busy": "Waiting for the backup on this repository to finish",
+        "lane_busy": "{{kind}} still running",
+        "index_busy": "Waiting for this repository's other index work to finish",
         "workers": "Waiting for an index worker",
         "queued": "Next in line"
       },

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -3621,7 +3621,8 @@
       "pauseAdminOnly": "Solo los administradores pueden pausar el trabajo en segundo plano.",
       "reason": {
         "paused": "En pausa",
-        "lane_busy": "Esperando a que termine la copia de este repositorio",
+        "lane_busy": "{{kind}} aún en ejecución",
+        "index_busy": "Esperando a que termine el otro trabajo de índice de este repositorio",
         "workers": "Esperando un worker de índice",
         "queued": "Siguiente en la cola"
       },

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -3621,7 +3621,8 @@
       "pauseAdminOnly": "Solo gli amministratori possono mettere in pausa il lavoro in background.",
       "reason": {
         "paused": "In pausa",
-        "lane_busy": "In attesa che il backup di questo repository finisca",
+        "lane_busy": "{{kind}} ancora in esecuzione",
+        "index_busy": "In attesa che termini l'altro lavoro di indice di questo repository",
         "workers": "In attesa di un worker di indicizzazione",
         "queued": "Prossimo in coda"
       },

--- a/frontend/src/types/operations.ts
+++ b/frontend/src/types/operations.ts
@@ -82,10 +82,23 @@ export interface QueueLimits {
   max_concurrent_scheduled_checks: number
 }
 
+/** The running exclusive operation a repository's lane is taken by. */
+export interface LaneHolder {
+  kind: OperationKind
+  id: number
+}
+
 export interface QueueRepository {
   repository_id: number | null
   repository_name: string
   lane_busy: boolean
+  // Sent whenever `lane_busy` is true; optional so a page loaded before
+  // the server carried it keeps working (queued stages stay next in line
+  // until a running holder is known).
+  lane_holder?: LaneHolder | null
+  // A listing, merge or stats of the repository is running: the next index
+  // operation waits for it, whatever the lane and the worker count say.
+  index_busy: boolean
   operations: OperationItem[]
 }
 

--- a/tests/unit/test_api_operations.py
+++ b/tests/unit/test_api_operations.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 import pytest
+from sqlalchemy import text
 
 from app.database.models import (
     Operation,
@@ -90,6 +91,151 @@ class TestOperationsList:
 
 @pytest.mark.unit
 class TestOperationsQueue:
+    def test_queue_reports_running_index_work_of_a_repository(
+        self, test_client, test_db, admin_headers
+    ):
+        """A running listing, merge or stats holds the repository's index
+        slot, not the lane; the board needs the difference to explain a
+        queued index stage next to free workers."""
+        repo = _repo(test_db)
+        _settings(test_db)
+        running = enqueue(test_db, "stats", repository_id=repo.id)
+        running.status = "running"
+        enqueue(test_db, "archive_sync", repository_id=repo.id)
+        test_db.commit()
+        system = enqueue(test_db, "package_install", repository_id=None)
+        system.status = "running"
+        test_db.commit()
+        body = test_client.get("/api/operations/queue", headers=admin_headers).json()
+        groups = {g["repository_id"]: g for g in body["repositories"]}
+        assert groups[repo.id]["lane_busy"] is False
+        assert groups[repo.id]["index_busy"] is True
+        # the system lane has no repository, so nothing of the sort
+        assert groups[None]["index_busy"] is False
+
+    def test_queue_names_the_maintenance_operation_that_holds_the_lane(
+        self, test_client, test_db, admin_headers
+    ):
+        """A prune holds the lane as much as a backup does; the payload says
+        which one it is, so the waiting stages do not have to guess."""
+        repo = _repo(test_db)
+        _settings(test_db)
+        prune = enqueue(test_db, "prune", repository_id=repo.id)
+        prune.status = "running"
+        waiting = enqueue(test_db, "stats", repository_id=repo.id)
+        test_db.commit()
+
+        body = test_client.get("/api/operations/queue", headers=admin_headers).json()
+        group = body["repositories"][0]
+
+        assert group["lane_busy"] is True
+        assert group["lane_holder"] == {"kind": "prune", "id": prune.id}
+        assert waiting.id in {o["id"] for o in group["operations"]}
+
+    def test_queue_reports_no_lane_holder_while_the_lane_is_free(
+        self, test_client, test_db, admin_headers
+    ):
+        """A running index operation shares the repository rather than
+        taking it, so it is not a holder and the lane stays free."""
+        repo = _repo(test_db)
+        _settings(test_db)
+        running = enqueue(test_db, "stats", repository_id=repo.id)
+        running.status = "running"
+        enqueue(test_db, "archive_sync", repository_id=repo.id)
+        test_db.commit()
+
+        body = test_client.get("/api/operations/queue", headers=admin_headers).json()
+        group = body["repositories"][0]
+
+        assert group["lane_busy"] is False
+        assert group["lane_holder"] is None
+
+    def test_queue_holder_is_the_operation_that_took_the_lane(
+        self, test_client, test_db, admin_headers
+    ):
+        """With two running exclusive rows the earliest start holds the
+        lane; a row without one falls behind it rather than winning on id."""
+        repo = _repo(test_db)
+        _settings(test_db)
+        later = enqueue(test_db, "check", repository_id=repo.id)
+        later.status = "running"
+        later.started_at = utc_now() - timedelta(minutes=1)
+        undated = enqueue(test_db, "compact", repository_id=repo.id)
+        undated.status = "running"
+        undated.started_at = None
+        earlier = enqueue(test_db, "prune", repository_id=repo.id)
+        earlier.status = "running"
+        earlier.started_at = utc_now() - timedelta(minutes=9)
+        test_db.commit()
+
+        body = test_client.get("/api/operations/queue", headers=admin_headers).json()
+        group = body["repositories"][0]
+
+        assert group["lane_holder"] == {"kind": "prune", "id": earlier.id}
+
+    def test_queue_holder_falls_back_to_the_lowest_id_without_starts(
+        self, test_client, test_db, admin_headers
+    ):
+        """A plan creates its post-backup prune and compact already running
+        and without a start, so two rows can tie on the sentinel; the
+        lowest id decides rather than the iteration order."""
+        repo = _repo(test_db)
+        _settings(test_db)
+        first = enqueue(test_db, "prune", repository_id=repo.id)
+        first.status = "running"
+        first.started_at = None
+        second = enqueue(test_db, "compact", repository_id=repo.id)
+        second.status = "running"
+        second.started_at = None
+        test_db.commit()
+
+        body = test_client.get("/api/operations/queue", headers=admin_headers).json()
+        group = body["repositories"][0]
+
+        assert first.id < second.id
+        assert group["lane_holder"] == {"kind": "prune", "id": first.id}
+
+    def test_queue_never_gives_the_system_group_a_lane_holder(
+        self, test_client, test_db, admin_headers
+    ):
+        """Work without a repository is listed under System, which has no
+        lane to take."""
+        _settings(test_db)
+        op = enqueue(test_db, "package_install")
+        op.status = "running"
+        test_db.commit()
+
+        body = test_client.get("/api/operations/queue", headers=admin_headers).json()
+        system = [g for g in body["repositories"] if g["repository_id"] is None][0]
+
+        assert system["lane_busy"] is False
+        assert system["lane_holder"] is None
+
+    def test_queue_survives_an_operation_kind_this_build_does_not_know(
+        self, test_client, test_db, admin_headers
+    ):
+        """A row left by a newer build costs its claim to the lane, not the
+        board: it stays in the listing, and the stages under it read as
+        merely queued rather than the whole page failing to load."""
+        repo = _repo(test_db)
+        _settings(test_db)
+        known = enqueue(test_db, "prune", repository_id=repo.id)
+        known.status = "running"
+        test_db.commit()
+        test_db.execute(
+            text("UPDATE operations SET kind = :kind WHERE id = :id"),
+            {"kind": "teleport", "id": known.id},
+        )
+        test_db.commit()
+
+        response = test_client.get("/api/operations/queue", headers=admin_headers)
+
+        assert response.status_code == 200
+        group = response.json()["repositories"][0]
+        assert known.id in {o["id"] for o in group["operations"]}
+        assert group["lane_busy"] is False
+        assert group["lane_holder"] is None
+
     def test_queue_groups_and_limits(self, test_client, test_db, admin_headers):
         repo = _repo(test_db)
         settings = _settings(test_db)
@@ -109,6 +255,9 @@ class TestOperationsQueue:
         assert group["repository_id"] == repo.id
         assert group["repository_name"] == "r"
         assert group["lane_busy"] is True
+        # the waiting stages name what holds the lane instead of guessing
+        assert group["lane_holder"] == {"kind": "history_index", "id": running.id}
+        assert group["index_busy"] is False
         assert {o["id"] for o in group["operations"]} == {running.id, recent.id}
         assert body["limits"]["index_workers"] == 3
         assert body["limits"]["index_running"] == 1

--- a/tests/unit/test_archive_change_path_index_migration.py
+++ b/tests/unit/test_archive_change_path_index_migration.py
@@ -13,12 +13,12 @@ from datetime import datetime
 
 import pytest
 from alembic import command
-from sqlalchemy import inspect, text
+from sqlalchemy import MetaData, Table, inspect, text
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import sessionmaker
 
 from app.database.db_upgrade import _alembic_config, _engine
-from app.database.models import Archive, ArchiveChange, Repository
+from app.database.models import ArchiveChange, Repository
 
 REVISION = "e4f5a6b7c8d9"
 PREVIOUS = "d3e4f5a6b7c8"
@@ -68,17 +68,22 @@ def _insert_long_path(url):
         repo_id = session.execute(
             Repository.__table__.insert().values(name="r", path="/srv/r")
         ).inserted_primary_key[0]
-        archive = Archive(
-            repository_id=repo_id,
-            borg_id="b",
-            name="a",
-            series="s",
-            start=datetime(2026, 9, 4),
-        )
-        session.add(archive)
-        session.flush()
+        # This historical revision predates the archive generation column.
+        # Reflect it so the current ORM cannot insert newer columns.
+        archives = Table("archives", MetaData(), autoload_with=session.connection())
+        archive_id = session.execute(
+            archives.insert().values(
+                repository_id=repo_id,
+                borg_id="b",
+                name="a",
+                series="s",
+                start=datetime(2026, 9, 4),
+                first_seen_at=datetime(2026, 9, 4),
+                last_seen_at=datetime(2026, 9, 4),
+            )
+        ).inserted_primary_key[0]
         session.add(
-            ArchiveChange(archive_id=archive.id, path=LONG_PATH, change="added")
+            ArchiveChange(archive_id=archive_id, path=LONG_PATH, change="added")
         )
         session.commit()
     except Exception:

--- a/tests/unit/test_archive_generation_migration.py
+++ b/tests/unit/test_archive_generation_migration.py
@@ -1,0 +1,81 @@
+"""Preserve existing archive history while adding durable row identities."""
+
+from datetime import datetime
+
+import pytest
+from alembic import command
+from sqlalchemy import MetaData, Table, inspect, select
+from sqlalchemy.orm import Session
+
+from app.database.db_upgrade import _alembic_config, _engine
+from app.database.models import Archive, Repository
+from app.services.operations.executors.index import apply_listing
+
+PREVIOUS = "e1f2a3b4c5d6"
+REVISION = "f2a3b4c5d6e7"
+
+
+def _migrate(url, target, *, down=False):
+    engine = _engine(url)
+    try:
+        with engine.connect() as connection:
+            config = _alembic_config(url)
+            config.attributes["connection"] = connection
+            (command.downgrade if down else command.upgrade)(config, target)
+            connection.commit()
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.unit
+def test_upgrade_and_downgrade_preserve_history_and_initialize_legacy_identity(
+    tmp_path,
+):
+    url = f"sqlite:///{tmp_path / 'borg.db'}"
+    _migrate(url, PREVIOUS)
+    engine = _engine(url)
+    metadata = MetaData()
+    archives = Table("archives", metadata, autoload_with=engine)
+    changes = Table("archive_changes", metadata, autoload_with=engine)
+    now = datetime(2026, 9, 12)
+    with engine.begin() as connection:
+        repo_id = connection.execute(
+            Repository.__table__.insert().values(name="r", path="/tmp/r")
+        ).inserted_primary_key[0]
+        archive_id = connection.execute(
+            archives.insert().values(
+                repository_id=repo_id,
+                borg_id="old",
+                name="old",
+                series="old",
+                start=now,
+                first_seen_at=now,
+                last_seen_at=now,
+            )
+        ).inserted_primary_key[0]
+        connection.execute(
+            changes.insert().values(archive_id=archive_id, path="keep", change="added")
+        )
+    _migrate(url, REVISION)
+    with Session(engine) as db:
+        row = db.get(Archive, archive_id)
+        assert row.generation_id is None
+        # An absent legacy row also needs an identity for a fresh merge.
+        _, removed = apply_listing(
+            db, db.get(Repository, repo_id), [], timezone_name="UTC"
+        )
+        assert removed == [archive_id]
+        generation = row.generation_id
+        assert generation
+        db.expire_all()
+        assert db.get(Archive, archive_id).generation_id == generation
+        apply_listing(db, db.get(Repository, repo_id), [], timezone_name="UTC")
+        assert row.generation_id == generation
+    _migrate(url, PREVIOUS, down=True)
+    assert "generation_id" not in {
+        c["name"] for c in inspect(engine).get_columns("archives")
+    }
+    with engine.connect() as connection:
+        assert connection.execute(select(changes.c.path)).scalars().all() == ["keep"]
+        assert connection.execute(select(archives.c.borg_id)).scalars().all() == ["old"]
+    engine.dispose()

--- a/tests/unit/test_history_merge.py
+++ b/tests/unit/test_history_merge.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -15,6 +15,7 @@ from app.database.models import (
     SystemSettings,
 )
 from app.services.operations.executors import history
+from app.services.operations.executors import index as index_exec
 
 
 @pytest.fixture()
@@ -25,7 +26,15 @@ def db():
     def _fk_on(dbapi_conn, record):
         dbapi_conn.execute("PRAGMA foreign_keys=ON")
 
-    Base.metadata.create_all(engine)
+    # The operations migration creates archives without AUTOINCREMENT,
+    # although fresh model-created databases enable it. Exercise that schema.
+    archive_options = Archive.__table__.dialect_options["sqlite"]
+    original_autoincrement = archive_options["autoincrement"]
+    try:
+        archive_options["autoincrement"] = False
+        Base.metadata.create_all(engine)
+    finally:
+        archive_options["autoincrement"] = original_autoincrement
     session = sessionmaker(bind=engine)()
     try:
         yield session
@@ -82,7 +91,21 @@ def _ops(db, repo, removed_ids):
         trigger="reconcile",
         priority=20,
         run_id="run",
-        result={"removed_archive_ids": removed_ids},
+        result={
+            "removed_archive_ids": removed_ids,
+            "removed_archive_generations": {
+                str(a.id): a.generation_id
+                for a in db.query(Archive).filter(Archive.id.in_(removed_ids)).all()
+            },
+            "removed_archive_last_seen_at": {
+                str(a.id): a.last_seen_at.isoformat()
+                for a in db.query(Archive).filter(Archive.id.in_(removed_ids)).all()
+            },
+            "removed_archive_borg_ids": {
+                str(a.id): a.borg_id
+                for a in db.query(Archive).filter(Archive.id.in_(removed_ids)).all()
+            },
+        },
     )
     db.add(parent)
     db.commit()
@@ -277,7 +300,7 @@ async def test_dependency_that_is_not_archive_sync_merges_nothing(db, repo):
     )
     db.add(child)
     db.commit()
-    assert history.removed_archive_ids_from_dependency(db, child) == []
+    assert history.removed_archive_targets_from_dependency(db, child) == []
 
 
 @pytest.mark.unit
@@ -333,3 +356,256 @@ async def test_fold_result_is_capped_like_an_indexed_archive(db, repo, monkeypat
     assert sum(x.summary_count for x in summary) == 3
     db.refresh(s)
     assert s.history_rows == len(rows) and s.history_truncated is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("interrupt_after_delete", [False, True])
+async def test_replay_preserves_new_archive_reusing_deleted_id(
+    db, repo, interrupt_after_delete
+):
+    removed = _archive(db, repo, "removed", 1)
+    removed_id = removed.id
+    op = _ops(db, repo, [removed_id])
+    operation_id = op.id
+    repository_id = repo.id
+    ctx = _ctx(db, repo, op)
+    if interrupt_after_delete:
+        ctx.progress.side_effect = RuntimeError("progress unavailable")
+        with pytest.raises(RuntimeError, match="progress unavailable"):
+            await history.run_history_merge(ctx)
+    else:
+        await history.run_history_merge(ctx)
+    # The runner's terminal write did not commit. Only executor checkpoints
+    # survive a new session, as when an abandoned operation is requeued.
+    db.rollback()
+    db.expunge_all()
+    op = db.get(Operation, operation_id)
+    repo = db.get(Repository, repository_id)
+    replacement = _archive(db, repo, "replacement", 2)
+    assert replacement.id == removed_id
+    _row(db, replacement, "keep", "added", after=9)
+
+    out = await history.run_history_merge(_ctx(db, repo, op))
+
+    assert db.get(Archive, removed_id) is not None
+    assert db.query(ArchiveChange).filter_by(archive_id=removed_id).one().path == "keep"
+    assert out.result == {"merged": 1, "folded": 0, "reset": 0, "dropped": 1}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("foreign_target", [False, True])
+async def test_replay_does_not_revisit_previously_skipped_ids(db, repo, foreign_target):
+    if foreign_target:
+        other = Repository(name="other", path="/tmp/other", encryption="none")
+        db.add(other)
+        db.commit()
+        target = _archive(db, other, "foreign", 1)
+        target_id = target.id
+    else:
+        target_id = 1
+    op = _ops(db, repo, [target_id])
+    await history.run_history_merge(_ctx(db, repo, op))
+    if foreign_target:
+        db.delete(target)
+        db.commit()
+    replacement = _archive(db, repo, "replacement", 2)
+    assert replacement.id == target_id
+
+    out = await history.run_history_merge(_ctx(db, repo, op))
+
+    assert db.get(Archive, target_id) is not None
+    assert out.result["merged"] == 0
+
+
+@pytest.mark.unit
+async def test_failed_merge_commit_does_not_checkpoint_uncommitted_deletion(db, repo):
+    removed = _archive(db, repo, "removed", 1)
+    removed_id = removed.id
+    op = _ops(db, repo, [removed_id])
+    with patch.object(db, "commit", side_effect=RuntimeError("disk full")):
+        with pytest.raises(RuntimeError, match="disk full"):
+            await history.run_history_merge(_ctx(db, repo, op))
+    assert db.get(Archive, removed_id) is not None
+
+    out = await history.run_history_merge(_ctx(db, repo, op))
+
+    assert db.get(Archive, removed_id) is None
+    assert out.result == {"merged": 1, "folded": 0, "reset": 0, "dropped": 1}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("partially_merged", [False, True])
+async def test_overtaking_chain_cannot_make_merge_delete_reused_unvisited_id(
+    db, repo, partially_merged
+):
+    first = _archive(db, repo, "first", 1, series="first")
+    second = _archive(db, repo, "second", 2, series="second")
+    removed_ids = [first.id, second.id]
+    delayed = _ops(db, repo, removed_ids)
+    delayed_id = delayed.id
+    repository_id = repo.id
+    if partially_merged:
+        ctx = _ctx(db, repo, delayed)
+        ctx.progress.side_effect = RuntimeError("progress unavailable")
+        with pytest.raises(RuntimeError, match="progress unavailable"):
+            await history.run_history_merge(ctx)
+    # Another chain runs before this merge first starts, or during its retry
+    # backoff. Its listing rediscovers and its merge deletes the remaining rows.
+    _, remaining = index_exec.apply_listing(db, repo, [], timezone_name="UTC")
+    overtaking = _ops(db, repo, remaining)
+    await history.run_history_merge(_ctx(db, repo, overtaking))
+    first_new = _archive(db, repo, "first-new", 3)
+    second_new = _archive(db, repo, "second-new", 4)
+    assert [first_new.id, second_new.id] == removed_ids
+    _row(db, second_new, "keep", "added", after=9)
+    db.rollback()
+    db.expunge_all()
+    repo = db.get(Repository, repository_id)
+    delayed = db.get(Operation, delayed_id)
+
+    out = await history.run_history_merge(_ctx(db, repo, delayed))
+
+    assert [a.borg_id for a in db.query(Archive).order_by(Archive.id)] == [
+        "id-first-new",
+        "id-second-new",
+    ]
+    assert db.query(ArchiveChange).one().path == "keep"
+    assert out.result["merged"] == int(partially_merged)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "missing_identity",
+    [
+        "removed_archive_borg_ids",
+        "removed_archive_last_seen_at",
+        "removed_archive_generations",
+    ],
+)
+async def test_legacy_targets_wait_for_a_listing_with_complete_identities(
+    db, repo, missing_identity
+):
+    removed = _archive(db, repo, "removed", 1)
+    removed_id = removed.id
+    legacy = _ops(db, repo, [removed_id])
+    parent = db.get(Operation, legacy.depends_on_id)
+    parent.result = {k: v for k, v in parent.result.items() if k != missing_identity}
+    db.commit()
+
+    out = await history.run_history_merge(_ctx(db, repo, legacy))
+
+    assert out.result["merged"] == 0
+    assert db.get(Archive, removed_id) is not None
+    _, rediscovered = index_exec.apply_listing(db, repo, [], timezone_name="UTC")
+    assert rediscovered == [removed_id]
+    followup = _ops(db, repo, rediscovered)
+    out = await history.run_history_merge(_ctx(db, repo, followup))
+    assert out.result["merged"] == 1
+    assert db.get(Archive, removed_id) is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("partially_merged", [False, True])
+@pytest.mark.parametrize("clock_delta", [-1, 0, 1])
+async def test_delayed_merge_preserves_rediscovered_archive(
+    db, repo, monkeypatch, partially_merged, clock_delta
+):
+    first = _archive(db, repo, "first", 1, series="first")
+    revived = _archive(db, repo, "revived", 2, series="revived")
+    revived_id = revived.id
+    last_seen = datetime(2026, 9, 10, 12)
+    revived.last_seen_at = last_seen
+    db.commit()
+    _row(db, revived, "keep", "added", after=9)
+    delayed = _ops(db, repo, [first.id, revived_id])
+    if partially_merged:
+        ctx = _ctx(db, repo, delayed)
+        ctx.progress.side_effect = RuntimeError("progress unavailable")
+        with pytest.raises(RuntimeError, match="progress unavailable"):
+            await history.run_history_merge(ctx)
+
+    # A later successful listing sees the same archive in the same DB row.
+    # Its observation must invalidate deletion even if wall time is unchanged
+    # or moves backward, and even when the merge is resuming after a failure.
+    monkeypatch.setattr(
+        index_exec, "utc_now", lambda: last_seen + timedelta(seconds=clock_delta)
+    )
+    index_exec.apply_listing(
+        db,
+        repo,
+        [
+            {
+                "id": revived.borg_id,
+                "name": "revived",
+                "start": revived.start.isoformat(),
+            }
+        ],
+        timezone_name="UTC",
+    )
+    db.expire_all()
+
+    for _ in range(2):
+        out = await history.run_history_merge(_ctx(db, repo, delayed))
+        assert db.get(Archive, revived_id) is not None
+        assert (
+            db.query(ArchiveChange).filter_by(archive_id=revived_id).one().path
+            == "keep"
+        )
+        assert out.result["merged"] == 1
+
+    # A fresh absence observation may still legitimately remove it later.
+    _, absent = index_exec.apply_listing(db, repo, [], timezone_name="UTC")
+    followup = _ops(db, repo, absent)
+    out = await history.run_history_merge(_ctx(db, repo, followup))
+    assert out.result["merged"] == 1
+    assert db.get(Archive, revived_id) is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("partially_merged", [False, True])
+async def test_delayed_merge_preserves_recreated_archive_with_identical_timestamps(
+    db, repo, monkeypatch, partially_merged
+):
+    first = _archive(db, repo, "first", 1, series="first")
+    old = _archive(db, repo, "recreated", 2, series="recreated")
+    old_id = old.id
+    captured_time = datetime(2026, 9, 12, 12)
+    old.last_seen_at = captured_time
+    db.commit()
+    delayed = _ops(db, repo, [first.id, old_id])
+    if partially_merged:
+        ctx = _ctx(db, repo, delayed)
+        ctx.progress.side_effect = RuntimeError("progress unavailable")
+        with pytest.raises(RuntimeError, match="progress unavailable"):
+            await history.run_history_merge(ctx)
+
+    _, absent = index_exec.apply_listing(db, repo, [], timezone_name="UTC")
+    overtaking = _ops(db, repo, absent)
+    await history.run_history_merge(_ctx(db, repo, overtaking))
+    monkeypatch.setattr(index_exec, "utc_now", lambda: captured_time)
+    index_exec.apply_listing(
+        db,
+        repo,
+        [
+            {"id": "id-first-new", "name": "first-new", "start": "2026-09-01T02:00:00"},
+            {
+                "id": "id-recreated",
+                "name": "recreated",
+                "start": "2026-09-02T02:00:00",
+                "comment": "new metadata",
+            },
+        ],
+        timezone_name="UTC",
+    )
+    replacement = db.query(Archive).filter_by(borg_id="id-recreated").one()
+    assert replacement.id == old_id
+    assert replacement.last_seen_at == captured_time
+    _row(db, replacement, "keep", "added", after=9)
+    db.expire_all()
+
+    for _ in range(2):
+        await history.run_history_merge(_ctx(db, repo, delayed))
+        replacement = db.get(Archive, old_id)
+        assert replacement is not None
+        assert replacement.comment == "new metadata"
+        assert db.query(ArchiveChange).filter_by(archive_id=old_id).one().path == "keep"

--- a/tests/unit/test_operations_index_executors.py
+++ b/tests/unit/test_operations_index_executors.py
@@ -187,6 +187,9 @@ async def test_run_archive_sync_updates_repository_columns(db, repo, monkeypatch
         "new": 1,
         "info_filled": 1,
         "removed_archive_ids": [],
+        "removed_archive_borg_ids": {},
+        "removed_archive_last_seen_at": {},
+        "removed_archive_generations": {},
     }
     db.refresh(repo)
     assert repo.archive_count == 1
@@ -1438,3 +1441,32 @@ async def test_agent_listing_reports_the_timeout_when_the_cancel_fails(
     db.commit()
     db.expire_all()
     assert db.get(type(repo), repo.id).total_size == "1.0 GB"
+
+
+@pytest.mark.unit
+async def test_archive_sync_reports_stable_identities_for_removed_archives(
+    db, repo, monkeypatch
+):
+    index_exec.apply_listing(db, repo, [BORG1_ENTRY], timezone_name="UTC")
+    removed = db.query(Archive).one()
+    removed_id = removed.id
+    monkeypatch.setattr(
+        index_exec,
+        "list_archives_for_repository",
+        AsyncMock(return_value=(True, [], "UTC")),
+    )
+    monkeypatch.setattr(index_exec, "fill_archive_info", AsyncMock(return_value=0))
+    monkeypatch.setattr(
+        index_exec, "_prepare_repository_borg_env", lambda repository, db: ({}, None)
+    )
+
+    outcome = await index_exec.run_archive_sync(_ctx(db, repo))
+
+    assert outcome.result["removed_archive_ids"] == [removed_id]
+    assert outcome.result["removed_archive_borg_ids"] == {str(removed_id): "aa11"}
+    assert outcome.result["removed_archive_last_seen_at"] == {
+        str(removed_id): removed.last_seen_at.isoformat()
+    }
+    assert outcome.result["removed_archive_generations"] == {
+        str(removed_id): removed.generation_id
+    }

--- a/tests/unit/test_operations_lanes.py
+++ b/tests/unit/test_operations_lanes.py
@@ -98,6 +98,49 @@ def test_index_kind_waits_without_bypass_and_runs_with_bypass(db, repo, settings
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("running_kind", ["archive_sync", "history_merge", "stats"])
+@pytest.mark.parametrize("waiting_kind", ["archive_sync", "history_merge", "stats"])
+def test_index_kinds_of_one_repository_run_one_at_a_time(
+    db, repo, settings, running_kind, waiting_kind
+):
+    """A listing next to a stats refresh of the same repository dies with
+    rc 2 on Borg 1 (the cache lock), and two chains of one run otherwise
+    start their stats side by side: while one of them runs, the next waits,
+    and bypass does not change that (it reads past a backup's lock, not past
+    another index job). Another repository is unaffected."""
+    _running(db, running_kind, repo)
+    op = enqueue(db, waiting_kind, repository_id=repo.id)
+    assert lanes.can_start(db, op, settings) is False
+    settings.bypass_lock_on_list = True
+    repo.bypass_lock = True
+    db.commit()
+    assert lanes.can_start(db, op, settings) is False
+    other = enqueue(db, waiting_kind, repository_id=_other_repo(db).id)
+    assert lanes.can_start(db, other, settings) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("running_kind", ["archive_sync", "history_merge", "stats"])
+def test_history_index_waits_for_running_index_work_of_its_repository(
+    db, repo, settings, running_kind
+):
+    """The exclusive index kind is held back the same way."""
+    _running(db, running_kind, repo)
+    op = enqueue(db, "history_index", repository_id=repo.id)
+    assert lanes.can_start(db, op, settings) is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("kind", ["backup", "check", "prune", "restore"])
+def test_running_index_work_leaves_the_other_kinds_alone(db, repo, settings, kind):
+    """The rule is index against index; a backup or maintenance job of the
+    repository is governed by the lane as before."""
+    _running(db, "stats", repo)
+    op = enqueue(db, kind, repository_id=repo.id)
+    assert lanes.can_start(db, op, settings) is True
+
+
+@pytest.mark.unit
 def test_index_workers_limit(db, repo, settings):
     settings.index_workers = 1
     db.commit()

--- a/tests/unit/test_operations_runner.py
+++ b/tests/unit/test_operations_runner.py
@@ -7,7 +7,7 @@ from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from app.database.models import Base, Operation, Repository, SystemSettings
+from app.database.models import Base, Operation, Repository, SystemSettings, utc_now
 from app.services.operations.enqueue import enqueue, enqueue_chain
 from app.services.operations.runner import (
     OperationContext,
@@ -109,8 +109,13 @@ async def test_tick_does_not_dispatch_a_row_cancelled_while_it_awaited(
         return Outcome()
 
     registry["stats"] = record
+    # two repositories: on one, the second stats would wait for the first
+    # (one index operation per repository) and never reach the claim
+    other = Repository(name="o", path="/tmp/o", encryption="none", compression="lz4")
+    db.add(other)
+    db.commit()
     first = enqueue(db, "stats", repository_id=repo.id, priority=0)
-    second = enqueue(db, "stats", repository_id=repo.id, priority=5)
+    second = enqueue(db, "stats", repository_id=other.id, priority=5)
 
     import app.services.operations.runner as runner_module
 
@@ -120,11 +125,11 @@ async def test_tick_does_not_dispatch_a_row_cancelled_while_it_awaited(
     async def broadcast_then_cancel(op, session):
         calls.append(op.id)
         if len(calls) == 1:
-            other = session_factory()
-            row = other.get(Operation, second.id)
+            aside = session_factory()
+            row = aside.get(Operation, second.id)
             row.status = "cancelled"
-            other.commit()
-            other.close()
+            aside.commit()
+            aside.close()
         return await real_broadcast(op, session)
 
     monkeypatch.setattr(
@@ -355,6 +360,295 @@ async def test_no_followups_on_failure(db, repo, runner, registry):
     db.expire_all()
     assert db.query(Operation).count() == 1
     assert db.query(Operation).first().error_message == "nope"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_index_operations_of_one_repository_start_one_at_a_time(
+    db, repo, runner, registry
+):
+    """Two chains of one run (the backup's follow-ups and the prune's) each
+    queue index work for the same repository: the tick starts the second
+    operation only once the first has finished, with index_workers=2 (the
+    default)."""
+    gate = asyncio.Event()
+    reached = asyncio.Event()
+    started = []
+
+    async def wait(ctx):
+        started.append(ctx.operation_id)
+        reached.set()
+        await gate.wait()
+        return Outcome()
+
+    registry["stats"] = wait
+    registry["archive_sync"] = wait
+    first = enqueue(db, "stats", repository_id=repo.id, trigger="followup")
+    enqueue(
+        db,
+        "archive_sync",
+        repository_id=repo.id,
+        trigger="followup",
+        run_id=first.run_id,
+    )
+    assert await runner.tick() == 1
+    await asyncio.wait_for(reached.wait(), 5)
+    assert await runner.tick() == 0
+    assert len(started) == 1
+    gate.set()
+    await asyncio.gather(*runner.running_tasks.values())
+    assert await runner.tick() == 1
+    await asyncio.gather(*runner.running_tasks.values())
+    assert len(started) == 2
+    db.expire_all()
+    assert {o.status for o in db.query(Operation)} == {"completed"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_row_left_running_by_a_dead_task_is_requeued_by_the_tick(
+    db, repo, runner, registry
+):
+    """A `running` index row whose task is gone (died before its terminal
+    commit) or never existed holds no lock; left alone it would hold every
+    index operation of the repository and a worker until the next restart.
+    The tick puts it back to `queued`, as startup does, and it runs again."""
+    seen = []
+
+    async def ok(ctx):
+        seen.append(ctx.kind)
+        return Outcome()
+
+    registry["stats"] = ok
+    registry["archive_sync"] = ok
+    no_task = enqueue(db, "stats", repository_id=repo.id)
+    no_task.status = "running"
+    dead_task = enqueue(db, "archive_sync", repository_id=repo.id)
+    dead_task.status = "running"
+    dead_task.started_at = utc_now()
+    db.commit()
+    finished = asyncio.ensure_future(asyncio.sleep(0))
+    await finished
+    runner.running_tasks[dead_task.id] = finished
+
+    assert await runner.requeue_abandoned_index_rows(db) == 2
+    db.expire_all()
+    for op in (no_task, dead_task):
+        row = db.get(Operation, op.id)
+        assert row.status == "queued" and row.started_at is None
+        assert row.params["requeues"] == 1
+    assert dead_task.id not in runner.running_tasks
+    # abandoned again: the count is what bounds the loop
+    for op in (no_task, dead_task):
+        db.get(Operation, op.id).status = "running"
+    db.commit()
+    assert await runner.requeue_abandoned_index_rows(db) == 2
+    db.expire_all()
+    assert {
+        db.get(Operation, op.id).params["requeues"] for op in (no_task, dead_task)
+    } == {2}
+    await _drain(runner)
+    db.expire_all()
+    assert {o.status for o in db.query(Operation)} == {"completed"}
+    assert sorted(seen) == ["archive_sync", "stats"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_tick_requeues_the_abandoned_row_before_it_dispatches(
+    db, repo, runner, registry
+):
+    """The wiring: an abandoned row holds the repository under the new
+    rule, so the tick must clear it before it looks at the queue. With the
+    backoff the requeued row itself may wait a moment; what the tick must
+    do is sweep first and then dispatch something."""
+
+    async def ok(ctx):
+        return Outcome()
+
+    registry["stats"] = ok
+    registry["archive_sync"] = ok
+    orphan = enqueue(db, "stats", repository_id=repo.id)
+    orphan.status = "running"
+    db.commit()
+    enqueue(db, "archive_sync", repository_id=repo.id)
+    assert await runner.tick() == 1
+    db.expire_all()
+    swept = db.get(Operation, orphan.id)
+    assert swept.params["requeues"] == 1
+    assert swept.status in ("queued", "running")  # requeued, or already re-run
+    await _drain(runner)
+    db.expire_all()
+    assert {o.status for o in db.query(Operation)} == {"completed"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_requeued_row_waits_out_the_backoff(
+    db, repo, session_factory, registry, monkeypatch, tmp_path
+):
+    """The deferral path's backoff applies: the row is not re-run in the
+    same pass, and a third requeue still requeues (the cap is four)."""
+    monkeypatch.setattr("app.config.settings.data_dir", str(tmp_path))
+    slow = OperationRunner(
+        session_factory=session_factory,
+        registry=registry,
+        poll_interval=0.01,
+        deferral_delay=2.0,
+    )
+    op = enqueue(db, "stats", repository_id=repo.id)
+    op.status = "running"
+    op.params = {"requeues": 2}
+    db.commit()
+    before = time.time()
+    assert await slow.requeue_abandoned_index_rows(db) == 1
+    db.expire_all()
+    row = db.get(Operation, op.id)
+    assert row.status == "queued" and row.params["requeues"] == 3
+    assert row.params["deferred_until"] >= before + slow.deferral_delay_for(3)
+    assert await slow.tick() == 0  # waiting out the backoff
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_index_row_abandoned_again_and_again_fails(db, repo, runner):
+    """Bounded: a task that keeps dying (a terminal commit that keeps
+    failing) must not re-run the listing every tick forever."""
+    from app.services.operations.runner import MAX_REQUEUES
+
+    op = enqueue(db, "history_index", repository_id=repo.id)  # the exclusive one too
+    op.status = "running"
+    op.started_at = utc_now()
+    op.progress_percent = 40
+    op.params = {"requeues": MAX_REQUEUES}
+    db.commit()
+    assert await runner.requeue_abandoned_index_rows(db) == 1
+    db.expire_all()
+    row = db.get(Operation, op.id)
+    assert row.status == "failed"
+    assert row.completed_at is not None
+    # how far it got stays on the row
+    assert row.started_at is not None and row.progress_percent == 40
+    assert f"after {MAX_REQUEUES} requeues" in row.error_message
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_failing_sweep_does_not_cost_the_dispatch_pass(
+    db, repo, runner, registry, monkeypatch
+):
+    """The sweep is housekeeping: a row whose bookkeeping cannot be read,
+    or a commit that fails, must not stop the tick from dispatching."""
+    seen = []
+
+    async def ok(ctx):
+        seen.append(ctx.kind)
+        return Outcome()
+
+    registry["stats"] = ok
+
+    async def dirty_then_boom(db_):
+        # the sweep has touched a row when its commit fails: the dirty
+        # session must be rolled back before the dispatch pass uses it
+        row = db_.query(Operation).first()
+        row.error_message = "half-swept"
+        raise RuntimeError("database is locked")
+
+    monkeypatch.setattr(runner, "requeue_abandoned_index_rows", dirty_then_boom)
+    op = enqueue(db, "stats", repository_id=repo.id)
+    assert await runner.tick() == 1
+    await asyncio.gather(*runner.running_tasks.values())
+    assert seen == ["stats"]
+    db.expire_all()
+    assert db.get(Operation, op.id).error_message is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_sweep_leaves_running_rows_of_other_kinds_alone(db, repo, runner):
+    """Inline maintenance (`start_inline_maintenance`) records prune, compact
+    and check rows as `running` with no task in this runner; the sweep is
+    for index kinds only and must never touch them."""
+    for kind in ("prune", "compact", "check", "backup"):
+        row = enqueue(db, kind, repository_id=repo.id)
+        row.status = "running"
+    db.commit()
+    assert await runner.requeue_abandoned_index_rows(db) == 0
+    db.expire_all()
+    assert {o.status for o in db.query(Operation)} == {"running"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_task_entry_that_is_not_a_future_is_left_alone(db, repo, runner):
+    """A patched `create_task` can land a mock in `running_tasks`; that
+    row cannot be told apart from live work and stays running."""
+    from unittest.mock import MagicMock
+
+    op = enqueue(db, "stats", repository_id=repo.id)
+    op.status = "running"
+    db.commit()
+    runner.running_tasks[op.id] = MagicMock()
+    assert await runner.requeue_abandoned_index_rows(db) == 0
+    db.expire_all()
+    assert db.get(Operation, op.id).status == "running"
+    runner.running_tasks.pop(op.id)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_tick_leaves_a_running_index_task_alone(db, repo, runner, registry):
+    """The requeue is for rows without a live task; a row with one is
+    running index work and stays so."""
+    gate = asyncio.Event()
+    reached = asyncio.Event()
+
+    async def wait(ctx):
+        reached.set()
+        await gate.wait()
+        return Outcome()
+
+    registry["stats"] = wait
+    op = enqueue(db, "stats", repository_id=repo.id)
+    assert await runner.tick() == 1
+    await asyncio.wait_for(reached.wait(), 5)
+    assert await runner.requeue_abandoned_index_rows(db) == 0
+    db.expire_all()
+    assert db.get(Operation, op.id).status == "running"
+    gate.set()
+    await asyncio.gather(*runner.running_tasks.values())
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_history_index_waits_for_running_index_work_through_the_tick(
+    db, repo, runner, registry
+):
+    """The exclusive index kind is held back by a running listing of its
+    repository too, and the tick reaches that rule before the lane one."""
+    gate = asyncio.Event()
+    reached = asyncio.Event()
+    started = []
+
+    async def wait(ctx):
+        started.append(ctx.kind)
+        reached.set()
+        await gate.wait()
+        return Outcome()
+
+    registry["archive_sync"] = wait
+    registry["history_index"] = wait
+    enqueue(db, "archive_sync", repository_id=repo.id, priority=5)
+    enqueue(db, "history_index", repository_id=repo.id, priority=10)
+    assert await runner.tick() == 1
+    await asyncio.wait_for(reached.wait(), 5)
+    assert started == ["archive_sync"]
+    assert await runner.tick() == 0
+    gate.set()
+    await asyncio.gather(*runner.running_tasks.values())
+    assert await runner.tick() == 1
+    await asyncio.gather(*runner.running_tasks.values())
+    assert started == ["archive_sync", "history_index"]
 
 
 @pytest.mark.unit
@@ -1073,3 +1367,171 @@ async def test_repository_busy_fails_after_the_deferral_cap(db, repo, runner, re
     db.expire_all()
     assert db.get(Operation, other_op.id).status == "failed"
     assert (db.get(Operation, other_op.id).params or {}).get("deferrals") is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "kind", ["archive_sync", "history_merge", "history_index", "stats"]
+)
+def test_startup_recovery_fails_exhausted_index_rows_without_losing_progress(
+    db, repo, runner, kind
+):
+    op = enqueue(db, kind, repository_id=repo.id)
+    op.status = "running"
+    op.started_at = datetime(2026, 9, 1)
+    op.progress_percent = 40
+    op.progress_current = 4
+    op.progress_total = 10
+    op.progress_message = "archive 4"
+    op.params = {"requeues": 3}
+    db.commit()
+
+    counts = runner.recover_on_startup(db)
+
+    db.refresh(op)
+    assert counts == {"requeued": 0, "failed": 1, "kept": 0}
+    assert op.status == "failed" and op.completed_at is not None
+    assert op.started_at == datetime(2026, 9, 1)
+    assert (op.progress_percent, op.progress_current, op.progress_total) == (40, 4, 10)
+    assert op.progress_message == "archive 4"
+    assert "after 3 requeues" in op.error_message
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "requeues,deferrals,expected_requeues,delay",
+    [(2, 0, 3, 8), (0, 4, 1, 16)],
+)
+async def test_startup_recovery_waits_for_the_larger_retry_backoff(
+    db,
+    repo,
+    session_factory,
+    registry,
+    monkeypatch,
+    requeues,
+    deferrals,
+    expected_requeues,
+    delay,
+):
+    async def ok(ctx):
+        return Outcome()
+
+    registry["history_merge"] = ok
+    slow = OperationRunner(
+        session_factory=session_factory, registry=registry, deferral_delay=2.0
+    )
+    op = enqueue(db, "history_merge", repository_id=repo.id)
+    op.status = "running"
+    op.params = {
+        "requeues": requeues,
+        "deferrals": deferrals,
+        "deferred_until": 100.0,
+        "history_merge_completed": {"1": "dropped"},
+    }
+    db.commit()
+    monkeypatch.setattr("app.services.operations.runner.time.time", lambda: 1000.0)
+
+    counts = slow.recover_on_startup(db)
+
+    db.refresh(op)
+    assert counts == {"requeued": 1, "failed": 0, "kept": 0}
+    assert op.params["requeues"] == expected_requeues
+    assert op.params["deferrals"] == deferrals
+    assert op.params["deferred_until"] == 1000.0 + delay
+    assert op.params["history_merge_completed"] == {"1": "dropped"}
+    assert await slow.tick() == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_startup_and_runtime_recovery_share_the_same_retry_budget(
+    db, repo, runner
+):
+    op = enqueue(db, "stats", repository_id=repo.id)
+    op.status = "running"
+    db.commit()
+    assert runner.recover_on_startup(db)["requeued"] == 1
+    op.status = "running"
+    db.commit()
+    assert await runner.requeue_abandoned_index_rows(db) == 1
+    op.status = "running"
+    db.commit()
+    assert runner.recover_on_startup(db)["requeued"] == 1
+    op.status = "running"
+    db.commit()
+
+    counts = runner.recover_on_startup(db)
+
+    db.refresh(op)
+    assert counts == {"requeued": 0, "failed": 1, "kept": 0}
+    assert op.status == "failed"
+    assert op.params["requeues"] == 3
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_accepted_cancel_survives_failed_terminal_and_recovery_commits(
+    db, repo, runner, registry, monkeypatch
+):
+    from unittest.mock import patch
+
+    started = asyncio.Event()
+    finish = asyncio.Event()
+    attempts = []
+    dependants_run = []
+
+    def fail_commit():
+        raise RuntimeError("database is locked")
+
+    async def interrupted(ctx):
+        attempts.append(ctx.operation_id)
+        started.set()
+        await finish.wait()
+        if len(attempts) == 1:
+            # Fail the runner's terminal write after it observes the accepted
+            # cancellation. The session close rolls this transaction back.
+            monkeypatch.setattr(ctx.db, "commit", fail_commit)
+        return Outcome()
+
+    async def dependant(ctx):
+        dependants_run.append(ctx.operation_id)
+        return Outcome()
+
+    registry["archive_sync"] = interrupted
+    registry["history_merge"] = dependant
+    first = enqueue(db, "archive_sync", repository_id=repo.id)
+    child = enqueue(
+        db,
+        "history_merge",
+        repository_id=repo.id,
+        depends_on_id=first.id,
+        run_id=first.run_id,
+    )
+    assert await runner.tick() == 1
+    await started.wait()
+    assert await runner.request_cancel(first.id) is True
+    finish.set()
+    errors = await asyncio.gather(
+        *runner.running_tasks.values(), return_exceptions=True
+    )
+    assert len(errors) == 1 and isinstance(errors[0], RuntimeError)
+    db.refresh(first)
+    assert first.status == "running"
+
+    # A second transient failure in the recovery sweep must not consume the
+    # cancellation either. A subsequent tick can durably finish it.
+    with patch.object(db, "commit", side_effect=fail_commit):
+        with pytest.raises(RuntimeError, match="database is locked"):
+            await runner.requeue_abandoned_index_rows(db)
+    db.rollback()
+    await _drain(runner)
+
+    db.refresh(first)
+    db.refresh(child)
+    assert first.status == "cancelled"
+    assert first.completed_at is not None
+    assert first.id not in runner.cancel_requested
+    assert attempts == [first.id]
+    assert dependants_run == []
+    assert (child.status, child.skip_reason) == ("skipped", "dependency_failed")


### PR DESCRIPTION
> [!WARNING]
> This PR replaces [karanhudia/borg-ui#1023](https://github.com/karanhudia/borg-ui/pull/1023) and [karanhudia/borg-ui#1024](https://github.com/karanhudia/borg-ui/pull/1024), because they could not be merged sequentially without conflicts. Their overlapping changes in ten files are resolved together here, including maintainer feedback and review side findings. Please use this combined change instead of merging the two original PRs separately.

## Description

This combines the repository lane captions from karanhudia/borg-ui#1023 with the index-operation serialization and recovery from karanhudia/borg-ui#1024 on current upstream main.

Two symptoms led to the original changes. A queued stage on the Background work page said “Waiting for the backup on this repository to finish” even when prune, compact, check, delete, wipe, or file-history indexing held the lane. Separately, the runner could start a listing, merge, or stats refresh beside another shared index operation on the same repository. Backup and post-backup maintenance follow-ups can create independent branches within one plan run. On agent repositories using Borg 1, concurrent `info` and `list` calls can contend for Borg's cache lock and lose the follow-up indexing until the next reconcile.

### Repository lane holder and captions — karanhudia/borg-ui#1023

- The queue payload carries `lane_holder: {kind, id} | null` alongside `lane_busy`. Both are derived from the running operations already included in the response, avoiding an N+1 query and disagreement between separate lookups. The earliest start wins; missing start times fall behind known starts and ties use the operation ID. Unknown kinds stay visible without claiming a lane; the System group has no holder.
- Captions put the existing localized kind label first: “prune still running”, for example. Kind labels include titles and verb phrases, so inserting them into a sentence would be ungrammatical in several locales. English, German, Spanish, and Italian are covered; missing or unknown labels cannot expose a raw interpolation placeholder.
- The frontend names a holder only while its ID is still running in the current rows. Following karanhudia's feedback, there is no frontend copy of the exclusive-kind set and no `lane_busy_unnamed` state. Without a live holder, the track falls through to another applicable wait reason or “Next in line”.

### Index serialization, recovery, and waiting reasons — karanhudia/borg-ui#1024

- At most one shared index operation (`archive_sync`, `history_merge`, or `stats`) runs per repository. `history_index` also waits for those shared kinds. Bypass settings do not bypass shared index work. A running `history_index` retains the existing exclusive-lane and listing-bypass behavior, so this does not turn an hours-long history index into a new unconditional block on hourly listing. The global `index_workers` limit is preserved.
- The tick recovers abandoned running index rows whose tasks are missing or finished. Recovery uses deferred backoff and a bounded retry count; exhausted rows fail visibly while retaining their start time and progress. Live tasks, non-future test entries, and running non-index operations are left alone. A failed housekeeping sweep does not prevent dispatch.
- `/queue` reports repository-scoped `index_busy` with one grouped lookup narrowed to repositories accessible to the caller. Waiting stages explain contention with “Waiting for this repository's other index work to finish”. A live named lane holder has precedence over index contention, followed by worker limits and queued wording.
- Both busy flags remain server-derived. Between requests, SSE updates change operation rows and the track interprets the flags against those rows. A transition into running refetches authoritative ownership. Status events received during an active shared queue request are coalesced into one follow-up fetch, avoiding ambiguous event/response ordering. Progress ticks during a fetch rely on its response and never sustain additional requests. Independent branches sharing a run ID still contend; only actual dependency ancestors are excluded as expected predecessors.

## Maintainer feedback and review side findings

- **No duplicated exclusive-kind list:** the holder ID/status check implements the requested simplification while retaining protection against unknown kinds incorrectly keeping a lane busy.
- **Backoff continuity:** recovery uses the larger of the requeue and deferral counters, preserving delays already accumulated by the deferral path.
- **Startup retry limit:** startup recovery and runtime recovery now share the same retry budget and backoff. Restarting the server can no longer bypass the three-requeue limit; exhausted rows retain diagnostic progress.
- **Cancellation during recovery:** an accepted cancellation remains pending if the terminal database commit fails. Recovery commits cancellation before clearing the request, rather than re-running the operation and its dependants.
- **Access scope:** the index-work query uses the repository IDs from the access-scoped response.
- **Consistent SSE handling:** lane and index flags follow the same fetched-state model; false-to-running transitions and delayed responses have regression coverage.
- **Fixture correctness:** running shared stats carries `index_busy: true`; the named lane holder still takes precedence.
- **Safe history-merge replay:** deletions and their outcomes are checkpointed atomically. Listing results also preserve Borg archive identities, and a merge verifies repository, database ID, Borg ID, a persisted row-generation UUID, and the last-seen observation before deleting. Every sighting advances that observation even if the clock is frozen or moves backward, protecting an archive rediscovered before a delayed merge. This protects both completed and unvisited targets when another chain deletes an archive and SQLite reuses its ID during a delay. Legacy results missing any required identity skip destructive work until a later listing rediscovers the stale rows with stable identities.
- **Sibling branches:** the track distinguishes actual dependency predecessors from independent work in the same run, avoiding an incorrect “Next in line” caption when a hidden sibling holds the index slot.

- **Identity across row recreation:** each archive row has a persisted generation UUID, so reused SQLite IDs, Borg IDs, and timestamps cannot make a stale merge delete a recreated archive. A nullable additive migration preserves existing data; the next listing initializes missing identities, including absent rows. Upgrade/downgrade and interrupted-replay regressions cover this path.

## Scope and related work

Fixes karanhudia/borg-ui#1001.
Fixes karanhudia/borg-ui#1003.
Related: karanhudia/borg-ui#982, karanhudia/borg-ui#983, and karanhudia/borg-ui#1012.

Manual API admission rules are unchanged. The optional process/agent-job diagnostic hint from karanhudia/borg-ui#1001 is not included; karanhudia/borg-ui#1008 addressed the orphan-creation path. Recovery retains the application's single-runner assumption, matching its startup design and one-worker deployment. The per-operation admission query is retained; batching it remains a separate optimization. Current-main changes, including karanhudia/borg-ui#1027, are preserved.

## Validation

- Full frontend suite: 2,734 tests in 231 files passed. The subsequent two test-only improvements passed all 60 affected board/track tests; CI runs the full suite on the final commit.
- After the upstream review correction and rebase onto main `172d7574`: 238 targeted queue API, admission, recovery, history merge, index executor, and migration tests passed; one PostgreSQL-specific test was skipped locally because no test server is configured. Full Ruff lint and format checks passed. The [complete upstream CI](https://github.com/karanhudia/borg-ui/actions/runs/34679625643) and [security checks](https://github.com/karanhudia/borg-ui/actions/runs/34679625619) passed on this revised head. [CodeRabbit formally approved it](https://github.com/karanhudia/borg-ui/pull/1031#pullrequestreview-5185705845), confirmed the recreation-identity fix, and resolved the original finding. No actionable findings or nitpicks remain.
- Full backend suite before the final cancellation regression: 4,150 passed, 14 skipped. Later cancellation and rediscovery fixes are covered by targeted regressions; CI validates the final squashed commit.
- Ruff, frontend typecheck, lint, formatting, and locale parity passed. Storybook built successfully; affected maintenance-holder, missing-holder, index-contention, and sibling-branch states were rendered and inspected at desktop and mobile sizes.
- Regressions cover stable archive identities on migrated SQLite schemas, interrupted and overtaken merges, rollback, shared startup/runtime retry limits, sibling branches, and both directions of the SSE/HTTP response race, including parent-triggered refetches. Rediscovery regressions preserve current archive history across delayed merges with advancing, frozen, and backward clocks.
- Five local isolated review rounds used OpenAI Astra 6 and CodeRabbit in every round. Round 5 had no blockers. Its remaining follow-ups—preserving cancellation intent during recovery, bounding repeated progress-driven refetches, and giving the serialization test a shared run ID—are fixed and covered by regressions. GitHub CodeRabbit also reviewed the pre-upstream squashed commit in the fork: its two test findings and archive-rediscovery finding are fixed, and it withdrew the multi-runner finding after confirming the existing single-runner scope.

The branch contains one squashed commit: `cef7be3d4c96b49becace08a198fd98fd5de6e47`, rebased onto upstream main `172d757403861ae71a0056a5b3e27b3ea43efcdd`.

## Fork validation and replacement process

Before upstream submission, validation of `f391736d` took place in [ioanalytica/borg-ui#72](https://github.com/ioanalytica/borg-ui/pull/72). CodeRabbit [explicitly approved that squashed head](https://github.com/ioanalytica/borg-ui/pull/72#issuecomment-5641528920) and confirmed that there are no unresolved findings. Its review status check passed. Formal GitHub approval reviews are disabled in the fork's CodeRabbit configuration, so the approval is recorded in its comment.

That fork-validated commit passed the [test, lint, build, coverage, integration, and smoke CI](https://github.com/ioanalytica/borg-ui/actions/runs/34655332312) and [security checks](https://github.com/ioanalytica/borg-ui/actions/runs/34655332402). The [Storybook report publication](https://github.com/ioanalytica/borg-ui/actions/runs/34655332403) failed at the push to the protected `visual-regression-state` branch (GH013), as expected on this fork. This accepted fork-only publication failure is excluded from the gate; no branch protection was changed.

The fork validation PR is closed without merging in favor of this upstream PR. The original PRs #1023 and #1024 are closed with a reference to this combined replacement. Please do not merge them separately.
