### PR TITLE
feat(operations): link from the background work hub to the repository

### DIFF
--- a/frontend/src/components/background-work/RepositoryTrackDialog.tsx
+++ b/frontend/src/components/background-work/RepositoryTrackDialog.tsx
@@ -217,6 +217,14 @@ export default function RepositoryTrackDialog({
           </Typography>
           <MuiLink
             component={RouterLink}
+            to={`/repositories?q=${encodeURIComponent(repositoryName)}`}
+            variant="body2"
+            sx={{ flexShrink: 0 }}
+          >
+            {t('operations.background.hub.openRepository')}
+          </MuiLink>
+          <MuiLink
+            component={RouterLink}
             to={`/activity?repository_id=${repositoryId}&category=index`}
             variant="body2"
             sx={{ flexShrink: 0 }}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -3736,6 +3736,7 @@
         "detailAllIndexed": "Jedes Archiv hat seinen Dateiverlauf.",
         "detailHint": "Baue ab Dateiverlauf neu auf, um diese Archive erneut zu indizieren.",
         "viewIndexRuns": "Indexläufe anzeigen",
+        "openRepository": "Repository öffnen",
         "historyAgentUnsupported": "Für Agent-Repositories nicht verfügbar"
       },
       "rebuildMenuHint": "Jede Stufe nach der gewählten wird ebenfalls neu aufgebaut. Frühere Stufen bleiben erhalten. Statistiken laufen immer zuletzt, weil sie zusammenzählen, was die anderen Stufen erzeugt haben.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -3736,6 +3736,7 @@
         "detailAllIndexed": "Every archive has its file history.",
         "detailHint": "Rebuild from File history to index these archives again.",
         "viewIndexRuns": "View index runs",
+        "openRepository": "Open repository",
         "historyAgentUnsupported": "Not available for agent repositories"
       },
       "rebuildMenuHint": "Every stage after the one you pick is rebuilt too. Earlier stages are kept. Stats always run last, because they total up what the other stages produced.",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -3736,6 +3736,7 @@
         "detailAllIndexed": "Todos los archivos tienen su historial de ficheros.",
         "detailHint": "Reconstruye desde Historial de ficheros para indexar estos archivos de nuevo.",
         "viewIndexRuns": "Ver ejecuciones de índice",
+        "openRepository": "Abrir repositorio",
         "historyAgentUnsupported": "No disponible para repositorios de agente"
       },
       "rebuildMenuHint": "Cada etapa posterior a la elegida también se reconstruye. Las anteriores se conservan. Las estadísticas siempre van al final, porque suman lo que produjeron las demás etapas.",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -3736,6 +3736,7 @@
         "detailAllIndexed": "Ogni archivio ha la sua cronologia dei file.",
         "detailHint": "Ricostruisci da Cronologia dei file per indicizzare di nuovo questi archivi.",
         "viewIndexRuns": "Vedi esecuzioni di indicizzazione",
+        "openRepository": "Apri repository",
         "historyAgentUnsupported": "Non disponibile per i repository agente"
       },
       "rebuildMenuHint": "Ogni fase successiva a quella scelta viene ricostruita a sua volta. Le fasi precedenti restano. Le statistiche vengono sempre per ultime, perché sommano ciò che le altre fasi hanno prodotto.",

--- a/frontend/src/pages/Repositories.tsx
+++ b/frontend/src/pages/Repositories.tsx
@@ -174,7 +174,8 @@ export default function Repositories() {
   const announcedWipeJobsRef = useRef<Set<number>>(new Set())
 
   // Filter, sort, and search state
-  const [searchQuery, setSearchQuery] = useState('')
+  // `?q=` lets other pages (the background work hub) land on one repository.
+  const [searchQuery, setSearchQuery] = useState(() => searchParams.get('q') ?? '')
   const [sortBy, setSortBy] = useState<string>(() => {
     return localStorage.getItem('repos_sort') || 'name-asc'
   })

--- a/frontend/src/pages/Repositories.tsx
+++ b/frontend/src/pages/Repositories.tsx
@@ -175,7 +175,13 @@ export default function Repositories() {
 
   // Filter, sort, and search state
   // `?q=` lets other pages (the background work hub) land on one repository.
-  const [searchQuery, setSearchQuery] = useState(() => searchParams.get('q') ?? '')
+  const urlQuery = searchParams.get('q') ?? ''
+  const [searchQuery, setSearchQuery] = useState(urlQuery)
+  // The page stays mounted across `/repositories?q=a` -> `/repositories`, so
+  // the initial value alone would leave a stale search in place.
+  React.useEffect(() => {
+    setSearchQuery(urlQuery)
+  }, [urlQuery])
   const [sortBy, setSortBy] = useState<string>(() => {
     return localStorage.getItem('repos_sort') || 'name-asc'
   })


### PR DESCRIPTION
## Summary

The repository dialog on the Background Work tab shows the repository name but had no way to reach the repository itself.

- Add an "Open repository" link in the dialog header, next to "View index runs".
- The Repositories page now seeds its search box from a `?q=` URL param, so the link lands on that one repository. There is no per-repository detail page, so filtering the list is the closest landing spot.
- Locale strings added for en, de, es, it.

## Verification

- `tsc --noEmit`, `oxlint`, and the background-work plus Repositories test suites pass (119 tests).
- Storybook: `BackgroundWork/RepositoryTrackDialog` rendered with the new link in place.
- Local CodeRabbit review against `main`: 0 findings across all 6 changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- visual-regression:start -->
## Visual regression report
Visual changes detected: 10 changed, 0 added, 0 removed, 806 unchanged.
Report: https://docs.borgui.com/visual/reports/pr-1032/
Workflow run: https://github.com/karanhudia/borg-ui/actions/runs/34680597242
<details>
<summary>Changed files</summary>
- `backgroundwork-repositorytrackdialog--agent-repository--mobile.png` (0.20%)
- `backgroundwork-repositorytrackdialog--agent-repository.png` (0.06%)
- `backgroundwork-repositorytrackdialog--all-indexed--mobile.png` (0.20%)
- `backgroundwork-repositorytrackdialog--all-indexed.png` (0.06%)
- `backgroundwork-repositorytrackdialog--archives-only-mode--mobile.png` (0.20%)
- `backgroundwork-repositorytrackdialog--archives-only-mode.png` (0.06%)
- `backgroundwork-repositorytrackdialog--history-partial--mobile.png` (0.20%)
- `backgroundwork-repositorytrackdialog--history-partial.png` (0.06%)
- `backgroundwork-repositorytrackdialog--with-problems--mobile.png` (0.20%)
- `backgroundwork-repositorytrackdialog--with-problems.png` (0.06%)
</details>
<details>
<summary>New screenshots</summary>
- None
</details>
<details>
<summary>Removed screenshots</summary>
- None
</details>
<!-- visual-regression:end -->