### PR TITLE
refactor(operations): restore a handed-over start where the runner ends the run

### DIFF
--- a/app/services/operations/executors/maintenance.py
+++ b/app/services/operations/executors/maintenance.py
@@ -140,70 +140,6 @@ async def _hand_over_to_service(ctx, claimed_at: Optional[datetime]) -> None:
         )
 
 
-async def _restore_start(ctx, claimed_at: Optional[datetime]) -> None:
-    """A service that never claimed the row (it ended the run before that
-    on a missing repository or a lock it gave up on, returned without a
-    verdict, or raised out of the call) left it with no start; the runner's
-    start is put back, whatever the status, so the run keeps its place in
-    the history and its duration. A start the service wrote stays. If the
-    first commit exhausts its retries, retry the guarded write in a fresh
-    transaction before returning control to the runner's finalization."""
-    if claimed_at is None:
-        return
-
-    restored = 0
-
-    def restore():
-        nonlocal restored
-        restored = (
-            ctx.db.query(Operation)
-            .filter(
-                Operation.id == ctx.operation_id,
-                Operation.started_at.is_(None),
-            )
-            .update({Operation.started_at: claimed_at}, synchronize_session=False)
-        )
-
-    for action in ("maintenance_restore_start", "maintenance_restore_start_recovery"):
-        try:
-            await commit_with_retry(
-                ctx.db,
-                prepare=restore,
-                logger=logger,
-                action=action,
-                operation_id=ctx.operation_id,
-            )
-            break
-        except asyncio.CancelledError:
-            # A shutdown drain must still be able to interrupt either retry.
-            ctx.db.rollback()
-            logger.warning(
-                "Maintenance start not restored, task cancelled",
-                operation_id=ctx.operation_id,
-            )
-            raise
-        except Exception as exc:
-            # Rollback discards the UPDATE as well as the failed transaction.
-            # Recovery must execute it again, keeping the NULL guard in case
-            # a service has since recorded its own start. Neither failure may
-            # replace the service's exception escaping the executor's finally.
-            ctx.db.rollback()
-            logger.warning(
-                "Maintenance start restore failed",
-                operation_id=ctx.operation_id,
-                action=action,
-                error=str(exc),
-            )
-    else:
-        return
-    if restored:
-        logger.info(
-            "Maintenance start restored, the service never claimed the row",
-            operation_id=ctx.operation_id,
-            kind=ctx.kind,
-        )
-
-
 async def _run(
     ctx,
     call: Callable[[BorgRouter, int], Awaitable[None]],
@@ -222,19 +158,18 @@ async def _run(
 
     if borg2_canceller is not None and _borg2_server_service(repository):
         canceller = borg2_canceller
-    handed_over = _hands_over(ctx, repository)
-    claimed_at = ctx.operation.started_at
-    if handed_over:
-        await _hand_over_to_service(ctx, claimed_at)
+    if _hands_over(ctx, repository):
+        # The row is left with no start until the service claims it. A
+        # service that never gets that far (a missing repository, a lock it
+        # gave up on, a raise) leaves it that way, and the runner puts the
+        # dispatch's start back when it writes the terminal state, so the
+        # run keeps its place in the history and its duration.
+        await _hand_over_to_service(ctx, ctx.operation.started_at)
     watcher = asyncio.create_task(cancel_watcher(ctx, canceller))
     try:
         await call(BorgRouter(repository), ctx.operation_id)
     finally:
         watcher.cancel()
-        if handed_over:
-            # Also on a raise or a cancel out of the call: the runner then
-            # writes the verdict, and the row must not lose its start.
-            await _restore_start(ctx, claimed_at)
 
     # The service ran in its own session and committed there. Expire this
     # one so the verdict it wrote is read back rather than assumed.

--- a/app/services/operations/runner.py
+++ b/app/services/operations/runner.py
@@ -378,6 +378,13 @@ class OperationRunner:
             op = db.get(Operation, operation_id)
             if op is None or op.status != "running":
                 return
+            # The start this dispatch's claim wrote. An executor that hands
+            # its row to a service which claims it through `claim_running`
+            # (`executors/maintenance.py`) clears it first; a service that
+            # never gets that far leaves the row with no start, and the
+            # terminal writes below put this one back so the run keeps its
+            # place in the history and its duration.
+            claimed_at = op.started_at
             executor = self._get_executor(op.kind)
             ctx = OperationContext(self, db, op)
             outcome: Optional[Outcome]
@@ -386,6 +393,8 @@ class OperationRunner:
                 outcome = await executor(ctx)
             except asyncio.CancelledError:
                 op.status = "cancelled"
+                if op.started_at is None:
+                    op.started_at = claimed_at
                 op.completed_at = utc_now()
                 db.commit()
                 await broadcast_operation_updated(op, db)
@@ -467,6 +476,8 @@ class OperationRunner:
             op.result = outcome.result
             op.skip_reason = outcome.skip_reason
             op.error_message = outcome.error_message
+            if op.started_at is None:
+                op.started_at = claimed_at
             op.completed_at = utc_now()
             db.commit()
             await broadcast_operation_updated(op, db)

--- a/tests/unit/test_operations_maintenance_executors.py
+++ b/tests/unit/test_operations_maintenance_executors.py
@@ -692,16 +692,16 @@ async def test_run_leaves_a_row_a_cancel_made_terminal_alone(tmp_path, monkeypat
 
 
 @pytest.mark.asyncio
-async def test_run_restores_the_runner_start_when_the_service_never_claimed(
+async def test_run_leaves_the_row_startless_when_the_service_never_claimed(
     db, borg2_repository, monkeypatch
 ):
     """A service that ends the run before it claims (a missing repository, a
-    lock it gave up on) writes a terminal status with no start; the runner's
-    start is put back so the run keeps its place in the history."""
+    lock it gave up on) writes a terminal status with no start. The executor
+    leaves it that way: the runner puts the dispatch's start back when it
+    writes the terminal state (`test_operations_runner.py`)."""
     from app.services.operations.executors import maintenance
 
     op = _runner_claimed(db, borg2_repository)
-    runner_started_at = op.started_at
 
     async def fake_compact(self, job_id):
         other = _other_session(db)
@@ -722,21 +722,20 @@ async def test_run_restores_the_runner_start_when_the_service_never_claimed(
 
     assert outcome.status == "failed"
     db.expire_all()
-    assert db.get(Operation, op.id).started_at == runner_started_at
+    assert db.get(Operation, op.id).started_at is None
 
 
 @pytest.mark.asyncio
-async def test_run_restores_the_runner_start_when_the_service_raises(
+async def test_run_leaves_the_row_startless_when_the_service_raises(
     db, borg2_repository, monkeypatch
 ):
     """A service that raises out of the call (a cancel arriving while it
-    retries a lock, before it claimed) leaves the row with no start; the
-    restore runs in the executor's `finally`, so the runner's verdict that
-    follows lands on a row that still has one."""
+    retries a lock, before it claimed) leaves the row with no start. The
+    exception travels on untouched; the runner stamps the start with the
+    verdict it writes."""
     from app.services.operations.executors import maintenance
 
     op = _runner_claimed(db, borg2_repository)
-    runner_started_at = op.started_at
 
     async def fake_compact(self, job_id):
         other = _other_session(db)
@@ -756,20 +755,19 @@ async def test_run_restores_the_runner_start_when_the_service_raises(
     db.expire_all()
     row = db.get(Operation, op.id)
     assert row.status == "running"  # the runner writes the verdict
-    assert row.started_at == runner_started_at
+    assert row.started_at is None
 
 
 @pytest.mark.asyncio
-async def test_run_restores_the_runner_start_when_the_service_gave_no_verdict(
+async def test_run_leaves_the_row_startless_when_the_service_gave_no_verdict(
     db, borg2_repository, monkeypatch
 ):
     """A service that returns with the row still `running` (its own failure
-    write lost to a lock) never claimed it; the start comes back before the
-    executor reports the missing verdict."""
+    write lost to a lock) never claimed it; the executor reports the missing
+    verdict and leaves the start to the runner."""
     from app.services.operations.executors import maintenance
 
     op = _runner_claimed(db, borg2_repository)
-    runner_started_at = op.started_at
 
     async def fake_compact(self, job_id):
         return None
@@ -783,7 +781,7 @@ async def test_run_restores_the_runner_start_when_the_service_gave_no_verdict(
     assert outcome.status == "failed"
     assert outcome.error_message == "service returned no result"
     db.expire_all()
-    assert db.get(Operation, op.id).started_at == runner_started_at
+    assert db.get(Operation, op.id).started_at is None
 
 
 @pytest.mark.asyncio
@@ -905,174 +903,6 @@ async def test_hand_over_commit_failure_propagates_before_the_service_runs(
     assert called == []
     db.expire_all()
     assert db.get(Operation, op.id).started_at == started_at
-
-
-@pytest.mark.asyncio
-async def test_restore_failure_does_not_replace_the_services_error(
-    db, borg2_repository, monkeypatch
-):
-    """The restore runs in the executor's `finally`; when its own commit
-    fails, the service's failure is what reaches the runner."""
-    from sqlalchemy.exc import OperationalError
-
-    from app.services.operations.executors import maintenance
-
-    op = _runner_claimed(db, borg2_repository)
-    real = maintenance.commit_with_retry
-
-    async def commit(session, **kwargs):
-        if kwargs.get("action") == "maintenance_restore_start":
-            session.rollback()
-            raise OperationalError("UPDATE operations", {}, Exception("locked"))
-        return await real(session, **kwargs)
-
-    monkeypatch.setattr(maintenance, "commit_with_retry", commit)
-
-    async def fake_compact(self, job_id):
-        raise RuntimeError("borg2 compact failed")
-
-    monkeypatch.setattr(
-        "app.core.borg_router.BorgRouter.compact", fake_compact, raising=True
-    )
-
-    with pytest.raises(RuntimeError, match="borg2 compact failed"):
-        await maintenance.run_compact(FakeContext(db, op))
-
-    db.expire_all()
-    assert db.get(Operation, op.id).started_at == _RUNNER_CLAIMED_AT
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "service_result", ["raises", "failed", "completed", "no_verdict"]
-)
-async def test_restore_recovers_after_exhausting_commit_retries(
-    db, borg2_repository, monkeypatch, service_result
-):
-    """Recovery persists the start before returning the original service verdict."""
-    from sqlalchemy.exc import OperationalError
-
-    from app.services.operations.executors import maintenance
-    from app.utils import db_retries
-
-    op = _runner_claimed(db, borg2_repository)
-    operation_id = op.id
-    real_commit = db.commit
-    failed_commits = 0
-
-    def locked_commit():
-        nonlocal failed_commits
-        if failed_commits < 6:  # initial attempt plus all five retries
-            failed_commits += 1
-            raise OperationalError("COMMIT", {}, Exception("database is locked"))
-        real_commit()
-
-    async def no_sleep(delay):
-        return None
-
-    async def fake_compact(self, job_id):
-        with _other_session(db) as other:
-            job = MaintenanceJobFacade(other, other.get(Operation, job_id))
-            assert job.started_at is None
-            if service_result in ("failed", "completed"):
-                job.status = service_result
-                if service_result == "failed":
-                    job.error_message = "borg2 compact failed"
-                other.commit()
-        monkeypatch.setattr(db, "commit", locked_commit)
-        if service_result == "raises":
-            raise RuntimeError("borg2 compact failed")
-
-    monkeypatch.setattr(db_retries.asyncio, "sleep", no_sleep)
-    monkeypatch.setattr("app.core.borg_router.BorgRouter.compact", fake_compact)
-
-    if service_result == "raises":
-        with pytest.raises(RuntimeError, match="borg2 compact failed"):
-            await maintenance.run_compact(FakeContext(db, op))
-    else:
-        outcome = await maintenance.run_compact(FakeContext(db, op))
-        assert outcome.status == (
-            "completed" if service_result == "completed" else "failed"
-        )
-        if service_result == "failed":
-            assert outcome.error_message == "borg2 compact failed"
-        elif service_result == "no_verdict":
-            assert outcome.error_message == "service returned no result"
-
-    assert failed_commits == 6
-    with _other_session(db) as other:
-        assert other.get(Operation, operation_id).started_at == _RUNNER_CLAIMED_AT
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("cancel_recovery", [False, True])
-async def test_failed_restore_recovery_preserves_service_error_or_cancellation(
-    db, borg2_repository, monkeypatch, cancel_recovery
-):
-    """Recovery is bounded and does not mask service errors or shutdown cancellation."""
-    from app.services.operations.executors import maintenance
-
-    op = _runner_claimed(db, borg2_repository)
-    real = maintenance.commit_with_retry
-    actions = []
-
-    async def commit(session, **kwargs):
-        action = kwargs["action"]
-        if action.startswith("maintenance_restore_start"):
-            actions.append(action)
-            kwargs["prepare"]()
-            if len(actions) == 2 and cancel_recovery:
-                raise asyncio.CancelledError()
-            raise RuntimeError("restore unavailable")
-        return await real(session, **kwargs)
-
-    async def fake_compact(self, job_id):
-        raise RuntimeError("borg2 compact failed")
-
-    monkeypatch.setattr(maintenance, "commit_with_retry", commit)
-    monkeypatch.setattr("app.core.borg_router.BorgRouter.compact", fake_compact)
-
-    if cancel_recovery:
-        with pytest.raises(asyncio.CancelledError):
-            await maintenance.run_compact(FakeContext(db, op))
-    else:
-        with pytest.raises(RuntimeError, match="borg2 compact failed"):
-            await maintenance.run_compact(FakeContext(db, op))
-
-    assert len(actions) == 2
-    assert not db.in_transaction()
-
-
-@pytest.mark.asyncio
-async def test_restore_recovery_keeps_a_start_written_between_attempts(
-    db, borg2_repository, monkeypatch
-):
-    """The recovery UPDATE preserves a service start committed after the rollback."""
-    from app.services.operations.executors import maintenance
-
-    op = _runner_claimed(db, borg2_repository)
-    operation_id = op.id
-    service_start = utc_now()
-    real = maintenance.commit_with_retry
-
-    async def commit(session, **kwargs):
-        if kwargs["action"] == "maintenance_restore_start":
-            kwargs["prepare"]()
-            session.rollback()
-            with _other_session(db) as other:
-                other.get(Operation, operation_id).started_at = service_start
-                other.commit()
-            raise RuntimeError("restore commit failed")
-        return await real(session, **kwargs)
-
-    monkeypatch.setattr(maintenance, "commit_with_retry", commit)
-    monkeypatch.setattr("app.core.borg_router.BorgRouter.compact", _completing(db))
-
-    outcome = await maintenance.run_compact(FakeContext(db, op))
-
-    assert outcome.status == "completed"
-    with _other_session(db) as other:
-        assert other.get(Operation, operation_id).started_at == service_start
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_operations_runner.py
+++ b/tests/unit/test_operations_runner.py
@@ -440,6 +440,96 @@ async def test_cancel_preserves_a_service_written_cancelled_status(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+@pytest.mark.parametrize("verdict", ["completed", "failed"])
+async def test_terminal_write_restores_a_start_the_executor_handed_over(
+    db, repo, runner, registry, verdict
+):
+    """A maintenance executor hands its row to a Borg 2 service by clearing
+    the start the dispatch wrote, so the service's `claim_running` matches
+    (executors/maintenance.py). A service that never claims leaves the row
+    with no start; the terminal write puts the dispatch's start back, so the
+    run keeps its place in the history and its duration."""
+    seen = {}
+
+    async def hands_the_row_over(ctx):
+        seen["claimed_at"] = ctx.operation.started_at
+        ctx.db.query(Operation).filter(Operation.id == ctx.operation_id).update(
+            {Operation.started_at: None}, synchronize_session=False
+        )
+        ctx.db.commit()
+        return Outcome(status=verdict)
+
+    registry["stats"] = hands_the_row_over
+    op = enqueue(db, "stats", repository_id=repo.id)
+    await _drain(runner)
+    db.expire_all()
+    row = db.get(Operation, op.id)
+    assert row.status == verdict
+    assert seen["claimed_at"] is not None
+    assert row.started_at == seen["claimed_at"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_terminal_write_restores_the_start_when_the_executor_raises(
+    db, repo, runner, registry
+):
+    """The same, for an executor that raises after the hand-over (a service
+    that gave up on a lock): the failure the runner writes lands on a row
+    that still carries its start."""
+    seen = {}
+
+    async def hands_over_then_raises(ctx):
+        seen["claimed_at"] = ctx.operation.started_at
+        ctx.db.query(Operation).filter(Operation.id == ctx.operation_id).update(
+            {Operation.started_at: None}, synchronize_session=False
+        )
+        ctx.db.commit()
+        raise RuntimeError("database is locked")
+
+    registry["stats"] = hands_over_then_raises
+    op = enqueue(db, "stats", repository_id=repo.id)
+    await _drain(runner)
+    db.expire_all()
+    row = db.get(Operation, op.id)
+    assert row.status == "failed"
+    assert row.started_at == seen["claimed_at"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cancelled_task_keeps_a_start_the_executor_handed_over(
+    db, repo, runner, registry
+):
+    """A shutdown drain cancels the task while the row is handed over. The
+    cancelled row keeps its start too: it ran, and the history says so."""
+    seen = {}
+    handed_over = asyncio.Event()
+
+    async def hands_over_then_waits(ctx):
+        seen["claimed_at"] = ctx.operation.started_at
+        ctx.db.query(Operation).filter(Operation.id == ctx.operation_id).update(
+            {Operation.started_at: None}, synchronize_session=False
+        )
+        ctx.db.commit()
+        handed_over.set()
+        await asyncio.sleep(60)
+        return Outcome()
+
+    registry["stats"] = hands_over_then_waits
+    op = enqueue(db, "stats", repository_id=repo.id)
+    await runner.tick()
+    await handed_over.wait()
+    runner.running_tasks[op.id].cancel()
+    await asyncio.gather(*runner.running_tasks.values(), return_exceptions=True)
+    db.expire_all()
+    row = db.get(Operation, op.id)
+    assert row.status == "cancelled"
+    assert row.started_at == seen["claimed_at"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_cancel_refused_for_running_rows_this_process_does_not_own(
     db, repo, runner
 ):


### PR DESCRIPTION
Follow-up to #1025, which shipped the fix for runner-dispatched Borg 2 maintenance never running borg.

## What this changes

The hand-over stays as it is. The executor clears the start its dispatch wrote so the Borg 2 service's `claim_running` matches, and that clear is the part of #1025 that actually fixes the bug.

What comes out is `_restore_start`. Putting the start back does not need its own guarded UPDATE, its own two-attempt retry budget and its own `CancelledError` branch in the executor's `finally`, written once per way a run can end. Every one of those ways already converges on `run_operation`'s terminal write, which is the transaction that stamps the row anyway.

So `run_operation` keeps the start its claim wrote and puts it back when it writes the terminal state, on the verdict path and on the cancelled one:

```python
claimed_at = op.started_at   # after loading the row
...
if op.started_at is None:
    op.started_at = claimed_at
```

A start the service wrote is left alone: the guard only fires on a row that has none. Nothing else leaves a row startless today, so no other kind changes behaviour.

`app/`: +18 / -72.

## Why the in-session read is safe

The hand-over's UPDATE uses `synchronize_session=False`, so the runner's copy of the row could have been stale at the terminal write. It is not: `SessionLocal` leaves `expire_on_commit` at its default, so the hand-over's commit expires the instance and `op.started_at` re-reads from the table.

## Tests

- The three executor tests now pin the hand-over contract (the row is left startless whether the service declines, raises, or returns no verdict) rather than the restore.
- `test_operations_runner.py` gains the restore itself: a verdict (completed and failed), a raise, and a cancelled task.
- The four tests of the restore's retry and recovery machinery go with the machinery.

Full unit suite green on the pre-rebase commit (4134 passed, 14 skipped); the runner, maintenance-executor and v2-service suites re-run green after the rebase onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)