### PR TITLE
ci(pages): publish Storybook at docs.borgui.com/storybook

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,7 @@ on:
       - "docs/**"
       - "frontend/src/**"
       - "frontend/.storybook/**"
+      - "frontend/package.json"
       - "frontend/package-lock.json"
       - ".github/workflows/pages.yml"
   workflow_dispatch:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths:
       - "docs/**"
+      - "frontend/src/**"
+      - "frontend/.storybook/**"
+      - "frontend/package-lock.json"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 
@@ -29,9 +32,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
-          cache-dependency-path: docs/package-lock.json
+          cache-dependency-path: |
+            docs/package-lock.json
+            frontend/package-lock.json
 
       - name: Install dependencies
         working-directory: docs
@@ -40,6 +45,12 @@ jobs:
       - name: Build docs
         working-directory: docs
         run: npm run build
+
+      - name: Build Storybook
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build-storybook -- -o ../docs/.vitepress/dist/storybook
 
       - name: Restore visual reports
         env:

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -102,6 +102,12 @@ export default defineConfig({
           { text: 'Architecture', link: '/SPECIFICATION' },
           { text: 'Job System', link: '/architecture/job-system' },
           { text: 'Development', link: '/development' },
+          {
+            text: 'Storybook',
+            link: 'https://docs.borgui.com/storybook/',
+            target: '_blank',
+            rel: 'noreferrer',
+          },
           { text: 'Testing', link: '/testing' },
           { text: 'Contributing', link: '/contributing' },
         ],

--- a/tests/unit/test_operations_runner.py
+++ b/tests/unit/test_operations_runner.py
@@ -906,19 +906,26 @@ async def test_deferral_waits_out_its_delay_despite_wakes(
     not_before = runner_module.deferred_until(row)
     assert not_before is not None and not_before > time.time()
 
-    # ten wakes in a row change nothing
+    # ten wakes in a row change nothing. The deadline is held far out rather
+    # than raced against the real 0.2s, which a loaded runner loses.
+    row.params = {**row.params, "deferred_until": time.time() + 60}
+    db.commit()
     await _drain(runner, rounds=10)
     db.expire_all()
     assert db.get(Operation, op.id).params["deferrals"] == 1
     assert len(attempts) == 1
 
-    await asyncio.sleep(0.25)
+    # once the deadline has passed, the next wake re-dispatches it
+    row = db.get(Operation, op.id)
+    row.params = {**row.params, "deferred_until": time.time() - 1}
+    db.commit()
+    before = time.time()
     await _drain(runner, rounds=1)
     db.expire_all()
     row = db.get(Operation, op.id)
     assert row.params["deferrals"] == 2 and len(attempts) == 2
-    # the second wait is longer than the first
-    assert runner_module.deferred_until(row) - not_before > 0.3
+    # the second wait is the doubled one, not the first delay again
+    assert runner_module.deferred_until(row) - before >= runner.deferral_delay_for(2)
 
     # the delay doubles and is capped
     assert runner.deferral_delay_for(1) == 0.2


### PR DESCRIPTION
## What

Builds the Storybook static site into the VitePress `dist` so the existing GitHub Pages deploy serves it at `docs.borgui.com/storybook/`, and links it from the Reference sidebar.

Same trick the workflow already uses for the visual regression reports. No new host, no new domain, no new token.

## Changes

- `pages.yml`: new "Build Storybook" step writing to `docs/.vitepress/dist/storybook`
- `pages.yml`: trigger also on `frontend/src/**`, `frontend/.storybook/**`, `frontend/package.json`, `frontend/package-lock.json`
- `pages.yml`: Node 20 to 22, matching the rest of CI (Storybook 10 needs >= 20.19)
- `config.mts`: "Storybook" entry under Reference, opening in a new tab
- `test_operations_runner.py`: unrelated flaky test, see below

## Why not storybook.borgui.com

GitHub Pages allows one custom domain per repo site and `docs.borgui.com` has it. A real subdomain would mean a second repo or a second host (Cloudflare Pages, Netlify) plus its own deploy credentials. Not worth it for a subpath that works.

## Verified locally

- Built Storybook into `docs/.vitepress/dist/storybook`, served the whole `dist` over HTTP, confirmed `/storybook/` loads and renders stories with no console errors
- Storybook's static build already emits relative asset paths, so no `base` override is needed
- Docs build passes with the new sidebar entry; confirmed the link renders in the Reference section

## The flaky test

`test_deferral_waits_out_its_delay_despite_wakes` failed on the first CI run here with `assert 2 == 1`. Nothing in this branch touches the backend, and main is green on the same code, so it is a pre-existing flake rather than a regression.

It raced a real 0.2s deferral window: the "ten wakes change nothing" phase has to finish ten drain rounds inside that window, and a loaded runner does not. When it overruns, the operation is legitimately re-dispatched and the deferral count reads 2.

Fixed by holding the not-before deadline explicitly instead of racing the clock, then moving it into the past to exercise the re-dispatch. The doubled-delay assertion now compares against `deferral_delay_for(2)` rather than an elapsed-time threshold. Same behaviour covered, no wall-clock dependency, and the test drops from ~0.5s to ~0.2s. 40/40 local passes, 38 passed for the whole file.

## Review

Local CodeRabbit: 1 major finding (missing `frontend/package.json` in the path filter), fixed. Re-runs clean at 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)